### PR TITLE
docs: remove unused grammar idents from enums macro

### DIFF
--- a/enums/src/languages.rs
+++ b/enums/src/languages.rs
@@ -1,27 +1,27 @@
 use tree_sitter::Language;
 
 mk_langs!(
-    // 1) Name for enum
-    // 2) tree-sitter function to call to get a Language
-    (Kotlin, tree_sitter_kotlin_ng),
-    (Lua, tree_sitter_lua),
-    (Java, tree_sitter_java),
-    (Go, tree_sitter_go),
-    (Rust, tree_sitter_rust),
-    (Tcl, tree_sitter_tcl),
-    (Cpp, tree_sitter_cpp),
-    (Python, tree_sitter_python),
-    (Tsx, tree_sitter_tsx),
-    (Typescript, tree_sitter_typescript),
-    (Bash, tree_sitter_bash),
-    (Csharp, tree_sitter_c_sharp),
-    (Elixir, tree_sitter_elixir),
-    (Ccomment, tree_sitter_ccomment),
-    (Preproc, tree_sitter_preproc),
-    (Mozjs, tree_sitter_mozjs),
-    (Javascript, tree_sitter_javascript),
-    (Perl, tree_sitter_perl),
-    (Php, tree_sitter_php),
-    (Ruby, tree_sitter_ruby),
-    (Groovy, dekobon_tree_sitter_groovy)
+    // Enum variants only. Grammar resolution lives in mk_get_language!.
+    (Kotlin),
+    (Lua),
+    (Java),
+    (Go),
+    (Rust),
+    (Tcl),
+    // Cpp intentionally resolves to tree_sitter_mozcpp::LANGUAGE.
+    (Cpp),
+    (Python),
+    (Tsx),
+    (Typescript),
+    (Bash),
+    (Csharp),
+    (Elixir),
+    (Ccomment),
+    (Preproc),
+    (Mozjs),
+    (Javascript),
+    (Perl),
+    (Php),
+    (Ruby),
+    (Groovy)
 );

--- a/enums/src/macros.rs
+++ b/enums/src/macros.rs
@@ -16,7 +16,7 @@ macro_rules! mk_enum {
 }
 
 macro_rules! mk_get_language {
-    ( $( ($camel:ident, $name:ident) ),* ) => {
+    ( $( ($camel:ident) ),* ) => {
         pub fn get_language(lang: &Lang) -> Language {
             match lang {
                 Lang::Kotlin => tree_sitter_kotlin_ng::LANGUAGE.into(),
@@ -58,9 +58,9 @@ macro_rules! mk_get_language_name {
 }
 
 macro_rules! mk_langs {
-    ( $( ($camel:ident, $name:ident) ),* ) => {
+    ( $( ($camel:ident) ),* ) => {
         mk_enum!($( $camel ),*);
-        mk_get_language!($( ($camel, $name) ),*);
+        mk_get_language!($( ($camel) ),*);
         mk_get_language_name!($( $camel ),*);
     };
 }


### PR DESCRIPTION
## Summary
- remove the unused second tuple element from `enums/src/languages.rs`
- keep grammar resolution centralized in `mk_get_language!` instead of implying the list is load-bearing
- add an explicit note that `Cpp` intentionally resolves to `tree_sitter_mozcpp::LANGUAGE`

## Validation
- `git diff --check`
- `cargo test --manifest-path enums/Cargo.toml` *(could not run in this environment: `cargo` is not installed)*

Closes #344
