### PR TITLE
ci(pages): stop emitting suppressed offenders to Code Scanning

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -282,17 +282,23 @@ jobs:
       # match the gate's offender set. `if: always()` mirrors the report
       # steps: the SARIF is most useful precisely when CI is red.
       #
-      # `--report-suppressed` surfaces the debt the gate tolerates —
-      # in-source `bca: suppress` markers and baseline-covered offenders —
-      # as SARIF `suppressions` entries, so Code Scanning shows them as
-      # suppressed (closed) alerts: visible for tracking without counting
-      # against the open-alert total. `--tier soft --headroom 0.95`
-      # matches the baseline's provenance so baseline-covered offenders
-      # below the hard limit (the cognitive entries) still appear.
+      # We deliberately DROP `--report-suppressed` here: GitHub code
+      # scanning does not honor the SARIF `suppressions` property
+      # natively (it is absent from GitHub's supported-SARIF subset), so
+      # offenders emitted as `suppressions` entries surface as *open*
+      # alerts anyway — the opposite of the intent. Without the flag the
+      # SARIF carries only genuinely-active offenders (those not silenced
+      # by an in-source `bca: suppress` marker or covered by the
+      # baseline); suppressed/baselined debt is tracked where it lives —
+      # the markers in source and `.bca-baseline.toml` — not as phantom
+      # Code Scanning alerts. `--tier soft --headroom 0.95` keeps the
+      # published alert set aligned with the soft (headroom) gate, so an
+      # unsuppressed function creeping into the 95-100% band shows up as
+      # an early warning before the hard gate trips.
       - name: Generate self-scan SARIF
         if: always()
         run: >-
-          bca check --output-format sarif --no-fail --report-suppressed
+          bca check --output-format sarif --no-fail
           --tier soft --headroom 0.95 --output bca.sarif
 
       # Fork PRs get a read-only GITHUB_TOKEN without security-events

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,12 +41,14 @@ for historical reference.
   in-source `bca: suppress` marker or covered by the baseline stay out of
   the gate (exit code and human stream unchanged) but are emitted into the
   `--output-format sarif` document carrying a SARIF `suppressions` entry
-  (`kind: "inSource"` for markers, `"external"` for the baseline) — GitHub
-  Code Scanning renders them as suppressed (closed) alerts so the debt
-  stays visible without counting against the open-alert total. Only the
+  (`kind: "inSource"` for markers, `"external"` for the baseline). Only the
   SARIF format represents suppression; the flag is mutually exclusive with
-  `--no-suppress` and `--write-baseline`. The repo's own Pages workflow
-  opts in so the published self-scan alerts include the suppressed debt.
+  `--no-suppress` and `--write-baseline`. Note: GitHub code scanning does
+  not honor the SARIF `suppressions` property natively — it ingests such
+  results as *open* alerts — so this flag targets downstream tooling that
+  reads suppressions (e.g. the `advanced-security/dismiss-alerts` action).
+  The repo's own Pages workflow does not pass it; its Code Scanning upload
+  carries active offenders only.
 - Library: new `write_sarif_with_suppressed(active, in_source, baseline,
   writer)` writer that emits SARIF `suppressions` entries for suppressed
   offenders. `write_sarif` is unchanged (the active-only special case),

--- a/big-code-analysis-book/src/commands/suppression.md
+++ b/big-code-analysis-book/src/commands/suppression.md
@@ -201,11 +201,19 @@ bca check --output-format sarif --no-fail --report-suppressed \
 
 Offenders silenced by an in-source marker or covered by the baseline are
 emitted into the SARIF document with a SARIF `suppressions` entry —
-`kind: "inSource"` for markers, `kind: "external"` for the baseline. GitHub
-Code Scanning renders these as *suppressed (closed)* alerts: the debt stays
-visible for tracking, but it does not count against the open-alert total
-and never fails the gate (exit code and the human stderr stream are
-unaffected).
+`kind: "inSource"` for markers, `kind: "external"` for the baseline. The
+suppression never fails the gate (exit code and the human stderr stream are
+unaffected); the `suppressions` entry lets downstream tooling tell
+suppressed debt apart from active offenders.
+
+> **GitHub Code Scanning caveat.** GitHub does **not** honor the SARIF
+> `suppressions` property natively — it ingests suppressed results as
+> *open* alerts, not closed ones. To dismiss them on the Security tab you
+> need a follow-up step such as the
+> [`advanced-security/dismiss-alerts`](https://github.com/advanced-security/dismiss-alerts)
+> action, which reads `suppressions[]` and dismisses the matching alerts.
+> If you only want active offenders to appear, omit `--report-suppressed`
+> from the upload (this repo's own Pages workflow does exactly that).
 
 Notes:
 


### PR DESCRIPTION
## Problem

The Security tab showed ~503 **open** `big-code-analysis` code-scanning alerts that are all, in fact, suppressed (`// bca: suppress` markers) or baseline-covered.

Investigation: bca's SARIF path honors the markers correctly — every one of the 503 results was emitted with a SARIF `suppressions` entry (`kind: "inSource"` / `"external"`). The breakage is downstream: **GitHub code scanning does not honor the SARIF `suppressions` property natively** (it is absent from GitHub's supported-SARIF subset), so suppressed results are ingested as *open* alerts. The `pages.yml` use of `--report-suppressed` was therefore producing phantom open alerts — the opposite of the intent.

## Change

- **`pages.yml`**: drop `--report-suppressed` from the Code Scanning SARIF step. The upload now carries only genuinely-active offenders. With every current offender suppressed or baselined, the new SARIF has **zero results**, so the next `pages.yml` run on `main` re-uploads the `bca` category empty and GitHub marks the 503 stale alerts **fixed**. Suppressed/baselined debt stays tracked in-source and in `.bca-baseline.toml`. `--tier soft --headroom 0.95` is retained so an unsuppressed function entering the 95–100% band still surfaces as an early warning.
- **Docs** (`CHANGELOG.md`, `big-code-analysis-book/src/commands/suppression.md`): correct the false claim that GitHub renders SARIF-suppressed results as *suppressed (closed)* alerts. State the limitation, point at the [`advanced-security/dismiss-alerts`](https://github.com/advanced-security/dismiss-alerts) action as the way to actually dismiss them, and drop the now-false "the Pages workflow opts in" line.

The `bca check --report-suppressed` CLI feature is unchanged; only the Pages workflow's use of it is removed.

## Validation

- Reproduced the new command locally: valid SARIF, **0 results**.
- `make pre-commit` green (cargo gates, `actionlint`, man-page/self-scan tiers, markdown lint, Python suite 192 passed / 1 xfailed).
