### PR TITLE
Batch fix: collapse lang_to_name (#500) + honor suppress markers in reports (#501)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,19 @@ for historical reference.
 
 ### Added
 
+- `bca report markdown|html` now honors in-source suppression markers
+  (`bca: suppress`, `bca: suppress-file`, `#lizard forgives`) **by
+  default**, omitting a function from a metric's hotspot table when that
+  metric is suppressed for it — matching `bca check` and the SARIF
+  emitter (the report previously listed raw values and re-surfaced every
+  silenced function). Suppression is per-metric and folds the file's
+  `suppress-file` scope into each function's own scope. `bca report
+  --no-suppress` (or `[report] no_suppress = true` in `bca.toml`) opts
+  into the raw audit view that lists every offender. Advisory roll-ups
+  (the actionable summary, CC-stats note) intentionally keep counting
+  raw measurements. `SuppressionScope::merge` is now `pub` (additive) so
+  report consumers can fold scopes
+  ([#501](https://github.com/dekobon/big-code-analysis/issues/501)).
 - `bca check --report-suppressed`: surface the debt the gate tolerates in
   the code-scan document instead of dropping it. Offenders silenced by an
   in-source `bca: suppress` marker or covered by the baseline stay out of
@@ -423,6 +436,13 @@ for historical reference.
 
 ### Changed
 
+- Python bindings: `lang_to_name` now delegates to `LANG::get_name()`
+  for all but three lookup-token overrides (`Cpp` → `"cpp"`, `Csharp` →
+  `"csharp"`, `Tsx` → `"tsx"`), collapsing a 22-arm hand-maintained
+  table that duplicated the upstream CLI display names. The Python-facing
+  `language` identifiers are byte-identical for every variant; this only
+  removes drift risk between the facade and the CLI display names
+  ([#500](https://github.com/dekobon/big-code-analysis/issues/500)).
 - **(breaking)** `FilesData` and `ConcurrentRunner` are reshaped into a
   terminal file-set processor: `FilesData` drops its `include` /
   `exclude` `GlobSet` fields (now just `FilesData { paths }`),

--- a/big-code-analysis-book/src/commands/report.md
+++ b/big-code-analysis-book/src/commands/report.md
@@ -37,7 +37,35 @@ bca --paths /path/to/project report markdown --output report.md
 | --- | --- | --- |
 | `--top N` | 20 | Maximum entries per hotspot table. |
 | `--strip-prefix PATH` | *(empty)* | Prefix removed from file paths. |
+| `--no-suppress` | *(off)* | Include functions silenced by in-source suppression markers (raw audit view). |
 | `-o, --output FILE` | *(stdout)* | Output file. Parent directory must exist. |
+
+## Suppression markers
+
+By default, `bca report markdown|html` **honours** in-source suppression
+markers — the same `// bca: suppress`, `// bca: suppress-file`, and
+`#lizard forgives` comments that [`bca check`](check.md) and the SARIF
+emitter respect (see [Suppression](suppression.md)). A function is
+omitted from a metric's hotspot table when that metric is suppressed for
+it, so the published report agrees with the threshold gate instead of
+re-surfacing every silenced offender.
+
+Suppression is per-metric: a `// bca: suppress(cyclomatic)` marker drops
+the function from the Cyclomatic table only — it still appears in the
+Cognitive, Halstead, and other tables. A bare `// bca: suppress` (or
+`// bca: suppress-file`) covers every metric.
+
+Pass `--no-suppress` for the raw audit view that lists every offender
+regardless of markers. The setting can also be pinned in the
+[`bca.toml` manifest](check.md):
+
+```toml
+[report]
+no_suppress = true
+```
+
+The CLI flag wins; a bare `--no-suppress` can force the audit view on,
+but the manifest never forces it off.
 
 ## Examples
 

--- a/big-code-analysis-book/src/commands/suppression.md
+++ b/big-code-analysis-book/src/commands/suppression.md
@@ -4,9 +4,12 @@ In-source suppression markers silence threshold violations without
 editing the offending function or excluding the file from the walk.
 Drop a marker in any comment in the source file and `bca check`
 treats the covered metrics as if they were within limits for that
-scope. Metric computation is unaffected — raw `bca metrics` /
-`bca report` output still reports every number. Suppression is a
-threshold-check concern only.
+scope. Metric computation is unaffected — raw `bca metrics` output
+still reports every number. Suppression is a measurement-display
+concern: `bca check` drops the covered violations from the gate, and
+`bca report markdown|html` omits the covered functions from the
+matching hotspot tables by default (pass `bca report --no-suppress`
+for the raw audit view — see [report](report.md)).
 
 Markers exist for the cases editing the code is not an option:
 generated-style legacy modules awaiting rewrite, accepted exceptions
@@ -179,9 +182,10 @@ offender list:
 bca --paths src/ check --no-suppress
 ```
 
-The flag has no effect on metric values themselves: raw
-`bca metrics` / `bca report` output already ignores markers, since
-suppression is a threshold-check concern only.
+The flag has no effect on metric values themselves: raw `bca metrics`
+output always reports every number. `bca report markdown|html` honours
+markers in its hotspot tables by default and accepts its own
+[`--no-suppress`](report.md) flag for the same raw audit view.
 
 ## Surfacing suppressed debt (`--report-suppressed`)
 

--- a/big-code-analysis-cli/src/commands.rs
+++ b/big-code-analysis-cli/src/commands.rs
@@ -1422,7 +1422,9 @@ pub fn run() {
         Command::Functions => run_command_functions(cli.globals, preproc),
         Command::Metrics(args) => run_command_metrics(cli.globals, args, preproc),
         Command::Ops(args) => run_command_ops(cli.globals, args, preproc),
-        Command::Report(args) => run_command_report(cli.globals, args, preproc),
+        Command::Report(args) => {
+            run_command_report(cli.globals, args, manifest.as_ref(), preproc);
+        }
         Command::Find(args) => run_command_find(cli.globals, args, preproc),
         Command::Count(args) => run_command_count(cli.globals, args, preproc),
         Command::StripComments(args) => run_command_strip_comments(cli.globals, args, preproc),
@@ -1563,7 +1565,16 @@ fn run_command_ops(
     run_walk(globals, cfg);
 }
 
-fn run_command_report(globals: GlobalOpts, args: ReportArgs, preproc: Option<Arc<PreprocResults>>) {
+fn run_command_report(
+    globals: GlobalOpts,
+    mut args: ReportArgs,
+    manifest: Option<&Manifest>,
+    preproc: Option<Arc<PreprocResults>>,
+) {
+    if let Some(m) = manifest {
+        m.merge_report(&mut args);
+    }
+    let policy = SuppressionPolicy::from_no_suppress(args.no_suppress);
     if let Some(ref output) = args.output {
         if output.exists() && output.is_dir() {
             die("--output must be a file path for `report`");
@@ -1590,8 +1601,8 @@ fn run_command_report(globals: GlobalOpts, args: ReportArgs, preproc: Option<Arc
     // All worker threads have joined, so `rx.into_iter()` terminates.
     let summaries: Vec<FunctionSummary> = rx.into_iter().collect();
     let report = match args.format {
-        ReportFormat::Markdown => generate_report(&summaries, args.top as usize),
-        ReportFormat::Html => generate_html_report(&summaries, args.top as usize),
+        ReportFormat::Markdown => generate_report(&summaries, args.top as usize, policy),
+        ReportFormat::Html => generate_html_report(&summaries, args.top as usize, policy),
     };
     if let Some(ref output_path) = args.output {
         std::fs::write(output_path, &report)
@@ -1739,6 +1750,16 @@ nargs = 7
 nexits = 5
 abc = 50
 wmc = 60
+
+# Aggregated-report options for `bca report markdown|html` (#501). By
+# default the report honours in-source suppression markers
+# (`bca: suppress`, `bca: suppress-file`, `#lizard forgives`) and omits a
+# function from a metric's hotspot table when that metric is suppressed
+# for it — matching `bca check` and the SARIF emitter. Uncomment to opt
+# into the raw audit view that lists every offender (equivalent to
+# `bca report --no-suppress`).
+# [report]
+# no_suppress = true
 ";
 
 /// Canonical contents of a freshly-scaffolded `.bcaignore`. The

--- a/big-code-analysis-cli/src/html_report.rs
+++ b/big-code-analysis-cli/src/html_report.rs
@@ -38,7 +38,7 @@ use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::fmt::Write;
 
-use big_code_analysis::SpaceKind;
+use big_code_analysis::{MetricKind, SpaceKind, SuppressionPolicy};
 
 use crate::format_util::MetricScalar;
 use crate::markdown_report::{
@@ -319,6 +319,12 @@ struct HotspotSpec {
     metric: fn(&FunctionSummary) -> f64,
     dir: SortDir,
     columns: &'static [HotspotColumn],
+    /// Which metric family this table ranks. When the report honors
+    /// suppression markers (the default), an entry is dropped if its
+    /// effective scope covers this kind — the same per-table filtering
+    /// the Markdown report applies (issue #501). `--no-suppress`
+    /// (`SuppressionPolicy::Ignore`) bypasses it.
+    metric_kind: MetricKind,
 }
 
 // Column descriptors shared verbatim across multiple hotspot specs.
@@ -365,6 +371,7 @@ const MI_LOWEST_HOTSPOT: HotspotSpec = HotspotSpec {
     keep: |s| s.mi_visual_studio > 0.0,
     metric: |s| s.mi_visual_studio,
     dir: SortDir::Asc,
+    metric_kind: MetricKind::Mi,
     columns: &[
         COL_FILE,
         HotspotColumn {
@@ -381,6 +388,7 @@ const CC_HOTSPOT: HotspotSpec = HotspotSpec {
     keep: |s| s.cyclomatic > 0.0,
     metric: |s| s.cyclomatic,
     dir: SortDir::Desc,
+    metric_kind: MetricKind::Cyclomatic,
     columns: &[
         COL_FUNCTION,
         COL_FILE,
@@ -396,6 +404,7 @@ const COGNITIVE_HOTSPOT: HotspotSpec = HotspotSpec {
     keep: |s| s.cognitive > 0.0,
     metric: |s| s.cognitive,
     dir: SortDir::Desc,
+    metric_kind: MetricKind::Cognitive,
     columns: &[
         COL_FUNCTION,
         COL_FILE,
@@ -411,6 +420,7 @@ const HALSTEAD_EFFORT_HOTSPOT: HotspotSpec = HotspotSpec {
     keep: |s| s.halstead_effort > 0.0,
     metric: |s| s.halstead_effort,
     dir: SortDir::Desc,
+    metric_kind: MetricKind::Halstead,
     columns: &[
         COL_FUNCTION,
         COL_FILE,
@@ -438,6 +448,7 @@ const LARGEST_BY_SLOC_HOTSPOT: HotspotSpec = HotspotSpec {
     keep: |s| s.sloc > 0,
     metric: |s| s.sloc as f64,
     dir: SortDir::Desc,
+    metric_kind: MetricKind::Loc,
     columns: &[
         COL_FUNCTION,
         COL_FILE,
@@ -453,6 +464,7 @@ const MANY_PARAMS_HOTSPOT: HotspotSpec = HotspotSpec {
     keep: |s| s.nargs > 3,
     metric: |s| s.nargs as f64,
     dir: SortDir::Desc,
+    metric_kind: MetricKind::Nargs,
     columns: &[
         COL_FUNCTION,
         COL_FILE,
@@ -475,6 +487,7 @@ const WMC_HOTSPOT: HotspotSpec = HotspotSpec {
     keep: |s| is_class_like(s.kind) && s.wmc > 0.0,
     metric: |s| s.wmc,
     dir: SortDir::Desc,
+    metric_kind: MetricKind::Wmc,
     columns: &[
         HotspotColumn {
             header: "Class",
@@ -508,10 +521,15 @@ const WMC_HOTSPOT: HotspotSpec = HotspotSpec {
     ],
 };
 
+// The exit-points table maps to `MetricKind::Exit` — the suppression
+// vocabulary's spelling of the threshold engine's `nexits` (matching
+// `MetricKind::for_threshold_name`'s `nexits → exit` alias), so a
+// `bca: suppress(exit)` marker silences it.
 const NEXITS_HOTSPOT: HotspotSpec = HotspotSpec {
     keep: |s| s.nexits > 0,
     metric: |s| s.nexits as f64,
     dir: SortDir::Desc,
+    metric_kind: MetricKind::Exit,
     columns: &[
         COL_FUNCTION,
         COL_FILE,
@@ -531,6 +549,7 @@ const ABC_HOTSPOT: HotspotSpec = HotspotSpec {
     keep: |s| s.abc > 0.0,
     metric: |s| s.abc,
     dir: SortDir::Desc,
+    metric_kind: MetricKind::Abc,
     columns: &[
         COL_FUNCTION,
         COL_FILE,
@@ -617,9 +636,13 @@ fn emit_hotspot(
     base: &[&FunctionSummary],
     top_n: usize,
     spec: &HotspotSpec,
+    policy: SuppressionPolicy,
 ) -> bool {
-    let mut entries: Vec<&FunctionSummary> =
-        base.iter().copied().filter(|s| (spec.keep)(s)).collect();
+    let mut entries: Vec<&FunctionSummary> = base
+        .iter()
+        .copied()
+        .filter(|s| (spec.keep)(s) && !s.is_hidden_for(spec.metric_kind, policy))
+        .collect();
     if entries.is_empty() {
         return false;
     }
@@ -838,7 +861,11 @@ fn write_html_tail(out: &mut String) {
 /// Produce a self-contained HTML quality-metrics report from the
 /// collected summaries. `top_n` controls how many entries appear in
 /// each hotspot table.
-pub(crate) fn generate_html_report(summaries: &[FunctionSummary], top_n: usize) -> String {
+pub(crate) fn generate_html_report(
+    summaries: &[FunctionSummary],
+    top_n: usize,
+    policy: SuppressionPolicy,
+) -> String {
     // Each summary contributes at most one row across all hotspot
     // tables (sections × top_n is bounded), but the per-language
     // overview table plus the inline CSS/JS already costs a few KB of
@@ -854,7 +881,7 @@ pub(crate) fn generate_html_report(summaries: &[FunctionSummary], top_n: usize) 
     if !by_lang.is_empty() {
         write_overview_table(&mut out, &by_lang);
         for (&lang_name, lang_summaries) in &by_lang {
-            write_language_section(&mut out, lang_name, lang_summaries, top_n);
+            write_language_section(&mut out, lang_name, lang_summaries, top_n, policy);
         }
     }
     write_html_tail(&mut out);
@@ -1001,7 +1028,12 @@ impl CyclomaticStats {
 /// stats are computed first so the note can be gated on the table
 /// actually rendering — an empty `funcs` slice yields no table and no
 /// misleading `Average CC: 0.0` line.
-fn emit_cc_hotspot_with_stats(out: &mut String, funcs: &[&FunctionSummary], top_n: usize) {
+fn emit_cc_hotspot_with_stats(
+    out: &mut String,
+    funcs: &[&FunctionSummary],
+    top_n: usize,
+    policy: SuppressionPolicy,
+) {
     let stats = CyclomaticStats::from_funcs(funcs);
     if emit_hotspot(
         out,
@@ -1009,6 +1041,7 @@ fn emit_cc_hotspot_with_stats(out: &mut String, funcs: &[&FunctionSummary], top_
         funcs,
         top_n,
         &CC_HOTSPOT,
+        policy,
     ) {
         let _ = writeln!(
             out,
@@ -1109,6 +1142,7 @@ fn write_language_section(
     lang_name: &str,
     entries: &[&FunctionSummary],
     top_n: usize,
+    policy: SuppressionPolicy,
 ) {
     write_language_header(out, lang_name);
     let (units, funcs) = partition_by_kind(entries);
@@ -1120,14 +1154,16 @@ fn write_language_section(
         &units,
         top_n,
         &MI_LOWEST_HOTSPOT,
+        policy,
     );
-    emit_cc_hotspot_with_stats(out, &funcs, top_n);
+    emit_cc_hotspot_with_stats(out, &funcs, top_n, policy);
     emit_hotspot(
         out,
         "Cognitive Complexity Hotspots",
         &funcs,
         top_n,
         &COGNITIVE_HOTSPOT,
+        policy,
     );
     emit_hotspot(
         out,
@@ -1135,6 +1171,7 @@ fn write_language_section(
         &funcs,
         top_n,
         &HALSTEAD_EFFORT_HOTSPOT,
+        policy,
     );
     emit_hotspot(
         out,
@@ -1142,6 +1179,7 @@ fn write_language_section(
         &funcs,
         top_n,
         &LARGEST_BY_SLOC_HOTSPOT,
+        policy,
     );
     emit_hotspot(
         out,
@@ -1149,6 +1187,7 @@ fn write_language_section(
         &funcs,
         top_n,
         &MANY_PARAMS_HOTSPOT,
+        policy,
     );
     write_actionable_summary(out, &funcs);
     // WMC sources `entries` (all kinds), not `funcs`: class-likes are
@@ -1159,6 +1198,7 @@ fn write_language_section(
         entries,
         top_n,
         &WMC_HOTSPOT,
+        policy,
     );
     emit_hotspot(
         out,
@@ -1166,8 +1206,16 @@ fn write_language_section(
         &funcs,
         top_n,
         &NEXITS_HOTSPOT,
+        policy,
     );
-    emit_hotspot(out, "ABC Magnitude Hotspots", &funcs, top_n, &ABC_HOTSPOT);
+    emit_hotspot(
+        out,
+        "ABC Magnitude Hotspots",
+        &funcs,
+        top_n,
+        &ABC_HOTSPOT,
+        policy,
+    );
 
     let _ = out.write_str("</section>\n");
 }
@@ -1205,6 +1253,7 @@ mod tests {
             name: name.to_string(),
             kind,
             language,
+            suppressed: big_code_analysis::SuppressionScope::default(),
             start_line: 1,
             end_line: 10,
             sloc: 20,
@@ -1271,7 +1320,7 @@ mod tests {
 
     #[test]
     fn empty_summaries_emit_no_tables() {
-        let out = generate_html_report(&[], 20);
+        let out = generate_html_report(&[], 20, SuppressionPolicy::Honor);
         assert!(out.contains("<h1>Code Quality Metrics Summary</h1>"));
         assert!(!out.contains("<table"));
         assert_html_well_formed(&out);
@@ -1279,7 +1328,7 @@ mod tests {
 
     #[test]
     fn js_handler_binds_all_hotspot_tables() {
-        let out = generate_html_report(&[], 20);
+        let out = generate_html_report(&[], 20, SuppressionPolicy::Honor);
         assert!(
             out.contains("document.querySelectorAll('table.hotspot')"),
             "JS sort handler must bind to every hotspot table by class, not by id"
@@ -1318,7 +1367,7 @@ mod tests {
             s.tokens = 1_500_000 * (i + 1);
             summaries.push(s);
         }
-        let out = generate_html_report(&summaries, 5);
+        let out = generate_html_report(&summaries, 5, SuppressionPolicy::Honor);
         assert!(
             out.contains(">10,000<") && out.contains(">1,500,000<"),
             "expected thousands-formatted cells in output"
@@ -1327,7 +1376,7 @@ mod tests {
 
     #[test]
     fn single_language_well_formed() {
-        let out = generate_html_report(&rust_fixture(), 20);
+        let out = generate_html_report(&rust_fixture(), 20, SuppressionPolicy::Honor);
         assert!(out.contains("<h2>Rust</h2>"));
         assert!(out.contains("class=\"hotspot\""));
         assert_html_well_formed(&out);
@@ -1335,7 +1384,7 @@ mod tests {
 
     #[test]
     fn two_language_well_formed_and_alphabetical() {
-        let out = generate_html_report(&two_lang_fixture(), 20);
+        let out = generate_html_report(&two_lang_fixture(), 20, SuppressionPolicy::Honor);
         assert!(out.contains("<h2>Python</h2>"));
         assert!(out.contains("<h2>Rust</h2>"));
         let py = out.find("<h2>Python</h2>").expect("python heading");
@@ -1353,7 +1402,7 @@ mod tests {
         summaries[1].name = "<script>alert(1)</script>".to_string();
         summaries[1].file = "a&b\"c'd<e>".to_string();
 
-        let out = generate_html_report(&summaries, 20);
+        let out = generate_html_report(&summaries, 20, SuppressionPolicy::Honor);
         assert!(
             !out.contains("<script>alert(1)"),
             "raw <script> payload must not appear in output"
@@ -1385,7 +1434,7 @@ mod tests {
             summaries.push(s);
         }
 
-        let out = generate_html_report(&summaries, 5);
+        let out = generate_html_report(&summaries, 5, SuppressionPolicy::Honor);
         let cc_section = out
             .split_once("<h3>Cyclomatic Complexity Hotspots</h3>")
             .expect("cyclomatic section present")
@@ -1414,7 +1463,7 @@ mod tests {
             make_summary("lib.rs", "src/lib.rs", SpaceKind::Unit, LANG::Rust),
             make_summary("Widget", "src/lib.rs", SpaceKind::Class, LANG::Rust),
         ];
-        let out = generate_html_report(&entries, 20);
+        let out = generate_html_report(&entries, 20, SuppressionPolicy::Honor);
         let wmc_table = out
             .split_once("<h3>Class/Trait/Impl Hotspots (WMC)</h3>")
             .expect("WMC section present even with no functions")
@@ -1432,8 +1481,8 @@ mod tests {
     #[test]
     fn output_is_byte_deterministic() {
         let s = two_lang_fixture();
-        let a = generate_html_report(&s, 20);
-        let b = generate_html_report(&s, 20);
+        let a = generate_html_report(&s, 20, SuppressionPolicy::Honor);
+        let b = generate_html_report(&s, 20, SuppressionPolicy::Honor);
         assert_eq!(a, b, "renderer must be byte-deterministic across runs");
     }
 
@@ -1447,7 +1496,7 @@ mod tests {
         let mut summaries = rust_fixture();
         summaries[1].cyclomatic = f64::NAN;
         summaries[2].cyclomatic = 5.0;
-        let out = generate_html_report(&summaries, 20);
+        let out = generate_html_report(&summaries, 20, SuppressionPolicy::Honor);
         assert_html_well_formed(&out);
     }
 
@@ -1492,7 +1541,7 @@ mod tests {
         // The "Args" table is gated on nargs > 3; bump one function so
         // the section actually renders.
         summaries[1].nargs = 5;
-        let out = generate_html_report(&summaries, 20);
+        let out = generate_html_report(&summaries, 20, SuppressionPolicy::Honor);
 
         // Drive the loop from the catalogue itself so a new tooltip
         // arm is required to appear in real output without anyone
@@ -1583,7 +1632,7 @@ mod tests {
             make_summary("App.tsx", "src/App.tsx", SpaceKind::Unit, LANG::Tsx),
             make_summary("render", "src/App.tsx", SpaceKind::Function, LANG::Tsx),
         ];
-        let out = generate_html_report(&entries, 5);
+        let out = generate_html_report(&entries, 5, SuppressionPolicy::Honor);
         assert!(
             out.contains("<section class=\"lang-section lang-typescript\">"),
             "Tsx must reuse the typescript palette class"
@@ -1594,7 +1643,7 @@ mod tests {
 
     #[test]
     fn per_language_sections_carry_palette_class() {
-        let out = generate_html_report(&two_lang_fixture(), 5);
+        let out = generate_html_report(&two_lang_fixture(), 5, SuppressionPolicy::Honor);
         assert!(
             out.contains("<section class=\"lang-section lang-rust\"><h2>Rust</h2>"),
             "Rust section must carry stable lang-rust palette class"
@@ -1624,7 +1673,7 @@ mod tests {
 
     #[test]
     fn overview_table_and_actionable_summary_not_tinted() {
-        let out = generate_html_report(&two_lang_fixture(), 5);
+        let out = generate_html_report(&two_lang_fixture(), 5, SuppressionPolicy::Honor);
         // The per-language overview heading + table must not sit
         // inside a `<section class="lang-section …">`. We verify
         // structurally: the prefix from the start of the document
@@ -1660,9 +1709,78 @@ mod tests {
         assert!(!out.contains("lang-section lang-other"));
     }
 
+    /// Honoring suppression markers drops a function from its metric's
+    /// HTML hotspot table by default, and `--no-suppress` re-includes it.
+    /// Mirrors the markdown-side coverage for the parallel HTML renderer
+    /// (issue #501).
+    #[test]
+    fn suppression_honored_by_default_and_bypassed_by_no_suppress() {
+        use big_code_analysis::SuppressionScope;
+        use std::collections::BTreeSet;
+        let unit = make_summary("lib.rs", "src/lib.rs", SpaceKind::Unit, LANG::Rust);
+        let mut func = make_summary("hot", "src/lib.rs", SpaceKind::Function, LANG::Rust);
+        func.cyclomatic = 25.0;
+        func.cognitive = 18.0;
+        func.suppressed = SuppressionScope::Some(BTreeSet::from([MetricKind::Cyclomatic]));
+
+        let honored = generate_html_report(
+            &[unit_clone(&unit), func_clone(&func)],
+            20,
+            SuppressionPolicy::Honor,
+        );
+        // The CC table must not list the suppressed function, but the
+        // cognitive table (a different metric) still does.
+        let cc = html_section(&honored, "Cyclomatic Complexity Hotspots");
+        assert!(
+            !cc.contains(">hot<"),
+            "suppressed function must be omitted from the CC table:\n{cc}"
+        );
+        let cog = html_section(&honored, "Cognitive Complexity Hotspots");
+        assert!(
+            cog.contains(">hot<"),
+            "function suppressed only for cyclomatic stays in the Cognitive table:\n{cog}"
+        );
+
+        let audit = generate_html_report(&[unit, func], 20, SuppressionPolicy::Ignore);
+        let cc_audit = html_section(&audit, "Cyclomatic Complexity Hotspots");
+        assert!(
+            cc_audit.contains(">hot<"),
+            "--no-suppress must include the suppressed function:\n{cc_audit}"
+        );
+    }
+
+    fn unit_clone(s: &FunctionSummary) -> FunctionSummary {
+        let mut c = make_summary(&s.name, &s.file, s.kind, s.language);
+        c.suppressed = s.suppressed.clone();
+        c
+    }
+    fn func_clone(s: &FunctionSummary) -> FunctionSummary {
+        let mut c = make_summary(&s.name, &s.file, s.kind, s.language);
+        c.cyclomatic = s.cyclomatic;
+        c.cognitive = s.cognitive;
+        c.suppressed = s.suppressed.clone();
+        c
+    }
+
+    /// Slice the rendered HTML from `<h3>{title}</h3>` to the next `<h3>`
+    /// (or `</section>`), so a per-table membership check does not match a
+    /// name in a sibling table.
+    fn html_section<'a>(html: &'a str, title: &str) -> &'a str {
+        let needle = format!("<h3>{title}</h3>");
+        let Some(start) = html.find(&needle) else {
+            return "";
+        };
+        let rest = &html[start + needle.len()..];
+        let end = rest
+            .find("<h3>")
+            .or_else(|| rest.find("</section>"))
+            .unwrap_or(rest.len());
+        &rest[..end]
+    }
+
     #[test]
     fn snapshot_two_lang_report() {
-        let out = generate_html_report(&two_lang_fixture(), 5);
+        let out = generate_html_report(&two_lang_fixture(), 5, SuppressionPolicy::Honor);
         insta::assert_snapshot!("html_report_two_lang", out);
     }
 }

--- a/big-code-analysis-cli/src/lib.rs
+++ b/big-code-analysis-cli/src/lib.rs
@@ -384,6 +384,14 @@ struct ReportArgs {
     /// Path prefix to strip from displayed file paths.
     #[clap(long, default_value = "")]
     strip_prefix: String,
+    /// Include functions silenced by in-source suppression markers
+    /// (`bca: suppress`, `bca: suppress-file`, `#lizard forgives`) in the
+    /// hotspot tables. By default the report honors these markers and
+    /// omits a function from a metric's hotspot table when that metric is
+    /// suppressed for it — matching `bca check` and the SARIF emitter.
+    /// Pass this for the raw audit view that lists every offender.
+    #[clap(long = "no-suppress")]
+    no_suppress: bool,
 }
 
 #[derive(Args, Debug)]

--- a/big-code-analysis-cli/src/manifest.rs
+++ b/big-code-analysis-cli/src/manifest.rs
@@ -34,7 +34,9 @@ use std::str::FromStr;
 use serde::Deserialize;
 
 use crate::thresholds::{ParsedThresholds, split_thresholds_table};
-use crate::{CheckArgs, ExemptionsArgs, GlobalOpts, NumJobs, die, die_io, read_utf8_file};
+use crate::{
+    CheckArgs, ExemptionsArgs, GlobalOpts, NumJobs, ReportArgs, die, die_io, read_utf8_file,
+};
 
 /// Filename discovered by convention at (or above) the working directory.
 const MANIFEST_FILE: &str = "bca.toml";
@@ -60,6 +62,7 @@ const KNOWN_KEYS: &[&str] = &[
     "headroom",
     "thresholds",
     "check",
+    "report",
 ];
 
 /// A parsed `bca.toml` plus the directory it was found in.
@@ -105,6 +108,22 @@ struct RawManifest {
     /// reported.
     #[serde(default)]
     check: RawCheck,
+    /// The `[report]` table (#501): options for the aggregated
+    /// `bca report markdown|html` hotspot tables.
+    #[serde(default)]
+    report: RawReport,
+}
+
+/// Typed view of the `[report]` table (#501). Mirrors the `bca report`
+/// CLI flags; the CLI value wins when both are present.
+#[derive(Debug, Default, Deserialize)]
+struct RawReport {
+    /// When `true`, the aggregated report includes functions silenced by
+    /// in-source suppression markers (the raw audit view). Mirrors
+    /// `--no-suppress`, which ORs on top (a bare CLI flag can only
+    /// enable, never disable). Absent / `false` honors markers — the
+    /// default that matches `bca check` and the SARIF emitter.
+    no_suppress: Option<bool>,
 }
 
 /// Typed view of the `[check]` table (#378). Both keys mirror a CLI
@@ -338,6 +357,18 @@ impl Manifest {
             && let Some(exclude_from) = &self.raw.check.exclude_from
         {
             args.check_exclude_from = Some(self.resolve(exclude_from));
+        }
+    }
+
+    /// Merge `[report]` options into `args` (#501). A bare
+    /// `--no-suppress` flag (clap `bool`) cannot represent "unset", so
+    /// the manifest can only *enable* the audit view; it never overrides
+    /// an explicit CLI opt-in. OR the two sources, mirroring
+    /// `baseline_fuzzy_match` and `[check] exit_codes` in
+    /// [`Self::merge_check`].
+    pub(crate) fn merge_report(&self, args: &mut ReportArgs) {
+        if self.raw.report.no_suppress == Some(true) {
+            args.no_suppress = true;
         }
     }
 

--- a/big-code-analysis-cli/src/manifest_tests.rs
+++ b/big-code-analysis-cli/src/manifest_tests.rs
@@ -224,9 +224,7 @@ fn known_keys_covers_report_table() {
 /// `baseline_fuzzy_match`).
 #[test]
 fn merge_report_enables_no_suppress_from_manifest() {
-    let m = manifest(
-        toml::from_str("[report]\nno_suppress = true\n").expect("parse"),
-    );
+    let m = manifest(toml::from_str("[report]\nno_suppress = true\n").expect("parse"));
     let mut args = report_args(false);
     m.merge_report(&mut args);
     assert!(args.no_suppress, "manifest must enable the audit view");

--- a/big-code-analysis-cli/src/manifest_tests.rs
+++ b/big-code-analysis-cli/src/manifest_tests.rs
@@ -203,3 +203,53 @@ fn known_keys_covers_cyclomatic_count_try() {
         "cyclomatic_count_try is consumed but flagged as unknown"
     );
 }
+
+/// The `[report]` table (#501) must be on the allowlist; otherwise the
+/// typed parse honors it while `warn_unknown_keys` prints a misleading
+/// "ignoring unrecognized key `report`" warning.
+#[test]
+fn known_keys_covers_report_table() {
+    let text = "[report]\nno_suppress = true\n";
+    let raw: RawManifest = toml::from_str(text).expect("typed parse");
+    assert_eq!(raw.report.no_suppress, Some(true));
+    assert!(
+        unknown_top_level_keys(text).is_empty(),
+        "[report] is consumed but flagged as unknown"
+    );
+}
+
+/// `[report] no_suppress = true` enables the audit view when the CLI
+/// did not pass `--no-suppress`; a bare CLI flag can still force it on,
+/// but the manifest never forces it off (OR semantics, like
+/// `baseline_fuzzy_match`).
+#[test]
+fn merge_report_enables_no_suppress_from_manifest() {
+    let m = manifest(
+        toml::from_str("[report]\nno_suppress = true\n").expect("parse"),
+    );
+    let mut args = report_args(false);
+    m.merge_report(&mut args);
+    assert!(args.no_suppress, "manifest must enable the audit view");
+
+    // Absent / false manifest key leaves an explicit CLI opt-in intact
+    // and does not turn a default-honor run into audit.
+    let m_default = manifest(RawManifest::default());
+    let mut honor = report_args(false);
+    m_default.merge_report(&mut honor);
+    assert!(!honor.no_suppress, "default honors markers");
+    let mut already_on = report_args(true);
+    m_default.merge_report(&mut already_on);
+    assert!(already_on.no_suppress, "CLI opt-in survives empty manifest");
+}
+
+/// Build a `ReportArgs` for merge tests with the given `no_suppress`
+/// flag; other fields take their non-interesting defaults.
+fn report_args(no_suppress: bool) -> ReportArgs {
+    ReportArgs {
+        format: crate::formats::ReportFormat::Markdown,
+        output: None,
+        top: 20,
+        strip_prefix: String::new(),
+        no_suppress,
+    }
+}

--- a/big-code-analysis-cli/src/markdown_report.rs
+++ b/big-code-analysis-cli/src/markdown_report.rs
@@ -1492,10 +1492,23 @@ mod tests {
         func.halstead_effort = 0.0;
         func.suppressed = SuppressionScope::Some(BTreeSet::from([MetricKind::Exit]));
 
-        let report = generate_report(&[unit, func], 20, SuppressionPolicy::Honor);
+        let summaries = vec![unit, func];
+        const NEXITS_HEADER: &str = "### Functions with the most exit points (NEXITS)";
+
+        let honored = generate_report(&summaries, 20, SuppressionPolicy::Honor);
         assert!(
-            !report.contains("### Functions with the most exit points (NEXITS)"),
-            "exit-suppressed function must be omitted from the NEXITS table:\n{report}"
+            !honored.contains(NEXITS_HEADER),
+            "exit-suppressed function must be omitted from the NEXITS table:\n{honored}"
+        );
+
+        // Positive control: the only thing keeping the table empty is the
+        // suppression. Under --no-suppress the same function (nexits = 5)
+        // is a hotspot and the table renders — so the absence above is
+        // attributable to the exit-alias filter, not to a missing hotspot.
+        let bypassed = generate_report(&summaries, 20, SuppressionPolicy::Ignore);
+        assert!(
+            bypassed.contains(NEXITS_HEADER),
+            "--no-suppress must restore the exit-suppressed function:\n{bypassed}"
         );
     }
 

--- a/big-code-analysis-cli/src/markdown_report.rs
+++ b/big-code-analysis-cli/src/markdown_report.rs
@@ -22,7 +22,9 @@ mod sections;
 use std::collections::BTreeMap;
 use std::fmt::Write;
 
-use big_code_analysis::{FuncSpace, LANG, SpaceKind};
+use big_code_analysis::{
+    FuncSpace, LANG, MetricKind, SpaceKind, SuppressionPolicy, SuppressionScope,
+};
 
 /// Compact per-function/class metric record for the markdown report pipeline.
 #[derive(Debug)]
@@ -31,6 +33,14 @@ pub(crate) struct FunctionSummary {
     pub name: String,
     pub kind: SpaceKind,
     pub language: LANG,
+    /// Effective suppression scope for this space: the enclosing file's
+    /// `suppress-file` scope merged with the space's own `bca: suppress`
+    /// markers. A hotspot table omits this entry when the table's
+    /// [`MetricKind`] is covered here and the report honors markers
+    /// (the default; `--no-suppress` opts back in). Mirrors the gate's
+    /// `ThresholdSet::evaluate_with_policy` logic so the published report
+    /// agrees with `bca check` and the SARIF emitter (issue #501).
+    pub suppressed: SuppressionScope,
     pub start_line: usize,
     #[allow(dead_code)]
     pub end_line: usize,
@@ -61,6 +71,23 @@ pub(crate) struct FunctionSummary {
     pub wmc: f64,
     pub npa: f64,
     pub npm: f64,
+}
+
+impl FunctionSummary {
+    /// Whether this entry should be hidden from the hotspot table for
+    /// `kind` under `policy`.
+    ///
+    /// Under [`SuppressionPolicy::Honor`] (the report default) an entry
+    /// is hidden when its effective scope covers `kind` — i.e. a
+    /// `bca: suppress(<kind>)` marker on the function, or a
+    /// `bca: suppress-file(<kind>)` marker anywhere in the file, folded
+    /// into [`Self::suppressed`] by [`extract_summaries`]. Under
+    /// [`SuppressionPolicy::Ignore`] (`--no-suppress`) nothing is hidden,
+    /// giving the raw audit view. Mirrors the gate's per-metric check in
+    /// `ThresholdSet::evaluate_with_policy` (issue #501).
+    pub(crate) fn is_hidden_for(&self, kind: MetricKind, policy: SuppressionPolicy) -> bool {
+        matches!(policy, SuppressionPolicy::Honor) && self.suppressed.covers(kind)
+    }
 }
 
 /// Extract [`FunctionSummary`] records from a [`FuncSpace`] tree in
@@ -95,6 +122,13 @@ fn extract_summaries_inner(
     language: LANG,
     out: &mut Vec<FunctionSummary>,
 ) {
+    // The root space IS the top-level `Unit`; its `suppressed` scope
+    // carries any `bca: suppress-file` markers, which apply to every
+    // function in the file. Capture it once so each summary's effective
+    // scope is `file_scope ∪ own_scope` — the same union the threshold
+    // gate forms in `ThresholdSet::evaluate_with_policy` (issue #501).
+    let file_scope = &space.suppressed;
+
     // Iterative pre-order walk over the FuncSpace tree. Children are
     // pushed in reverse so `pop()` visits them in source order — this
     // produces the same FunctionSummary ordering as the prior recursive
@@ -102,11 +136,14 @@ fn extract_summaries_inner(
     let mut stack: Vec<&FuncSpace> = vec![space];
     while let Some(current) = stack.pop() {
         let m = &current.metrics;
+        let mut suppressed = file_scope.clone();
+        suppressed.merge(&current.suppressed);
         out.push(FunctionSummary {
             file: display_file.to_string(),
             name: current.name.clone().unwrap_or_default(),
             kind: current.kind,
             language,
+            suppressed,
             start_line: current.start_line,
             end_line: current.end_line,
             sloc: m.loc.sloc() as usize,
@@ -310,7 +347,11 @@ fn push_separator(out: &mut String, align: Align, width: usize) {
     out.push('|');
 }
 
-pub(crate) fn generate_report(summaries: &[FunctionSummary], top_n: usize) -> String {
+pub(crate) fn generate_report(
+    summaries: &[FunctionSummary],
+    top_n: usize,
+    policy: SuppressionPolicy,
+) -> String {
     let mut out = String::new();
 
     // Group by language display name (BTreeMap → deterministic alphabetical order).
@@ -326,7 +367,7 @@ pub(crate) fn generate_report(summaries: &[FunctionSummary], top_n: usize) -> St
     write_per_language_overview(&mut out, &by_lang);
 
     for (&lang_name, lang_summaries) in &by_lang {
-        write_language_section(&mut out, lang_name, lang_summaries, top_n);
+        write_language_section(&mut out, lang_name, lang_summaries, top_n, policy);
     }
 
     out
@@ -507,6 +548,7 @@ fn write_language_section(
     lang_name: &str,
     entries: &[&FunctionSummary],
     top_n: usize,
+    policy: SuppressionPolicy,
 ) {
     let display_name = title_case(lang_name);
     let _ = writeln!(out, "\n## {display_name}\n");
@@ -514,16 +556,16 @@ fn write_language_section(
     let (units, funcs) = sections::split_units_and_functions(entries);
 
     sections::write_summary(out, &units);
-    sections::write_mi_lowest(out, &units, top_n);
-    sections::write_cyclomatic_hotspots(out, &funcs, top_n);
-    sections::write_cognitive_hotspots(out, &funcs, top_n);
-    sections::write_halstead_hotspots(out, &funcs, top_n);
-    sections::write_largest_by_sloc(out, &funcs, top_n);
-    sections::write_many_params(out, &funcs, top_n);
+    sections::write_mi_lowest(out, &units, top_n, policy);
+    sections::write_cyclomatic_hotspots(out, &funcs, top_n, policy);
+    sections::write_cognitive_hotspots(out, &funcs, top_n, policy);
+    sections::write_halstead_hotspots(out, &funcs, top_n, policy);
+    sections::write_largest_by_sloc(out, &funcs, top_n, policy);
+    sections::write_many_params(out, &funcs, top_n, policy);
     sections::write_actionable_summary(out, &funcs);
-    sections::write_wmc_hotspots(out, entries, top_n);
-    sections::write_nexits_hotspots(out, &funcs, top_n);
-    sections::write_abc_hotspots(out, &funcs, top_n);
+    sections::write_wmc_hotspots(out, entries, top_n, policy);
+    sections::write_nexits_hotspots(out, &funcs, top_n, policy);
+    sections::write_abc_hotspots(out, &funcs, top_n, policy);
 }
 
 #[cfg(test)]
@@ -578,6 +620,7 @@ mod tests {
             name: name.to_string(),
             kind,
             language,
+            suppressed: big_code_analysis::SuppressionScope::default(),
             start_line: 1,
             end_line: 10,
             sloc: 20,
@@ -757,7 +800,7 @@ mod tests {
             make_summary("main.py", "main.py", SpaceKind::Unit, LANG::Python),
             make_summary("run", "main.py", SpaceKind::Function, LANG::Python),
         ];
-        let report = generate_report(&summaries, 20);
+        let report = generate_report(&summaries, 20, SuppressionPolicy::Honor);
 
         assert!(report.contains("## Rust"), "missing Rust section header");
         assert!(
@@ -795,7 +838,7 @@ mod tests {
         func.halstead_volume = 0.0;
         func.halstead_bugs = 0.0;
 
-        let report = generate_report(&[unit, func], 20);
+        let report = generate_report(&[unit, func], 20, SuppressionPolicy::Honor);
         assert!(
             !report.contains("### Halstead Effort Hotspots"),
             "Halstead section should be omitted"
@@ -825,7 +868,7 @@ mod tests {
             f.sloc = (i + 1) * 5;
             summaries.push(f);
         }
-        let report = generate_report(&summaries, 5);
+        let report = generate_report(&summaries, 5, SuppressionPolicy::Honor);
 
         // Count data rows (lines starting with "| `") in each section.
         let sections = [
@@ -865,8 +908,8 @@ mod tests {
             make_summary("main.py", "main.py", SpaceKind::Unit, LANG::Python),
             make_summary("run", "main.py", SpaceKind::Function, LANG::Python),
         ];
-        let a = generate_report(&summaries, 10);
-        let b = generate_report(&summaries, 10);
+        let a = generate_report(&summaries, 10, SuppressionPolicy::Honor);
+        let b = generate_report(&summaries, 10, SuppressionPolicy::Honor);
         assert_eq!(a, b, "report must be byte-equal across runs");
     }
 
@@ -875,7 +918,7 @@ mod tests {
         let mut f = make_summary("foo|bar", "dir/a|b.rs", SpaceKind::Function, LANG::Rust);
         f.cyclomatic = 5.0;
         let unit = make_summary("a|b.rs", "dir/a|b.rs", SpaceKind::Unit, LANG::Rust);
-        let report = generate_report(&[unit, f], 20);
+        let report = generate_report(&[unit, f], 20, SuppressionPolicy::Honor);
         // The pipe inside the name must be escaped.
         assert!(
             report.contains("foo\\|bar"),
@@ -892,7 +935,7 @@ mod tests {
         let mut f = make_summary("foo`bar", "src/lib.rs", SpaceKind::Function, LANG::Rust);
         f.cyclomatic = 5.0;
         let unit = make_summary("lib.rs", "src/lib.rs", SpaceKind::Unit, LANG::Rust);
-        let report = generate_report(&[unit, f], 20);
+        let report = generate_report(&[unit, f], 20, SuppressionPolicy::Honor);
         // Backtick in a name is replaced with modifier letter grave accent.
         assert!(
             report.contains("foo\u{02CB}bar"),
@@ -909,7 +952,7 @@ mod tests {
         f.cognitive = f64::NAN;
         f.halstead_effort = f64::NAN;
         // Must not panic.
-        let report = generate_report(&[unit, f], 20);
+        let report = generate_report(&[unit, f], 20, SuppressionPolicy::Honor);
         assert!(report.contains("# Code Quality Metrics Summary"));
     }
 
@@ -951,7 +994,7 @@ mod tests {
 
     #[test]
     fn empty_input() {
-        let report = generate_report(&[], 20);
+        let report = generate_report(&[], 20, SuppressionPolicy::Honor);
         assert!(report.contains("**Files analyzed:** 0"));
         assert!(report.contains("**Functions/methods:** 0"));
         // No per-language sections.
@@ -1083,7 +1126,7 @@ mod tests {
             make_summary("lib.rs", "src/lib.rs", SpaceKind::Unit, LANG::Rust),
             make_summary("f", "src/lib.rs", SpaceKind::Function, LANG::Rust),
         ];
-        let report = generate_report(&summaries, 20);
+        let report = generate_report(&summaries, 20, SuppressionPolicy::Honor);
         assert!(
             report.contains("No major quality concerns detected."),
             "clean codebase should show no-concerns message"
@@ -1100,7 +1143,7 @@ mod tests {
         f.nargs = 5;
         f.halstead_bugs = 2.0;
 
-        let report = generate_report(&[unit, f], 20);
+        let report = generate_report(&[unit, f], 20, SuppressionPolicy::Honor);
         assert!(report.contains("functions with CC > 10"));
         assert!(report.contains("functions with cognitive complexity > 15"));
         assert!(report.contains("functions with SLOC > 100"));
@@ -1115,7 +1158,7 @@ mod tests {
         let mut unit_bad = make_summary("bad.rs", "bad.rs", SpaceKind::Unit, LANG::Rust);
         unit_bad.mi_visual_studio = 15.0;
 
-        let report = generate_report(&[unit_good, unit_bad], 20);
+        let report = generate_report(&[unit_good, unit_bad], 20, SuppressionPolicy::Honor);
         // The bad file should appear first in the MI table.
         let mi_section = report
             .find("### Maintainability Index")
@@ -1142,7 +1185,7 @@ mod tests {
         cls.sloc = 80;
         let func = make_summary("f", "src/lib.rs", SpaceKind::Function, LANG::Rust);
 
-        let report = generate_report(&[unit, cls, func], 20);
+        let report = generate_report(&[unit, cls, func], 20, SuppressionPolicy::Honor);
         assert!(
             report.contains("### Class/Trait/Impl Hotspots (WMC)"),
             "WMC section should be present when class-kind summaries exist"
@@ -1165,7 +1208,7 @@ mod tests {
         let unit = make_summary("lib.rs", "src/lib.rs", SpaceKind::Unit, LANG::Rust);
         let func = make_summary("f", "src/lib.rs", SpaceKind::Function, LANG::Rust);
 
-        let report = generate_report(&[unit, func], 20);
+        let report = generate_report(&[unit, func], 20, SuppressionPolicy::Honor);
         assert!(
             !report.contains("### Class/Trait/Impl Hotspots (WMC)"),
             "WMC section should be absent when no class-kind summaries exist"
@@ -1180,7 +1223,7 @@ mod tests {
         func.cyclomatic = 7.0;
         func.sloc = 40;
 
-        let report = generate_report(&[unit, func], 20);
+        let report = generate_report(&[unit, func], 20, SuppressionPolicy::Honor);
         assert!(
             report.contains("### Functions with the most exit points (NEXITS)"),
             "NEXITS section should be present when functions have exits > 0"
@@ -1203,7 +1246,7 @@ mod tests {
         func.abc = 15.5;
         func.sloc = 35;
 
-        let report = generate_report(&[unit, func], 20);
+        let report = generate_report(&[unit, func], 20, SuppressionPolicy::Honor);
         assert!(
             report.contains("### ABC Magnitude Hotspots"),
             "ABC section should be present when functions have abc > 0"
@@ -1253,7 +1296,7 @@ mod tests {
             f.start_line = 200 + i;
             summaries.push(f);
         }
-        let report = generate_report(&summaries, 3);
+        let report = generate_report(&summaries, 3, SuppressionPolicy::Honor);
 
         let sections = [
             "### Class/Trait/Impl Hotspots (WMC)",
@@ -1296,7 +1339,7 @@ mod tests {
         cls.wmc = 6.0;
         cls.tokens = 99;
 
-        let report = generate_report(&[unit, func, cls], 20);
+        let report = generate_report(&[unit, func, cls], 20, SuppressionPolicy::Honor);
 
         for header in [
             "### Maintainability Index",
@@ -1345,7 +1388,7 @@ mod tests {
         func.nexits = 2;
         func.abc = 0.0;
 
-        let report = generate_report(&[unit, func], 20);
+        let report = generate_report(&[unit, func], 20, SuppressionPolicy::Honor);
         assert!(
             report.contains("### Functions with the most exit points (NEXITS)"),
             "NEXITS section should be present"
@@ -1354,5 +1397,165 @@ mod tests {
             !report.contains("### ABC Magnitude Hotspots"),
             "ABC section should be absent when all abc values are 0"
         );
+    }
+
+    // ── suppression-marker honoring (issue #501) ───────────────────
+
+    use std::collections::BTreeSet;
+
+    /// A `bca: suppress(cyclomatic)` marker on the function-local scope
+    /// must drop it from the Cyclomatic table by default while leaving it
+    /// in the Cognitive table — per-metric, not all-or-nothing.
+    #[test]
+    fn function_scope_suppression_drops_only_its_metric_table() {
+        let unit = make_summary("lib.rs", "src/lib.rs", SpaceKind::Unit, LANG::Rust);
+        let mut func = make_summary("hot", "src/lib.rs", SpaceKind::Function, LANG::Rust);
+        func.cyclomatic = 25.0;
+        func.cognitive = 18.0;
+        func.suppressed = SuppressionScope::Some(BTreeSet::from([MetricKind::Cyclomatic]));
+
+        let report = generate_report(&[unit, func], 20, SuppressionPolicy::Honor);
+
+        let cc = section_body(&report, "### Cyclomatic Complexity Hotspots");
+        assert!(
+            !cc.contains("`hot`"),
+            "suppressed function must be omitted from the Cyclomatic table:\n{cc}"
+        );
+        let cog = section_body(&report, "### Cognitive Complexity Hotspots");
+        assert!(
+            cog.contains("`hot`"),
+            "function suppressed only for cyclomatic must still appear in Cognitive:\n{cog}"
+        );
+    }
+
+    /// `--no-suppress` (SuppressionPolicy::Ignore) re-includes the same
+    /// function in its suppressed metric's table — the audit view.
+    #[test]
+    fn no_suppress_policy_includes_suppressed_function() {
+        let unit = make_summary("lib.rs", "src/lib.rs", SpaceKind::Unit, LANG::Rust);
+        let mut func = make_summary("hot", "src/lib.rs", SpaceKind::Function, LANG::Rust);
+        func.cyclomatic = 25.0;
+        func.suppressed = SuppressionScope::Some(BTreeSet::from([MetricKind::Cyclomatic]));
+
+        let report = generate_report(&[unit, func], 20, SuppressionPolicy::Ignore);
+        let cc = section_body(&report, "### Cyclomatic Complexity Hotspots");
+        assert!(
+            cc.contains("`hot`"),
+            "--no-suppress must include the suppressed function:\n{cc}"
+        );
+    }
+
+    /// A whole-file `bca: suppress-file` (scope `All`) lives on the Unit
+    /// and is folded into every function by `extract_summaries`; here we
+    /// simulate the merged effect on a function summary and confirm it is
+    /// dropped from a hotspot table by default.
+    #[test]
+    fn file_scope_suppression_all_drops_function_from_table() {
+        let unit = make_summary("lib.rs", "src/lib.rs", SpaceKind::Unit, LANG::Rust);
+        let mut func = make_summary("hot", "src/lib.rs", SpaceKind::Function, LANG::Rust);
+        func.cyclomatic = 25.0;
+        func.cognitive = 18.0;
+        // `suppress-file` (no metric list) is `All`; extract_summaries
+        // merges it onto each function's effective scope.
+        func.suppressed = SuppressionScope::All;
+
+        let report = generate_report(&[unit, func], 20, SuppressionPolicy::Honor);
+        let cc = section_body(&report, "### Cyclomatic Complexity Hotspots");
+        assert!(
+            !cc.contains("`hot`"),
+            "file-scoped suppress-all must hide the function from every table:\n{cc}"
+        );
+        assert!(
+            !report.contains("### Cognitive Complexity Hotspots"),
+            "with the only function suppressed, the Cognitive section is empty/absent"
+        );
+
+        let report_audit = generate_report(&[unit2(), func_all()], 20, SuppressionPolicy::Ignore);
+        let cc_audit = section_body(&report_audit, "### Cyclomatic Complexity Hotspots");
+        assert!(
+            cc_audit.contains("`hot`"),
+            "--no-suppress must include the file-suppressed function:\n{cc_audit}"
+        );
+    }
+
+    /// The `exit` MetricKind aliases the `nexits` hotspot table: a
+    /// `bca: suppress(exit)` marker must drop the function from the
+    /// NEXITS table (matching `MetricKind::for_threshold_name`'s alias).
+    #[test]
+    fn exit_suppression_drops_function_from_nexits_table() {
+        let unit = make_summary("lib.rs", "src/lib.rs", SpaceKind::Unit, LANG::Rust);
+        let mut func = make_summary("multi_exit", "src/lib.rs", SpaceKind::Function, LANG::Rust);
+        func.nexits = 5;
+        func.cyclomatic = 0.0;
+        func.cognitive = 0.0;
+        func.abc = 0.0;
+        func.halstead_effort = 0.0;
+        func.suppressed = SuppressionScope::Some(BTreeSet::from([MetricKind::Exit]));
+
+        let report = generate_report(&[unit, func], 20, SuppressionPolicy::Honor);
+        assert!(
+            !report.contains("### Functions with the most exit points (NEXITS)"),
+            "exit-suppressed function must be omitted from the NEXITS table:\n{report}"
+        );
+    }
+
+    /// `extract_summaries` must fold the Unit's `suppress-file` scope into
+    /// every descendant function's effective `suppressed` scope.
+    #[test]
+    fn extract_summaries_folds_file_scope_into_functions() {
+        let mut root = make_space("root.rs", SpaceKind::Unit, 1, 20);
+        root.suppressed = SuppressionScope::Some(BTreeSet::from([MetricKind::Halstead]));
+        let mut func = make_space("f", SpaceKind::Function, 2, 8);
+        func.suppressed = SuppressionScope::Some(BTreeSet::from([MetricKind::Cyclomatic]));
+        root.spaces.push(func);
+
+        let mut out = Vec::new();
+        extract_summaries(&root, "root.rs", LANG::Rust, "", &mut out);
+        assert_eq!(out.len(), 2);
+        // out[1] is the function (pre-order: root then child). Its
+        // effective scope is the union of the file scope (halstead) and
+        // its own scope (cyclomatic).
+        let f = &out[1];
+        assert_eq!(f.name, "f");
+        assert!(
+            f.suppressed.covers(MetricKind::Halstead),
+            "file scope merged"
+        );
+        assert!(
+            f.suppressed.covers(MetricKind::Cyclomatic),
+            "own scope kept"
+        );
+        assert!(
+            !f.suppressed.covers(MetricKind::Cognitive),
+            "unrelated metric untouched"
+        );
+    }
+
+    /// Helpers for `file_scope_suppression_all_drops_function_from_table`'s
+    /// audit-view assertion (the first pair is moved by value into the
+    /// honor-view report).
+    fn unit2() -> FunctionSummary {
+        make_summary("lib.rs", "src/lib.rs", SpaceKind::Unit, LANG::Rust)
+    }
+    fn func_all() -> FunctionSummary {
+        let mut func = make_summary("hot", "src/lib.rs", SpaceKind::Function, LANG::Rust);
+        func.cyclomatic = 25.0;
+        func.suppressed = SuppressionScope::All;
+        func
+    }
+
+    /// Slice the rendered report from `header` to the next `##`/`###`
+    /// heading (or end), so a per-section membership assertion does not
+    /// accidentally match a name appearing in a different table.
+    fn section_body<'a>(report: &'a str, header: &str) -> &'a str {
+        let Some(start) = report.find(header) else {
+            return "";
+        };
+        let rest = &report[start..];
+        let end = rest[1..]
+            .find("\n## ")
+            .or_else(|| rest[1..].find("\n### "))
+            .map_or(rest.len(), |p| p + 1);
+        &rest[..end]
     }
 }

--- a/big-code-analysis-cli/src/markdown_report.rs
+++ b/big-code-analysis-cli/src/markdown_report.rs
@@ -1483,6 +1483,7 @@ mod tests {
     /// NEXITS table (matching `MetricKind::for_threshold_name`'s alias).
     #[test]
     fn exit_suppression_drops_function_from_nexits_table() {
+        const NEXITS_HEADER: &str = "### Functions with the most exit points (NEXITS)";
         let unit = make_summary("lib.rs", "src/lib.rs", SpaceKind::Unit, LANG::Rust);
         let mut func = make_summary("multi_exit", "src/lib.rs", SpaceKind::Function, LANG::Rust);
         func.nexits = 5;
@@ -1493,7 +1494,6 @@ mod tests {
         func.suppressed = SuppressionScope::Some(BTreeSet::from([MetricKind::Exit]));
 
         let summaries = vec![unit, func];
-        const NEXITS_HEADER: &str = "### Functions with the most exit points (NEXITS)";
 
         let honored = generate_report(&summaries, 20, SuppressionPolicy::Honor);
         assert!(

--- a/big-code-analysis-cli/src/markdown_report/sections.rs
+++ b/big-code-analysis-cli/src/markdown_report/sections.rs
@@ -13,7 +13,7 @@
 
 use std::fmt::Write as _;
 
-use big_code_analysis::SpaceKind;
+use big_code_analysis::{MetricKind, SpaceKind, SuppressionPolicy};
 
 use super::{
     Align, FunctionSummary, escape_cell, escape_name, is_class_like, mi_rating, sort_by_metric_asc,
@@ -57,10 +57,15 @@ pub(super) fn write_summary(out: &mut String, units: &[&FunctionSummary]) {
     let _ = writeln!(out, "Average MI: {avg_mi:.1} ({rating})");
 }
 
-pub(super) fn write_mi_lowest(out: &mut String, units: &[&FunctionSummary], top_n: usize) {
+pub(super) fn write_mi_lowest(
+    out: &mut String,
+    units: &[&FunctionSummary],
+    top_n: usize,
+    policy: SuppressionPolicy,
+) {
     let mut mi_entries: Vec<&FunctionSummary> = units
         .iter()
-        .filter(|s| s.mi_visual_studio > 0.0)
+        .filter(|s| s.mi_visual_studio > 0.0 && !s.is_hidden_for(MetricKind::Mi, policy))
         .copied()
         .collect();
     if mi_entries.is_empty() {
@@ -96,10 +101,11 @@ pub(super) fn write_cyclomatic_hotspots(
     out: &mut String,
     funcs: &[&FunctionSummary],
     top_n: usize,
+    policy: SuppressionPolicy,
 ) {
     let mut cc_entries: Vec<&FunctionSummary> = funcs
         .iter()
-        .filter(|s| s.cyclomatic > 0.0)
+        .filter(|s| s.cyclomatic > 0.0 && !s.is_hidden_for(MetricKind::Cyclomatic, policy))
         .copied()
         .collect();
     if cc_entries.is_empty() {
@@ -250,8 +256,18 @@ where
     Some(filtered)
 }
 
-pub(super) fn write_cognitive_hotspots(out: &mut String, funcs: &[&FunctionSummary], top_n: usize) {
-    let Some(entries) = top_n_desc(funcs, top_n, |s| s.cognitive > 0.0, |s| s.cognitive) else {
+pub(super) fn write_cognitive_hotspots(
+    out: &mut String,
+    funcs: &[&FunctionSummary],
+    top_n: usize,
+    policy: SuppressionPolicy,
+) {
+    let Some(entries) = top_n_desc(
+        funcs,
+        top_n,
+        |s| s.cognitive > 0.0 && !s.is_hidden_for(MetricKind::Cognitive, policy),
+        |s| s.cognitive,
+    ) else {
         return;
     };
 
@@ -294,11 +310,16 @@ pub(super) fn write_cognitive_hotspots(out: &mut String, funcs: &[&FunctionSumma
     );
 }
 
-pub(super) fn write_halstead_hotspots(out: &mut String, funcs: &[&FunctionSummary], top_n: usize) {
+pub(super) fn write_halstead_hotspots(
+    out: &mut String,
+    funcs: &[&FunctionSummary],
+    top_n: usize,
+    policy: SuppressionPolicy,
+) {
     let Some(entries) = top_n_desc(
         funcs,
         top_n,
-        |s| s.halstead_effort > 0.0,
+        |s| s.halstead_effort > 0.0 && !s.is_hidden_for(MetricKind::Halstead, policy),
         |s| s.halstead_effort,
     ) else {
         return;
@@ -343,8 +364,18 @@ pub(super) fn write_halstead_hotspots(out: &mut String, funcs: &[&FunctionSummar
     );
 }
 
-pub(super) fn write_largest_by_sloc(out: &mut String, funcs: &[&FunctionSummary], top_n: usize) {
-    let Some(entries) = top_n_desc(funcs, top_n, |s| s.sloc > 0, |s| s.sloc as f64) else {
+pub(super) fn write_largest_by_sloc(
+    out: &mut String,
+    funcs: &[&FunctionSummary],
+    top_n: usize,
+    policy: SuppressionPolicy,
+) {
+    let Some(entries) = top_n_desc(
+        funcs,
+        top_n,
+        |s| s.sloc > 0 && !s.is_hidden_for(MetricKind::Loc, policy),
+        |s| s.sloc as f64,
+    ) else {
         return;
     };
 
@@ -387,8 +418,18 @@ pub(super) fn write_largest_by_sloc(out: &mut String, funcs: &[&FunctionSummary]
     );
 }
 
-pub(super) fn write_many_params(out: &mut String, funcs: &[&FunctionSummary], top_n: usize) {
-    let Some(entries) = top_n_desc(funcs, top_n, |s| s.nargs > 3, |s| s.nargs as f64) else {
+pub(super) fn write_many_params(
+    out: &mut String,
+    funcs: &[&FunctionSummary],
+    top_n: usize,
+    policy: SuppressionPolicy,
+) {
+    let Some(entries) = top_n_desc(
+        funcs,
+        top_n,
+        |s| s.nargs > 3 && !s.is_hidden_for(MetricKind::Nargs, policy),
+        |s| s.nargs as f64,
+    ) else {
         return;
     };
 
@@ -464,11 +505,16 @@ pub(super) fn write_actionable_summary(out: &mut String, funcs: &[&FunctionSumma
     }
 }
 
-pub(super) fn write_wmc_hotspots(out: &mut String, entries: &[&FunctionSummary], top_n: usize) {
+pub(super) fn write_wmc_hotspots(
+    out: &mut String,
+    entries: &[&FunctionSummary],
+    top_n: usize,
+    policy: SuppressionPolicy,
+) {
     let Some(classes) = top_n_desc(
         entries,
         top_n,
-        |s| is_class_like(s.kind) && s.wmc > 0.0,
+        |s| is_class_like(s.kind) && s.wmc > 0.0 && !s.is_hidden_for(MetricKind::Wmc, policy),
         |s| s.wmc,
     ) else {
         return;
@@ -511,8 +557,22 @@ pub(super) fn write_wmc_hotspots(out: &mut String, entries: &[&FunctionSummary],
     );
 }
 
-pub(super) fn write_nexits_hotspots(out: &mut String, funcs: &[&FunctionSummary], top_n: usize) {
-    let Some(entries) = top_n_desc(funcs, top_n, |s| s.nexits > 0, |s| s.nexits as f64) else {
+pub(super) fn write_nexits_hotspots(
+    out: &mut String,
+    funcs: &[&FunctionSummary],
+    top_n: usize,
+    policy: SuppressionPolicy,
+) {
+    // The exit-points table maps to `MetricKind::Exit`: a
+    // `bca: suppress(exit)` marker (the suppression vocabulary's spelling
+    // of the threshold engine's `nexits`) silences it, matching
+    // `MetricKind::for_threshold_name`'s `nexits → exit` alias.
+    let Some(entries) = top_n_desc(
+        funcs,
+        top_n,
+        |s| s.nexits > 0 && !s.is_hidden_for(MetricKind::Exit, policy),
+        |s| s.nexits as f64,
+    ) else {
         return;
     };
 
@@ -547,8 +607,18 @@ pub(super) fn write_nexits_hotspots(out: &mut String, funcs: &[&FunctionSummary]
     );
 }
 
-pub(super) fn write_abc_hotspots(out: &mut String, funcs: &[&FunctionSummary], top_n: usize) {
-    let Some(entries) = top_n_desc(funcs, top_n, |s| s.abc > 0.0, |s| s.abc) else {
+pub(super) fn write_abc_hotspots(
+    out: &mut String,
+    funcs: &[&FunctionSummary],
+    top_n: usize,
+    policy: SuppressionPolicy,
+) {
+    let Some(entries) = top_n_desc(
+        funcs,
+        top_n,
+        |s| s.abc > 0.0 && !s.is_hidden_for(MetricKind::Abc, policy),
+        |s| s.abc,
+    ) else {
         return;
     };
 

--- a/big-code-analysis-cli/src/markdown_report/sections.rs
+++ b/big-code-analysis-cli/src/markdown_report/sections.rs
@@ -460,6 +460,14 @@ pub(super) fn write_many_params(
     );
 }
 
+/// Emits the advisory "functions over threshold" roll-up.
+///
+/// Unlike the per-metric hotspot tables, this summary intentionally
+/// counts raw measurements regardless of suppression policy: it is a
+/// whole-codebase health indicator, not a gate, so a `bca: suppress`
+/// marker that silences a function in one metric's hotspot table does
+/// not erase it from the aggregate concern count (#501). It therefore
+/// takes no [`SuppressionPolicy`].
 pub(super) fn write_actionable_summary(out: &mut String, funcs: &[&FunctionSummary]) {
     let (cc_gt10, cog_gt15, sloc_gt100, nargs_gt3, bugs_gt1) = funcs.iter().fold(
         (0usize, 0usize, 0usize, 0usize, 0usize),

--- a/big-code-analysis-cli/src/markdown_report/sections_tests.rs
+++ b/big-code-analysis-cli/src/markdown_report/sections_tests.rs
@@ -17,6 +17,7 @@ fn summary(name: &str, file: &str, start_line: usize, metric: f64) -> FunctionSu
         name: name.to_string(),
         kind: SpaceKind::Function,
         language: LANG::Rust,
+        suppressed: big_code_analysis::SuppressionScope::default(),
         start_line,
         end_line: start_line + 10,
         sloc: metric as usize,

--- a/big-code-analysis-py/src/language.rs
+++ b/big-code-analysis-py/src/language.rs
@@ -30,10 +30,10 @@ use crate::analysis::AnalysisError;
 ///   `language=` lookup token; the facade exposes `"cpp"`.
 /// - `Csharp`: `get_name()` returns `"c#"`; the facade exposes
 ///   `"csharp"`.
-/// - `Tsx`: `get_name()` returns `"typescript"`, colliding with
-///   `Typescript`'s display name; the facade exposes `"tsx"` so the
-///   two TypeScript variants stay distinct lookup keys (TSX via
-///   `.tsx`, TypeScript via `.ts`).
+/// - `Tsx`: `get_name()` returns `"typescript"` for *both* `Tsx` and
+///   `Typescript`, so without an override the two would collapse to
+///   one lookup key. The override exposes `"tsx"`, making them
+///   distinct (TSX via `.tsx`, TypeScript via `.ts`).
 ///
 /// Every other variant delegates to `get_name()` unchanged. Notably
 /// `Mozjs` and `Javascript` both report `"javascript"` upstream:
@@ -405,6 +405,7 @@ mod tests {
         // turns an accidental upstream display rename into a test
         // failure rather than a silent Python-API drift.
         const OVERRIDES: [LANG; 3] = [LANG::Cpp, LANG::Csharp, LANG::Tsx];
+        let mut checked = 0;
         for lang in public_languages() {
             if OVERRIDES.contains(&lang) {
                 continue;
@@ -414,6 +415,14 @@ mod tests {
                 lang.get_name(),
                 "non-override variant {lang:?} must mirror get_name()"
             );
+            checked += 1;
         }
+        // Guard against a vacuous pass: if `public_languages()` ever
+        // shrank to nothing (or to only the overrides), the loop above
+        // would assert nothing yet still report green.
+        assert!(
+            checked > 0,
+            "parity loop exercised no non-override variants"
+        );
     }
 }

--- a/big-code-analysis-py/src/language.rs
+++ b/big-code-analysis-py/src/language.rs
@@ -1,7 +1,6 @@
 // bca: suppress-file(halstead, nargs)
 // Language-name / enum mapping helpers; file-level halstead and summed
-// nargs are many-fn aggregation artifacts. (`lang_to_name`'s cyclomatic — a
-// flat `match` over every LANG variant — is suppressed per-function below.)
+// nargs are many-fn aggregation artifacts.
 
 //! Language detection helpers exposed to Python.
 //!
@@ -23,61 +22,31 @@ use crate::analysis::AnalysisError;
 
 /// Returns the Python-facing language identifier for `lang`.
 ///
-/// The upstream `LANG::get_name` returns a *display* name shared
-/// across variants — both `LANG::Tsx` and `LANG::Typescript` report
-/// `"typescript"`, both `LANG::Mozjs` and `LANG::Javascript` report
-/// `"javascript"` — which makes it ambiguous as a *lookup* key when
-/// two variants would round-trip differently through
-/// `parse_language_name`. The Python bindings disambiguate by
-/// preferring the upstream display name when only one variant in a
-/// display group is actually reachable (no helper-variant collision),
-/// and falling back to the lowercase Rust variant name otherwise:
+/// The rule is: use the upstream CLI display name
+/// ([`LANG::get_name`]), except for three tokens that are unusable as
+/// `parse_language_name` lookup identifiers and are overridden here:
 ///
-/// - `Mozjs` is exposed as `"javascript"` — matches the CLI's
-///   `"language"` field on every `.js` / `.jsm` / `.mjs` / `.jsx`
-///   file. `LANG::Javascript` exists as a placeholder for a future
-///   strict-ECMAScript dispatch but has no registered extensions
-///   and is filtered out by [`public_languages`], so the shared
-///   `"javascript"` name is unambiguous from the Python API.
-/// - `Tsx` and `Typescript` get distinct variant names (`"tsx"`,
-///   `"typescript"`) because both are reachable (TSX via `.tsx`
-///   files, TypeScript via `.ts`) and the CLI display collision
-///   would lose information at the API boundary.
-/// - `Csharp` is exposed as `"csharp"`.
-/// - All other variants use their variant name lowercased
-///   (`Rust` → `"rust"`, `Java` → `"java"`, …).
+/// - `Cpp`: `get_name()` returns `"c/c++"`, which is not a valid
+///   `language=` lookup token; the facade exposes `"cpp"`.
+/// - `Csharp`: `get_name()` returns `"c#"`; the facade exposes
+///   `"csharp"`.
+/// - `Tsx`: `get_name()` returns `"typescript"`, colliding with
+///   `Typescript`'s display name; the facade exposes `"tsx"` so the
+///   two TypeScript variants stay distinct lookup keys (TSX via
+///   `.tsx`, TypeScript via `.ts`).
+///
+/// Every other variant delegates to `get_name()` unchanged. Notably
+/// `Mozjs` and `Javascript` both report `"javascript"` upstream:
+/// `Mozjs` is the reachable `.js` / `.jsm` / `.mjs` / `.jsx` variant,
+/// while `Javascript` has no registered extensions and is filtered
+/// out by [`public_languages`], so the shared name is unambiguous
+/// from the Python API.
 pub(crate) fn lang_to_name(lang: LANG) -> &'static str {
-    // bca: suppress(cyclomatic)
-    // Flat `match lang { … }` over every LANG variant — cyclomatic is
-    // arm count, not branching logic.
     match lang {
-        LANG::Bash => "bash",
-        LANG::Ccomment => "ccomment",
         LANG::Cpp => "cpp",
         LANG::Csharp => "csharp",
-        LANG::Elixir => "elixir",
-        LANG::Go => "go",
-        LANG::Groovy => "groovy",
-        LANG::Irules => "irules",
-        LANG::Java => "java",
-        // `Javascript` has no extensions and is filtered out of
-        // `public_languages`, so this arm is never reached through
-        // the Python API — but the match must stay exhaustive, and
-        // grouping the two `"javascript"` variants together documents
-        // the intentional CLI-name alias and keeps clippy
-        // (`match_same_arms`) quiet.
-        LANG::Javascript | LANG::Mozjs => "javascript",
-        LANG::Kotlin => "kotlin",
-        LANG::Lua => "lua",
-        LANG::Perl => "perl",
-        LANG::Php => "php",
-        LANG::Preproc => "preproc",
-        LANG::Python => "python",
-        LANG::Ruby => "ruby",
-        LANG::Rust => "rust",
-        LANG::Tcl => "tcl",
         LANG::Tsx => "tsx",
-        LANG::Typescript => "typescript",
+        other => other.get_name(),
     }
 }
 
@@ -415,5 +384,36 @@ mod tests {
         // them and get nonsense metrics back.
         assert!(parse_language_name("ccomment").is_none());
         assert!(parse_language_name("preproc").is_none());
+    }
+
+    #[test]
+    fn lang_to_name_overrides_cpp_and_csharp() {
+        // Pin the two overrides that no other test fixes. Upstream
+        // `get_name()` returns "c/c++" / "c#", neither of which is a
+        // usable `parse_language_name` lookup token. Test-via-revert:
+        // deleting the matching override arm makes `get_name()`'s value
+        // leak through and fails these assertions.
+        assert_eq!(lang_to_name(LANG::Cpp), "cpp");
+        assert_eq!(lang_to_name(LANG::Csharp), "csharp");
+    }
+
+    #[test]
+    fn lang_to_name_delegates_to_get_name_outside_overrides() {
+        // Parity contract: every public variant EXCEPT the three
+        // identifier/collision overrides exposes exactly the upstream
+        // CLI display name. This makes the delegation explicit and
+        // turns an accidental upstream display rename into a test
+        // failure rather than a silent Python-API drift.
+        const OVERRIDES: [LANG; 3] = [LANG::Cpp, LANG::Csharp, LANG::Tsx];
+        for lang in public_languages() {
+            if OVERRIDES.contains(&lang) {
+                continue;
+            }
+            assert_eq!(
+                lang_to_name(lang),
+                lang.get_name(),
+                "non-override variant {lang:?} must mirror get_name()"
+            );
+        }
     }
 }

--- a/big-code-analysis-py/src/language.rs
+++ b/big-code-analysis-py/src/language.rs
@@ -1,6 +1,8 @@
-// bca: suppress-file(halstead, nargs)
-// Language-name / enum mapping helpers; file-level halstead and summed
-// nargs are many-fn aggregation artifacts.
+// bca: suppress-file(halstead, nargs, nom)
+// Language-name / enum mapping helpers; file-level halstead, summed
+// nargs, and method count (nom) are many-fn aggregation artifacts — the
+// module is a handful of tiny lookup helpers plus their regression
+// tests, none individually complex.
 
 //! Language detection helpers exposed to Python.
 //!

--- a/man/bca-report.1
+++ b/man/bca-report.1
@@ -4,7 +4,7 @@
 .SH NAME
 bca\-report \- Generate an aggregated report across the analyzed source
 .SH SYNOPSIS
-\fBbca\-report\fR [\fB\-o\fR|\fB\-\-output\fR] [\fB\-\-top\fR] [\fB\-\-strip\-prefix\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fIFORMAT\fR> 
+\fBbca\-report\fR [\fB\-o\fR|\fB\-\-output\fR] [\fB\-\-top\fR] [\fB\-\-strip\-prefix\fR] [\fB\-\-no\-suppress\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fIFORMAT\fR> 
 .SH DESCRIPTION
 Generate an aggregated report across the analyzed source
 .SH OPTIONS
@@ -17,6 +17,9 @@ Maximum number of entries per hotspot table
 .TP
 \fB\-\-strip\-prefix\fR \fI<STRIP_PREFIX>\fR [default: ]
 Path prefix to strip from displayed file paths
+.TP
+\fB\-\-no\-suppress\fR
+Include functions silenced by in\-source suppression markers (`bca: suppress`, `bca: suppress\-file`, `#lizard forgives`) in the hotspot tables. By default the report honors these markers and omits a function from a metric\*(Aqs hotspot table when that metric is suppressed for it — matching `bca check` and the SARIF emitter. Pass this for the raw audit view that lists every offender
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help

--- a/src/suppression.rs
+++ b/src/suppression.rs
@@ -238,8 +238,9 @@ impl SuppressionScope {
 
     /// Merge `other` into `self`. `All` absorbs everything; otherwise
     /// the two sets union. Used when multiple markers stack on the
-    /// same function or file.
-    pub(crate) fn merge(&mut self, other: &SuppressionScope) {
+    /// same function or file, and by report consumers to fold a file's
+    /// `suppress-file` scope into each function's own scope (issue #501).
+    pub fn merge(&mut self, other: &SuppressionScope) {
         match (&mut *self, other) {
             (Self::All, _) => {}
             (slot, Self::All) => *slot = Self::All,


### PR DESCRIPTION
Batch fix for two related findings surfaced by the published metrics report's `lang_to_name` cyclomatic hotspot.

## #500 — `refactor(py): collapse lang_to_name onto LANG::get_name`

`lang_to_name` was a 22-arm flat `match` whose 19 non-override arms duplicated the upstream `LANG::get_name()` display names. It now delegates to `get_name()` and keeps only the three genuine lookup-token overrides:

- `Cpp` → `"cpp"` (upstream `"c/c++"` isn't a usable lookup token)
- `Csharp` → `"csharp"` (upstream `"c#"`)
- `Tsx` → `"tsx"` (upstream `"typescript"` collides with `Typescript`)

Output is **byte-identical for all 22 variants** (verified arm-by-arm against `src/langs.rs`); the change removes the hand-maintained duplication and the drift risk against the documented CLI-parity contract. Added an override pin test (`Cpp`/`Csharp`) and a `get_name()` parity test over the non-override public variants (with a vacuity guard).

## #501 — `feat(report): honor bca: suppress markers in aggregated reports`

`bca report markdown|html` listed raw metric values and ignored `bca: suppress` / `bca: suppress-file` markers, so the published hotspots report re-surfaced every silenced function — contradicting `bca check` and the SARIF emitter.

The report now **honors markers by default, per metric**: a function is omitted from a metric's hotspot table when that metric is suppressed for it. `extract_summaries` folds the top-level Unit's `suppress-file` scope into each function's own scope (file ∪ function), mirroring `ThresholdSet::evaluate_with_policy`; each table filters on its `MetricKind` via `SuppressionScope::covers`, including the `nexits → exit` alias.

- `bca report --no-suppress` (or `[report] no_suppress = true` in `bca.toml`) opts into the raw audit view.
- Advisory roll-ups (actionable summary, CC-stats note) intentionally keep counting raw measurements.
- `SuppressionScope::merge` widened `pub(crate)` → `pub` (additive; `SuppressionScope` is already re-exported from `lib.rs`).

## Quality / review

Each issue went through fix → simplify → review → remediation. After each wave the simplify-rust / rust-optimize / audit-tests / code-review / review skills were run; remediations applied:

- vacuity guard on the #500 parity test
- `--no-suppress` positive control on the exit-table drop test
- in-code rationale for why advisory roll-ups stay raw
- `suppress-file(nom)` on `language.rs` (the #500 regression tests tipped file-level `nom` past the headroom gate — an aggregation artifact, like the already-suppressed `halstead`/`nargs`)

The 8 new #501 tests were verified by **test-via-revert** (the filter-dependent ones fail when `is_hidden_for` is neutered).

## Validation

`make pre-commit` green: fmt, clippy `-D warnings` (both feature flavors), workspace tests, doc, udeps, markdown/TOML/shell/Makefile/Actions lints, man-page drift, both self-scan tiers, and the Python suite (192 passed, 1 xfailed).

Closes #500
Closes #501
