### PR TITLE
fix(cli): make diff keys and a preproc test Windows path-safe

### DIFF
--- a/.bca-baseline.toml
+++ b/.bca-baseline.toml
@@ -625,14 +625,14 @@ path = "big-code-analysis-cli/src/metric_diff.rs"
 qualified = "<file>"
 start_line = 1
 metric = "halstead.effort"
-value = 1579186.894855429
+value = 1578036.5821063574
 
 [[entry]]
 path = "big-code-analysis-cli/src/metric_diff.rs"
 qualified = "<file>"
 start_line = 1
 metric = "nargs"
-value = 43.0
+value = 44.0
 
 [[entry]]
 path = "big-code-analysis-cli/src/metric_diff.rs"
@@ -646,7 +646,7 @@ path = "big-code-analysis-cli/src/metric_diff.rs"
 qualified = "<file>"
 start_line = 1
 metric = "nom"
-value = 39.0
+value = 40.0
 
 [[entry]]
 path = "big-code-analysis-cli/src/metric_diff.rs"

--- a/big-code-analysis-cli/src/metric_diff.rs
+++ b/big-code-analysis-cli/src/metric_diff.rs
@@ -533,9 +533,15 @@ fn read_json(path: &Path) -> Result<Value, DiffError> {
 
 /// Convert a path into a stable string key, erroring on non-UTF-8 rather
 /// than lossily transcoding (identifier paths must round-trip).
+///
+/// The OS separator is normalized to `/` so a directory-set's relpath
+/// fallback key is platform-independent: a file at `nested/y.json` keys
+/// identically whether the walk ran on Unix or Windows (where
+/// `to_str()` would otherwise yield `nested\y.json`, breaking pairing
+/// against a `/`-keyed set and the documented `bca diff` contract).
 fn path_to_key(path: &Path) -> Result<String, DiffError> {
     path.to_str()
-        .map(str::to_string)
+        .map(|s| s.replace(std::path::MAIN_SEPARATOR, "/"))
         .ok_or_else(|| DiffError::NonUtf8Path {
             path: path.to_path_buf(),
         })

--- a/big-code-analysis-cli/tests/cli_smoke.rs
+++ b/big-code-analysis-cli/tests/cli_smoke.rs
@@ -230,7 +230,11 @@ fn preproc_resolves_cross_file_include_across_directory() {
     let dir = TempDir::new().unwrap();
     std::fs::create_dir(dir.path().join("sub")).unwrap();
     let main_c = dir.path().join("main.c");
-    let helper_h = dir.path().join("sub/helper.h");
+    // Join components separately so the path uses the OS separator: a
+    // literal `"sub/helper.h"` would leave a forward slash on Windows
+    // (mixed `...\sub/helper.h`) that never matches the walk-emitted,
+    // backslash-separated `indirect_includes` path.
+    let helper_h = dir.path().join("sub").join("helper.h");
     std::fs::write(
         &main_c,
         "#include \"helper.h\"\nint main(void){ return HELPER; }\n",

--- a/big-code-analysis-cli/tests/common/mod.rs
+++ b/big-code-analysis-cli/tests/common/mod.rs
@@ -37,6 +37,17 @@ pub mod validators;
 /// bounded by fixed sentinels, the last test wins, replacing every
 /// earlier block (see #388).
 ///
+/// The diff-scope auto-detection vars (`diff.rs::auto_detect_base`)
+/// are scrubbed for the same reason: on a `pull_request` event GitHub
+/// sets `GITHUB_BASE_REF` (and a push sets `GITHUB_EVENT_BEFORE`), so a
+/// hermetic-tempdir `bca check` would auto-enable a `--since` scope,
+/// fail to resolve `origin/<base>` (the tempdir is not a git checkout),
+/// and emit a "proceeding without diff scope" warning to stderr —
+/// breaking every test that asserts clean stderr. This only surfaces on
+/// `pull_request` CI events (push runs leave `GITHUB_BASE_REF` unset),
+/// which is why it stayed latent until the first PR. A test that
+/// *wants* a diff scope sets the var explicitly after construction.
+///
 /// Call sites name their builder `cli()` (or `bin()` in
 /// `big-code-analysis-web`); each delegates to this helper so a
 /// future new env-leak only needs to be patched once.
@@ -44,6 +55,9 @@ pub mod validators;
 pub fn scrub_ci_env(cmd: &mut Command) -> &mut Command {
     cmd.env_remove("GITHUB_STEP_SUMMARY")
         .env_remove("GITHUB_ACTIONS")
+        .env_remove("GITHUB_BASE_REF")
+        .env_remove("BCA_DIFF_BASE")
+        .env_remove("GITHUB_EVENT_BEFORE")
 }
 
 /// Build a `bca` `Command` with CI-side env vars scrubbed. The


### PR DESCRIPTION
Two Windows-only CI failures (run 26799627900), both `/` vs `\` separator issues in the #482 epic work, latent until the push hit Windows CI (local dev is Linux).

- metric_diff `path_to_key`: `to_str()` kept the OS separator, so a directory-set's relpath fallback key was `nested\y.json` on Windows and could not pair with a `/`-keyed set. Normalize the separator to `/` so directory-set diff keys are platform-independent, matching the `name`-field branch's `/`-form.

- cli_smoke `preproc_resolves_cross_file_include_across_directory`: the test built `helper_h` via `join("sub/helper.h")`, a mixed-separator path on Windows (`...\sub/helper.h`) that never matched the walk-emitted, backslash-separated `indirect_includes` path. Build the path component-by-component so it uses the OS separator. Test-only; the production preproc output was internally consistent.

Both changes are no-ops on Linux (verified the two tests plus the metric_diff / cli_smoke / diff_since / check_exclude / check_baseline suites still pass). Baseline refreshed for the one-closure growth in metric_diff.rs.