### PR TITLE
ci(pages): upload bca self-scan offenders to Code Scanning

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -156,6 +156,17 @@ jobs:
     # ceiling absorbs the worst-case "Cargo.lock churned + Swatinem
     # cache evicted" combo without killing useful runs.
     timeout-minutes: 30
+    # security-events:write lets the upload-sarif step publish bca's own
+    # self-scan offenders to GitHub code scanning (Security tab + PR
+    # annotations) — dogfooding the SARIF path we document for adopters
+    # in commands/check.md and recipes/ci.md. actions:read is required by
+    # upload-sarif on private/internal repos (harmless on public ones)
+    # and matches ci.yml's clippy job. The workflow-level default is
+    # contents:read.
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
     # The workspace-minus-vendored exclude list lives in `.bcaignore`
     # at the repo root and is wired in via `exclude_from` in the
     # auto-discovered `bca.toml` manifest, so the invocations below
@@ -261,6 +272,29 @@ jobs:
         run: make self-scan
         env:
           BCA_SINCE: origin/${{ github.base_ref || 'main' }}
+
+      # Dogfood bca's own SARIF writer: re-run the gate as a pure
+      # emitter (`--no-fail` keeps exit 0 regardless of offenders) so
+      # this step runs even when the gate above is red, and upload the
+      # result to Code Scanning below. Path selection, thresholds, and
+      # the baseline all come from the auto-discovered `bca.toml`
+      # manifest — same config the gate uses — so the published alerts
+      # match the gate's offender set. `if: always()` mirrors the report
+      # steps: the SARIF is most useful precisely when CI is red.
+      - name: Generate self-scan SARIF
+        if: always()
+        run: bca check --output-format sarif --no-fail --output bca.sarif
+
+      # Fork PRs get a read-only GITHUB_TOKEN without security-events
+      # scope, so the upload would error; skip it there (and when no
+      # SARIF was produced). `category: bca` keeps these alerts a
+      # distinct analysis from ci.yml's `category: clippy` upload.
+      - name: Upload self-scan SARIF to code scanning
+        if: always() && hashFiles('bca.sarif') != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        with:
+          sarif_file: bca.sarif
+          category: bca
 
       - name: Upload reports artifact
         if: always()

--- a/big-code-analysis-book/src/recipes/ci.md
+++ b/big-code-analysis-book/src/recipes/ci.md
@@ -43,8 +43,11 @@ the [Quality reports recipe](quality-reports.md).
 `big-code-analysis` runs the recipes below against its own source on
 every push and PR. The workflow source —
 [`.github/workflows/pages.yml`](https://github.com/dekobon/big-code-analysis/blob/main/.github/workflows/pages.yml) —
-exercises the threshold gate, the baseline ratchet, and both report
-formats end-to-end against the workspace itself. The output sits on
+exercises the threshold gate, the baseline ratchet, both report
+formats, and a SARIF upload to GitHub Code Scanning end-to-end against
+the workspace itself. (The SARIF upload runs on same-repo pushes and
+PRs only; fork PRs skip it because the upload needs a write-scoped
+token, exactly as the clippy SARIF job does.) The output sits on
 GitHub Pages alongside this book:
 
 - HTML hotspot report:


### PR DESCRIPTION
## What

Wire `bca`'s own SARIF output into the `scan` job in `pages.yml` and
upload it to GitHub Code Scanning, closing a dogfooding gap: the repo
already ships a SARIF writer and documents `bca check --output-format
sarif --no-fail` + `upload-sarif` as *the* GitHub-native integration
path for adopters — and `ci.yml` already uploads **clippy's** SARIF —
yet `bca`'s own self-scan offenders never reached Code Scanning.

## Changes

- **`.github/workflows/pages.yml`**
  - Add a job-scoped `permissions` block to `scan`
    (`security-events: write` + `actions: read`; workflow default
    stays `contents: read`), mirroring `ci.yml`'s clippy job.
  - Add a **Generate self-scan SARIF** step:
    `bca check --output-format sarif --no-fail --output bca.sarif`.
    `--no-fail` + `if: always()` means it emits even when the gate is
    red. It reads the same auto-discovered `bca.toml` manifest as the
    gate, so published alerts match the gate's baseline-filtered
    offender set.
  - Add an **Upload self-scan SARIF to code scanning** step using the
    same pinned `github/codeql-action/upload-sarif` as clippy, under a
    distinct `category: bca`, with the same fork-PR guard.
- **`big-code-analysis-book/src/recipes/ci.md`** — update the
  "Live worked example" to note the workflow now also exercises a
  SARIF upload end-to-end, including the fork-PR exception.

## Semantics

The SARIF is **baseline-filtered** (same config as the gate), so Code
Scanning shows only regressions past `.bca-baseline.toml` — i.e. what
would actually fail CI — rather than permanently surfacing accepted
debt. The Markdown/HTML reports keep the full offender picture.

## Validation

- `make actionlint` — clean.
- `make markdown-lint` — clean.
- Ran `bca check --output-format sarif --no-fail --output bca.sarif`
  locally: well-formed SARIF 2.1.0; 0 results today because the repo
  sits at a clean baseline (expected — it lights up on the first
  beyond-baseline regression).

## Notes

The `scan` job now runs `bca check` twice (gate + SARIF emit). This is
a deliberate tradeoff: collapsing to one parse would mean making the
SARIF invocation the gate, which breaks the local/CI gate-invocation
unification and replaces human-readable gate logs with raw SARIF JSON.
The extra analysis pass is seconds in a job dominated by the release
build, so two parses is the right call.
