### PR TITLE
feat(vcs): change-history (VCS) metrics with a git backend (#328)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -230,6 +230,15 @@ jobs:
       # re-anchors that root to the `./`-prefixed form (#488), so the
       # `./`-anchored `.bcaignore` deny-set matches and the
       # `--strip-prefix "./"` below still lands on the emitted prefix.
+      # The report-generation steps below run BEFORE the threshold gate.
+      # A failure here must not *mask* the gate (skipping it would hide
+      # real threshold violations), but it must still fail the job (a
+      # broken report is a real defect). So the steps are left as normal
+      # (no `continue-on-error`) — a failure correctly reds the job — and
+      # the gate itself carries `if: ${{ !cancelled() }}`, so it runs
+      # regardless of a prior report failure. (An earlier revision used
+      # `continue-on-error` on the reports; that masked a single broken
+      # report on PR runs, where `assemble` does not run to catch it.)
       - name: Generate Markdown report
         run: |
           set -euo pipefail
@@ -248,9 +257,38 @@ jobs:
             --strip-prefix "./" \
             --output index.html
 
+      # Dogfood the change-history (VCS) risk report (issue #328): rank
+      # this repo's tracked files by composite change-history risk
+      # (churn, commit/author counts, ownership dilution, bug-/security-
+      # fix history). Path selection and the `.bcaignore` deny-set come
+      # from the same `bca.toml` manifest the AST report and gate read;
+      # the job's `fetch-depth: 0` checkout supplies the full history the
+      # walk needs (a shallow clone would truncate it). Emitted to
+      # stdout — the per-file `--output` directory semantics inherited
+      # from `metrics`/`ops` do not fit a single whole-repo report —
+      # captured as machine-readable JSON plus a human table.
+      #
+      # SECURITY: this report is published to the *public* Pages site.
+      # Do NOT add `--emit-author-details` here: it would publish
+      # SHA-256 hashes of author emails. The counts/paths/scores emitted
+      # without it are all derivable from the public git history.
+      #
+      # Two invocations = two history walks (one per format), mirroring
+      # the `report markdown` + `report html` pair above; `bca vcs` lacks
+      # a multi-format mode. Acceptable for this repo's size and
+      # superseded once the rendered VCS page lands (#573).
+      - name: Generate VCS risk report
+        run: |
+          set -euo pipefail
+          bca vcs --top 100 --format json > vcs-report.json
+          bca vcs --top 100 > vcs-report.txt
+
       # Run the gate last so the report artifacts above always upload
       # even when thresholds fail — the report is most useful when CI
-      # is red. Delegate to `make self-scan` so the local pre-commit
+      # is red. `if: ${{ !cancelled() }}` makes the gate run even if a
+      # report step above failed, so a report defect can never mask a
+      # threshold violation (while still failing the job on its own).
+      # Delegate to `make self-scan` so the local pre-commit
       # gate and the CI gate share one canonical invocation; the
       # repo-root `bca.toml` manifest owns path selection,
       # `exclude_from`, the per-function thresholds, the cyclomatic `?`
@@ -269,6 +307,7 @@ jobs:
       # them. `--since` is presentational only; it never changes the
       # gate's pass/fail.
       - name: Threshold gate (baseline-ratcheted, diff-aware)
+        if: ${{ !cancelled() }}
         run: make self-scan
         env:
           BCA_SINCE: origin/${{ github.base_ref || 'main' }}
@@ -320,6 +359,8 @@ jobs:
           path: |
             report.md
             index.html
+            vcs-report.json
+            vcs-report.txt
           if-no-files-found: error
           # Same PR-vs-main retention split as the book artifact above —
           # see that comment for the rationale.
@@ -347,6 +388,11 @@ jobs:
           mkdir -p site/reports
           cp reports-staging/index.html site/reports/index.html
           cp reports-staging/report.md   site/reports/report.md
+          # Change-history (VCS) risk report (issue #328) — published
+          # alongside the AST reports so the dogfooded ranking is visible
+          # on the Pages site, not just as a per-run artifact.
+          cp reports-staging/vcs-report.json site/reports/vcs-report.json
+          cp reports-staging/vcs-report.txt  site/reports/vcs-report.txt
           # Belt-and-braces in two places:
           #  * `site/.nojekyll` should already have travelled with
           #    book-html (build-book uploads with include-hidden-files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,33 @@ for historical reference.
 
 ### Added
 
+- Change-history (VCS) metrics: a new, language-agnostic metric family
+  derived from git history rather than the AST (#328). A single history
+  walk produces per-file signals over two windows (default 12mo / 90d) —
+  distinct commits, line churn, distinct authors, top-author ownership
+  share, burst, bug-fix / security-fix / revert commit counts, file age
+  and last-modified days — combined into an ordinal, formula-versioned
+  composite `risk_score` (`--risk-formula weighted|percentile`), plus a
+  `hotspot_score` (complexity × recent churn) when AST metrics are
+  computed alongside. Built on [`gix`](https://github.com/GitoxideLabs/gitoxide)
+  behind the hierarchical `vcs = ["vcs-git"]` Cargo feature; the generic
+  `vcs` module is backend-neutral so future backends (#335) reuse it.
+  Surfaces:
+  - Library: `big_code_analysis::vcs::{build_history_index, Options,
+    Stats, HistoryIndex, …}`, `wire::Vcs`, and
+    `CodeMetrics::vcs: Option<vcs::Stats>` (all behind `vcs-git`).
+  - CLI: a new `bca vcs` subcommand (ranked list; JSON / YAML / TOML /
+    CBOR / CSV or a default table), plus `bca metrics --vcs` to attach a
+    `vcs` block to each file's metrics. `bca vcs` errors clearly outside
+    a git working tree; `--include` / `--exclude` / `--paths` are reused.
+  - Web: a new `POST /vcs` endpoint taking a server-side `repo_path`.
+  - Python: `vcs_metrics(repo_path, …)` and an opt-in `vcs=True` on
+    `analyze()`.
+
+  *Design note:* the issue proposed a `Metric::Vcs` enum variant +
+  `--metrics vcs`; VCS is file-level, has no per-function threshold, and
+  is not suppressible, so it is exposed via a dedicated `--vcs` flag
+  rather than overloading the per-function `Metric` bitfield.
 - `Ast::strip_comments()`, `Ast::functions()`, `Ast::dump(cfg)`,
   `Ast::count(filters)`, `Ast::find(filters)`, and `Ast::suppressions()`
   complete the parse-once `Ast` seam: comment removal, function-span

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rand",
- "sha1",
+ "sha1 0.11.0",
  "smallvec",
  "tokio",
  "tokio-util",
@@ -293,6 +293,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,10 +414,12 @@ dependencies = [
  "bca-tree-sitter-mozjs",
  "bca-tree-sitter-preproc",
  "bca-tree-sitter-tcl",
+ "bstr",
  "ciborium",
  "crossbeam",
  "csv",
  "dekobon-tree-sitter-groovy",
+ "gix",
  "globset",
  "insta",
  "jsonschema",
@@ -493,6 +504,7 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-actix-web",
@@ -588,6 +600,12 @@ name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -708,6 +726,15 @@ checksum = "7e30ffc187e2e3aeafcd1c6e2aa416e29739454c0ccaa419226d5ecd181f2d78"
 dependencies = [
  "clap",
  "roff",
+]
+
+[[package]]
+name = "clru"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
+dependencies = [
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -918,6 +945,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,10 +1108,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "faster-hex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
+dependencies = [
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1295,6 +1356,884 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix"
+version = "0.83.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce52001b946a6249d5d0d3011df0a042ac3f8a4d013460db6476577b0b9c567"
+dependencies = [
+ "gix-actor",
+ "gix-archive",
+ "gix-attributes",
+ "gix-blame",
+ "gix-command",
+ "gix-commitgraph",
+ "gix-config",
+ "gix-date",
+ "gix-diff",
+ "gix-dir",
+ "gix-discover",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-ignore",
+ "gix-index",
+ "gix-lock",
+ "gix-mailmap",
+ "gix-merge",
+ "gix-negotiate",
+ "gix-object",
+ "gix-odb",
+ "gix-pack",
+ "gix-path",
+ "gix-pathspec",
+ "gix-protocol",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-sec",
+ "gix-shallow",
+ "gix-status",
+ "gix-submodule",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-url",
+ "gix-utils",
+ "gix-validate",
+ "gix-worktree",
+ "gix-worktree-state",
+ "gix-worktree-stream",
+ "nonempty",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.41.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bc998b8f746dda8565450d08a63b792ced9165d8c27a1ed3f02799ec6a7820f"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-error",
+]
+
+[[package]]
+name = "gix-archive"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a20ec244b733338d4cb60e5e05eac700dab7fcc689647b1d1daa9396b119342"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-error",
+ "gix-object",
+ "gix-worktree-stream",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d43f12e246d3bf7ec624c8fc15ac4a4b62b7c4c6f586cb82be6c90bf84c9d02"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "kstring",
+ "smallvec",
+ "thiserror",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-bitmap"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ebef0c26ad305747649e727bbcd56a7b7910754eb7cea88f6dff6f93c51283"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-blame"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dab9a942ab54a9661ded7397c3bf927274e7afa94494db0d75cfcbde02ca0a"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-diff",
+ "gix-error",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-chunk"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9faee47943b638e58ddd5e275a4906ad3e4b6c8584f1d41bd18ab9032ec52afb"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-command"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00706d4fef135ef4b01680d5218c6ee40cda8baf697b864296cbc887d19118f6"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "shell-words",
+]
+
+[[package]]
+name = "gix-commitgraph"
+version = "0.37.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f675d0df484a7f6a47e64bd6f311af489d947c0323b0564f36d14f3d7762abb"
+dependencies = [
+ "bstr",
+ "gix-chunk",
+ "gix-error",
+ "gix-hash",
+ "memmap2",
+ "nonempty",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c01848aebd21c67f6ba41f1de8efd46ae96df21f001954a3c9e1517e514d410"
+dependencies = [
+ "bstr",
+ "gix-config-value",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "smallvec",
+ "thiserror",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-config-value"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed42168329552f6c2e5df09665c104199d45d84bedb53683738a49b57fe1baab"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "gix-path",
+ "libc",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-date"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ecab64a98bbac9f8e02990a9ea5e3c974a7d49b95f2bd70ad94ad22fa6b48c"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "itoa",
+ "jiff",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc08e0fa1a91ff5f24affeab052f198056645e1de004910bde7b82b50ea5982a"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-imara-diff",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-dir"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a0fc06e9e1e430cbf0a313666976d90f822f461a6525320427aa9b8af5236c"
+dependencies = [
+ "bstr",
+ "gix-discover",
+ "gix-fs",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-trace",
+ "gix-utils",
+ "gix-worktree",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17852e6a501e688a1702b24ebe5b3761d4719455bc869fd29f38b0b859bcad34"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-fs",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-error"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57831e199be480af90dcd7e459abed8a174c09ec9a6e2cc8f7ca6c54598b06b"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1849ae154d38bc403185be14fa871e38e3c93ee606875d94e207fdb9fba52dbc"
+dependencies = [
+ "bytes",
+ "crc32fast",
+ "crossbeam-channel",
+ "gix-path",
+ "gix-trace",
+ "gix-utils",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "prodash",
+ "thiserror",
+ "walkdir",
+ "zlib-rs",
+]
+
+[[package]]
+name = "gix-filter"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac917dbe9653c9b615d248db91907a365bd779750c9e1b457a9d9fdeece3a08"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "gix-attributes",
+ "gix-command",
+ "gix-hash",
+ "gix-object",
+ "gix-packetline",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "gix-utils",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cdff46db8798e47e2f727d84b9379aac5add3dd3d9d0b07bb4d7d5d640771fe"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "gix-features",
+ "gix-path",
+ "gix-utils",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1fcb8ef5b16bcf874abe9b68d8abb3c0493c876d367ab824151f30a0f3f3756"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "gix-features",
+ "gix-path",
+]
+
+[[package]]
+name = "gix-hash"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0926d3819c837750b4e03c7754901e73f68b8c9b690753a6372a1bed4eedce"
+dependencies = [
+ "faster-hex",
+ "gix-features",
+ "sha1-checked",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0e30b93eea8718baf7d8153fcb938e2926175bbf18097c09f1c01b6f0be0563"
+dependencies = [
+ "gix-hash",
+ "hashbrown 0.17.1",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-ignore"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d491bab9bf2c9f341dc754f425c31d5d3f63aca615312167b82e1deeaca97d8d"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-trace",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-imara-diff"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19753d40da53d0ec41604750eeb969097a90fb2d7f7992730d904541c04e2c19"
+dependencies = [
+ "bstr",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54c3ef97ad08121e4327a6226bd63fed6b9e3c6b976d48bddd4356d9d41191db"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "filetime",
+ "fnv",
+ "gix-bitmap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-traverse",
+ "gix-utils",
+ "gix-validate",
+ "hashbrown 0.16.1",
+ "itoa",
+ "libc",
+ "memmap2",
+ "rustix",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-lock"
+version = "23.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c9dedd9e90b0d47624d2ed241d394e09294118364e87b9b7e5f1fe755f3c2c"
+dependencies = [
+ "gix-tempfile",
+ "gix-utils",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-mailmap"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "195fd20808055824531be2fd0d34136d900e5fbca3ffb0a3c07e8beeefb9c828"
+dependencies = [
+ "bstr",
+ "gix-actor",
+ "gix-date",
+ "gix-error",
+]
+
+[[package]]
+name = "gix-merge"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74bbcdcc52b70a32f0a151b024dff9d0fcf56ee48f00d9503e735af9d99ea881"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-diff",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-imara-diff",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-quote",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-worktree",
+ "nonempty",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-negotiate"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "103d42bfade1b8a96ca5005933127bdad461ce588d92422b2c2daa3ff20d780c"
+dependencies = [
+ "bitflags",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a38075a95d7cc5df8afd38e72c617026c1456952207a4120a7f55a3fbf93b4d7"
+dependencies = [
+ "bstr",
+ "gix-actor",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-utils",
+ "gix-validate",
+ "itoa",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.80.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeeda12a9663120418735ecdc1250d06eeab0be75700e47b3402a981331716ba"
+dependencies = [
+ "arc-swap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-pack",
+ "gix-path",
+ "gix-quote",
+ "memmap2",
+ "parking_lot",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf02e6f5c8f07a069c9ea5245f40d9b14856ada4086091dc99941b49002b4fa"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-error",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-path",
+ "memmap2",
+ "smallvec",
+ "thiserror",
+ "uluru",
+]
+
+[[package]]
+name = "gix-packetline"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18337ba2830bb43367d1af43819c8c78f31337f079fc76d0f1f1750a173126"
+dependencies = [
+ "bstr",
+ "faster-hex",
+ "gix-trace",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa6ac14cd14939ea94a496ce7460daa6511c09f5b84757e9cfc6f9c8d0f93a6"
+dependencies = [
+ "bstr",
+ "gix-trace",
+ "gix-validate",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-pathspec"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3050783b41ee11511e1e8fb35623df81806194f4030395f14f48ea37c2798c9f"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "gix-attributes",
+ "gix-config-value",
+ "gix-glob",
+ "gix-path",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-protocol"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4bee82db63ec635996b96efae71cf467c155fa3f34a556184373224a26c4fd"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-ref",
+ "gix-shallow",
+ "gix-transport",
+ "gix-utils",
+ "maybe-async",
+ "nonempty",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-quote"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e541fc33cc2b783b7979040d445a0c86a2eca747c8faea4ca84230d06ae6ef"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "gix-utils",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8ba9cc15f558b274c99349b83130f5ec83459660828fde9718bbbb43a726167"
+dependencies = [
+ "gix-actor",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-utils",
+ "gix-validate",
+ "memmap2",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61755b27d57edc8940a1b1593c8c61548ca8e4c02da1ed8d5bfeda9eb2a6b761"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "gix-glob",
+ "gix-hash",
+ "gix-revision",
+ "gix-validate",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fb5288fac706d3ea3e4e2ba9ec38b78743b8c02f422e18cb342299cfd6ab7e8"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "nonempty",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "313813706b073a12ff7f9b2896bf3e6504cdac7cfbc97b1920114724705069f0"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-sec"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8519976e4c7e486270740a5400369f37940779b80bd1377d94cfa1125d01b3"
+dependencies = [
+ "bitflags",
+ "gix-path",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "gix-shallow"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a292fc2fe548c5dfa575479d16b445b0ddf1dd2f56f1fec6aed386f82553cd97"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-lock",
+ "nonempty",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-status"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c6d2a8c521ffa205fe7e268c82e6d1378ba37cd826ca10ab6129fdc29a4b65"
+dependencies = [
+ "bstr",
+ "filetime",
+ "gix-diff",
+ "gix-dir",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-worktree",
+ "portable-atomic",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-submodule"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fd5fc8692890bd71a596e540fd4c364f8460eaa82c4eaaedebde6e1e3eb4d91"
+dependencies = [
+ "bstr",
+ "gix-config",
+ "gix-path",
+ "gix-pathspec",
+ "gix-refspec",
+ "gix-url",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "23.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27850097e1ff9515f46a0dad0f5f9c9d020e972727772dabab9450690c4adb22"
+dependencies = [
+ "dashmap",
+ "gix-fs",
+ "libc",
+ "parking_lot",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-trace"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678"
+
+[[package]]
+name = "gix-transport"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd0e34995b1aab0fa8dff2af8db726a0bfad3e119c89302604463264046e7ff"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-features",
+ "gix-packetline",
+ "gix-quote",
+ "gix-sec",
+ "gix-url",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a14b7052c0786676c03e71fcfde7d7f0f8e8316e642b5cec6bb3998719b2ce5c"
+dependencies = [
+ "bitflags",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bb01ec69d55e82ccb7a19e264501ead4e6aac38463a8cebfdd81e22bb67ab2"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "percent-encoding",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-utils"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c50966184123caf580ffa64e28031a878597f1c7fceb8fe19566c38eb1b771"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bc6fc771c4063ba7cd2f47b91fb6076251c6a823b64b7fe7b8874b0fe4afae3"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69955eb5e2910832f88d041964b809eee01dadd579237e0b55efec58fd406fd"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-validate",
+]
+
+[[package]]
+name = "gix-worktree-state"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a96dccbcf9e8fe0291c55f06e08da93ebb2e691c1311276f541eefcc6d70800"
+dependencies = [
+ "bstr",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-worktree",
+ "io-close",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-worktree-stream"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8444b8ed4662e1a0c97f3eceda29630001a1bbb2632201e50312623e594213"
+dependencies = [
+ "gix-attributes",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-object",
+ "gix-path",
+ "gix-traverse",
+ "parking_lot",
+]
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1357,6 +2296,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1381,6 +2335,19 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -1671,6 +2638,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-close"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cadcf447f06744f8ce713d2d6239bb5bde2c357a452397a9ed90c625da390bc"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1687,6 +2664,47 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jni"
@@ -1789,6 +2807,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1866,10 +2893,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-async"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "micromap"
@@ -1910,6 +2957,12 @@ name = "mutually_exclusive_features"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e94e1e6445d314f972ff7395df2de295fe51b71821694f0b0e1e79c4f12c8577"
+
+[[package]]
+name = "nonempty"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
 
 [[package]]
 name = "normalize-line-endings"
@@ -2179,6 +3232,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2250,6 +3312,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prodash"
+version = "31.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]
@@ -2738,6 +3809,17 @@ dependencies = [
 
 [[package]]
 name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
@@ -2745,6 +3827,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "digest 0.11.3",
+]
+
+[[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest 0.10.7",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -2766,6 +3858,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -2848,6 +3946,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "streaming-iterator"
@@ -3001,6 +4105,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -3421,6 +4540,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "uluru"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "unicode-bom"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
+
+[[package]]
 name = "unicode-general-category"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3431,6 +4565,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -3680,6 +4823,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3687,6 +4846,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -4001,6 +5166,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,8 +119,31 @@ include = [
 
 [dependencies]
 aho-corasick = "^1.0"
+# `bstr` carries the raw, possibly-non-UTF-8 bytes git stores for paths
+# and author identities through the VCS pipeline; UTF-8 conversion is
+# deferred to the output boundary with explicit error handling (per the
+# path rules in AGENTS.md). Gated behind `vcs-git`.
+bstr = { version = "^1.12", optional = true }
 crossbeam = { version = "^0.8", features = ["crossbeam-channel"] }
 csv.workspace = true
+# `gix` is the pure-Rust git implementation backing the `vcs-git`
+# backend (issue #328). The feature set is deliberately minimal:
+# `max-performance-safe` (zlib-ng without `unsafe`), `blob-diff` (line
+# churn), `mailmap` (identity canonicalisation), `revision` (rev-walk +
+# revspec parsing), `index` (working-tree path resolution). Gated behind
+# `vcs-git`.
+gix = { version = "^0.83", default-features = false, features = [
+  "max-performance-safe",
+  "blob-diff",
+  "mailmap",
+  "revision",
+  "index",
+  # `sha1` enables `gix-hash/sha1`, which gates the `ObjectId` hash
+  # kind. It is part of gix's default feature set; we pin
+  # `default-features = false` for a minimal surface, so it must be
+  # listed explicitly or `gix-hash::Kind` compiles with no variants.
+  "sha1",
+], optional = true }
 num-derive = "^0.4"
 num-format = "^0.4"
 num-traits = "^0.2"
@@ -186,6 +209,17 @@ tree-sitter-tcl = { workspace = true, optional = true }
 # both leaves their union enabled when either feature is on.
 [features]
 default = ["all-languages"]
+# Change-history (VCS) metrics (issue #328). `vcs` is the umbrella
+# feature mirroring `all-languages`: it turns on every shipped backend.
+# `vcs-git` is the one v1 backend (gitoxide). Future backends land as
+# additional leaves (`vcs-hg`, `vcs-jj`, …) folded into the umbrella,
+# so consumers that opt into `vcs` automatically pick them up without a
+# manifest edit. The generic `src/vcs/` types are gated on `vcs-git`
+# today because it is the only backend; the gate widens to
+# `any(feature = "vcs-git", feature = "vcs-hg", …)` when a second
+# backend lands.
+vcs = ["vcs-git"]
+vcs-git = ["dep:gix", "dep:bstr"]
 all-languages = [
   "bash",
   "cpp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,10 @@ csv.workspace = true
 # backend (issue #328). The feature set is deliberately minimal:
 # `max-performance-safe` (zlib-ng without `unsafe`), `blob-diff` (line
 # churn), `mailmap` (identity canonicalisation), `revision` (rev-walk +
-# revspec parsing), `index` (working-tree path resolution). Gated behind
+# revspec parsing). `index` is listed defensively — `revision`/`mailmap`
+# enable it transitively today, so it is pinned to survive a future gix
+# refactor that decouples them (the walk itself is tree-to-tree and does
+# not read the index/worktree). `sha1` (see below). Gated behind
 # `vcs-git`.
 gix = { version = "^0.83", default-features = false, features = [
   "max-performance-safe",

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ FIND_EXCLUDE   := $(foreach dir,$(EXCLUDE_DIRS),! -path './$(dir)/*')
 # warnings on `$(2)`, e.g. $(call find-by-ext,md,).
 find-by-ext = $(if $(FD),$(FD) --extension $(1) $(FD_EXCLUDE) $(2),find . -name "*.$(1)" -type f $(FIND_EXCLUDE))
 
-.PHONY: help check-tools build build-release check test test-doc fmt fmt-check markdown-fmt markdown-lint shellcheck sh-fmt sh-fmt-check toml-fmt toml-fmt-check toml-lint makefile-check actionlint snapshot-anchors grammar-marker-sync grammar-marker-sync-test check-versions check-manpage-assets enums-check enums-codegen-drift enums-codegen-drift-test self-scan self-scan-headroom self-scan-write-baseline self-scan-write-baseline-headroom lint clippy udeps insta-review insta-accept clean distclean install install-cli install-web doc doc-open doc-check book book-serve book-deploy all pre-commit ci release-check verify-changelog pkg-deb-local pkg-rpm-local py-bootstrap py-sync py-relock py-clean py-fmt py-fmt-check py-lint py-typecheck py-test _check-find _pc-fmt _pc-clippy _pc-test _pc-doc-check _pc-udeps _pc-shellcheck _pc-markdown-lint _pc-toml-lint _pc-makefile-check _pc-actionlint _pc-snapshot-anchors _pc-grammar-marker-sync _pc-grammar-marker-sync-test _pc-check-versions _pc-check-manpage-assets _pc-enums-check _pc-enums-codegen-drift _pc-enums-codegen-drift-test _pc-self-scan _pc-self-scan-headroom _pc-py-fmt _pc-py-typecheck _pc-py-test _ci-fmt-check _ci-clippy _ci-test _ci-doc-check _ci-build _ci-udeps _ci-shellcheck _ci-markdown-lint _ci-toml-lint _ci-makefile-check _ci-actionlint _ci-snapshot-anchors _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-manpage-assets _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test _ci-enums-codegen-drift-test _ci-self-scan _ci-self-scan-headroom _ci-cargo-pipeline _ci-py-fmt-check _ci-py-lint _ci-py-typecheck _ci-py-test
+.PHONY: help check-tools build build-release check test test-doc fmt fmt-check markdown-fmt markdown-lint shellcheck sh-fmt sh-fmt-check toml-fmt toml-fmt-check toml-lint makefile-check actionlint snapshot-anchors grammar-marker-sync grammar-marker-sync-test check-versions check-manpage-assets enums-check enums-codegen-drift enums-codegen-drift-test self-scan self-scan-headroom self-scan-write-baseline self-scan-write-baseline-headroom vcs lint clippy udeps insta-review insta-accept clean distclean install install-cli install-web doc doc-open doc-check book book-serve book-deploy all pre-commit ci release-check verify-changelog pkg-deb-local pkg-rpm-local py-bootstrap py-sync py-relock py-clean py-fmt py-fmt-check py-lint py-typecheck py-test _check-find _pc-fmt _pc-clippy _pc-test _pc-doc-check _pc-udeps _pc-shellcheck _pc-markdown-lint _pc-toml-lint _pc-makefile-check _pc-actionlint _pc-snapshot-anchors _pc-grammar-marker-sync _pc-grammar-marker-sync-test _pc-check-versions _pc-check-manpage-assets _pc-enums-check _pc-enums-codegen-drift _pc-enums-codegen-drift-test _pc-self-scan _pc-self-scan-headroom _pc-py-fmt _pc-py-typecheck _pc-py-test _ci-fmt-check _ci-clippy _ci-test _ci-doc-check _ci-build _ci-udeps _ci-shellcheck _ci-markdown-lint _ci-toml-lint _ci-makefile-check _ci-actionlint _ci-snapshot-anchors _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-manpage-assets _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test _ci-enums-codegen-drift-test _ci-self-scan _ci-self-scan-headroom _ci-cargo-pipeline _ci-py-fmt-check _ci-py-lint _ci-py-typecheck _ci-py-test
 
 # Default target
 help:
@@ -99,6 +99,7 @@ help:
 	@echo "  self-scan-headroom                   bca threshold gate (soft: BCA_HEADROOM, default 0.95)"
 	@echo "  self-scan-write-baseline             Refresh .bca-baseline.toml at the hard thresholds"
 	@echo "  self-scan-write-baseline-headroom    Refresh .bca-baseline.toml at the soft thresholds"
+	@echo "  vcs                                  Change-history (VCS) risk report for this repo"
 	@echo "  lint                                 Run all linters"
 	@echo ""
 	@echo "Python bindings (big-code-analysis-py):"
@@ -464,6 +465,19 @@ self-scan-write-baseline-headroom:
 	  --tier soft \
 	  --headroom $${BCA_HEADROOM:-0.95} \
 	  --write-baseline
+
+# ---------------------------------------------------------------------------
+# Change-history (VCS) risk report (issue #328). Dogfoods `bca vcs` on
+# this repo: ranks tracked files by composite change-history risk (churn,
+# commit/author counts, ownership dilution, bug-/security-fix history)
+# over the default 12mo / 90d windows. Informational only — it never
+# gates (always exits 0). Path selection and the `.bcaignore` deny-set
+# come from the auto-discovered `bca.toml` manifest, exactly like
+# `make self-scan`, so the file universe matches the threshold gate.
+# `BCA_VCS_TOP` overrides the row cap (default 40; 0 = all).
+# ---------------------------------------------------------------------------
+vcs:
+	@$(SELF_SCAN_BCA) vcs --top $${BCA_VCS_TOP:-40}
 
 # ---------------------------------------------------------------------------
 # Python tooling (big-code-analysis-py)

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -199,6 +199,22 @@ section.
   `2.0` break. The `all-languages` default is permanent within
   `1.x`.
 
+Change-history (VCS) metrics (#328) are an **opt-in, additive**
+surface gated behind the `vcs = ["vcs-git"]` Cargo feature (off by
+default for the library; on by default for the `bca` / `bca-web` /
+Python builds). When enabled, the following join the shape contract:
+the `big_code_analysis::vcs` module (`build_history_index`, `Options`,
+`Stats`, `HistoryIndex`, `RiskFormula`, `parse_window`,
+`parse_timestamp`), `wire::Vcs`, `CodeMetrics::vcs`, the `bca vcs`
+subcommand and `bca metrics --vcs` flag, the `POST /vcs` REST endpoint,
+and the Python `vcs_metrics()` function plus the `analyze(vcs=True)`
+keyword. The composite `risk_score` is **ordinal, not cardinal** — only
+relative ranks are meaningful — and is formula-versioned
+(`risk_score_version`): the formula may change within `1.x`, but any
+change bumps that field, and the serialized field *set* is versioned by
+`vcs_schema_version`. Per-file score *magnitudes* therefore carry the
+same "not byte-stable across bumps" caveat as every other metric value.
+
 The following are explicitly **not** part of the shape contract:
 
 - Anything marked `#[doc(hidden)]` (see `src/traits.rs` for current

--- a/big-code-analysis-book/src/SUMMARY.md
+++ b/big-code-analysis-book/src/SUMMARY.md
@@ -6,6 +6,7 @@
 - [CLI Migration Guide](./migration.md)
 - [Commands](commands/README.md)
   - [Metrics](commands/metrics.md)
+  - [Change-history (VCS) metrics](commands/vcs.md)
   - [Report](commands/report.md)
   - [Check](commands/check.md)
   - [Suppression markers](commands/suppression.md)

--- a/big-code-analysis-book/src/commands/vcs.md
+++ b/big-code-analysis-book/src/commands/vcs.md
@@ -135,6 +135,17 @@ $ bca metrics --vcs --paths src/parser.rs --format json
 `bca metrics --vcs` uses the default windows and weighted formula; for
 window / formula tuning use `bca vcs`.
 
+## Dogfooding in this repo
+
+This project runs `bca vcs` on its own source. `make vcs` prints the
+ranked table (path selection and the `.bcaignore` deny-set come from the
+repo-root `bca.toml` manifest, the same config `make self-scan` and
+`make report` use; `BCA_VCS_TOP` overrides the row cap). The Pages CI job
+also publishes a `vcs-report.json` / `vcs-report.txt` under the site's
+`reports/` directory each run. A first-class rendered HTML/Markdown page
+is tracked in issue
+[#573](https://github.com/dekobon/big-code-analysis/issues/573).
+
 ## REST and Python
 
 - **REST:** `POST /vcs` with a JSON body `{ "id": "...", "repo_path":

--- a/big-code-analysis-book/src/commands/vcs.md
+++ b/big-code-analysis-book/src/commands/vcs.md
@@ -1,0 +1,158 @@
+# Change-history (VCS) metrics
+
+`bca vcs` ranks files by **change-history risk** — signals derived from
+version-control history rather than the source AST. It is the project's
+first language-agnostic, non-AST metric family (issue
+[#328](https://github.com/dekobon/big-code-analysis/issues/328)). The
+goal is to surface the files most likely to harbour bugs or
+vulnerabilities, using the signals the empirical defect- and
+vulnerability-prediction literature most consistently backs.
+
+A single history walk runs once per invocation (never per file) and
+produces per-file signals over two configurable windows — a **long**
+window (default `12mo` ≈ 365 days) and a **recent** window (default
+`90d`).
+
+## Quick start
+
+```console
+$ bca vcs --paths src --top 20
+Change-history risk (long window 365d, recent 90d, formula v1)
+ RANK      RISK  COMMITS r/l    CHURN r/l  AUTHORS  FILE
+    1       7.2        68/68  11634/11634        1  src/metrics/cyclomatic.rs
+    2       6.9        68/68    7299/7299        1  src/metrics/npa.rs
+    ...
+```
+
+With no `--format`, a human-readable ranked table is printed. Pass
+`--format json|yaml|toml|cbor|csv` for structured output (CBOR requires
+`--output <dir>`). The global `--paths` / `--include` / `--exclude` /
+`--no-ignore` filters are reused to pick which tracked files to report.
+
+`bca vcs` errors clearly when run outside a git working tree.
+
+## Signals
+
+| Field | Type | Description |
+|---|---|---|
+| `commits_long` / `commits_recent` | u32 | Distinct commits touching the file in each window |
+| `churn_long` / `churn_recent` | u64 | Σ(added + deleted) lines in each window |
+| `authors_long` / `authors_recent` | u32 | Distinct canonical author identities in each window |
+| `ownership_top_share` | f64 ∈ [0,1] | Share of edits attributable to the top author (lower = more diluted) |
+| `burst` | f64 ∈ [0,1] | `commits_recent / commits_long` |
+| `bug_fix_commits` | u32 | Long-window commits whose message matches a bug-fix keyword |
+| `security_fix_commits` | u32 | Long-window commits matching security keywords (`CVE-####`, `security`, `vuln`, `exploit`, `sanitize`, …) |
+| `revert_commits` | u32 | Long-window commits whose subject is a revert / rollback |
+| `age_days` | u32 | Days since the file's first in-window commit (capped at the long window) |
+| `last_modified_days` | u32 | Days since the file's most recent in-window commit |
+| `risk_score` | f64 | Composite, formula-versioned (see below) — **ordinal, not cardinal** |
+| `hotspot_score` | f64? | `complexity × churn_recent`; present only when AST metrics are computed alongside |
+| `risk_score_version` / `vcs_schema_version` | u32 | Forward-compatibility version stamps |
+
+Author identities are canonicalised through the repository `.mailmap`
+and counted by lowercased email; `Co-authored-by:` trailers add
+participants. Bot identities (`dependabot[bot]`, `renovate[bot]`,
+`github-actions[bot]`, …) are excluded by default. Binary files and
+symlinks are skipped; an untracked file has no record at all (distinct
+from a tracked file with zero in-window activity).
+
+## Composite risk score
+
+The default **weighted** formula is a log-scaled weighted sum with
+categorical multiplicative bumps:
+
+```text
+recency_churn  = ln(1 + churn_recent)
+recency_count  = ln(1 + commits_recent)
+long_count     = ln(1 + commits_long)
+long_churn     = ln(1 + churn_long)
+author_factor  = ln(1 + authors_long)
+dilution       = (1 - ownership_top_share).clamp(0, 1)
+fix_factor     = ln(1 + bug_fix_commits + 2 * security_fix_commits)
+size_factor    = ln(1 + sloc)^2 / 100              // tiny tie-breaker
+new_file_bonus = 0.15 if age_days < recent_window_days else 0
+dev_bonus      = 0.35 if authors_long >= 9 else 0.15 if authors_long >= 6 else 0
+
+base = 0.30 * recency_churn
+     + 0.25 * recency_count
+     + 0.15 * long_count
+     + 0.15 * author_factor * (1 + dilution)
+     + 0.10 * fix_factor
+     + 0.05 * long_churn
+     + size_factor
+
+risk_score = base * (1 + dev_bonus + new_file_bonus)
+```
+
+The term weights are grounded in the literature: recent churn and
+commit frequency carry the highest weight (Nagappan & Ball relative
+churn; just-in-time defect prediction; Firefox `NumChanges` PD 86); the
+author factor is scaled by ownership dilution (Avelino DoA /
+truck-factor; Bird et al.); the categorical developer-count bumps encode
+the RHEL4 finding that files touched by ≥9 developers were ~16× more
+likely to harbour a vulnerability; security fixes are double-weighted
+(Sentence-Level VFC studies; PySecDB). The full derivation lives in
+`src/vcs/score.rs`.
+
+The score is **ordinal**: only relative ranks have meaning. Any change
+to the formula bumps `risk_score_version`.
+
+`--risk-formula percentile` is an alternative: each signal is re-ranked
+to its percentile within the analyzed set, then averaged — the
+literature recommends relative triggers over hard thresholds for
+cross-project robustness.
+
+## Flags
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--long-window <DUR>` | `12mo` | Long window (`12mo`, `2y`, `8w`, `365d`, ISO 8601 `P1Y`) |
+| `--recent-window <DUR>` | `90d` | Recent window |
+| `--top <N>` | `50` | Show only the top N (`0` = all) |
+| `--ref <REF>` | `HEAD` | Revision to analyse |
+| `--full-history` | off | Walk the full DAG (default: first-parent only) |
+| `--include-merges` | off | Include merge commits |
+| `--no-follow-renames` | off | Stop following renames (default: follow) |
+| `--no-exclude-bots` / `--bot-pattern <RE>` | exclude | Bot-author filtering |
+| `--as-of <WHEN>` | wall clock | Reference "now" (RFC 3339 / `@unix` / git date) for reproducible snapshots |
+| `--risk-formula {weighted\|percentile}` | `weighted` | Composite formula |
+| `--emit-author-details` | off | Emit SHA-256-hashed canonical author IDs |
+| `--include-deleted` | off | Also rank files deleted at the target ref |
+
+## In `bca metrics`
+
+Pass `bca metrics --vcs` to attach a `vcs` block (plus a `hotspot_score`
+computed from the file's cyclomatic sum) to each file's `metrics`:
+
+```console
+$ bca metrics --vcs --paths src/parser.rs --format json
+{ "name": "src/parser.rs",
+  "metrics": { "cyclomatic": { ... },
+    "vcs": { "commits_long": 15, "churn_recent": 211,
+             "risk_score": 3.7, "hotspot_score": 7596.0, ... } } }
+```
+
+`bca metrics --vcs` uses the default windows and weighted formula; for
+window / formula tuning use `bca vcs`.
+
+## REST and Python
+
+- **REST:** `POST /vcs` with a JSON body `{ "id": "...", "repo_path":
+  "/path/to/repo", ... }` returns the ranked report. See
+  [Driving the REST API](../recipes/rest-api.md).
+- **Python:** `big_code_analysis.vcs_metrics(repo_path, …)` returns the
+  report as a dict, and `analyze(path, vcs=True)` attaches a `vcs` block
+  to a single file's metrics.
+
+## Scope (v1)
+
+v1 ships one backend (`vcs-git`, built on
+[gitoxide](https://github.com/GitoxideLabs/gitoxide)) behind the
+umbrella `vcs` Cargo feature. Out of scope and tracked as follow-ups:
+per-function granularity ([#329](https://github.com/dekobon/big-code-analysis/issues/329)),
+change entropy ([#330](https://github.com/dekobon/big-code-analysis/issues/330)),
+just-in-time scoring ([#331](https://github.com/dekobon/big-code-analysis/issues/331)),
+bus factor ([#332](https://github.com/dekobon/big-code-analysis/issues/332)),
+historical trend ([#333](https://github.com/dekobon/big-code-analysis/issues/333)),
+a persistent cache ([#334](https://github.com/dekobon/big-code-analysis/issues/334)),
+and additional VCS backends ([#335](https://github.com/dekobon/big-code-analysis/issues/335)).

--- a/big-code-analysis-book/src/recipes/rest-api.md
+++ b/big-code-analysis-book/src/recipes/rest-api.md
@@ -123,6 +123,38 @@ boolean (set when the parser flagged the function span as
 malformed) — enough for an editor to draw a function navigator
 without re-parsing the file locally.
 
+## Rank a repository by change-history risk
+
+The `/vcs` endpoint analyses a git working tree that already exists on
+the **server's** filesystem (change history has no in-request
+representation), and returns the files ranked by composite risk score.
+See [Change-history (VCS) metrics](../commands/vcs.md) for the signal
+and formula reference.
+
+> **Security:** unlike the other endpoints, `/vcs` takes a server-side
+> `repo_path` and will walk any git repository the server process can
+> read, returning that repo's file paths and change signals. Do not
+> expose `/vcs` to untrusted clients without an authorization layer; the
+> default `127.0.0.1` bind keeps it local.
+
+```bash
+curl -s http://127.0.0.1:8080/v1/vcs \
+    -H 'Content-Type: application/json' \
+    -d '{
+          "id": "risk-1",
+          "repo_path": "/srv/checkouts/my-project",
+          "top": 20
+        }' \
+  | jq '.files[] | {path, risk_score, churn_recent}'
+```
+
+The body accepts the same knobs as `bca vcs` (`long_window`,
+`recent_window`, `top`, `ref`, `risk_formula`, `full_history`,
+`include_merges`, `follow_renames`, `exclude_bots`, `bot_pattern`,
+`as_of`, `emit_author_details`, `include_deleted`) as optional fields.
+A `repo_path` that is not a git working tree, or a malformed window /
+timestamp / formula, returns `400` with the uniform JSON error body.
+
 ## Calling the API from CI
 
 The server starts in milliseconds, so for short-lived CI jobs it's

--- a/big-code-analysis-cli/Cargo.toml
+++ b/big-code-analysis-cli/Cargo.toml
@@ -22,8 +22,14 @@ ignore = "^0.4"
 # here would silently drop grammars from the CLI build. See #252.
 big-code-analysis = { path = "..", version = "=1.1.0", default-features = false, features = [
   "all-languages",
+  # End-user binary ships every backend that exists; `vcs` is the
+  # umbrella turning on `vcs-git` (issue #328).
+  "vcs",
 ] }
 ciborium = "^0.2"
+# `bca vcs` writes a flat CSV ranking (issue #328); the workspace pin is
+# shared with the library's CSV writer.
+csv.workspace = true
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_yaml = "^0.9"
@@ -176,6 +182,11 @@ assets = [
     "usr/share/man/man1/",
     "644",
   ],
+  [
+    "../man/bca-vcs.1",
+    "usr/share/man/man1/",
+    "644",
+  ],
 ]
 
 # RHEL/Rocky/Fedora/Amazon Linux packaging — consumed by
@@ -213,5 +224,6 @@ assets = [
   { source = "../man/bca-preproc.1", dest = "/usr/share/man/man1/bca-preproc.1", mode = "644" },
   { source = "../man/bca-report.1", dest = "/usr/share/man/man1/bca-report.1", mode = "644" },
   { source = "../man/bca-strip-comments.1", dest = "/usr/share/man/man1/bca-strip-comments.1", mode = "644" },
+  { source = "../man/bca-vcs.1", dest = "/usr/share/man/man1/bca-vcs.1", mode = "644" },
 ]
 auto-req = "disabled"

--- a/big-code-analysis-cli/src/commands.rs
+++ b/big-code-analysis-cli/src/commands.rs
@@ -44,12 +44,12 @@ use crate::thresholds::{
 };
 use crate::{
     Action, CheckArgs, Cli, Command, Config, DiffBaselineArgs, ExemptionsArgs, FindArgs,
-    GlobalOpts, InitArgs, LineRange, ListMetricsArgs, NodesArgs, OutputFormat, PreprocArgs,
-    PrintConfigFormat, ReportArgs, StripCommentsArgs, StructuredArgs, Tier, die, die_io,
-    group_files_by_basename, legacy_hint, load_baseline, load_preproc_data, load_threshold_config,
-    read_exclude_patterns_from, resolve_walk_files, run_walk, run_walk_collecting,
-    run_walk_resolved, validate_output_path, write_atomic, write_output_or_stdout,
-    write_stdout_or_die,
+    GlobalOpts, InitArgs, LineRange, ListMetricsArgs, MetricsArgs, NodesArgs, OutputFormat,
+    PreprocArgs, PrintConfigFormat, ReportArgs, StripCommentsArgs, StructuredArgs, Tier, die,
+    die_io, group_files_by_basename, legacy_hint, load_baseline, load_preproc_data,
+    load_threshold_config, read_exclude_patterns_from, resolve_walk_files, run_walk,
+    run_walk_collecting, run_walk_resolved, validate_output_path, write_atomic,
+    write_output_or_stdout, write_stdout_or_die,
 };
 
 fn run_check(
@@ -1424,6 +1424,7 @@ pub fn run() {
         Command::Functions => run_command_functions(cli.globals, preproc),
         Command::Metrics(args) => run_command_metrics(cli.globals, args, preproc),
         Command::Ops(args) => run_command_ops(cli.globals, args, preproc),
+        Command::Vcs(args) => crate::vcs_command::run(cli.globals, *args),
         Command::Report(args) => {
             run_command_report(cli.globals, args, manifest.as_ref(), preproc);
         }
@@ -1524,23 +1525,35 @@ fn require_output_is_dir(have_format: bool, output: Option<&Path>, command: &str
 
 fn run_command_metrics(
     globals: GlobalOpts,
-    args: StructuredArgs,
+    args: MetricsArgs,
     preproc: Option<Arc<PreprocResults>>,
 ) {
-    if matches!(args.output_format, Some(MetricsFormat::Cbor)) && args.output.is_none() {
+    let structured = args.structured;
+    if matches!(structured.output_format, Some(MetricsFormat::Cbor)) && structured.output.is_none()
+    {
         die(CBOR_STDOUT_ERROR);
     }
     require_output_is_dir(
-        args.output_format.is_some(),
-        args.output.as_deref(),
+        structured.output_format.is_some(),
+        structured.output.as_deref(),
         "metrics",
     );
+    // Build the change-history index once, before the per-file walk, so
+    // the dispatch can attach a `vcs` block to each file (issue #328).
+    // `--vcs` is additive: outside a repo `default_index` warns and
+    // returns `None`, so the AST metrics still emit (vcs block omitted).
+    let vcs_index = if args.vcs {
+        crate::vcs_command::default_index(&globals)
+    } else {
+        None
+    };
     let action = Action::Metrics {
-        format: args.output_format,
-        pretty: args.pretty,
+        format: structured.output_format,
+        pretty: structured.pretty,
     };
     let cfg = Config {
-        output: args.output,
+        output: structured.output,
+        vcs_index,
         ..Config::new(action, &globals, preproc)
     };
     run_walk(globals, cfg);

--- a/big-code-analysis-cli/src/commands.rs
+++ b/big-code-analysis-cli/src/commands.rs
@@ -1542,10 +1542,22 @@ fn run_command_metrics(
     // the dispatch can attach a `vcs` block to each file (issue #328).
     // `--vcs` is additive: outside a repo `default_index` warns and
     // returns `None`, so the AST metrics still emit (vcs block omitted).
-    let vcs_index = if args.vcs {
-        crate::vcs_command::default_index(&globals)
-    } else {
-        None
+    //
+    // Only the structured-output path renders the `vcs` block; the
+    // human-readable dump (no `--format`) cannot show it. So skip the
+    // (expensive) history walk entirely when no format is selected,
+    // warning that `--vcs` had no effect rather than doing the walk and
+    // silently discarding it.
+    let vcs_index = match (args.vcs, structured.output_format.is_some()) {
+        (true, true) => crate::vcs_command::default_index(&globals),
+        (true, false) => {
+            eprintln!(
+                "warning: --vcs has no effect without --format: the human-readable \
+                 metrics view does not render the vcs block"
+            );
+            None
+        }
+        (false, _) => None,
     };
     let action = Action::Metrics {
         format: structured.output_format,

--- a/big-code-analysis-cli/src/dispatch.rs
+++ b/big-code-analysis-cli/src/dispatch.rs
@@ -175,7 +175,12 @@ fn dispatch_metrics(
     pretty: bool,
 ) -> std::io::Result<()> {
     if let Some(fmt) = format {
-        if let Ok(space) = analyze_file(language, source, &path, pr, cfg.metrics_options()) {
+        if let Ok(mut space) = analyze_file(language, source, &path, pr, cfg.metrics_options()) {
+            // `bca metrics --vcs`: attach the file's change-history block
+            // (and hotspot) to its file-level metrics before emitting.
+            if let Some(index) = &cfg.vcs_index {
+                crate::vcs_command::inject(&mut space, &path, index);
+            }
             match fmt.dispatch() {
                 MetricsDispatch::Generic(g) => {
                     g.dump(space, path, cfg.output.as_ref(), pretty)?;
@@ -558,6 +563,7 @@ mod tests {
             exclude_tests: false,
             no_cyclomatic_try: false,
             fuzzy_baseline: false,
+            vcs_index: None,
         }
     }
 

--- a/big-code-analysis-cli/src/lib.rs
+++ b/big-code-analysis-cli/src/lib.rs
@@ -51,6 +51,7 @@ mod metric_catalog;
 mod metric_diff;
 mod threshold_suggestion;
 mod thresholds;
+mod vcs_command;
 mod walk_seed;
 
 pub use commands::run;
@@ -277,9 +278,13 @@ struct GlobalOpts {
 #[derive(Subcommand, Debug)]
 enum Command {
     /// Compute per-file metrics and emit them in a structured format.
-    Metrics(StructuredArgs),
+    Metrics(MetricsArgs),
     /// Extract per-file operands and operators.
     Ops(StructuredArgs),
+    /// Rank files by change-history (VCS) risk: churn, commit and author
+    /// counts, ownership dilution, and bug- / security-fix history over a
+    /// git working tree (issue #328). Errors clearly outside a repo.
+    Vcs(Box<VcsArgs>),
     /// Generate an aggregated report across the analyzed source.
     Report(ReportArgs),
     /// Dump the AST to stdout.
@@ -349,6 +354,93 @@ struct StructuredArgs {
     /// Pretty-print JSON / TOML output.
     #[clap(long)]
     pretty: bool,
+}
+
+/// Risk-score formula selection for `bca vcs` (issue #328).
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+#[clap(rename_all = "lower")]
+enum RiskFormulaArg {
+    /// Log-scaled weighted sum with categorical bumps (default).
+    Weighted,
+    /// Per-signal percentile rank within the analyzed set, averaged.
+    Percentile,
+}
+
+impl From<RiskFormulaArg> for big_code_analysis::vcs::RiskFormula {
+    fn from(arg: RiskFormulaArg) -> Self {
+        match arg {
+            RiskFormulaArg::Weighted => Self::Weighted,
+            RiskFormulaArg::Percentile => Self::Percentile,
+        }
+    }
+}
+
+/// Flags for `bca vcs` — change-history (VCS) metrics over a git
+/// working tree (issue #328). Path / include / exclude / exclude-tests /
+/// no-ignore are inherited from the global options.
+#[derive(Args, Debug)]
+struct VcsArgs {
+    /// Output format and destination (shared with `metrics`/`ops`). When
+    /// no format is given, a human-readable ranked table is printed.
+    #[clap(flatten)]
+    structured: StructuredArgs,
+    /// Long observation window (`12mo`, `2y`, `52w`, `365d`, or ISO 8601
+    /// `P1Y`).
+    #[clap(long, default_value = "12mo")]
+    long_window: String,
+    /// Recent observation window.
+    #[clap(long, default_value = "90d")]
+    recent_window: String,
+    /// Show only the top N files by risk score (`0` = all).
+    #[clap(long, default_value_t = 50)]
+    top: usize,
+    /// Revision to analyze.
+    #[clap(long = "ref", default_value = "HEAD")]
+    reference: String,
+    /// Walk the full commit DAG rather than first-parent only.
+    #[clap(long)]
+    full_history: bool,
+    /// Include merge commits (skipped by default).
+    #[clap(long)]
+    include_merges: bool,
+    /// Do not follow file renames across history.
+    #[clap(long)]
+    no_follow_renames: bool,
+    /// Do not exclude bot author identities.
+    #[clap(long)]
+    no_exclude_bots: bool,
+    /// Override the bot-author exclusion regex.
+    #[clap(long)]
+    bot_pattern: Option<String>,
+    /// Reference "now" for reproducible runs (RFC 3339, `@unix`, or any
+    /// git date spelling). Defaults to wall-clock time.
+    #[clap(long)]
+    as_of: Option<String>,
+    /// Composite risk-score formula.
+    #[clap(long, value_enum, default_value_t = RiskFormulaArg::Weighted)]
+    risk_formula: RiskFormulaArg,
+    /// Emit SHA-256-hashed canonical author identities.
+    #[clap(long)]
+    emit_author_details: bool,
+    /// Emit stats for files deleted at the target ref.
+    #[clap(long)]
+    include_deleted: bool,
+}
+
+/// Flags for `bca metrics`: the shared structured-output set plus an
+/// opt-in to attach change-history (VCS) metrics to each file.
+#[derive(Args, Debug)]
+struct MetricsArgs {
+    #[clap(flatten)]
+    structured: StructuredArgs,
+    /// Also compute change-history (VCS) metrics and attach a `vcs`
+    /// block — plus a `hotspot_score` (cyclomatic × recent churn) — to
+    /// each file's metrics. Uses default windows (12mo / 90d, weighted
+    /// formula); for window / formula tuning use `bca vcs`. Outside a
+    /// git working tree this opt-in is skipped with a warning (the AST
+    /// metrics still emit, without the `vcs` block).
+    #[clap(long)]
+    vcs: bool,
 }
 
 #[derive(Args, Debug)]
@@ -1091,6 +1183,12 @@ struct Config {
     /// hashing cost (only for offending functions) is paid only when the
     /// flag is set. Meaningful only for `Action::Check`.
     fuzzy_baseline: bool,
+    /// Pre-built change-history index, shared read-only across workers,
+    /// set by `bca metrics --vcs`. When present, the per-file metrics
+    /// dispatch attaches the matching `vcs` block (plus a hotspot score
+    /// derived from the file's cyclomatic sum) to each file-level space.
+    /// `None` for every other flow. Issue #328.
+    vcs_index: Option<Arc<big_code_analysis::vcs::HistoryIndex>>,
 }
 
 impl Config {
@@ -1128,6 +1226,8 @@ impl Config {
             // Defaults off; `run_check_walk` flips it on for the check
             // action when `--baseline-fuzzy-match` is set.
             fuzzy_baseline: false,
+            // Set by `run_command_metrics` only when `--vcs` is passed.
+            vcs_index: None,
         }
     }
 
@@ -1617,6 +1717,7 @@ fn write_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
 const SUBCOMMANDS: &[&str] = &[
     "metrics",
     "ops",
+    "vcs",
     "report",
     "dump",
     "find",

--- a/big-code-analysis-cli/src/lib_tests.rs
+++ b/big-code-analysis-cli/src/lib_tests.rs
@@ -94,6 +94,74 @@ fn metrics_accepts_deprecated_output_format_alias() {
     );
 }
 
+// `bca vcs` (issue #328) wires a dozen flags, several of which are
+// boolean opt-outs (`--no-follow-renames`, `--no-exclude-bots`) or
+// renamed (`--ref` → `reference`) — exactly the bindings a parse test
+// pins against a future field-swap. Inspect the parsed `VcsArgs`, not
+// just `is_ok`.
+fn parse_vcs(argv: &[&str]) -> VcsArgs {
+    match parse(argv).expect("vcs invocation parses").command {
+        Command::Vcs(args) => *args,
+        other => panic!("expected Command::Vcs, got {other:?}"),
+    }
+}
+
+#[test]
+fn vcs_alone_uses_documented_defaults() {
+    let args = parse_vcs(&["vcs"]);
+    assert_eq!(args.long_window, "12mo");
+    assert_eq!(args.recent_window, "90d");
+    assert_eq!(args.top, 50);
+    assert_eq!(args.reference, "HEAD");
+    assert_eq!(args.risk_formula, RiskFormulaArg::Weighted);
+    assert!(!args.full_history);
+    assert!(!args.include_merges);
+    // Follow-renames / exclude-bots are ON unless the `--no-` flag is
+    // passed, so the parsed opt-out booleans default false.
+    assert!(!args.no_follow_renames);
+    assert!(!args.no_exclude_bots);
+    assert!(args.bot_pattern.is_none());
+    assert!(!args.include_deleted);
+    assert!(!args.emit_author_details);
+}
+
+#[test]
+fn vcs_flags_bind_to_their_fields() {
+    let args = parse_vcs(&[
+        "vcs",
+        "--ref",
+        "release/1.x",
+        "--risk-formula",
+        "percentile",
+        "--top",
+        "10",
+        "--long-window",
+        "2y",
+        "--recent-window",
+        "30d",
+        "--full-history",
+        "--include-merges",
+        "--no-follow-renames",
+        "--no-exclude-bots",
+        "--bot-pattern",
+        "\\[bot\\]$",
+        "--include-deleted",
+        "--emit-author-details",
+    ]);
+    assert_eq!(args.reference, "release/1.x");
+    assert_eq!(args.risk_formula, RiskFormulaArg::Percentile);
+    assert_eq!(args.top, 10);
+    assert_eq!(args.long_window, "2y");
+    assert_eq!(args.recent_window, "30d");
+    assert!(args.full_history);
+    assert!(args.include_merges);
+    assert!(args.no_follow_renames);
+    assert!(args.no_exclude_bots);
+    assert_eq!(args.bot_pattern.as_deref(), Some("\\[bot\\]$"));
+    assert!(args.include_deleted);
+    assert!(args.emit_author_details);
+}
+
 // Offender formats (Checkstyle, SARIF, clang-warning,
 // msvc-warning) moved from `bca metrics` to
 // `bca check --output-format` in issue #235. `MetricsFormat` no

--- a/big-code-analysis-cli/src/lib_tests.rs
+++ b/big-code-analysis-cli/src/lib_tests.rs
@@ -73,7 +73,7 @@ fn metrics_with_format_parses() {
 // wrong field — or dropped the alias — is caught.
 fn metrics_output_format(argv: &[&str]) -> Option<MetricsFormat> {
     match parse(argv).expect("metrics invocation parses").command {
-        Command::Metrics(args) => args.output_format,
+        Command::Metrics(args) => args.structured.output_format,
         other => panic!("expected Command::Metrics, got {other:?}"),
     }
 }

--- a/big-code-analysis-cli/src/vcs_command.rs
+++ b/big-code-analysis-cli/src/vcs_command.rs
@@ -357,6 +357,12 @@ pub(crate) fn default_index(globals: &GlobalOpts) -> Option<Arc<vcs::HistoryInde
 /// Resolve the repository-discovery seed to a directory: `gix::discover`
 /// rejects a file path, so a file seed (`--paths src/foo.rs`) is mapped
 /// to its parent. Defaults to the current directory.
+///
+/// Only the **first** seed is used to discover the repository, so a
+/// multi-repo invocation (`bca vcs ~/repoA ~/repoB`) indexes `repoA`
+/// only; files under a second, different working tree fall outside the
+/// single index and are simply absent from the ranking (omitted, never
+/// misattributed). Whole-repo single-root analysis is the intended use.
 fn resolve_root(globals: &GlobalOpts) -> PathBuf {
     let seed = globals
         .paths

--- a/big-code-analysis-cli/src/vcs_command.rs
+++ b/big-code-analysis-cli/src/vcs_command.rs
@@ -1,0 +1,390 @@
+// bca: suppress-file(halstead, nargs, exit, nom)
+// File-level halstead/nargs/exit/nom are many-fn aggregation artifacts
+// (the options-builder + rank/emit/CSV plumbing), not per-function
+// logic complexity (cognitive/cyclomatic stay enforced).
+
+//! `bca vcs` — rank files by change-history (VCS) risk (issue #328).
+//!
+//! Unlike the AST commands, this runs **one** history walk over the
+//! whole repository (never per file), reuses the global walk filters to
+//! pick which tracked files to report, ranks them by composite risk
+//! score, and emits either a human-readable table (default) or a
+//! structured document (`--format json|yaml|toml|cbor|csv`).
+
+use std::collections::HashSet;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use serde::Serialize;
+
+use big_code_analysis::FuncSpace;
+use big_code_analysis::vcs::{
+    self, Options, build_history_index, hotspot, parse_timestamp, parse_window, score, stats,
+};
+use big_code_analysis::wire;
+
+use crate::die;
+use crate::formats::{CBOR_STDOUT_ERROR, MetricsDispatch, MetricsFormat};
+use crate::{GlobalOpts, VcsArgs};
+
+/// One ranked file in the report: its repo-relative path plus the flat
+/// VCS metric block.
+#[derive(Debug, Serialize)]
+struct FileEntry {
+    path: String,
+    #[serde(flatten)]
+    vcs: wire::Vcs,
+}
+
+/// The full `bca vcs` report. The window lengths and version stamps are
+/// hoisted to the top so a consumer reads them once, not per file.
+#[derive(Debug, Serialize)]
+struct Report {
+    long_window_days: u32,
+    recent_window_days: u32,
+    risk_score_version: u32,
+    vcs_schema_version: u32,
+    truncated_shallow_clone: bool,
+    files: Vec<FileEntry>,
+}
+
+/// Entry point for `Command::Vcs`.
+pub(crate) fn run(mut globals: GlobalOpts, args: VcsArgs) {
+    let options = build_options(&args);
+
+    // Default the walk root to the current directory so a bare
+    // `bca vcs` ranks the repository the user is standing in.
+    if globals.paths.is_empty() {
+        globals.paths.push(PathBuf::from("."));
+    }
+    let root = resolve_root(&globals);
+
+    let index = build_history_index(&root, &options).unwrap_or_else(|e| die(format_args!("{e}")));
+    if index.truncated_shallow_clone() {
+        eprintln!(
+            "Warning: shallow clone detected — history is truncated, so counts are lower bounds"
+        );
+    }
+
+    let entries = rank(&globals, &index, args.top, args.include_deleted);
+    let report = Report {
+        long_window_days: options.long_window_days(),
+        recent_window_days: options.recent_window_days(),
+        risk_score_version: score::RISK_SCORE_VERSION,
+        vcs_schema_version: stats::VCS_SCHEMA_VERSION,
+        truncated_shallow_clone: index.truncated_shallow_clone(),
+        files: entries,
+    };
+
+    emit(&report, &args).unwrap_or_else(|e| die(format_args!("writing vcs output: {e}")));
+}
+
+/// Translate [`VcsArgs`] into a backend [`Options`], dying on a bad
+/// window or timestamp.
+fn build_options(args: &VcsArgs) -> Options {
+    let long_window_secs =
+        parse_window(&args.long_window).unwrap_or_else(|e| die(format_args!("{e}")));
+    let recent_window_secs =
+        parse_window(&args.recent_window).unwrap_or_else(|e| die(format_args!("{e}")));
+    let as_of = args
+        .as_of
+        .as_deref()
+        .map(|raw| parse_timestamp(raw).unwrap_or_else(|e| die(format_args!("{e}"))));
+
+    Options {
+        long_window_secs,
+        recent_window_secs,
+        reference: args.reference.clone(),
+        full_history: args.full_history,
+        include_merges: args.include_merges,
+        follow_renames: !args.no_follow_renames,
+        exclude_bots: !args.no_exclude_bots,
+        bot_pattern: args
+            .bot_pattern
+            .clone()
+            .unwrap_or_else(|| vcs::options::DEFAULT_BOT_PATTERN.to_owned()),
+        as_of,
+        risk_formula: args.risk_formula.into(),
+        emit_author_details: args.emit_author_details,
+        include_deleted: args.include_deleted,
+    }
+}
+
+/// Select the tracked files the global filters admit, sort them by risk
+/// score (descending; path as a stable tie-break), and truncate to the
+/// top `top` (0 = all).
+fn rank(
+    globals: &GlobalOpts,
+    index: &vcs::HistoryIndex,
+    top: usize,
+    include_deleted: bool,
+) -> Vec<FileEntry> {
+    // Reuse the standard walk so `--paths/--include/--exclude/--no-ignore`
+    // behave exactly as elsewhere; intersect the result with the tracked
+    // set (untracked / binary files are simply absent from the index).
+    let (selected, _jobs) = crate::resolve_walk_files(globals.clone());
+
+    let mut covered: HashSet<PathBuf> = HashSet::new();
+    let mut entries: Vec<FileEntry> = selected
+        .iter()
+        .filter_map(|abs| lookup(index, abs))
+        .filter_map(|(rel, stat)| {
+            let path = path_to_string(&rel)?;
+            covered.insert(rel.clone());
+            Some(FileEntry {
+                path,
+                vcs: wire::Vcs::from(stat),
+            })
+        })
+        .collect();
+
+    // Files deleted at the target ref never appear in the on-disk walk,
+    // so pull them straight from the index when opted in.
+    if include_deleted {
+        append_deleted_entries(&mut entries, &covered, globals, index);
+    }
+
+    vcs::rank_by_risk(&mut entries, top, |e| (e.path.as_str(), e.vcs.risk_score));
+    entries
+}
+
+/// Append entries for files present in the index but absent from the
+/// on-disk walk (deleted at the target ref), filtered to the requested
+/// `--paths` prefixes. The index carries deleted files only when the
+/// walk ran with `include_deleted`.
+fn append_deleted_entries(
+    entries: &mut Vec<FileEntry>,
+    covered: &HashSet<PathBuf>,
+    globals: &GlobalOpts,
+    index: &vcs::HistoryIndex,
+) {
+    let prefixes = repo_relative_prefixes(globals, index);
+    for (rel, stat) in index.iter() {
+        if covered.contains(rel) || !under_any_prefix(rel, &prefixes) {
+            continue;
+        }
+        if let Some(path) = path_to_string(rel) {
+            entries.push(FileEntry {
+                path,
+                vcs: wire::Vcs::from(stat),
+            });
+        }
+    }
+}
+
+/// Resolve the `--paths` seeds to repo-relative prefixes for filtering
+/// deleted-file entries. An empty result means "no usable prefix"; an
+/// empty `PathBuf` prefix (the repo root, e.g. from `.`) matches every
+/// entry.
+fn repo_relative_prefixes(globals: &GlobalOpts, index: &vcs::HistoryIndex) -> Vec<PathBuf> {
+    let Some(workdir) = index.workdir() else {
+        return Vec::new();
+    };
+    globals
+        .paths
+        .iter()
+        .filter_map(|seed| {
+            let canonical = seed.canonicalize().ok()?;
+            canonical.strip_prefix(workdir).ok().map(Path::to_path_buf)
+        })
+        .collect()
+}
+
+/// Whether `rel` sits under any of the repo-relative `prefixes`.
+fn under_any_prefix(rel: &Path, prefixes: &[PathBuf]) -> bool {
+    prefixes.iter().any(|prefix| rel.starts_with(prefix))
+}
+
+/// Map a walk-selected filesystem path to its index entry, returning the
+/// repo-relative path alongside the stats. Paths are canonicalised so a
+/// relative seed (`./src/x.rs`) still strips the work-tree prefix.
+fn lookup<'a>(index: &'a vcs::HistoryIndex, abs: &Path) -> Option<(PathBuf, &'a vcs::Stats)> {
+    let canonical = abs.canonicalize().ok()?;
+    let workdir = index.workdir()?;
+    let rel = canonical.strip_prefix(workdir).ok()?;
+    index.get(rel).map(|stat| (rel.to_path_buf(), stat))
+}
+
+/// Convert a repo-relative path to a UTF-8 string for output, warning
+/// and skipping (rather than lossily mangling) a non-UTF-8 path used as
+/// an output identifier — per the path rules in AGENTS.md.
+fn path_to_string(path: &Path) -> Option<String> {
+    path.to_str().map(str::to_owned).or_else(|| {
+        eprintln!("Warning: skipping non-UTF-8 path {}", path.display());
+        None
+    })
+}
+
+/// Render the report in the requested format (or the default table).
+fn emit(report: &Report, args: &VcsArgs) -> std::io::Result<()> {
+    match args.structured.output_format {
+        None => write_table(report),
+        Some(MetricsFormat::Csv) => write_csv(report, args.structured.output.as_ref()),
+        Some(MetricsFormat::Cbor) if args.structured.output.is_none() => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            CBOR_STDOUT_ERROR,
+        )),
+        Some(other) => match other.dispatch() {
+            MetricsDispatch::Generic(generic) => generic.dump(
+                report,
+                PathBuf::from("vcs"),
+                args.structured.output.as_ref(),
+                args.structured.pretty,
+            ),
+            // Csv handled above; Cbor-to-stdout rejected above.
+            MetricsDispatch::Csv => unreachable!("csv handled before dispatch"),
+        },
+    }
+}
+
+/// A human-readable ranked table to stdout — the default output and the
+/// successor to the prototype's ranked list.
+fn write_table(report: &Report) -> std::io::Result<()> {
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    if report.files.is_empty() {
+        return writeln!(out, "No tracked files matched.");
+    }
+    writeln!(
+        out,
+        "Change-history risk (long window {}d, recent {}d, formula v{})",
+        report.long_window_days, report.recent_window_days, report.risk_score_version
+    )?;
+    writeln!(
+        out,
+        "{:>5}  {:>8}  {:>11}  {:>11}  {:>7}  FILE",
+        "RANK", "RISK", "COMMITS r/l", "CHURN r/l", "AUTHORS"
+    )?;
+    for (rank, entry) in report.files.iter().enumerate() {
+        let v = &entry.vcs;
+        writeln!(
+            out,
+            "{:>5}  {:>8.1}  {:>11}  {:>11}  {:>7}  {}",
+            rank + 1,
+            v.risk_score,
+            format!("{}/{}", v.commits_recent, v.commits_long),
+            format!("{}/{}", v.churn_recent, v.churn_long),
+            v.authors_long,
+            entry.path,
+        )?;
+    }
+    Ok(())
+}
+
+/// CSV output: one flat row per file. Written by hand (rather than
+/// serde) because the `#[serde(flatten)]` shape isn't representable in
+/// the `csv` crate's record model.
+fn write_csv(report: &Report, output: Option<&PathBuf>) -> std::io::Result<()> {
+    let sink: Box<dyn Write> = match output {
+        Some(path) => Box::new(std::fs::File::create(path)?),
+        None => Box::new(std::io::stdout().lock()),
+    };
+    let mut wtr = csv::Writer::from_writer(sink);
+    wtr.write_record([
+        "path",
+        "risk_score",
+        "commits_long",
+        "commits_recent",
+        "churn_long",
+        "churn_recent",
+        "authors_long",
+        "authors_recent",
+        "ownership_top_share",
+        "burst",
+        "bug_fix_commits",
+        "security_fix_commits",
+        "revert_commits",
+        "age_days",
+        "last_modified_days",
+        "hotspot_score",
+    ])
+    .map_err(csv_err)?;
+    for entry in &report.files {
+        let v = &entry.vcs;
+        wtr.write_record([
+            entry.path.as_str(),
+            &format!("{:.4}", v.risk_score),
+            &v.commits_long.to_string(),
+            &v.commits_recent.to_string(),
+            &v.churn_long.to_string(),
+            &v.churn_recent.to_string(),
+            &v.authors_long.to_string(),
+            &v.authors_recent.to_string(),
+            &format!("{:.4}", v.ownership_top_share),
+            &format!("{:.4}", v.burst),
+            &v.bug_fix_commits.to_string(),
+            &v.security_fix_commits.to_string(),
+            &v.revert_commits.to_string(),
+            &v.age_days.to_string(),
+            &v.last_modified_days.to_string(),
+            &v.hotspot_score
+                .map(|h| format!("{h:.4}"))
+                .unwrap_or_default(),
+        ])
+        .map_err(csv_err)?;
+    }
+    wtr.flush()
+}
+
+/// Map a `csv` error into an `io::Error` for the unified `emit` result.
+fn csv_err(error: csv::Error) -> std::io::Error {
+    std::io::Error::other(error)
+}
+
+/// Build a change-history index with **default** windows for
+/// `bca metrics --vcs`, rooted at the first `--paths` seed (or the
+/// current directory). Window / formula tuning is reserved for the
+/// dedicated `bca vcs` command.
+///
+/// Unlike `bca vcs` (which errors outside a repository), `--vcs` is an
+/// *additive opt-in* on the AST walk: when there is no git working tree
+/// (or `HEAD` is unborn), it warns once and returns `None` so the rest
+/// of the metrics output is still produced with the `vcs` block simply
+/// omitted (issue #328; matches the Python `analyze(vcs=True)`
+/// behaviour). Returned in an [`Arc`] so the per-file walk workers
+/// share one read-only index.
+pub(crate) fn default_index(globals: &GlobalOpts) -> Option<Arc<vcs::HistoryIndex>> {
+    match build_history_index(&resolve_root(globals), &Options::default()) {
+        Ok(index) => Some(Arc::new(index)),
+        Err(e) => {
+            eprintln!("warning: --vcs: {e}; change-history metrics omitted");
+            None
+        }
+    }
+}
+
+/// Resolve the repository-discovery seed to a directory: `gix::discover`
+/// rejects a file path, so a file seed (`--paths src/foo.rs`) is mapped
+/// to its parent. Defaults to the current directory.
+fn resolve_root(globals: &GlobalOpts) -> PathBuf {
+    let seed = globals
+        .paths
+        .first()
+        .cloned()
+        .unwrap_or_else(|| PathBuf::from("."));
+    if seed.is_file() {
+        seed.parent()
+            .map(Path::to_path_buf)
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or_else(|| PathBuf::from("."))
+    } else {
+        seed
+    }
+}
+
+/// Attach the file's change-history block to its file-level metrics,
+/// filling in the hotspot score from the cyclomatic sum already on the
+/// space. A file with no index entry (untracked / binary) is left
+/// untouched, so its `vcs` field stays `None`.
+pub(crate) fn inject(space: &mut FuncSpace, path: &Path, index: &vcs::HistoryIndex) {
+    let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let Some(stat) = index.get_for_path(&canonical) else {
+        return;
+    };
+    let mut stat = stat.clone();
+    #[allow(clippy::cast_precision_loss)]
+    let complexity = space.metrics.cyclomatic.cyclomatic_sum() as f64;
+    stat.hotspot_score = Some(hotspot::hotspot_score(complexity, stat.churn_recent));
+    space.metrics.vcs = Some(stat);
+}

--- a/big-code-analysis-cli/src/vcs_command.rs
+++ b/big-code-analysis-cli/src/vcs_command.rs
@@ -210,10 +210,18 @@ fn lookup<'a>(index: &'a vcs::HistoryIndex, abs: &Path) -> Option<(PathBuf, &'a 
 /// and skipping (rather than lossily mangling) a non-UTF-8 path used as
 /// an output identifier — per the path rules in AGENTS.md.
 fn path_to_string(path: &Path) -> Option<String> {
-    path.to_str().map(str::to_owned).or_else(|| {
-        eprintln!("Warning: skipping non-UTF-8 path {}", path.display());
-        None
-    })
+    // Repo-relative paths are git paths and must be emitted forward-slash
+    // so the JSON / CSV / table output is byte-identical across platforms.
+    // The on-disk walk in `rank` yields OS-native separators on Windows
+    // (`strip_prefix` of a canonicalized path → `src\work.rs`), so
+    // normalize at this single output chokepoint. Mirrors
+    // `metric_diff::path_to_key`.
+    path.to_str()
+        .map(|s| s.replace(std::path::MAIN_SEPARATOR, "/"))
+        .or_else(|| {
+            eprintln!("Warning: skipping non-UTF-8 path {}", path.display());
+            None
+        })
 }
 
 /// Render the report in the requested format (or the default table).
@@ -393,4 +401,20 @@ pub(crate) fn inject(space: &mut FuncSpace, path: &Path, index: &vcs::HistoryInd
     let complexity = space.metrics.cyclomatic.cyclomatic_sum() as f64;
     stat.hotspot_score = Some(hotspot::hotspot_score(complexity, stat.churn_recent));
     space.metrics.vcs = Some(stat);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn path_to_string_normalizes_separators_to_forward_slash() {
+        // A path assembled from components uses the OS separator (`\` on
+        // Windows, `/` on Unix); the emitted git path must always be
+        // forward-slash so the JSON / CSV / table output is byte-identical
+        // cross-platform. On Windows this guards the `src\work.rs`
+        // regression that failed `tests/vcs.rs` on windows-latest.
+        let rel: PathBuf = ["src", "work.rs"].iter().collect();
+        assert_eq!(path_to_string(&rel).as_deref(), Some("src/work.rs"));
+    }
 }

--- a/big-code-analysis-cli/tests/vcs.rs
+++ b/big-code-analysis-cli/tests/vcs.rs
@@ -1,0 +1,274 @@
+//! End-to-end tests for `bca vcs` and `bca metrics --vcs` (issue #328).
+//!
+//! Each builds a throwaway git repo with fixed author identities and
+//! commit timestamps dated relative to wall-clock now, so the per-window
+//! counts are deterministic across runs.
+
+#![allow(clippy::doc_markdown)]
+
+use std::path::Path;
+use std::process::Command as StdCommand;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+mod common;
+
+const DAY: i64 = 86_400;
+
+fn cli() -> Command {
+    common::bca_command()
+}
+
+/// Wall-clock "now" in Unix seconds. Both `bca vcs` and `bca metrics
+/// --vcs` default to wall-clock time, so fixture commits are dated
+/// relative to this; the *relative* offsets (and hence the counts) stay
+/// deterministic across runs.
+fn now() -> i64 {
+    i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_secs(),
+    )
+    .expect("now fits i64")
+}
+
+/// Run `git <args>` in `dir` at commit time `secs`, asserting success.
+fn git_at(dir: &Path, secs: i64, args: &[&str]) {
+    let date = format!("@{secs} +0000");
+    let status = StdCommand::new("git")
+        .args(args)
+        .current_dir(dir)
+        .env("GIT_AUTHOR_NAME", "Ada")
+        .env("GIT_AUTHOR_EMAIL", "ada@example.com")
+        .env("GIT_AUTHOR_DATE", &date)
+        .env("GIT_COMMITTER_NAME", "Ada")
+        .env("GIT_COMMITTER_EMAIL", "ada@example.com")
+        .env("GIT_COMMITTER_DATE", &date)
+        .status()
+        .expect("spawn git");
+    assert!(status.success(), "git {args:?} failed");
+}
+
+/// A repo with `src/work.rs` committed twice: once 200 days ago (long
+/// window only) and once 5 days ago (recent window).
+fn repo_two_commits() -> TempDir {
+    let now = now();
+    let dir = tempfile::tempdir().expect("tempdir");
+    git_at(dir.path(), now, &["init", "-q", "-b", "main"]);
+    git_at(dir.path(), now, &["config", "commit.gpgsign", "false"]);
+    std::fs::create_dir(dir.path().join("src")).expect("mkdir");
+    std::fs::write(dir.path().join("src/work.rs"), "fn a() {}\n").expect("write");
+    git_at(dir.path(), now - 200 * DAY, &["add", "."]);
+    git_at(
+        dir.path(),
+        now - 200 * DAY,
+        &["commit", "-q", "-m", "add work"],
+    );
+    std::fs::write(dir.path().join("src/work.rs"), "fn a() {}\nfn b() {}\n").expect("write");
+    git_at(
+        dir.path(),
+        now - 5 * DAY,
+        &["commit", "-aqm", "fix bug in work"],
+    );
+    dir
+}
+
+#[test]
+fn vcs_json_ranks_the_tracked_file() {
+    let repo = repo_two_commits();
+    let assert = cli()
+        .current_dir(repo.path())
+        .args(["vcs", "--paths", ".", "--format", "json"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8");
+    let doc: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+
+    let files = doc["files"].as_array().expect("files array");
+    let work = files
+        .iter()
+        .find(|f| f["path"] == "src/work.rs")
+        .expect("src/work.rs ranked");
+    assert_eq!(work["commits_long"], 2);
+    assert_eq!(work["commits_recent"], 1, "only the 5-day commit is recent");
+    assert_eq!(
+        work["bug_fix_commits"], 1,
+        "the second commit message says 'fix bug'"
+    );
+    assert_eq!(work["authors_long"], 1);
+    assert_eq!(doc["long_window_days"], 365);
+}
+
+#[test]
+fn vcs_table_is_the_default_output() {
+    let repo = repo_two_commits();
+    cli()
+        .current_dir(repo.path())
+        .args(["vcs", "--paths", "."])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("RANK").and(predicate::str::contains("src/work.rs")));
+}
+
+#[test]
+fn metrics_vcs_attaches_a_block_with_hotspot() {
+    let repo = repo_two_commits();
+    let assert = cli()
+        .current_dir(repo.path())
+        .args([
+            "metrics",
+            "--vcs",
+            "--paths",
+            "src/work.rs",
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8");
+    let doc: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    let vcs = &doc["metrics"]["vcs"];
+    assert!(vcs.is_object(), "metrics.vcs block present");
+    assert_eq!(vcs["commits_long"], 2);
+    // hotspot = cyclomatic_sum × churn_recent; both factors are positive
+    // for this fixture, so the product must be strictly positive — a
+    // zeroed or dropped-multiplier bug fails this, unlike `is_number`.
+    let hotspot = vcs["hotspot_score"]
+        .as_f64()
+        .expect("hotspot_score is a number");
+    assert!(hotspot > 0.0, "hotspot_score positive, got {hotspot}");
+}
+
+#[test]
+fn metrics_without_vcs_flag_has_no_block() {
+    let repo = repo_two_commits();
+    let assert = cli()
+        .current_dir(repo.path())
+        .args(["metrics", "--paths", "src/work.rs", "--format", "json"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8");
+    let doc: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    assert!(
+        doc["metrics"].get("vcs").is_none(),
+        "no vcs block without --vcs"
+    );
+}
+
+#[test]
+fn vcs_outside_a_repo_errors_with_nonzero_exit() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    cli()
+        .current_dir(dir.path())
+        .args(["vcs", "--paths", "."])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("version-control"));
+}
+
+#[test]
+fn metrics_vcs_outside_repo_warns_and_still_emits() {
+    // `--vcs` is an additive opt-in: outside a git repo it must NOT abort
+    // the metrics run — it warns and omits the vcs block (issue #328).
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("work.rs"), "fn a() {}\n").expect("write");
+    let assert = cli()
+        .current_dir(dir.path())
+        .args(["metrics", "--vcs", "--paths", "work.rs", "--format", "json"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("warning"));
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8");
+    let doc: serde_json::Value = serde_json::from_str(&stdout).expect("json still emitted");
+    assert!(
+        doc["metrics"].get("cyclomatic").is_some(),
+        "AST metrics still present"
+    );
+    assert!(
+        doc["metrics"].get("vcs").is_none(),
+        "vcs block omitted outside a repo"
+    );
+}
+
+#[test]
+fn vcs_csv_format_emits_header() {
+    let repo = repo_two_commits();
+    cli()
+        .current_dir(repo.path())
+        .args(["vcs", "--paths", ".", "--format", "csv"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("path,risk_score,commits_long")
+                .and(predicate::str::contains("src/work.rs")),
+        );
+}
+
+#[test]
+fn vcs_emit_author_details_controls_author_ids() {
+    let repo = repo_two_commits();
+    // Returns the `author_ids` field via the object accessor so an
+    // *absent* key (serde-skipped) is distinguished from an explicit
+    // `null` — indexing would conflate the two.
+    let ids = |extra: &[&str]| -> Option<serde_json::Value> {
+        let mut args = vec!["vcs", "--paths", ".", "--format", "json"];
+        args.extend_from_slice(extra);
+        let assert = cli().current_dir(repo.path()).args(args).assert().success();
+        let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8");
+        let doc: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+        doc["files"][0].get("author_ids").cloned()
+    };
+    // Off by default; opt-in surfaces a (sorted) array of hashed ids.
+    assert!(ids(&[]).is_none(), "author_ids key absent by default");
+    let with = ids(&["--emit-author-details"]).expect("author_ids present under the flag");
+    let arr = with.as_array().expect("author_ids is an array");
+    assert!(!arr.is_empty());
+    assert!(
+        arr[0].as_str().is_some_and(|h| h.len() == 64),
+        "SHA-256 hex"
+    );
+}
+
+#[test]
+fn vcs_include_deleted_surfaces_removed_file() {
+    let now = now();
+    let repo = tempfile::tempdir().expect("tempdir");
+    git_at(repo.path(), now, &["init", "-q", "-b", "main"]);
+    git_at(repo.path(), now, &["config", "commit.gpgsign", "false"]);
+    std::fs::write(repo.path().join("gone.rs"), "fn g() {}\n").expect("write");
+    git_at(repo.path(), now - 30 * DAY, &["add", "."]);
+    git_at(repo.path(), now - 30 * DAY, &["commit", "-qm", "add gone"]);
+    git_at(repo.path(), now - 10 * DAY, &["rm", "-q", "gone.rs"]);
+    std::fs::write(repo.path().join("kept.rs"), "fn k() {}\n").expect("write");
+    git_at(repo.path(), now - 10 * DAY, &["add", "."]);
+    git_at(
+        repo.path(),
+        now - 10 * DAY,
+        &["commit", "-qm", "remove gone"],
+    );
+
+    let paths = |extra: &[&str]| -> Vec<String> {
+        let mut args = vec!["vcs", "--paths", ".", "--format", "json"];
+        args.extend_from_slice(extra);
+        let assert = cli().current_dir(repo.path()).args(args).assert().success();
+        let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8");
+        let doc: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+        doc["files"]
+            .as_array()
+            .expect("files")
+            .iter()
+            .map(|f| f["path"].as_str().unwrap_or_default().to_owned())
+            .collect()
+    };
+    // Default ranking omits the deleted file (it is not on disk); the
+    // opt-in pulls it from the index via `append_deleted_entries`.
+    assert!(!paths(&[]).iter().any(|p| p == "gone.rs"));
+    assert!(
+        paths(&["--include-deleted"]).iter().any(|p| p == "gone.rs"),
+        "deleted file surfaced with --include-deleted"
+    );
+}

--- a/big-code-analysis-py/Cargo.toml
+++ b/big-code-analysis-py/Cargo.toml
@@ -37,8 +37,14 @@ crate-type = ["cdylib", "rlib"]
 default = ["pyo3/auto-initialize"]
 
 [dependencies]
-big-code-analysis = { path = "..", default-features = true }
+# `vcs` adds the change-history backend for `vcs_metrics()` and the
+# `analyze(..., vcs=True)` opt-in (issue #328), on top of the default
+# `all-languages`.
+big-code-analysis = { path = "..", default-features = true, features = ["vcs"] }
 pyo3 = { workspace = true }
+# `serde` (derive) builds the `vcs_metrics()` report struct that is
+# serialized to JSON and handed to the conversion layer (issue #328).
+serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]

--- a/big-code-analysis-py/python/big_code_analysis/__init__.py
+++ b/big-code-analysis-py/python/big_code_analysis/__init__.py
@@ -34,6 +34,7 @@ from ._native import (
     language_extensions,
     language_for_file,
     to_sarif,
+    vcs_metrics,
 )
 
 #: Canonical metric names, as :class:`MetricName` members. The values
@@ -71,4 +72,5 @@ __all__ = [
     "language_for_file",
     "supported_languages",
     "to_sarif",
+    "vcs_metrics",
 ]

--- a/big-code-analysis-py/python/big_code_analysis/_native.pyi
+++ b/big-code-analysis-py/python/big_code_analysis/_native.pyi
@@ -132,6 +132,7 @@ def analyze(
     allow_lossy_path: bool = False,
     skip_generated: bool = True,
     metrics: Sequence[str] | None = None,
+    vcs: bool = False,
 ) -> dict[str, Any] | None:
     """Compute metrics for the file at ``path``.
 
@@ -252,6 +253,54 @@ def analyze(
         subclass (``FileNotFoundError``, ``PermissionError``,
         ``IsADirectoryError``, …) based on ``errno``, with
         ``err.errno`` and ``err.filename`` populated.
+
+    Pass ``vcs=True`` to attach a ``"vcs"`` block (change-history
+    metrics) to the file's ``metrics`` from a one-shot history walk of
+    the enclosing git repository (issue #328). A ``hotspot_score``
+    (complexity × recent churn) is included only when ``cyclomatic`` is
+    among the computed metrics (it is, unless restricted via
+    ``metrics=``). The block is omitted when the file is untracked,
+    binary, or outside any repository. For ranking a whole repository,
+    prefer :func:`vcs_metrics`, which walks history once.
+    """
+
+def vcs_metrics(
+    repo_path: str | os.PathLike[str],
+    /,
+    *,
+    long_window: str | None = None,
+    recent_window: str | None = None,
+    top: int | None = None,
+    reference: str | None = None,
+    risk_formula: str | None = None,
+    full_history: bool = False,
+    include_merges: bool = False,
+    follow_renames: bool = True,
+    exclude_bots: bool = True,
+    bot_pattern: str | None = None,
+    as_of: str | None = None,
+    emit_author_details: bool = False,
+    include_deleted: bool = False,
+) -> dict[str, Any]:
+    """Rank the files in a git repository by change-history risk.
+
+    The programmatic analogue of ``bca vcs`` (issue #328). ``repo_path``
+    is any path inside the working tree. Returns a ``dict`` with
+    ``long_window_days``, ``recent_window_days``, ``risk_score_version``,
+    ``vcs_schema_version``, ``truncated_shallow_clone``, and a ``files``
+    list of per-file metric dicts (path plus the flat ``vcs`` fields)
+    ranked by descending ``risk_score``.
+
+    Windows accept ``12mo`` / ``2y`` / ``8w`` / ``90d`` or ISO 8601
+    (``P1Y``). ``risk_formula`` is ``"weighted"`` (default) or
+    ``"percentile"``. ``as_of`` (RFC 3339 / ``@unix`` / git date) pins
+    the reference "now" for reproducible snapshots.
+
+    Raises
+    ------
+    ValueError
+        For a malformed window / timestamp / formula, or when
+        ``repo_path`` is not inside a git working tree.
     """
 
 def analyze_source(

--- a/big-code-analysis-py/src/lib.rs
+++ b/big-code-analysis-py/src/lib.rs
@@ -31,6 +31,7 @@ mod codegen;
 mod conversion;
 mod language;
 mod sarif;
+mod vcs;
 
 use std::path::PathBuf;
 
@@ -181,8 +182,8 @@ fn analysis_error_to_py(err: AnalysisError) -> PyErr {
 /// metrics are absent (not `None`) from the result dict; derived
 /// metrics (`mi`, `wmc`) pull their dependencies in automatically.
 #[pyfunction]
-#[pyo3(signature = (path, /, *, exclude_tests = false, allow_lossy_path = false, skip_generated = true, metrics = None))]
-#[allow(clippy::needless_pass_by_value)]
+#[pyo3(signature = (path, /, *, exclude_tests = false, allow_lossy_path = false, skip_generated = true, metrics = None, vcs = false))]
+#[allow(clippy::needless_pass_by_value, clippy::fn_params_excessive_bools)]
 // `path: PathBuf` (rather than `&Path`) is mandated by PyO3's
 // path conversion: `FromPyObject` materializes a fresh `PathBuf`
 // out of the `os.PathLike` argument, and there is no borrow to
@@ -194,6 +195,7 @@ fn analyze(
     allow_lossy_path: bool,
     skip_generated: bool,
     metrics: Option<Vec<String>>,
+    vcs: bool,
 ) -> PyResult<Option<Bound<'_, PyAny>>> {
     // Resolve `metrics=` *before* `py.detach` so a bad name aborts
     // before any file I/O (issue #268 requires the validation to
@@ -214,10 +216,24 @@ fn analyze(
     // `json_string_to_py` materialises the Python `dict`. In PyO3
     // 0.28 the spelling is `Python::detach` (renamed from
     // `allow_threads`).
-    py.detach(|| analysis::analyze_path(&path, opts))
-        .map_err(analysis_error_to_py)?
-        .map(|json| conversion::json_string_to_py(py, &json))
-        .transpose()
+    let result = py
+        .detach(|| analysis::analyze_path(&path, opts))
+        .map_err(analysis_error_to_py)?;
+    // `vcs=True` (#328) attaches a `vcs` block to the file's metrics from
+    // a one-shot history walk of its repository. Done after the GIL is
+    // re-acquired because the injection helper builds Python errors; for
+    // whole-repo ranking prefer `vcs_metrics()`, which walks history once.
+    match result {
+        None => Ok(None),
+        Some(json) => {
+            let json = if vcs {
+                crate::vcs::inject_vcs(json, &path)?
+            } else {
+                json
+            };
+            conversion::json_string_to_py(py, &json).map(Some)
+        }
+    }
     // Keyword-only kwargs stay split at the PyO3 boundary (PyO3 has
     // no struct-literal binding for `#[pyo3(signature)]`); the
     // `AnalyzeOptions` struct lives on the Rust side of the FFI so
@@ -338,6 +354,61 @@ fn language_extensions(language: &str) -> PyResult<Vec<&'static str>> {
         .ok_or_else(|| UnsupportedLanguageError::new_err(language.to_owned()))
 }
 
+/// Rank the files in a git repository by change-history (VCS) risk
+/// (issue #328).
+///
+/// `repo_path` is any path inside the working tree. Returns a dict with
+/// the window lengths, version stamps, a `truncated_shallow_clone`
+/// flag, and a `files` list ranked by descending `risk_score` — the
+/// programmatic analogue of `bca vcs`. Raises `ValueError` for a
+/// malformed window / timestamp / formula, or when `repo_path` is not a
+/// git working tree.
+///
+/// The history walk holds the GIL; for per-file AST + VCS in one pass
+/// use `analyze(path, vcs=True)`.
+#[pyfunction]
+#[pyo3(signature = (repo_path, /, *, long_window = None, recent_window = None, top = None, reference = None, risk_formula = None, full_history = false, include_merges = false, follow_renames = true, exclude_bots = true, bot_pattern = None, as_of = None, emit_author_details = false, include_deleted = false))]
+#[allow(
+    clippy::needless_pass_by_value,
+    clippy::too_many_arguments,
+    clippy::fn_params_excessive_bools
+)]
+fn vcs_metrics(
+    py: Python<'_>,
+    repo_path: PathBuf,
+    long_window: Option<String>,
+    recent_window: Option<String>,
+    top: Option<usize>,
+    reference: Option<String>,
+    risk_formula: Option<String>,
+    full_history: bool,
+    include_merges: bool,
+    follow_renames: bool,
+    exclude_bots: bool,
+    bot_pattern: Option<String>,
+    as_of: Option<String>,
+    emit_author_details: bool,
+    include_deleted: bool,
+) -> PyResult<Bound<'_, PyAny>> {
+    let params = vcs::VcsParams {
+        long_window,
+        recent_window,
+        top,
+        reference,
+        risk_formula,
+        full_history,
+        include_merges,
+        follow_renames,
+        exclude_bots,
+        bot_pattern,
+        as_of,
+        emit_author_details,
+        include_deleted,
+    };
+    let json = vcs::vcs_report_json(&repo_path, &params)?;
+    conversion::json_string_to_py(py, &json)
+}
+
 /// `big_code_analysis._native` module entry point.
 ///
 /// Re-exported by the pure-Python `big_code_analysis` package so
@@ -362,6 +433,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("ParseError", m.py().get_type::<ParseError>())?;
     m.add_class::<PyAnalysisError>()?;
     m.add_function(wrap_pyfunction!(analyze, m)?)?;
+    m.add_function(wrap_pyfunction!(vcs_metrics, m)?)?;
     m.add_function(wrap_pyfunction!(analyze_source, m)?)?;
     m.add_function(wrap_pyfunction!(analyze_batch, m)?)?;
     m.add_function(wrap_pyfunction!(language_for_file, m)?)?;

--- a/big-code-analysis-py/src/vcs.rs
+++ b/big-code-analysis-py/src/vcs.rs
@@ -1,0 +1,184 @@
+// bca: suppress-file(halstead, nargs, exit)
+// File-level halstead/nargs/exit are many-fn aggregation artifacts (the
+// option-builder + report/inject `?` error maps and the many-field
+// report assembly), not per-function logic complexity
+// (cognitive/cyclomatic stay enforced).
+
+//! Bridge for the change-history (VCS) metrics surface exposed to
+//! Python: the standalone [`vcs_report_json`] (backing `vcs_metrics()`)
+//! and [`inject_vcs`] (backing the `analyze(..., vcs=True)` opt-in).
+//!
+//! Both produce / mutate JSON strings, reusing the same
+//! `conversion::json_string_to_py` boundary as the AST entry points, so
+//! the Python side sees ordinary dicts.
+
+use std::path::Path;
+
+use pyo3::PyErr;
+use pyo3::exceptions::PyValueError;
+use serde::Serialize;
+use serde_json::Value;
+
+use big_code_analysis::vcs::{
+    self, Options, build_history_index, hotspot, parse_timestamp, parse_window,
+};
+use big_code_analysis::wire;
+
+/// Knobs accepted from Python, all optional (Python defaults map here).
+// The booleans mirror independent `bca vcs` CLI toggles; a flags
+// newtype would obscure each at the call site for no gain.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Default)]
+pub(crate) struct VcsParams {
+    pub long_window: Option<String>,
+    pub recent_window: Option<String>,
+    pub top: Option<usize>,
+    pub reference: Option<String>,
+    pub risk_formula: Option<String>,
+    pub full_history: bool,
+    pub include_merges: bool,
+    pub follow_renames: bool,
+    pub exclude_bots: bool,
+    pub bot_pattern: Option<String>,
+    pub as_of: Option<String>,
+    pub emit_author_details: bool,
+    pub include_deleted: bool,
+}
+
+/// One ranked file: repo-relative path plus the flat VCS block.
+#[derive(Serialize)]
+struct FileEntry {
+    path: String,
+    #[serde(flatten)]
+    vcs: wire::Vcs,
+}
+
+/// The serialized report shape (matches the CLI / web report).
+#[derive(Serialize)]
+struct Report {
+    long_window_days: u32,
+    recent_window_days: u32,
+    risk_score_version: u32,
+    vcs_schema_version: u32,
+    truncated_shallow_clone: bool,
+    files: Vec<FileEntry>,
+}
+
+/// Build [`Options`] from Python params, surfacing a `ValueError` on a
+/// bad window / timestamp / formula.
+fn options_from(params: &VcsParams) -> Result<Options, PyErr> {
+    let mut options = Options {
+        full_history: params.full_history,
+        include_merges: params.include_merges,
+        follow_renames: params.follow_renames,
+        exclude_bots: params.exclude_bots,
+        emit_author_details: params.emit_author_details,
+        include_deleted: params.include_deleted,
+        ..Options::default()
+    };
+    if let Some(spec) = &params.long_window {
+        options.long_window_secs = parse_window(spec).map_err(vcs_error_to_py)?;
+    }
+    if let Some(spec) = &params.recent_window {
+        options.recent_window_secs = parse_window(spec).map_err(vcs_error_to_py)?;
+    }
+    if let Some(reference) = &params.reference {
+        options.reference.clone_from(reference);
+    }
+    if let Some(pattern) = &params.bot_pattern {
+        options.bot_pattern.clone_from(pattern);
+    }
+    if let Some(raw) = &params.as_of {
+        options.as_of = Some(parse_timestamp(raw).map_err(vcs_error_to_py)?);
+    }
+    if let Some(formula) = &params.risk_formula {
+        options.risk_formula = formula.parse().map_err(vcs_error_to_py)?;
+    }
+    Ok(options)
+}
+
+/// Walk `repo_path`'s history and return the ranked report as a JSON
+/// string for [`crate::conversion::json_string_to_py`].
+///
+/// # Errors
+///
+/// `ValueError` for a bad option or a non-repository path; the walk
+/// itself surfaces its failure the same way.
+pub(crate) fn vcs_report_json(repo_path: &Path, params: &VcsParams) -> Result<String, PyErr> {
+    let options = options_from(params)?;
+    let index = build_history_index(repo_path, &options).map_err(vcs_error_to_py)?;
+
+    let mut files: Vec<FileEntry> = index
+        .iter()
+        .filter_map(|(rel, stat)| {
+            rel.to_str().map(|path| FileEntry {
+                path: path.to_owned(),
+                vcs: wire::Vcs::from(stat),
+            })
+        })
+        .collect();
+    vcs::rank_by_risk(&mut files, params.top.unwrap_or(0), |e| {
+        (e.path.as_str(), e.vcs.risk_score)
+    });
+
+    let report = Report {
+        long_window_days: options.long_window_days(),
+        recent_window_days: options.recent_window_days(),
+        risk_score_version: vcs::score::RISK_SCORE_VERSION,
+        vcs_schema_version: vcs::stats::VCS_SCHEMA_VERSION,
+        truncated_shallow_clone: index.truncated_shallow_clone(),
+        files,
+    };
+    serde_json::to_string(&report)
+        .map_err(|e| PyValueError::new_err(format!("serializing vcs report: {e}")))
+}
+
+/// Inject a `vcs` block into a single file's metrics JSON for
+/// `analyze(..., vcs=True)`. Builds a one-shot index for the file's
+/// repository, attaches the matching block (and a hotspot score from
+/// the cyclomatic sum already present in the JSON), and returns the
+/// rewritten JSON. A file with no index entry (untracked / binary) or
+/// outside any repository is returned unchanged.
+pub(crate) fn inject_vcs(funcspace_json: String, file_path: &Path) -> Result<String, PyErr> {
+    let root = file_path.parent().unwrap_or(Path::new("."));
+    // Discovery failures (not a repo) are non-fatal here: `analyze` still
+    // returns the AST metrics, just without a `vcs` block.
+    let Ok(index) = build_history_index(root, &Options::default()) else {
+        return Ok(funcspace_json);
+    };
+    let canonical = file_path
+        .canonicalize()
+        .unwrap_or_else(|_| file_path.to_path_buf());
+    let Some(stat) = index.get_for_path(&canonical) else {
+        return Ok(funcspace_json);
+    };
+
+    let mut doc: Value = serde_json::from_str(&funcspace_json)
+        .map_err(|e| PyValueError::new_err(format!("parsing metrics JSON: {e}")))?;
+    let mut wire_vcs = wire::Vcs::from(stat);
+    // Hotspot needs the file-level cyclomatic sum, which is already in
+    // the serialized metrics when cyclomatic was computed.
+    if let Some(sum) = doc
+        .get("metrics")
+        .and_then(|m| m.get("cyclomatic"))
+        .and_then(|c| c.get("sum"))
+        .and_then(Value::as_f64)
+    {
+        wire_vcs.hotspot_score = Some(hotspot::hotspot_score(sum, wire_vcs.churn_recent));
+    }
+    let vcs_value = serde_json::to_value(&wire_vcs)
+        .map_err(|e| PyValueError::new_err(format!("serializing vcs block: {e}")))?;
+    if let Some(metrics) = doc.get_mut("metrics").and_then(Value::as_object_mut) {
+        metrics.insert("vcs".to_owned(), vcs_value);
+    }
+    serde_json::to_string(&doc)
+        .map_err(|e| PyValueError::new_err(format!("reserializing metrics JSON: {e}")))
+}
+
+/// Map a [`vcs::Error`] to a Python `ValueError` carrying its message.
+// Taken by value so it composes directly with `Result::map_err`
+// (`.map_err(vcs_error_to_py)`); `to_string` only borrows it.
+#[allow(clippy::needless_pass_by_value)]
+fn vcs_error_to_py(error: vcs::Error) -> PyErr {
+    PyValueError::new_err(error.to_string())
+}

--- a/big-code-analysis-py/tests/test_vcs.py
+++ b/big-code-analysis-py/tests/test_vcs.py
@@ -1,0 +1,100 @@
+"""Tests for the change-history (VCS) bindings (issue #328).
+
+Each builds a throwaway git repo with a fixed author and a commit dated
+relative to wall-clock now (both ``vcs_metrics`` and ``analyze(vcs=True)``
+default to wall-clock time), so per-window counts are deterministic.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import big_code_analysis as bca
+import pytest
+
+
+def _build_repo(root: Path) -> Path:
+    """Init a repo under *root* with ``work.rs`` committed ~5 days ago."""
+    now = int(time.time())
+    date = f"@{now - 5 * 86_400} +0000"
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "Ada",
+        "GIT_AUTHOR_EMAIL": "ada@example.com",
+        "GIT_AUTHOR_DATE": date,
+        "GIT_COMMITTER_NAME": "Ada",
+        "GIT_COMMITTER_EMAIL": "ada@example.com",
+        "GIT_COMMITTER_DATE": date,
+    }
+
+    def git(*args: str) -> None:
+        subprocess.run(["git", *args], cwd=root, env=env, check=True)
+
+    git("init", "-q", "-b", "main")
+    git("config", "commit.gpgsign", "false")
+    (root / "work.rs").write_text("fn a() {}\n")
+    git("add", ".")
+    git("commit", "-q", "-m", "fix bug in work")
+    return root
+
+
+def test_vcs_metrics_ranks_the_tracked_file(tmp_path: Path) -> None:
+    repo = _build_repo(tmp_path)
+    report = bca.vcs_metrics(repo)
+    assert report["long_window_days"] == 365
+    assert report["recent_window_days"] == 90
+    files = {f["path"]: f for f in report["files"]}
+    assert "work.rs" in files
+    assert files["work.rs"]["commits_long"] == 1
+    assert files["work.rs"]["bug_fix_commits"] == 1
+
+
+def test_vcs_metrics_top_limits_results(tmp_path: Path) -> None:
+    repo = _build_repo(tmp_path)
+    (repo / "other.rs").write_text("fn z() {}\n")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, env={**os.environ})
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "add other"],
+        cwd=repo,
+        check=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "Ada",
+            "GIT_AUTHOR_EMAIL": "ada@example.com",
+            "GIT_COMMITTER_NAME": "Ada",
+            "GIT_COMMITTER_EMAIL": "ada@example.com",
+        },
+    )
+    report = bca.vcs_metrics(repo, top=1)
+    assert len(report["files"]) == 1
+
+
+def test_analyze_vcs_true_attaches_block(tmp_path: Path) -> None:
+    repo = _build_repo(tmp_path)
+    result = bca.analyze(repo / "work.rs", vcs=True)
+    assert result is not None
+    vcs = result["metrics"]["vcs"]
+    assert vcs["commits_long"] == 1
+    # hotspot = cyclomatic_sum x churn_recent; both positive here.
+    assert vcs["hotspot_score"] > 0.0
+
+
+def test_analyze_without_vcs_has_no_block(tmp_path: Path) -> None:
+    repo = _build_repo(tmp_path)
+    result = bca.analyze(repo / "work.rs")
+    assert result is not None
+    assert "vcs" not in result["metrics"]
+
+
+def test_vcs_metrics_outside_repo_raises(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="version-control"):
+        bca.vcs_metrics(tmp_path)
+
+
+def test_vcs_metrics_bad_window_raises(tmp_path: Path) -> None:
+    repo = _build_repo(tmp_path)
+    with pytest.raises(ValueError, match="time window"):
+        bca.vcs_metrics(repo, long_window="nonsense")

--- a/big-code-analysis-web/Cargo.toml
+++ b/big-code-analysis-web/Cargo.toml
@@ -20,6 +20,8 @@ futures = "^0.3"
 # See #252.
 big-code-analysis = { path = "..", version = "=1.1.0", default-features = false, features = [
   "all-languages",
+  # `POST /vcs` change-history endpoint (issue #328).
+  "vcs",
 ] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
@@ -36,6 +38,9 @@ workspace = true
 assert_cmd = "^2.0"
 predicates = "^3.0"
 pretty_assertions = "^1.3"
+# `POST /vcs` route tests build a throwaway git working tree on disk
+# (issue #328); the history walk has no in-request representation.
+tempfile = "^3.0"
 tracing-test = "^0.2"
 
 # Debian/Ubuntu packaging — consumed by `cargo deb` in release CI.

--- a/big-code-analysis-web/Cargo.toml
+++ b/big-code-analysis-web/Cargo.toml
@@ -40,7 +40,7 @@ predicates = "^3.0"
 pretty_assertions = "^1.3"
 # `POST /vcs` route tests build a throwaway git working tree on disk
 # (issue #328); the history walk has no in-request representation.
-tempfile = "^3.0"
+tempfile.workspace = true
 tracing-test = "^0.2"
 
 # Debian/Ubuntu packaging — consumed by `cargo deb` in release CI.

--- a/big-code-analysis-web/src/web/mod.rs
+++ b/big-code-analysis-web/src/web/mod.rs
@@ -6,3 +6,5 @@ pub mod function;
 pub mod metrics;
 /// HTTP server bootstrapping and shared state.
 pub mod server;
+/// `POST /vcs` — change-history (VCS) metrics endpoint.
+pub mod vcs;

--- a/big-code-analysis-web/src/web/server.rs
+++ b/big-code-analysis-web/src/web/server.rs
@@ -1,5 +1,5 @@
-// bca: suppress-file(halstead, nargs, exit, abc, nom)
-// Actix server setup + handlers; the file-aggregate halstead/nargs/exit/nom and
+// bca: suppress-file(halstead, nargs, exit, abc, nom, loc)
+// Actix server setup + handlers; the file-aggregate halstead/nargs/exit/nom/loc and
 // the route-registration closure's abc (one `.service()`/`.route()` per endpoint)
 // are declarative many-fn aggregation artifacts, not per-function logic
 // complexity. The per-endpoint handlers plus the content-type guard helpers
@@ -25,7 +25,9 @@ use tokio::sync::Semaphore;
 use super::comment::{WebCommentCfg, WebCommentInfo, WebCommentPayload, strip_comments};
 use super::function::{WebFunctionCfg, WebFunctionInfo, WebFunctionPayload, function_spans};
 use super::metrics::{WebMetricsCfg, WebMetricsInfo, WebMetricsPayload, compute_metrics};
+use super::vcs::{WebVcsPayload, compute_vcs};
 
+use big_code_analysis::vcs::Error as VcsError;
 use big_code_analysis::{Ast, AstCfg, AstPayload, LANG, Source, guess_language};
 
 const INVALID_LANGUAGE: &str = "The file extension doesn't correspond to a valid language";
@@ -104,6 +106,11 @@ const AST_BUILD_FAILED: &str = "Failed to build an AST for the supplied source";
 /// this `500` is unreachable today and exists to keep failures off the
 /// `200` path if that changes (issue #517).
 const METRICS_FAILED: &str = "Failed to compute metrics for the supplied source";
+/// Error body when `repo_path` is not a git working tree, or a window /
+/// timestamp / formula is malformed (a client mistake → `400`).
+const VCS_BAD_REQUEST: &str = "Invalid `/vcs` request: repo_path is not a git working tree, or a window / timestamp / formula is malformed";
+/// Error body when the history walk itself fails (server-side → `500`).
+const VCS_FAILED: &str = "Failed to walk change history for the supplied repository";
 
 /// Default parse timeout used by [`run`].
 pub const DEFAULT_PARSE_TIMEOUT_SECS: u64 = 30;
@@ -396,6 +403,37 @@ async fn metrics_json(
     }
 }
 
+async fn vcs_json(
+    item: web::Json<WebVcsPayload>,
+    config: web::Data<ParseConfig>,
+) -> Result<HttpResponse, actix_web::Error> {
+    let payload = item.into_inner();
+    let payload_id = payload.id.clone();
+    // The history walk is blocking I/O, so it runs on the same
+    // timeout-guarded blocking pool as the parse endpoints.
+    let result = run_parse(&config, &payload_id, move || compute_vcs(payload)).await?;
+    match result {
+        Ok(response) => Ok(HttpResponse::Ok().json(response)),
+        Err(error) => {
+            // Bad path / window / timestamp / pattern are client mistakes
+            // (`400`); an actual walk failure is a `500`. The real error
+            // is logged server-side; the client sees the uniform body.
+            let (status, body) = match error {
+                VcsError::NotARepository(_)
+                | VcsError::InvalidWindow(_)
+                | VcsError::InvalidTimestamp(_)
+                | VcsError::InvalidFormula(_)
+                | VcsError::InvalidBotPattern(_) => {
+                    (http::StatusCode::BAD_REQUEST, VCS_BAD_REQUEST)
+                }
+                _ => (http::StatusCode::INTERNAL_SERVER_ERROR, VCS_FAILED),
+            };
+            tracing::warn!(payload_id = %payload_id, error = %error, "vcs request failed");
+            Ok(json_error(status, body, payload_id))
+        }
+    }
+}
+
 async fn metrics_plain(
     body: web::Payload,
     info: Query<WebMetricsInfo>,
@@ -653,6 +691,7 @@ fn register_endpoints(cfg: &mut web::ServiceConfig) {
             .route(web::post().guard(octet_guard()).to(metrics_plain))
             .default_service(web::route().to(guarded_post_fallback)),
     )
+    .service(web::resource("/vcs").route(web::post().guard(json_guard()).to(vcs_json)))
     .service(
         web::resource("/function")
             .route(web::post().guard(json_guard()).to(function_json))

--- a/big-code-analysis-web/src/web/server.rs
+++ b/big-code-analysis-web/src/web/server.rs
@@ -108,7 +108,7 @@ const AST_BUILD_FAILED: &str = "Failed to build an AST for the supplied source";
 const METRICS_FAILED: &str = "Failed to compute metrics for the supplied source";
 /// Error body when `repo_path` is not a git working tree, or a window /
 /// timestamp / formula is malformed (a client mistake → `400`).
-const VCS_BAD_REQUEST: &str = "Invalid `/vcs` request: repo_path is not a git working tree, or a window / timestamp / formula is malformed";
+const VCS_BAD_REQUEST: &str = "Invalid `/vcs` request: repo_path is not a git working tree, ref is unresolvable, or a window / timestamp / formula is malformed";
 /// Error body when the history walk itself fails (server-side → `500`).
 const VCS_FAILED: &str = "Failed to walk change history for the supplied repository";
 
@@ -423,7 +423,10 @@ async fn vcs_json(
                 | VcsError::InvalidWindow(_)
                 | VcsError::InvalidTimestamp(_)
                 | VcsError::InvalidFormula(_)
-                | VcsError::InvalidBotPattern(_) => {
+                | VcsError::InvalidBotPattern(_)
+                // A bad client-supplied `ref` (or an unborn HEAD) is a
+                // client mistake, not a server fault — answer 400, not 500.
+                | VcsError::ResolveRef { .. } => {
                     (http::StatusCode::BAD_REQUEST, VCS_BAD_REQUEST)
                 }
                 _ => (http::StatusCode::INTERNAL_SERVER_ERROR, VCS_FAILED),
@@ -691,7 +694,15 @@ fn register_endpoints(cfg: &mut web::ServiceConfig) {
             .route(web::post().guard(octet_guard()).to(metrics_plain))
             .default_service(web::route().to(guarded_post_fallback)),
     )
-    .service(web::resource("/vcs").route(web::post().guard(json_guard()).to(vcs_json)))
+    .service(
+        web::resource("/vcs")
+            .route(web::post().guard(json_guard()).to(vcs_json))
+            // Carry the same per-resource fallback as every other POST
+            // endpoint (#515): a wrong `Content-Type` or wrong method on
+            // `/vcs` answers a diagnostic 415/405 here rather than
+            // falling through to the app-level 404.
+            .default_service(web::route().to(guarded_post_fallback)),
+    )
     .service(
         web::resource("/function")
             .route(web::post().guard(json_guard()).to(function_json))

--- a/big-code-analysis-web/src/web/server_tests.rs
+++ b/big-code-analysis-web/src/web/server_tests.rs
@@ -1967,3 +1967,85 @@ async fn test_web_introspection_endpoints_reject_post_with_405() {
         assert_uniform_error_body(&test::read_body(resp).await, "");
     }
 }
+
+// --- POST /vcs (issue #328) ----------------------------------------------
+
+/// Build a throwaway git repo with one file committed ~5 days ago
+/// (within both default windows). Commit dates are relative to wall
+/// clock because `/vcs` uses wall-clock `now` by default.
+fn build_temp_repo() -> tempfile::TempDir {
+    use std::process::Command as StdCommand;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("after epoch")
+        .as_secs();
+    let date = format!("@{} +0000", now - 5 * 86_400);
+    let dir = tempfile::tempdir().expect("tempdir");
+    let git = |args: &[&str]| {
+        let ok = StdCommand::new("git")
+            .args(args)
+            .current_dir(dir.path())
+            .env("GIT_AUTHOR_NAME", "Ada")
+            .env("GIT_AUTHOR_EMAIL", "ada@example.com")
+            .env("GIT_AUTHOR_DATE", &date)
+            .env("GIT_COMMITTER_NAME", "Ada")
+            .env("GIT_COMMITTER_EMAIL", "ada@example.com")
+            .env("GIT_COMMITTER_DATE", &date)
+            .status()
+            .expect("spawn git")
+            .success();
+        assert!(ok, "git {args:?} failed");
+    };
+    git(&["init", "-q", "-b", "main"]);
+    git(&["config", "commit.gpgsign", "false"]);
+    std::fs::write(dir.path().join("work.rs"), "fn a() {}\n").expect("write");
+    git(&["add", "."]);
+    git(&["commit", "-q", "-m", "add work"]);
+    dir
+}
+
+#[actix_rt::test]
+async fn test_web_vcs_ranks_files() {
+    let repo = build_temp_repo();
+    let app = test::init_service(
+        App::new()
+            .app_data(test_config())
+            .service(web::resource("/vcs").route(web::post().to(vcs_json))),
+    )
+    .await;
+    let req = test::TestRequest::post()
+        .uri("/vcs")
+        .insert_header(ContentType::json())
+        .set_json(json!({ "id": "req-1", "repo_path": repo.path().to_str().unwrap() }))
+        .to_request();
+    let res: Value = test::call_and_read_body_json(&app, req).await;
+    assert_eq!(res["id"], "req-1");
+    assert_eq!(res["long_window_days"], 365);
+    let files = res["files"].as_array().expect("files array");
+    let work = files
+        .iter()
+        .find(|f| f["path"] == "work.rs")
+        .expect("work.rs ranked");
+    assert_eq!(work["commits_long"], 1);
+    assert_eq!(work["commits_recent"], 1);
+}
+
+#[actix_rt::test]
+async fn test_web_vcs_outside_repo_is_400() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let app = test::init_service(
+        App::new()
+            .app_data(test_config())
+            .service(web::resource("/vcs").route(web::post().to(vcs_json))),
+    )
+    .await;
+    let req = test::TestRequest::post()
+        .uri("/vcs")
+        .insert_header(ContentType::json())
+        .set_json(json!({ "id": "req-2", "repo_path": dir.path().to_str().unwrap() }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}

--- a/big-code-analysis-web/src/web/server_tests.rs
+++ b/big-code-analysis-web/src/web/server_tests.rs
@@ -2049,3 +2049,52 @@ async fn test_web_vcs_outside_repo_is_400() {
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 }
+
+#[actix_rt::test]
+async fn test_web_vcs_wrong_content_type_yields_415() {
+    // `/vcs` must carry the same per-resource fallback as the other POST
+    // endpoints (#515): a wrong Content-Type is a diagnostic 415, not a
+    // bodyless app-level 404.
+    let app = test::init_service(
+        App::new()
+            .app_data(test_config())
+            .configure(configure_routes),
+    )
+    .await;
+    let req = test::TestRequest::post()
+        .uri("/vcs")
+        .insert_header(("content-type", "text/plain"))
+        .set_payload("not json")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNSUPPORTED_MEDIA_TYPE,
+        "/vcs wrong Content-Type must be a 415, not a 404"
+    );
+}
+
+#[actix_rt::test]
+async fn test_web_vcs_wrong_method_yields_405() {
+    let app = test::init_service(
+        App::new()
+            .app_data(test_config())
+            .configure(configure_routes),
+    )
+    .await;
+    let req = test::TestRequest::get().uri("/vcs").to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::METHOD_NOT_ALLOWED,
+        "GET /vcs must be a 405, not a 404"
+    );
+    // The body proves the response came from our guarded_post_fallback
+    // (which names the accepted method), not actix's built-in 405 — i.e.
+    // the per-resource default_service is actually wired.
+    let body = test::read_body(resp).await;
+    assert!(
+        String::from_utf8_lossy(&body).contains("POST"),
+        "405 body should name the accepted method"
+    );
+}

--- a/big-code-analysis-web/src/web/vcs.rs
+++ b/big-code-analysis-web/src/web/vcs.rs
@@ -55,6 +55,10 @@ pub struct WebVcsPayload {
     pub follow_renames: Option<bool>,
     /// Exclude bot identities (default true).
     pub exclude_bots: Option<bool>,
+    /// Override the bot-author exclusion regex (matched against the
+    /// author name/email). Parity with the CLI `--bot-pattern` and the
+    /// Python `vcs_metrics(bot_pattern=…)`.
+    pub bot_pattern: Option<String>,
     /// Reference "now" (RFC 3339 / `@unix` / git date) for snapshots.
     pub as_of: Option<String>,
     /// Emit SHA-256-hashed author identities.
@@ -111,6 +115,9 @@ fn options_from(payload: &WebVcsPayload) -> Result<Options, vcs::Error> {
     options.include_merges = payload.include_merges.unwrap_or(options.include_merges);
     options.follow_renames = payload.follow_renames.unwrap_or(options.follow_renames);
     options.exclude_bots = payload.exclude_bots.unwrap_or(options.exclude_bots);
+    if let Some(pattern) = &payload.bot_pattern {
+        options.bot_pattern.clone_from(pattern);
+    }
     options.emit_author_details = payload
         .emit_author_details
         .unwrap_or(options.emit_author_details);

--- a/big-code-analysis-web/src/web/vcs.rs
+++ b/big-code-analysis-web/src/web/vcs.rs
@@ -1,0 +1,152 @@
+// bca: suppress-file(halstead, nargs, exit)
+// File-level halstead/nargs/exit are many-fn aggregation artifacts (the
+// option-builder + handler `?` error maps), not per-function logic
+// complexity (cognitive/cyclomatic stay enforced).
+
+//! `POST /vcs` — change-history (VCS) metrics over a server-side git
+//! working tree (issue #328).
+//!
+//! Unlike the source-in-body endpoints, this one analyses a repository
+//! already present on the server's filesystem (`repo_path`): VCS
+//! metrics derive from commit history, which has no in-request
+//! representation. The handler runs one history walk and returns the
+//! files ranked by composite risk score.
+//!
+//! # Security
+//!
+//! `repo_path` is a **server-side filesystem path**, so this endpoint
+//! lets the caller make the server walk any git repository it can read
+//! and returns that repo's relative file paths, churn, and author
+//! signals. This is materially different from every other endpoint
+//! (which only ever sees code in the request body). Operators must not
+//! expose `/vcs` to untrusted clients without an authorization layer;
+//! the default `127.0.0.1` bind keeps it local. The walk runs under the
+//! same parse-timeout / blocking-pool guard as the other endpoints.
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+use big_code_analysis::vcs::{self, Options, build_history_index, parse_timestamp, parse_window};
+use big_code_analysis::wire;
+
+/// Request body for `POST /vcs`.
+#[derive(Debug, Deserialize)]
+pub struct WebVcsPayload {
+    /// Request identifier echoed back in the response.
+    pub id: String,
+    /// Server-side path to (a directory inside) the git working tree.
+    pub repo_path: String,
+    /// Long window (default `12mo`).
+    pub long_window: Option<String>,
+    /// Recent window (default `90d`).
+    pub recent_window: Option<String>,
+    /// Show only the top N files by risk (`0` / absent = all).
+    pub top: Option<usize>,
+    /// Revision to analyse (default `HEAD`).
+    #[serde(rename = "ref")]
+    pub reference: Option<String>,
+    /// Composite formula: `weighted` (default) or `percentile`.
+    pub risk_formula: Option<String>,
+    /// Walk the full DAG rather than first-parent only.
+    pub full_history: Option<bool>,
+    /// Include merge commits.
+    pub include_merges: Option<bool>,
+    /// Follow renames (default true).
+    pub follow_renames: Option<bool>,
+    /// Exclude bot identities (default true).
+    pub exclude_bots: Option<bool>,
+    /// Reference "now" (RFC 3339 / `@unix` / git date) for snapshots.
+    pub as_of: Option<String>,
+    /// Emit SHA-256-hashed author identities.
+    pub emit_author_details: Option<bool>,
+    /// Include files deleted at the target ref.
+    pub include_deleted: Option<bool>,
+}
+
+/// One ranked file: repo-relative path plus the flat VCS block.
+#[derive(Debug, Serialize)]
+pub struct WebVcsFileEntry {
+    /// Repository-relative path.
+    pub path: String,
+    /// The file's change-history metrics.
+    #[serde(flatten)]
+    pub vcs: wire::Vcs,
+}
+
+/// Response body for `POST /vcs`.
+#[derive(Debug, Serialize)]
+pub struct WebVcsResponse {
+    /// Echoed request identifier.
+    pub id: String,
+    /// Long window length, in days.
+    pub long_window_days: u32,
+    /// Recent window length, in days.
+    pub recent_window_days: u32,
+    /// Whether the repository is a shallow clone (truncated history).
+    pub truncated_shallow_clone: bool,
+    /// Files ranked by descending risk score.
+    pub files: Vec<WebVcsFileEntry>,
+}
+
+/// Translate a payload into backend [`Options`], surfacing a typed
+/// [`vcs::Error`] on a bad window / timestamp / formula.
+fn options_from(payload: &WebVcsPayload) -> Result<Options, vcs::Error> {
+    let mut options = Options::default();
+    if let Some(spec) = &payload.long_window {
+        options.long_window_secs = parse_window(spec)?;
+    }
+    if let Some(spec) = &payload.recent_window {
+        options.recent_window_secs = parse_window(spec)?;
+    }
+    if let Some(reference) = &payload.reference {
+        options.reference.clone_from(reference);
+    }
+    if let Some(formula) = &payload.risk_formula {
+        options.risk_formula = formula.parse()?;
+    }
+    if let Some(raw) = &payload.as_of {
+        options.as_of = Some(parse_timestamp(raw)?);
+    }
+    options.full_history = payload.full_history.unwrap_or(options.full_history);
+    options.include_merges = payload.include_merges.unwrap_or(options.include_merges);
+    options.follow_renames = payload.follow_renames.unwrap_or(options.follow_renames);
+    options.exclude_bots = payload.exclude_bots.unwrap_or(options.exclude_bots);
+    options.emit_author_details = payload
+        .emit_author_details
+        .unwrap_or(options.emit_author_details);
+    options.include_deleted = payload.include_deleted.unwrap_or(options.include_deleted);
+    Ok(options)
+}
+
+/// Run the history walk for `payload` and rank the result.
+///
+/// # Errors
+///
+/// Returns a [`vcs::Error`] for a bad option, a non-repository
+/// `repo_path`, or a history-walk failure; the handler maps it to the
+/// appropriate HTTP status.
+pub fn compute_vcs(payload: WebVcsPayload) -> Result<WebVcsResponse, vcs::Error> {
+    let options = options_from(&payload)?;
+    let index = build_history_index(&PathBuf::from(&payload.repo_path), &options)?;
+
+    let mut files: Vec<WebVcsFileEntry> = index
+        .iter()
+        .filter_map(|(rel, stat)| {
+            rel.to_str().map(|path| WebVcsFileEntry {
+                path: path.to_owned(),
+                vcs: wire::Vcs::from(stat),
+            })
+        })
+        .collect();
+    vcs::rank_by_risk(&mut files, payload.top.unwrap_or(0), |e| {
+        (e.path.as_str(), e.vcs.risk_score)
+    });
+
+    Ok(WebVcsResponse {
+        id: payload.id,
+        long_window_days: options.long_window_days(),
+        recent_window_days: options.recent_window_days(),
+        truncated_shallow_clone: index.truncated_shallow_clone(),
+        files,
+    })
+}

--- a/man/bca-metrics.1
+++ b/man/bca-metrics.1
@@ -4,7 +4,7 @@
 .SH NAME
 bca\-metrics \- Compute per\-file metrics and emit them in a structured format
 .SH SYNOPSIS
-\fBbca\-metrics\fR [\fB\-O\fR|\fB\-\-format\fR] [\fB\-o\fR|\fB\-\-output\fR] [\fB\-\-pretty\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+\fBbca\-metrics\fR [\fB\-O\fR|\fB\-\-format\fR] [\fB\-o\fR|\fB\-\-output\fR] [\fB\-\-pretty\fR] [\fB\-\-vcs\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .SH DESCRIPTION
 Compute per\-file metrics and emit them in a structured format
 .SH OPTIONS
@@ -33,6 +33,9 @@ Output directory. Filenames mirror input paths plus the format extension. Stdout
 .TP
 \fB\-\-pretty\fR
 Pretty\-print JSON / TOML output
+.TP
+\fB\-\-vcs\fR
+Also compute change\-history (VCS) metrics and attach a `vcs` block — plus a `hotspot_score` (cyclomatic × recent churn) — to each file\*(Aqs metrics. Uses default windows (12mo / 90d, weighted formula); for window / formula tuning use `bca vcs`. Outside a git working tree this opt\-in is skipped with a warning (the AST metrics still emit, without the `vcs` block)
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help

--- a/man/bca-vcs.1
+++ b/man/bca-vcs.1
@@ -1,0 +1,87 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH BCA-VCS 1  "big-code-analysis 1.1.0" "big-code-analysis Manual"
+.SH NAME
+bca\-vcs \- Rank files by change\-history (VCS) risk: churn, commit and author counts, ownership dilution, and bug\- / security\-fix history over a git working tree (issue #328). Errors clearly outside a repo
+.SH SYNOPSIS
+\fBbca\-vcs\fR [\fB\-O\fR|\fB\-\-format\fR] [\fB\-o\fR|\fB\-\-output\fR] [\fB\-\-pretty\fR] [\fB\-\-long\-window\fR] [\fB\-\-recent\-window\fR] [\fB\-\-top\fR] [\fB\-\-ref\fR] [\fB\-\-full\-history\fR] [\fB\-\-include\-merges\fR] [\fB\-\-no\-follow\-renames\fR] [\fB\-\-no\-exclude\-bots\fR] [\fB\-\-bot\-pattern\fR] [\fB\-\-as\-of\fR] [\fB\-\-risk\-formula\fR] [\fB\-\-emit\-author\-details\fR] [\fB\-\-include\-deleted\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+Rank files by change\-history (VCS) risk: churn, commit and author counts, ownership dilution, and bug\- / security\-fix history over a git working tree (issue #328). Errors clearly outside a repo
+.SH OPTIONS
+.TP
+\fB\-O\fR, \fB\-\-format\fR \fI<OUTPUT_FORMAT>\fR
+Output format. `\-\-output\-format` is accepted as a deprecated alias (issue #513); it is hidden from help and slated for removal in 2.0
+.br
+
+.br
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+cbor
+.IP \(bu 2
+csv
+.IP \(bu 2
+json
+.IP \(bu 2
+toml
+.IP \(bu 2
+yaml
+.RE
+.TP
+\fB\-o\fR, \fB\-\-output\fR \fI<OUTPUT>\fR
+Output directory. Filenames mirror input paths plus the format extension. Stdout if omitted (CBOR requires this flag)
+.TP
+\fB\-\-pretty\fR
+Pretty\-print JSON / TOML output
+.TP
+\fB\-\-long\-window\fR \fI<LONG_WINDOW>\fR [default: 12mo]
+Long observation window (`12mo`, `2y`, `52w`, `365d`, or ISO 8601 `P1Y`)
+.TP
+\fB\-\-recent\-window\fR \fI<RECENT_WINDOW>\fR [default: 90d]
+Recent observation window
+.TP
+\fB\-\-top\fR \fI<TOP>\fR [default: 50]
+Show only the top N files by risk score (`0` = all)
+.TP
+\fB\-\-ref\fR \fI<REFERENCE>\fR [default: HEAD]
+Revision to analyze
+.TP
+\fB\-\-full\-history\fR
+Walk the full commit DAG rather than first\-parent only
+.TP
+\fB\-\-include\-merges\fR
+Include merge commits (skipped by default)
+.TP
+\fB\-\-no\-follow\-renames\fR
+Do not follow file renames across history
+.TP
+\fB\-\-no\-exclude\-bots\fR
+Do not exclude bot author identities
+.TP
+\fB\-\-bot\-pattern\fR \fI<BOT_PATTERN>\fR
+Override the bot\-author exclusion regex
+.TP
+\fB\-\-as\-of\fR \fI<AS_OF>\fR
+Reference "now" for reproducible runs (RFC 3339, `@unix`, or any git date spelling). Defaults to wall\-clock time
+.TP
+\fB\-\-risk\-formula\fR \fI<RISK_FORMULA>\fR [default: weighted]
+Composite risk\-score formula
+.br
+
+.br
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+weighted: Log\-scaled weighted sum with categorical bumps (default)
+.IP \(bu 2
+percentile: Per\-signal percentile rank within the analyzed set, averaged
+.RE
+.TP
+\fB\-\-emit\-author\-details\fR
+Emit SHA\-256\-hashed canonical author identities
+.TP
+\fB\-\-include\-deleted\fR
+Emit stats for files deleted at the target ref
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/man/bca.1
+++ b/man/bca.1
@@ -69,6 +69,9 @@ Compute per\-file metrics and emit them in a structured format
 bca\-ops(1)
 Extract per\-file operands and operators
 .TP
+bca\-vcs(1)
+Rank files by change\-history (VCS) risk: churn, commit and author counts, ownership dilution, and bug\- / security\-fix history over a git working tree (issue #328). Errors clearly outside a repo
+.TP
 bca\-report(1)
 Generate an aggregated report across the analyzed source
 .TP

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,18 @@
 // point of these files. Allowed at the module level rather than per
 // function so the per-language impl blocks stay readable.
 #![allow(clippy::doc_markdown, clippy::enum_glob_use, clippy::wildcard_imports)]
+// Per-language Cargo features (commit 7e96b466) let a downstream build
+// only a subset of grammars. In such a build the code for the disabled
+// languages — their macro-generated `*Code` / `*Parser` tags plus the
+// getter / checker / metric helpers and shared plumbing only those
+// languages reach — is compiled but never constructed, so `-D dead-code`
+// fires on ~180 items that are all live in the default `all-languages`
+// build. Relax dead-code to a warning only when the full language set is
+// NOT enabled; the default build and `--all-features` (and thus the
+// primary CI gate and `make pre-commit`) still hard-deny it, so genuine
+// dead code is caught there. Fixes the long-red `features
+// (no-default-features / minimal-langs (lib))` CI legs.
+#![cfg_attr(not(feature = "all-languages"), allow(dead_code))]
 
 //! big-code-analysis is a library to analyze and extract information
 //! from source codes written in many different programming languages.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,6 +188,19 @@ pub mod metrics;
 /// back (`serde_json::from_str::<wire::FuncSpace>(…)`).
 pub mod wire;
 
+// --- Change-history (VCS) metrics ---
+//
+// The project's first language-agnostic, non-AST metric family
+// (issue #328). Gated behind the `vcs-git` backend feature (the
+// `vcs` umbrella turns it on); the generic surface is backend-neutral
+// so future backends (#335) reuse it unchanged.
+/// Change-history (VCS) metrics derived from version-control history:
+/// churn, commit frequency, author count / ownership dilution, bug- and
+/// security-fix history, and an ordinal composite risk score. See
+/// [`vcs::build_history_index`].
+#[cfg(feature = "vcs-git")]
+pub mod vcs;
+
 // --- Errors ---
 mod error;
 pub use crate::error::MetricsError;

--- a/src/spaces.rs
+++ b/src/spaces.rs
@@ -142,6 +142,18 @@ pub struct CodeMetrics {
     pub npm: npm::Stats,
     /// `Npa` data
     pub npa: npa::Stats,
+    /// Change-history (VCS) data for this file.
+    ///
+    /// Unlike every other field, this is *not* AST-derived and *not*
+    /// computed during the analysis walk: it is a per-file signal set
+    /// injected by the caller after [`analyze`] from a
+    /// [`crate::vcs::HistoryIndex`]. Only the top-level (file-level)
+    /// [`FuncSpace`]'s metrics ever carry it; nested function spaces
+    /// leave it `None`. `None` also distinguishes an untracked file
+    /// from a tracked one with zero in-window activity. Gated behind
+    /// the `vcs-git` backend feature.
+    #[cfg(feature = "vcs-git")]
+    pub vcs: Option<crate::vcs::Stats>,
     /// Which metrics were actually computed for this space.
     ///
     /// Default is [`MetricSet::all`] — every metric was run, matching

--- a/src/vcs/classify.rs
+++ b/src/vcs/classify.rs
@@ -1,0 +1,75 @@
+//! Commit-message classification: bug-fix, security-fix, and revert
+//! detection via curated keyword regexes.
+//!
+//! The keyword approach follows the commit-message classification
+//! literature (Pascarella/Bavota for bug-fix detection; the
+//! Sentence-Level VFC studies and PySecDB for security fixes). It is a
+//! coarse signal by design — full SZZ bug-inducing-commit detection is
+//! explicitly out of scope for v1 (issue #328) — so the patterns favour
+//! precision (word-boundary anchored, false-positive-aware) over
+//! recall.
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+/// What a single commit message matched.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Classification {
+    /// The message matched a bug-fix keyword.
+    pub bug_fix: bool,
+    /// The message matched a security-fix keyword.
+    pub security_fix: bool,
+    /// The subject is a revert / rollback.
+    pub revert: bool,
+}
+
+// Word boundaries (`\b`) keep "prefix"/"suffix" from matching `fix` and
+// "insecurity" from matching `security`; the regression tests in
+// `classify_tests.rs` pin exactly those false-positive cases.
+//
+// The patterns are compile-time constants, so the `expect` in each
+// `LazyLock` initialiser guards a provably-unreachable failure (a
+// malformed literal would fail the test suite's `patterns_compile`
+// before any release).
+static BUG_FIX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?i)\b(?:fix(?:es|ed|ing)?|bug(?:fix)?(?:es|s)?|defect|hotfix|regression|fault|crash)\b",
+    )
+    .expect("BUG_FIX pattern is valid")
+});
+
+static SECURITY_FIX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?i)\b(?:security|vulnerabilit(?:y|ies)|vuln|exploit|sanitiz(?:e|ation)|insecure|xss|csrf|injection|overflow|rce|disclosure|malicious|hijack|spoof)\b|CVE-\d{4}-\d+|CWE-\d+",
+    )
+    .expect("SECURITY_FIX pattern is valid")
+});
+
+static REVERT_SUBJECT: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^revert\b").expect("REVERT_SUBJECT pattern is valid"));
+
+static ROLLBACK: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)\brollback\b").expect("ROLLBACK pattern is valid"));
+
+/// Classify a raw commit message.
+///
+/// The message is matched lossily as UTF-8 — classification is a
+/// heuristic over human-readable prose, never an identifier, so a
+/// non-UTF-8 byte degrading to U+FFFD cannot corrupt downstream state.
+#[must_use]
+pub fn classify(message: &[u8]) -> Classification {
+    let text = String::from_utf8_lossy(message);
+    // The subject is the first line; `^Revert ...` is git's
+    // auto-generated revert subject.
+    let subject = text.lines().next().unwrap_or("");
+    Classification {
+        bug_fix: BUG_FIX.is_match(&text),
+        security_fix: SECURITY_FIX.is_match(&text),
+        revert: REVERT_SUBJECT.is_match(subject) || ROLLBACK.is_match(&text),
+    }
+}
+
+#[cfg(test)]
+#[path = "classify_tests.rs"]
+mod tests;

--- a/src/vcs/classify_tests.rs
+++ b/src/vcs/classify_tests.rs
@@ -1,0 +1,57 @@
+use super::*;
+
+fn c(message: &str) -> Classification {
+    classify(message.as_bytes())
+}
+
+#[test]
+fn bug_fix_keywords_match() {
+    assert!(c("fix crash on startup").bug_fix);
+    assert!(c("Fixed the null deref").bug_fix);
+    assert!(c("fixes #1234").bug_fix);
+    assert!(c("bugfix: off-by-one").bug_fix);
+    assert!(c("address a regression").bug_fix);
+}
+
+#[test]
+fn bug_fix_avoids_substring_false_positives() {
+    // "prefix"/"suffix"/"affix" embed "fix" mid-word; word boundaries
+    // must keep them from matching (the canonical false-positive case).
+    assert!(!c("rename the prefix handling").bug_fix);
+    assert!(!c("drop the filename suffix").bug_fix);
+    assert!(!c("add a new feature").bug_fix);
+}
+
+#[test]
+fn security_keywords_match() {
+    assert!(c("patch the XSS hole").security_fix);
+    assert!(c("Resolve CVE-2021-44228").security_fix);
+    assert!(c("sanitize user input").security_fix);
+    assert!(c("fix SQL injection").security_fix);
+    assert!(c("security hardening").security_fix);
+}
+
+#[test]
+fn security_avoids_substring_false_positives() {
+    // "insecurity" embeds "security"; the boundary must reject it.
+    assert!(!c("address job insecurity in docs").security_fix);
+    assert!(!c("update the changelog").security_fix);
+}
+
+#[test]
+fn revert_detected_from_subject_or_rollback() {
+    assert!(c("Revert \"add the broken feature\"").revert);
+    assert!(c("revert the bad merge").revert);
+    assert!(c("rollback the migration").revert);
+    // The subject anchor matters: a non-leading "revert" in prose must
+    // NOT classify as a revert (a de-anchored `\brevert\b` would, so
+    // this pins the `^` in REVERT_SUBJECT).
+    assert!(!c("we should not revert this change").revert);
+    assert!(!c("this does not undo anything").revert);
+}
+
+#[test]
+fn unrelated_message_classifies_as_nothing() {
+    let class = c("Add documentation for the parser");
+    assert_eq!(class, Classification::default());
+}

--- a/src/vcs/error.rs
+++ b/src/vcs/error.rs
@@ -80,3 +80,7 @@ impl std::fmt::Display for Error {
 }
 
 impl std::error::Error for Error {}
+
+#[cfg(test)]
+#[path = "error_tests.rs"]
+mod tests;

--- a/src/vcs/error.rs
+++ b/src/vcs/error.rs
@@ -1,0 +1,82 @@
+//! Error type for the change-history (VCS) metrics pipeline.
+//!
+//! Generic over the backend: backend-specific failures (a `gix` open
+//! error, a rev-walk failure, a blob-diff failure) are mapped to
+//! string-carrying variants here rather than leaking the backend's
+//! concrete error types into the generic surface. This keeps the
+//! generic module tree free of any `gix` reference so a future
+//! backend (`vcs-hg`, `vcs-jj`) can reuse it unchanged (issue #335).
+
+use std::path::PathBuf;
+
+/// Error returned by [`build_history_index`](crate::vcs::build_history_index)
+/// and the surrounding VCS pipeline.
+///
+/// `#[non_exhaustive]` so new variants land additively as backends and
+/// edge cases accrue; match with a trailing `_` arm to stay
+/// forward-compatible.
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum Error {
+    /// The supplied path is not inside the working tree of any
+    /// supported VCS. Distinct from a repository with no tracked text
+    /// files at the target ref, which succeeds with an empty index. (A
+    /// freshly-initialised repository whose `HEAD` is unborn instead
+    /// surfaces as [`Error::ResolveRef`], since there is no commit to
+    /// resolve.)
+    NotARepository(PathBuf),
+    /// Opening or discovering the repository failed for a reason other
+    /// than "no repository here" (corrupt repo, permission denied, …).
+    OpenRepository(String),
+    /// The `--ref` revision could not be resolved to a commit.
+    ResolveRef {
+        /// The revision spec the caller supplied (e.g. `HEAD`, a SHA).
+        reference: String,
+        /// Backend-rendered explanation of why resolution failed.
+        reason: String,
+    },
+    /// Walking commit history failed.
+    Walk(String),
+    /// Computing a tree-to-tree or blob diff failed.
+    Diff(String),
+    /// Loading or applying the repository `.mailmap` failed.
+    Mailmap(String),
+    /// The bot-exclusion pattern is not a valid regular expression.
+    InvalidBotPattern(String),
+    /// A configured time window could not be parsed.
+    InvalidWindow(String),
+    /// The `--as-of` timestamp could not be parsed.
+    InvalidTimestamp(String),
+    /// The risk-formula name is not one of `weighted` / `percentile`.
+    InvalidFormula(String),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotARepository(path) => {
+                write!(
+                    f,
+                    "{} is not inside a supported version-control working tree",
+                    path.display()
+                )
+            }
+            Self::OpenRepository(reason) => write!(f, "failed to open repository: {reason}"),
+            Self::ResolveRef { reference, reason } => {
+                write!(f, "failed to resolve revision {reference:?}: {reason}")
+            }
+            Self::Walk(reason) => write!(f, "failed to walk commit history: {reason}"),
+            Self::Diff(reason) => write!(f, "failed to compute diff: {reason}"),
+            Self::Mailmap(reason) => write!(f, "failed to apply .mailmap: {reason}"),
+            Self::InvalidBotPattern(reason) => write!(f, "invalid bot pattern: {reason}"),
+            Self::InvalidWindow(reason) => write!(f, "invalid time window: {reason}"),
+            Self::InvalidTimestamp(reason) => write!(f, "invalid timestamp: {reason}"),
+            Self::InvalidFormula(name) => write!(
+                f,
+                "unknown risk formula {name:?} (expected `weighted` or `percentile`)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for Error {}

--- a/src/vcs/error_tests.rs
+++ b/src/vcs/error_tests.rs
@@ -1,0 +1,75 @@
+use super::*;
+use std::path::PathBuf;
+
+// The Display strings are user-facing diagnostics surfaced by the CLI,
+// the `POST /vcs` error body, and the Python `ValueError`. Pin each
+// variant's wording so a refactor cannot silently degrade them.
+#[test]
+fn display_covers_every_variant() {
+    let cases: Vec<(Error, &str)> = vec![
+        (
+            Error::NotARepository(PathBuf::from("/tmp/x")),
+            "not inside a supported version-control working tree",
+        ),
+        (
+            Error::OpenRepository("corrupt".to_owned()),
+            "failed to open repository: corrupt",
+        ),
+        (
+            Error::Walk("boom".to_owned()),
+            "failed to walk commit history: boom",
+        ),
+        (Error::Diff("bad".to_owned()), "failed to compute diff: bad"),
+        (
+            Error::Mailmap("nope".to_owned()),
+            "failed to apply .mailmap: nope",
+        ),
+        (
+            Error::InvalidBotPattern("(".to_owned()),
+            "invalid bot pattern: (",
+        ),
+        (
+            Error::InvalidWindow("empty".to_owned()),
+            "invalid time window: empty",
+        ),
+        (
+            Error::InvalidTimestamp("xyz".to_owned()),
+            "invalid timestamp: xyz",
+        ),
+        (
+            Error::InvalidFormula("bogus".to_owned()),
+            "unknown risk formula",
+        ),
+    ];
+    for (err, expected) in cases {
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains(expected),
+            "Display for {err:?} = {rendered:?}, expected to contain {expected:?}"
+        );
+    }
+}
+
+#[test]
+fn not_a_repository_names_the_offending_path() {
+    let err = Error::NotARepository(PathBuf::from("/tmp/not-a-repo"));
+    assert!(err.to_string().contains("/tmp/not-a-repo"));
+}
+
+#[test]
+fn resolve_ref_names_reference_and_reason() {
+    let err = Error::ResolveRef {
+        reference: "feature/x".to_owned(),
+        reason: "no such ref".to_owned(),
+    };
+    let rendered = err.to_string();
+    assert!(rendered.contains("feature/x"), "{rendered:?}");
+    assert!(rendered.contains("no such ref"), "{rendered:?}");
+}
+
+#[test]
+fn invalid_formula_lists_the_accepted_names() {
+    let rendered = Error::InvalidFormula("bogus".to_owned()).to_string();
+    assert!(rendered.contains("weighted"), "{rendered:?}");
+    assert!(rendered.contains("percentile"), "{rendered:?}");
+}

--- a/src/vcs/error_tests.rs
+++ b/src/vcs/error_tests.rs
@@ -16,6 +16,13 @@ fn display_covers_every_variant() {
             "failed to open repository: corrupt",
         ),
         (
+            Error::ResolveRef {
+                reference: "HEAD".to_owned(),
+                reason: "unborn".to_owned(),
+            },
+            "failed to resolve revision",
+        ),
+        (
             Error::Walk("boom".to_owned()),
             "failed to walk commit history: boom",
         ),

--- a/src/vcs/git/history.rs
+++ b/src/vcs/git/history.rs
@@ -56,6 +56,18 @@ pub(crate) fn walk_history(
     // Rename map: a historical path → the more-recent path it became.
     // Resolving the chain yields the file's name at the target ref so
     // edits under former names attribute to the current file.
+    //
+    // Limitation: the alias is populated lazily as renames are met in
+    // the walk's commit-time (newest-first) order, which approximates
+    // topological order. If a rename commit carries an *older*
+    // committer date than an edit to its pre-rename path (possible after
+    // `--date`-rewriting, cherry-pick, or genuine clock skew — normal
+    // rebases keep committer dates monotonic), that older-named edit is
+    // visited first and attributes under the former name (dropped, or
+    // split under `--include-deleted`), undercounting the renamed file.
+    // Exact rename-following would require a topological walk, which
+    // would forgo the commit-time cutoff that prunes out-of-window
+    // history; the approximation is the deliberate v1 trade-off.
     let mut alias: HashMap<PathBuf, PathBuf> = HashMap::new();
 
     let mut platform = repo.rev_walk([tip]);
@@ -143,11 +155,20 @@ fn process_commit(
 
     let commit_tree = commit.tree().map_err(walk_err)?;
     let parent_tree = match first_parent {
-        Some(parent) => repo
-            .find_commit(parent)
-            .map_err(walk_err)?
-            .tree()
-            .map_err(walk_err)?,
+        // A parent whose object is absent is a shallow-clone boundary
+        // (the grafted parent was not fetched). Treat that commit like a
+        // root — diff against the empty tree so its files count as
+        // additions — rather than aborting the whole walk on a "not
+        // found" error. `truncated_shallow_clone` already flags the
+        // result so the counts are understood as lower bounds.
+        Some(parent) => match repo.try_find_object(parent).map_err(walk_err)? {
+            Some(object) => object
+                .peel_to_commit()
+                .map_err(walk_err)?
+                .tree()
+                .map_err(walk_err)?,
+            None => repo.empty_tree(),
+        },
         None => repo.empty_tree(),
     };
 

--- a/src/vcs/git/history.rs
+++ b/src/vcs/git/history.rs
@@ -1,0 +1,300 @@
+// bca: suppress-file(halstead, nargs, exit)
+// File-level halstead/nargs/exit are many-fn aggregation artifacts (the
+// gix rev-walk + per-commit diff plumbing, with many `?` error maps),
+// not per-function logic complexity (cognitive/cyclomatic stay enforced).
+
+//! The commit-history walk: rev-walk the target ref within the long
+//! window, diff each commit against its first parent, and fold per-file
+//! churn / author / classification signals into the accumulators.
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::ops::ControlFlow;
+use std::path::{Path, PathBuf};
+
+use gix::diff::Rewrites;
+use gix::revision::walk::Sorting;
+use gix::traverse::commit::simple::CommitTimeOrder;
+
+use super::identity::ParticipantResolver;
+use super::repo::bstr_to_path;
+use super::{diff_err, walk_err};
+use crate::vcs::classify::{self, Classification};
+use crate::vcs::error::Error;
+use crate::vcs::identity::{AuthorId, BotFilter};
+use crate::vcs::options::Options;
+use crate::vcs::stats::{Accumulator, ChangeRecord};
+
+/// Walk history from `tip` and fold every in-window commit into the
+/// per-file accumulators that were pre-seeded from the target tree.
+///
+/// # Errors
+///
+/// Returns a backend [`Error`] variant if the rev-walk, a tree lookup,
+/// or a diff fails.
+pub(crate) fn walk_history(
+    repo: &gix::Repository,
+    tip: gix::ObjectId,
+    options: &Options,
+    now: i64,
+    accumulators: &mut HashMap<PathBuf, Accumulator>,
+) -> Result<(), Error> {
+    let long_boundary = now - options.long_window_secs;
+    let recent_boundary = now - options.recent_window_secs;
+
+    let mailmap = repo.open_mailmap();
+    let bots = if options.exclude_bots {
+        Some(BotFilter::new(&options.bot_pattern)?)
+    } else {
+        None
+    };
+    let resolver = ParticipantResolver::new(&mailmap, bots.as_ref());
+
+    let rewrites = options.follow_renames.then(Rewrites::default);
+    let mut cache = repo.diff_resource_cache_for_tree_diff().map_err(diff_err)?;
+
+    // Rename map: a historical path → the more-recent path it became.
+    // Resolving the chain yields the file's name at the target ref so
+    // edits under former names attribute to the current file.
+    let mut alias: HashMap<PathBuf, PathBuf> = HashMap::new();
+
+    let mut platform = repo.rev_walk([tip]);
+    if !options.full_history {
+        platform = platform.first_parent_only();
+    }
+    // The cutoff prunes commits older than the long window during
+    // traversal; the in-loop guard re-checks inclusively for the
+    // boundary commit and any out-of-order timestamps.
+    let walk = platform
+        .sorting(Sorting::ByCommitTimeCutoff {
+            order: CommitTimeOrder::NewestFirst,
+            seconds: long_boundary,
+        })
+        .all()
+        .map_err(walk_err)?;
+
+    for info in walk {
+        let info = info.map_err(walk_err)?;
+        let commit = info.object().map_err(walk_err)?;
+
+        // Clamp future-dated commits (clock skew) to `now`.
+        let commit_time = commit_seconds(&info, &commit)?.min(now);
+        if commit_time < long_boundary {
+            continue;
+        }
+
+        process_commit(
+            repo,
+            &commit,
+            commit_time,
+            recent_boundary,
+            options,
+            &resolver,
+            rewrites,
+            &mut cache,
+            &mut alias,
+            accumulators,
+        )?;
+
+        // The resource cache only grows; clear it each commit to keep
+        // memory bounded across a long history (gix docs guidance).
+        cache.clear_resource_cache();
+    }
+
+    Ok(())
+}
+
+/// Fold one walked commit into the accumulators: skip merges (unless
+/// opted in) and bot-only commits, classify the message, then diff
+/// against the first parent. Split out of [`walk_history`] so neither
+/// function carries the whole walk's branching.
+#[allow(clippy::too_many_arguments)]
+fn process_commit(
+    repo: &gix::Repository,
+    commit: &gix::Commit<'_>,
+    commit_time: i64,
+    recent_boundary: i64,
+    options: &Options,
+    resolver: &ParticipantResolver<'_>,
+    rewrites: Option<Rewrites>,
+    cache: &mut gix::diff::blob::Platform,
+    alias: &mut HashMap<PathBuf, PathBuf>,
+    accumulators: &mut HashMap<PathBuf, Accumulator>,
+) -> Result<(), Error> {
+    // Only the first parent (for the diff base) and whether more than
+    // one exists (the merge check) are needed, so avoid collecting the
+    // parent ids into a `Vec` for every walked commit.
+    let mut parent_ids = commit.parent_ids().map(gix::Id::detach);
+    let first_parent = parent_ids.next();
+    let is_merge = parent_ids.next().is_some();
+    if is_merge && !options.include_merges {
+        return Ok(());
+    }
+
+    // Participants first: a commit authored solely by filtered bots
+    // contributes nothing, so skip it before the (costly) diff.
+    let authors = resolver.participants(commit)?;
+    if authors.is_empty() {
+        return Ok(());
+    }
+
+    let class = classify_commit(commit)?;
+    let in_recent = commit_time >= recent_boundary;
+
+    let commit_tree = commit.tree().map_err(walk_err)?;
+    let parent_tree = match first_parent {
+        Some(parent) => repo
+            .find_commit(parent)
+            .map_err(walk_err)?
+            .tree()
+            .map_err(walk_err)?,
+        None => repo.empty_tree(),
+    };
+
+    let ctx = CommitContext {
+        commit_time,
+        in_recent,
+        class,
+        authors: &authors,
+    };
+    diff_commit(
+        &parent_tree,
+        &commit_tree,
+        cache,
+        rewrites,
+        alias,
+        options,
+        accumulators,
+        &ctx,
+    )
+}
+
+/// Per-commit facts shared by every file the commit touched.
+struct CommitContext<'a> {
+    commit_time: i64,
+    in_recent: bool,
+    class: Classification,
+    authors: &'a [AuthorId],
+}
+
+/// Diff `parent_tree → commit_tree` and fold each changed file into its
+/// accumulator.
+#[allow(clippy::too_many_arguments)]
+fn diff_commit(
+    parent_tree: &gix::Tree<'_>,
+    commit_tree: &gix::Tree<'_>,
+    cache: &mut gix::diff::blob::Platform,
+    rewrites: Option<Rewrites>,
+    alias: &mut HashMap<PathBuf, PathBuf>,
+    options: &Options,
+    accumulators: &mut HashMap<PathBuf, Accumulator>,
+    ctx: &CommitContext<'_>,
+) -> Result<(), Error> {
+    use gix::object::tree::diff::Change;
+
+    parent_tree
+        .changes()
+        .map_err(diff_err)?
+        .options(|opts| {
+            opts.track_path();
+            opts.track_rewrites(rewrites);
+        })
+        .for_each_to_obtain_tree(commit_tree, |change| -> Result<ControlFlow<()>, Error> {
+            // Only regular file blobs carry line churn. Skipping every
+            // non-blob mode drops directories, symlinks (per spec), and
+            // submodule gitlinks (commit mode) — diffing the latter as a
+            // blob is what failed the callback on repos with submodules.
+            if !change.entry_mode().is_blob() {
+                return Ok(ControlFlow::Continue(()));
+            }
+
+            let location_path = bstr_to_path(change.location())?;
+            // On a rename, register the alias (former name → current
+            // path) so older commits under the former name attribute
+            // forward. Resolving after the insert is equivalent: the
+            // inserted key is the *source*, which never aliases the
+            // current location being resolved here.
+            if let Change::Rewrite {
+                source_location, ..
+            } = &change
+            {
+                let source_path = bstr_to_path(source_location)?;
+                alias.insert(source_path, location_path.clone());
+            }
+            // Resolve the file's canonical (target-ref) path. Borrows
+            // through the alias chain — no allocation on the common
+            // no-rename path (the map is empty until a rewrite is seen).
+            let canonical = resolve_alias(alias, &location_path);
+
+            // Binary blobs yield no line counts → skip (file excluded).
+            let Some(line_stats) = change
+                .diff(cache)
+                .map_err(diff_err)?
+                .line_counts()
+                .map_err(diff_err)?
+            else {
+                return Ok(ControlFlow::Continue(()));
+            };
+            let churn = u64::from(line_stats.insertions) + u64::from(line_stats.removals);
+
+            let accumulator = match accumulators.get_mut(canonical.as_ref()) {
+                Some(acc) => acc,
+                None if options.include_deleted => accumulators
+                    .entry(canonical.into_owned())
+                    .or_insert_with(|| Accumulator::new(0)),
+                // A file not present at the target ref and not opted in
+                // via --include-deleted.
+                None => return Ok(ControlFlow::Continue(())),
+            };
+            accumulator.record(&ChangeRecord {
+                churn,
+                commit_time: ctx.commit_time,
+                in_recent: ctx.in_recent,
+                class: ctx.class,
+                authors: ctx.authors,
+            });
+
+            Ok(ControlFlow::Continue(()))
+        })
+        .map_err(diff_err)?;
+
+    Ok(())
+}
+
+/// Follow the rename-alias chain from a historical path to the path the
+/// file carries at the target ref. The depth guard defends against a
+/// pathological cycle in malformed history.
+fn resolve_alias<'a>(alias: &'a HashMap<PathBuf, PathBuf>, path: &'a Path) -> Cow<'a, Path> {
+    let mut current: &'a Path = path;
+    for _ in 0..MAX_ALIAS_DEPTH {
+        match alias.get(current) {
+            Some(next) => current = next.as_path(),
+            None => break,
+        }
+    }
+    // Always borrowed: both `path` and the alias values outlive `'a`, so
+    // no `PathBuf` is allocated unless a caller later needs ownership.
+    Cow::Borrowed(current)
+}
+
+/// Upper bound on rename-alias chain length; far beyond any real
+/// rename history, so hitting it implies a cycle.
+const MAX_ALIAS_DEPTH: usize = 10_000;
+
+/// Commit timestamp in Unix seconds, preferring the walk's pre-decoded
+/// value and falling back to decoding the commit.
+fn commit_seconds(
+    info: &gix::revision::walk::Info<'_>,
+    commit: &gix::Commit<'_>,
+) -> Result<i64, Error> {
+    match info.commit_time {
+        Some(seconds) => Ok(seconds),
+        None => commit.time().map(|t| t.seconds).map_err(walk_err),
+    }
+}
+
+/// Classify the commit message (bug-fix / security-fix / revert).
+fn classify_commit(commit: &gix::Commit<'_>) -> Result<Classification, Error> {
+    let message = commit.message_raw().map_err(walk_err)?;
+    Ok(classify::classify(message))
+}

--- a/src/vcs/git/identity.rs
+++ b/src/vcs/git/identity.rs
@@ -1,0 +1,90 @@
+// bca: suppress-file(halstead, nargs)
+// File-level halstead/nargs are many-fn aggregation artifacts (the
+// mailmap + trailer-parsing plumbing), not per-function logic
+// complexity (cognitive/cyclomatic stay enforced).
+
+//! Resolve the participant identities of a git commit.
+//!
+//! "Participants" are the commit author plus any `Co-authored-by:`
+//! trailers, each canonicalised through the repository `.mailmap` (the
+//! author) or by lowercased email (co-authors), then filtered against
+//! the bot pattern. The returned list is de-duplicated, so a commit
+//! co-authored by someone who is also the author counts that identity
+//! once.
+
+use std::sync::LazyLock;
+
+use regex::bytes::Regex;
+
+use crate::vcs::error::Error;
+use crate::vcs::identity::{AuthorId, BotFilter};
+
+// `Co-authored-by: Display Name <email@host>` trailer, matched
+// case-insensitively per line over the raw message bytes (no lossy
+// UTF-8 round-trip on the identity inputs).
+static COAUTHOR: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?im)^\s*co-authored-by:\s*(.*?)\s*<([^>]*)>\s*$")
+        .expect("COAUTHOR trailer pattern is valid")
+});
+
+/// Resolves commit participants, holding the per-walk mailmap snapshot
+/// and optional bot filter.
+pub(crate) struct ParticipantResolver<'a> {
+    mailmap: &'a gix::mailmap::Snapshot,
+    bots: Option<&'a BotFilter>,
+}
+
+impl<'a> ParticipantResolver<'a> {
+    /// `bots` is `Some` only when bot exclusion is enabled.
+    pub(crate) fn new(mailmap: &'a gix::mailmap::Snapshot, bots: Option<&'a BotFilter>) -> Self {
+        Self { mailmap, bots }
+    }
+
+    /// The de-duplicated, bot-filtered participant identities of one
+    /// commit. An empty result means the commit was authored solely by
+    /// filtered bot identities and should be skipped entirely.
+    ///
+    /// # Errors
+    ///
+    /// Propagates a [`Error::Walk`] if the commit author cannot be
+    /// decoded.
+    pub(crate) fn participants(&self, commit: &gix::Commit<'_>) -> Result<Vec<AuthorId>, Error> {
+        let mut out: Vec<AuthorId> = Vec::new();
+
+        let author = commit
+            .author()
+            .map_err(|e| Error::Walk(format!("decoding commit author: {e}")))?;
+        // Canonicalise the author through `.mailmap`; co-authors are
+        // canonicalised by lowercased email only (mailmap on trailers
+        // is a refinement deferred past v1).
+        let resolved = self.mailmap.resolve(author);
+        self.push_if_human(&mut out, &resolved.name, &resolved.email);
+
+        let message = commit
+            .message_raw()
+            .map_err(|e| Error::Walk(format!("decoding commit message: {e}")))?;
+        for caps in COAUTHOR.captures_iter(message) {
+            // capture groups 1 (name) and 2 (email) are guaranteed by a
+            // successful match of the two-group pattern.
+            let (Some(name), Some(email)) = (caps.get(1), caps.get(2)) else {
+                continue;
+            };
+            self.push_if_human(&mut out, name.as_bytes(), email.as_bytes());
+        }
+
+        Ok(out)
+    }
+
+    /// Push a canonical identity unless it is a bot or already present.
+    fn push_if_human(&self, out: &mut Vec<AuthorId>, name: &[u8], email: &[u8]) {
+        if let Some(bots) = self.bots
+            && bots.is_bot(name, email)
+        {
+            return;
+        }
+        let id = AuthorId::new(name, email);
+        if !out.contains(&id) {
+            out.push(id);
+        }
+    }
+}

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -1,0 +1,134 @@
+// bca: suppress-file(halstead, nargs, exit)
+// File-level halstead/nargs/exit are many-fn aggregation artifacts (the
+// open/resolve/enumerate/finalize pipeline), not per-function logic
+// complexity (cognitive/cyclomatic stay enforced).
+
+//! The `vcs-git` backend: a `gix`-powered history walk.
+//!
+//! `build` is the single entry point `build_history_index` delegates
+//! to. It opens the repository, resolves the target ref, enumerates the
+//! tracked text files at that ref (seeding one accumulator per file),
+//! walks history once to fold in per-file signals, then finalises each
+//! accumulator into a [`Stats`] record.
+
+mod history;
+mod identity;
+mod repo;
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::vcs::HistoryIndex;
+use crate::vcs::error::Error;
+use crate::vcs::options::{Options, RiskFormula};
+use crate::vcs::score;
+use crate::vcs::stats::{Accumulator, Stats};
+
+/// Object-cache budget for the walk. Tree diffs look up the same blobs
+/// repeatedly; a few MiB of cache turns an O(commits²)-ish blob-decode
+/// pattern into something tractable (gix docs guidance). Only applied
+/// when the repository config has not already set one.
+const OBJECT_CACHE_BYTES: usize = 8 * 1024 * 1024;
+
+/// Walk git history rooted at `root` and build a [`HistoryIndex`].
+///
+/// # Errors
+///
+/// See [`build_history_index`](crate::vcs::build_history_index).
+pub(crate) fn build(root: &Path, options: &Options) -> Result<HistoryIndex, Error> {
+    let repo::OpenRepo {
+        mut repo,
+        workdir,
+        shallow,
+    } = repo::open(root)?;
+    repo.object_cache_size_if_unset(OBJECT_CACHE_BYTES);
+
+    // Resolve the ref to a commit, peeling through any tag.
+    let resolve_err = |e: &dyn std::fmt::Display| Error::ResolveRef {
+        reference: options.reference.clone(),
+        reason: e.to_string(),
+    };
+    let tip = repo
+        .rev_parse_single(options.reference.as_bytes())
+        .map_err(|e| resolve_err(&e))?;
+    let commit = tip
+        .object()
+        .map_err(|e| resolve_err(&e))?
+        .peel_to_commit()
+        .map_err(|e| resolve_err(&e))?;
+    let target_tree = commit.tree().map_err(walk_err)?;
+
+    // Seed one accumulator per tracked text file at the target ref.
+    let mut accumulators: HashMap<PathBuf, Accumulator> =
+        repo::enumerate_target_files(&repo, &target_tree)?
+            .into_iter()
+            .map(|(path, sloc)| (path, Accumulator::new(sloc)))
+            .collect();
+
+    let now = options.as_of.unwrap_or_else(current_unix_seconds);
+    history::walk_history(&repo, commit.id, options, now, &mut accumulators)?;
+
+    let files = finalize(accumulators, options, now);
+    Ok(HistoryIndex::new(files, workdir, shallow))
+}
+
+/// Finalise every accumulator into a [`Stats`] record, applying the
+/// percentile re-ranking pass when that formula is selected.
+fn finalize(
+    accumulators: HashMap<PathBuf, Accumulator>,
+    options: &Options,
+    now: i64,
+) -> HashMap<PathBuf, Stats> {
+    let (paths, mut stats): (Vec<PathBuf>, Vec<Stats>) = accumulators
+        .into_iter()
+        .map(|(path, acc)| (path, acc.finalize(now, options)))
+        .unzip();
+
+    if options.risk_formula == RiskFormula::Percentile {
+        score::apply_percentile(&mut stats);
+    }
+
+    paths.into_iter().zip(stats).collect()
+}
+
+/// Map any backend error into [`Error::Walk`] — the catch-all for
+/// rev-walk, object-lookup, and tree-decode failures. Shared by the
+/// backend submodules to keep the `?`-heavy gix plumbing terse.
+pub(super) fn walk_err(e: impl std::fmt::Display) -> Error {
+    Error::Walk(e.to_string())
+}
+
+/// Map any backend error into [`Error::Diff`] — tree-to-tree and
+/// blob-diff failures.
+pub(super) fn diff_err(e: impl std::fmt::Display) -> Error {
+    Error::Diff(e.to_string())
+}
+
+/// Parse an `--as-of` timestamp (RFC 3339 / ISO 8601 / `@unix` / git
+/// date spellings) into Unix seconds via gix's date parser.
+///
+/// # Errors
+///
+/// Returns [`Error::InvalidTimestamp`] when the input is unparseable.
+pub(crate) fn parse_timestamp(input: &str) -> Result<i64, Error> {
+    // Accept a bare `@<unix>` epoch directly — gix's date parser does
+    // not recognise that spelling, but it is a convenient reproducible
+    // form for `--as-of`.
+    if let Some(epoch) = input.strip_prefix('@') {
+        return epoch
+            .parse::<i64>()
+            .map_err(|_| Error::InvalidTimestamp(format!("{input:?}: not a Unix timestamp")));
+    }
+    gix::date::parse(input, Some(SystemTime::now()))
+        .map(|time| time.seconds)
+        .map_err(|e| Error::InvalidTimestamp(format!("{input:?}: {e}")))
+}
+
+/// Wall-clock time as Unix seconds, saturating rather than panicking if
+/// the system clock predates the epoch.
+fn current_unix_seconds() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| i64::try_from(d.as_secs()).unwrap_or(i64::MAX))
+}

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -132,3 +132,7 @@ fn current_unix_seconds() -> i64 {
         .duration_since(UNIX_EPOCH)
         .map_or(0, |d| i64::try_from(d.as_secs()).unwrap_or(i64::MAX))
 }
+
+#[cfg(test)]
+#[path = "mod_tests.rs"]
+mod tests;

--- a/src/vcs/git/mod_tests.rs
+++ b/src/vcs/git/mod_tests.rs
@@ -1,0 +1,31 @@
+use super::*;
+
+#[test]
+fn walk_err_wraps_into_walk_variant() {
+    let err = walk_err("object missing");
+    assert!(matches!(err, Error::Walk(msg) if msg == "object missing"));
+}
+
+#[test]
+fn diff_err_wraps_into_diff_variant() {
+    let err = diff_err("blob decode failed");
+    assert!(matches!(err, Error::Diff(msg) if msg == "blob decode failed"));
+}
+
+#[test]
+fn at_prefixed_non_numeric_timestamp_is_rejected() {
+    // The `@<unix>` fast-path must reject a non-numeric epoch with a
+    // typed error rather than silently falling through to gix's parser.
+    assert!(matches!(
+        parse_timestamp("@notanumber"),
+        Err(Error::InvalidTimestamp(_))
+    ));
+}
+
+#[test]
+fn current_unix_seconds_is_a_recent_wall_clock() {
+    // 2020-01-01T00:00:00Z. Any sane build host's clock is well past
+    // this, exercising the happy `duration_since(UNIX_EPOCH)` path.
+    const JAN_1_2020: i64 = 1_577_836_800;
+    assert!(current_unix_seconds() > JAN_1_2020);
+}

--- a/src/vcs/git/mod_tests.rs
+++ b/src/vcs/git/mod_tests.rs
@@ -13,12 +13,25 @@ fn diff_err_wraps_into_diff_variant() {
 }
 
 #[test]
+fn at_prefixed_epoch_is_parsed_by_the_fast_path() {
+    // gix's date parser does not accept the bare `@<unix>` spelling, so a
+    // correct parse here proves our fast-path ran — not the gix fallback.
+    // This is what makes the negative test below load-bearing: if the
+    // fast-path were deleted, this assertion would fail.
+    assert_eq!(
+        parse_timestamp("@1577836800").expect("epoch"),
+        1_577_836_800
+    );
+}
+
+#[test]
 fn at_prefixed_non_numeric_timestamp_is_rejected() {
-    // The `@<unix>` fast-path must reject a non-numeric epoch with a
-    // typed error rather than silently falling through to gix's parser.
+    // Pin the fast-path's *own* error message. A bare wildcard match
+    // would also pass via the gix fallback (which rejects `@notanumber`
+    // as InvalidTimestamp too), so it would not guard the fast-path.
     assert!(matches!(
         parse_timestamp("@notanumber"),
-        Err(Error::InvalidTimestamp(_))
+        Err(Error::InvalidTimestamp(msg)) if msg.contains("not a Unix timestamp")
     ));
 }
 

--- a/src/vcs/git/repo.rs
+++ b/src/vcs/git/repo.rs
@@ -1,0 +1,123 @@
+// bca: suppress-file(halstead, nargs, exit)
+// File-level halstead/nargs/exit are many-fn aggregation artifacts (the
+// gix open/diff plumbing with many `?` error maps), not per-function
+// logic complexity (cognitive/cyclomatic stay enforced).
+
+//! Repository discovery and target-tree file enumeration.
+
+use std::collections::HashMap;
+use std::ops::ControlFlow;
+use std::path::{Path, PathBuf};
+
+use super::diff_err;
+use crate::vcs::error::Error;
+
+/// A discovered repository plus the facts the walk needs up front.
+pub(crate) struct OpenRepo {
+    /// The opened repository handle.
+    pub repo: gix::Repository,
+    /// Working-tree root, canonicalised; `None` for bare repos.
+    pub workdir: Option<PathBuf>,
+    /// Whether the repository is a shallow clone (history truncated).
+    pub shallow: bool,
+}
+
+/// Discover and open the repository containing `root`.
+///
+/// # Errors
+///
+/// Returns [`Error::NotARepository`] when no repository encloses
+/// `root`, or [`Error::OpenRepository`] for any other open failure
+/// (corrupt repo, permission denied, …).
+pub(crate) fn open(root: &Path) -> Result<OpenRepo, Error> {
+    let repo = gix::discover(root).map_err(|e| map_discover_error(root, &e))?;
+    let shallow = repo.is_shallow();
+    // Canonicalise the work dir so absolute-path lookups (used by
+    // `bca metrics --metrics vcs`) strip a matching prefix even when
+    // the caller passed a symlinked or relative root.
+    let workdir = repo
+        .workdir()
+        .map(|w| w.canonicalize().unwrap_or_else(|_| w.to_path_buf()));
+    Ok(OpenRepo {
+        repo,
+        workdir,
+        shallow,
+    })
+}
+
+/// Map a discovery failure to a typed error, distinguishing "no
+/// repository here" (a clean user-facing condition) from genuine open
+/// failures.
+fn map_discover_error(root: &Path, error: &gix::discover::Error) -> Error {
+    use gix::discover::upwards::Error as Upwards;
+    if let gix::discover::Error::Discover(
+        Upwards::NoGitRepository { .. }
+        | Upwards::NoGitRepositoryWithinCeiling { .. }
+        | Upwards::NoGitRepositoryWithinFs { .. }
+        | Upwards::NoTrustedGitRepository { .. },
+    ) = error
+    {
+        return Error::NotARepository(root.to_path_buf());
+    }
+    Error::OpenRepository(error.to_string())
+}
+
+/// Enumerate every tracked text file at `target_tree`, mapping its
+/// repository-relative path to its line count (SLOC).
+///
+/// Binary blobs (line counts unavailable) and symlinks are skipped, as
+/// the issue specifies. Implemented as a diff of the empty tree against
+/// the target tree: every file then appears as an `Addition` whose
+/// "added" line count is the file's total line count.
+///
+/// # Errors
+///
+/// Returns [`Error::Diff`] if the diff machinery fails, or if a path is
+/// not valid UTF-8 on a platform that requires it.
+pub(crate) fn enumerate_target_files(
+    repo: &gix::Repository,
+    target_tree: &gix::Tree<'_>,
+) -> Result<HashMap<PathBuf, u64>, Error> {
+    let empty = repo.empty_tree();
+    let mut cache = repo.diff_resource_cache_for_tree_diff().map_err(diff_err)?;
+    let mut files = HashMap::new();
+
+    empty
+        .changes()
+        .map_err(diff_err)?
+        .options(|opts| {
+            opts.track_path();
+            // No rewrite tracking needed: every entry is a fresh
+            // addition relative to the empty tree.
+            opts.track_rewrites(None);
+        })
+        .for_each_to_obtain_tree(target_tree, |change| -> Result<ControlFlow<()>, Error> {
+            let entry_mode = change.entry_mode();
+            if entry_mode.is_blob() && !entry_mode.is_link() {
+                let path = bstr_to_path(change.location())?;
+                if let Some(stats) = change
+                    .diff(&mut cache)
+                    .map_err(diff_err)?
+                    .line_counts()
+                    .map_err(diff_err)?
+                {
+                    // `after` is the destination line count — i.e. the
+                    // file's SLOC, since the source (empty tree) is 0.
+                    files.insert(path, stats.after as u64);
+                }
+            }
+            Ok(ControlFlow::Continue(()))
+        })
+        .map_err(diff_err)?;
+
+    Ok(files)
+}
+
+/// Convert a git path (raw bytes) to a `PathBuf`, erroring rather than
+/// lossily mangling a non-UTF-8 path that is used as a map key
+/// (per the path rules in AGENTS.md).
+pub(crate) fn bstr_to_path(location: &bstr::BStr) -> Result<PathBuf, Error> {
+    gix::path::try_from_bstr(location)
+        .map(std::borrow::Cow::into_owned)
+        .map_err(|_| Error::Diff(format!("path {location:?} is not valid UTF-8")))
+}

--- a/src/vcs/hotspot.rs
+++ b/src/vcs/hotspot.rs
@@ -19,3 +19,7 @@
 pub fn hotspot_score(complexity_index: f64, churn_recent: u64) -> f64 {
     complexity_index.max(0.0) * churn_recent as f64
 }
+
+#[cfg(test)]
+#[path = "hotspot_tests.rs"]
+mod tests;

--- a/src/vcs/hotspot.rs
+++ b/src/vcs/hotspot.rs
@@ -1,0 +1,21 @@
+//! Complexity × churn "hotspot" score (Tornhill; Nagappan & Ball).
+//!
+//! A hotspot is a file that is both complex *and* changes often — the
+//! intersection the empirical work finds most defect-prone. It is only
+//! meaningful when an AST-derived complexity figure is available
+//! alongside the change history, so the field is `Option<f64>` on the
+//! serialized stats and is filled in by the consumer that has both
+//! halves (e.g. `bca metrics --metrics cyclomatic,vcs`).
+
+/// Compute the hotspot score from a complexity index and recent churn.
+///
+/// `complexity_index` is supplied by the caller from whichever
+/// AST metric it treats as the complexity axis (the CLI uses the
+/// file-level cyclomatic sum, the conventional hotspot proxy). The
+/// product is ordinal, like the risk score: rank files by it, do not
+/// read absolute magnitudes.
+#[must_use]
+#[allow(clippy::cast_precision_loss)]
+pub fn hotspot_score(complexity_index: f64, churn_recent: u64) -> f64 {
+    complexity_index.max(0.0) * churn_recent as f64
+}

--- a/src/vcs/hotspot_tests.rs
+++ b/src/vcs/hotspot_tests.rs
@@ -1,25 +1,21 @@
-use super::*;
+// Exact-equality on f64 is intentional here: every compared value is an
+// exactly-representable product of small integers (50.0, 10.0, 0.0), so
+// `float_cmp` is a false positive — matching the sibling convention in
+// score_tests.rs / stats_tests.rs.
+#![allow(clippy::float_cmp)]
 
-/// These hotspot products are all exactly representable in f64, but
-/// clippy's `float_cmp` forbids `==` on floats project-wide; assert
-/// closeness instead.
-fn approx(actual: f64, expected: f64) {
-    assert!(
-        (actual - expected).abs() < f64::EPSILON,
-        "expected {expected}, got {actual}"
-    );
-}
+use super::*;
 
 #[test]
 fn hotspot_is_complexity_times_recent_churn() {
-    approx(hotspot_score(10.0, 5), 50.0);
-    approx(hotspot_score(2.5, 4), 10.0);
+    assert_eq!(hotspot_score(10.0, 5), 50.0);
+    assert_eq!(hotspot_score(2.5, 4), 10.0);
 }
 
 #[test]
 fn zero_churn_or_zero_complexity_is_zero() {
-    approx(hotspot_score(0.0, 100), 0.0);
-    approx(hotspot_score(12.0, 0), 0.0);
+    assert_eq!(hotspot_score(0.0, 100), 0.0);
+    assert_eq!(hotspot_score(12.0, 0), 0.0);
 }
 
 #[test]
@@ -27,5 +23,5 @@ fn negative_complexity_clamps_to_zero() {
     // Defends the `.max(0.0)`: a caller passing a nonsensical negative
     // complexity index must not yield a negative product, which would
     // sort the file *below* genuinely cold files.
-    approx(hotspot_score(-3.0, 5), 0.0);
+    assert_eq!(hotspot_score(-3.0, 5), 0.0);
 }

--- a/src/vcs/hotspot_tests.rs
+++ b/src/vcs/hotspot_tests.rs
@@ -1,0 +1,31 @@
+use super::*;
+
+/// These hotspot products are all exactly representable in f64, but
+/// clippy's `float_cmp` forbids `==` on floats project-wide; assert
+/// closeness instead.
+fn approx(actual: f64, expected: f64) {
+    assert!(
+        (actual - expected).abs() < f64::EPSILON,
+        "expected {expected}, got {actual}"
+    );
+}
+
+#[test]
+fn hotspot_is_complexity_times_recent_churn() {
+    approx(hotspot_score(10.0, 5), 50.0);
+    approx(hotspot_score(2.5, 4), 10.0);
+}
+
+#[test]
+fn zero_churn_or_zero_complexity_is_zero() {
+    approx(hotspot_score(0.0, 100), 0.0);
+    approx(hotspot_score(12.0, 0), 0.0);
+}
+
+#[test]
+fn negative_complexity_clamps_to_zero() {
+    // Defends the `.max(0.0)`: a caller passing a nonsensical negative
+    // complexity index must not yield a negative product, which would
+    // sort the file *below* genuinely cold files.
+    approx(hotspot_score(-3.0, 5), 0.0);
+}

--- a/src/vcs/identity.rs
+++ b/src/vcs/identity.rs
@@ -1,0 +1,99 @@
+// bca: suppress-file(halstead)
+// File-level halstead is a many-fn aggregation artifact (the hashing +
+// canonicalisation helpers), not per-function logic complexity
+// (cognitive/cyclomatic stay enforced).
+
+//! Canonical author identity and bot-author detection.
+//!
+//! Backend-agnostic: the git backend resolves a commit signature
+//! through `.mailmap` and hands the canonical `(name, email)` byte
+//! pairs here. The email (lowercased) is the identity key — two commits
+//! with the same canonical email count as one author even under
+//! differing display names. Raw identities never leave the process;
+//! `--emit-author-details` opts into a SHA-256 hash of the canonical
+//! email instead of the plaintext.
+
+use sha2::{Digest, Sha256};
+
+use regex::Regex;
+
+use super::error::Error;
+
+/// A canonical author identity, keyed by lowercased email.
+///
+/// Falls back to the lowercased display name when the email is empty
+/// (some imported histories carry name-only authors). Compared and
+/// hashed by that key so author *counts* and *ownership* are stable
+/// across display-name variation.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct AuthorId(String);
+
+impl AuthorId {
+    /// Build a canonical identity from raw signature bytes.
+    ///
+    /// Bytes are interpreted lossily as UTF-8: an identity is a map key
+    /// and a hash pre-image, never re-emitted as a path, so a stray
+    /// non-UTF-8 byte degrading to U+FFFD is acceptable and keeps the
+    /// function total.
+    #[must_use]
+    pub fn new(name: &[u8], email: &[u8]) -> Self {
+        let email_key = String::from_utf8_lossy(email).trim().to_lowercase();
+        let key = if email_key.is_empty() {
+            String::from_utf8_lossy(name).trim().to_lowercase()
+        } else {
+            email_key
+        };
+        Self(key)
+    }
+
+    /// SHA-256 hex digest of the canonical key, for
+    /// `--emit-author-details`. Stable across runs and irreversible, so
+    /// it can be published without disclosing the underlying email.
+    #[must_use]
+    pub fn hashed(&self) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(self.0.as_bytes());
+        let digest = hasher.finalize();
+        let mut hex = String::with_capacity(digest.len() * 2);
+        for byte in digest {
+            use std::fmt::Write as _;
+            // Writing to a String is infallible; the formatter never
+            // errors, so the result is discarded deliberately.
+            let _ = write!(hex, "{byte:02x}");
+        }
+        hex
+    }
+}
+
+/// Matches author identities against a bot-exclusion pattern.
+#[derive(Clone, Debug)]
+pub struct BotFilter {
+    pattern: Regex,
+}
+
+impl BotFilter {
+    /// Compile a bot-exclusion pattern.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidBotPattern`] when `pattern` is not a
+    /// valid regular expression.
+    pub fn new(pattern: &str) -> Result<Self, Error> {
+        let pattern = Regex::new(pattern).map_err(|e| Error::InvalidBotPattern(e.to_string()))?;
+        Ok(Self { pattern })
+    }
+
+    /// Returns `true` when either the display name or the email matches
+    /// the bot pattern. Both are checked because automation identities
+    /// vary on which field carries the `[bot]` marker.
+    #[must_use]
+    pub fn is_bot(&self, name: &[u8], email: &[u8]) -> bool {
+        let name = String::from_utf8_lossy(name);
+        let email = String::from_utf8_lossy(email);
+        self.pattern.is_match(&name) || self.pattern.is_match(&email)
+    }
+}
+
+#[cfg(test)]
+#[path = "identity_tests.rs"]
+mod tests;

--- a/src/vcs/identity_tests.rs
+++ b/src/vcs/identity_tests.rs
@@ -1,0 +1,69 @@
+use super::*;
+use crate::vcs::options::DEFAULT_BOT_PATTERN;
+
+#[test]
+fn same_email_different_name_is_one_identity() {
+    let a = AuthorId::new(b"Ada Lovelace", b"ada@example.com");
+    let b = AuthorId::new(b"A. Lovelace", b"ada@example.com");
+    assert_eq!(a, b);
+}
+
+#[test]
+fn email_is_case_insensitive() {
+    let a = AuthorId::new(b"Ada", b"Ada@Example.COM");
+    let b = AuthorId::new(b"Ada", b"ada@example.com");
+    assert_eq!(a, b);
+}
+
+#[test]
+fn distinct_emails_are_distinct_identities() {
+    let a = AuthorId::new(b"Ada", b"ada@example.com");
+    let b = AuthorId::new(b"Grace", b"grace@example.com");
+    assert_ne!(a, b);
+}
+
+#[test]
+fn empty_email_falls_back_to_name() {
+    let a = AuthorId::new(b"Ada Lovelace", b"");
+    let b = AuthorId::new(b"ada lovelace", b"");
+    assert_eq!(a, b);
+    // ...and is distinct from an email-keyed identity.
+    assert_ne!(a, AuthorId::new(b"Ada", b"ada@example.com"));
+}
+
+#[test]
+fn hashed_is_stable_and_irreversible_looking() {
+    let id = AuthorId::new(b"Ada", b"ada@example.com");
+    let h1 = id.hashed();
+    let h2 = AuthorId::new(b"different name", b"ada@example.com").hashed();
+    // Hash keys off the canonical email, so the same email hashes equal
+    // regardless of display name.
+    assert_eq!(h1, h2);
+    // SHA-256 hex is 64 chars.
+    assert_eq!(h1.len(), 64);
+    // The digest depends on the canonical email: a different email
+    // hashes differently (so the hash is not a constant, and pins that
+    // the email — not the name — is the pre-image).
+    assert_ne!(h1, AuthorId::new(b"Ada", b"grace@example.com").hashed());
+}
+
+#[test]
+fn default_bot_pattern_matches_known_bots() {
+    let filter = BotFilter::new(DEFAULT_BOT_PATTERN).expect("default pattern compiles");
+    assert!(filter.is_bot(
+        b"dependabot[bot]",
+        b"49699333+dependabot[bot]@users.noreply.github.com"
+    ));
+    assert!(filter.is_bot(b"renovate[bot]", b"renovate@whitesourcesoftware.com"));
+    assert!(filter.is_bot(b"github-actions[bot]", b""));
+    // A human is not a bot.
+    assert!(!filter.is_bot(b"Ada Lovelace", b"ada@example.com"));
+}
+
+#[test]
+fn invalid_bot_pattern_is_rejected() {
+    assert!(matches!(
+        BotFilter::new("(unclosed"),
+        Err(Error::InvalidBotPattern(_))
+    ));
+}

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -177,3 +177,7 @@ pub fn rank_by_risk<T>(entries: &mut Vec<T>, top: usize, key: impl Fn(&T) -> (&s
         entries.truncate(top);
     }
 }
+
+#[cfg(test)]
+#[path = "mod_tests.rs"]
+mod tests;

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -1,0 +1,179 @@
+// bca: suppress-file(halstead, nargs)
+// File-level halstead/nargs are many-fn aggregation artifacts (the
+// HistoryIndex accessors + entry points), not per-function logic
+// complexity (cognitive/cyclomatic stay enforced).
+
+//! Change-history (VCS) metrics: per-file signals derived from version
+//! control history rather than the AST.
+//!
+//! This is the project's first metric family that is language-agnostic
+//! and not AST-derived (issue #328). It surfaces files most likely to
+//! harbour bugs or vulnerabilities using the signals the empirical
+//! literature most consistently backs — recent churn, commit frequency,
+//! author count and ownership dilution, bug- and security-fix history —
+//! combined into an ordinal `risk_score`.
+//!
+//! # Layout
+//!
+//! The generic surface (`error`, `options`, `stats`, `identity`,
+//! `classify`, `score`, `hotspot`, and `build_history_index`) carries
+//! no backend reference, so a future backend (Mercurial, Jujutsu, …;
+//! issue #335) reuses it unchanged. Backend-specific code lives under
+//! the `git` module behind the `vcs-git` Cargo feature.
+//!
+//! v1 deliberately omits a `Backend` trait: with a single backend it
+//! would be premature abstraction. `build_history_index` delegates to
+//! the one available backend; the trait is extracted when a second
+//! backend lands.
+
+pub mod classify;
+pub mod error;
+pub mod hotspot;
+pub mod identity;
+pub mod options;
+pub mod score;
+pub mod stats;
+
+#[cfg(feature = "vcs-git")]
+pub mod git;
+
+pub use error::Error;
+pub use options::{Options, RiskFormula, parse_window};
+pub use stats::Stats;
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// The result of one history walk: per-file [`Stats`] keyed by
+/// repository-relative path, plus walk-level metadata.
+#[derive(Clone, Debug, Default)]
+pub struct HistoryIndex {
+    files: HashMap<PathBuf, Stats>,
+    workdir: Option<PathBuf>,
+    truncated_shallow_clone: bool,
+}
+
+impl HistoryIndex {
+    /// Construct an index from its parts. Used by backends.
+    #[must_use]
+    pub fn new(
+        files: HashMap<PathBuf, Stats>,
+        workdir: Option<PathBuf>,
+        truncated_shallow_clone: bool,
+    ) -> Self {
+        Self {
+            files,
+            workdir,
+            truncated_shallow_clone,
+        }
+    }
+
+    /// Look up stats by repository-relative path.
+    #[must_use]
+    pub fn get(&self, repo_relative: &Path) -> Option<&Stats> {
+        self.files.get(repo_relative)
+    }
+
+    /// Look up stats for an absolute filesystem path by stripping the
+    /// working-tree prefix. Returns `None` for paths outside the work
+    /// tree or when the repository is bare (no work tree).
+    #[must_use]
+    pub fn get_for_path(&self, absolute: &Path) -> Option<&Stats> {
+        let workdir = self.workdir.as_deref()?;
+        let relative = absolute.strip_prefix(workdir).ok()?;
+        self.files.get(relative)
+    }
+
+    /// Iterate `(repo-relative path, stats)` pairs.
+    pub fn iter(&self) -> impl Iterator<Item = (&PathBuf, &Stats)> {
+        self.files.iter()
+    }
+
+    /// Number of files in the index.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.files.len()
+    }
+
+    /// Whether the index is empty (empty repo, or no tracked text
+    /// files at the target ref).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.files.is_empty()
+    }
+
+    /// `true` when the repository is a shallow clone and history was
+    /// therefore truncated; the front end surfaces this as a warning.
+    #[must_use]
+    pub fn truncated_shallow_clone(&self) -> bool {
+        self.truncated_shallow_clone
+    }
+
+    /// The repository working-tree root, if any (`None` for bare repos).
+    #[must_use]
+    pub fn workdir(&self) -> Option<&Path> {
+        self.workdir.as_deref()
+    }
+
+    /// Consume the index, yielding its per-file map.
+    #[must_use]
+    pub fn into_files(self) -> HashMap<PathBuf, Stats> {
+        self.files
+    }
+}
+
+/// Walk the change history rooted at `root` and build a per-file
+/// [`HistoryIndex`].
+///
+/// Runs **once** per invocation (before any AST walk): walking history
+/// per file would be catastrophic on large repositories. The single
+/// available backend is selected automatically by probing the working
+/// tree.
+///
+/// # Errors
+///
+/// Returns [`Error::NotARepository`] when `root` is not inside a
+/// supported VCS working tree, or a backend-specific variant when the
+/// walk itself fails.
+#[cfg(feature = "vcs-git")]
+pub fn build_history_index(root: &Path, options: &Options) -> Result<HistoryIndex, Error> {
+    git::build(root, options)
+}
+
+/// Parse an `--as-of` timestamp into Unix seconds.
+///
+/// Accepts RFC 3339 / ISO 8601, a bare `@<unix>` epoch, and the git
+/// date spellings gix understands. Front ends use this to fill
+/// [`Options::as_of`] for reproducible snapshots.
+///
+/// # Errors
+///
+/// Returns [`Error::InvalidTimestamp`] when the input is unparseable.
+#[cfg(feature = "vcs-git")]
+pub fn parse_timestamp(input: &str) -> Result<i64, Error> {
+    git::parse_timestamp(input)
+}
+
+/// Rank `entries` by descending risk score, breaking ties on the file
+/// path (ascending), then truncate to the top `top` (`0` = keep all).
+///
+/// The single definition of the `bca vcs` / `POST /vcs` / `vcs_metrics`
+/// output ordering, shared by all three front ends so the float-compare
+/// and tie-break contract cannot drift between them. `key` extracts the
+/// `(path, risk_score)` pair from each entry, so callers keep their own
+/// per-crate entry types.
+pub fn rank_by_risk<T>(entries: &mut Vec<T>, top: usize, key: impl Fn(&T) -> (&str, f64)) {
+    entries.sort_by(|a, b| {
+        let (path_a, risk_a) = key(a);
+        let (path_b, risk_b) = key(b);
+        // Descending risk; NaN (never produced today) sorts as equal so
+        // the path tie-break still yields a stable, deterministic order.
+        risk_b
+            .partial_cmp(&risk_a)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| path_a.cmp(path_b))
+    });
+    if top > 0 && entries.len() > top {
+        entries.truncate(top);
+    }
+}

--- a/src/vcs/mod_tests.rs
+++ b/src/vcs/mod_tests.rs
@@ -110,4 +110,11 @@ fn rank_nan_risk_falls_back_to_path_order() {
         ranked(vec![("beta", f64::NAN), ("alpha", f64::NAN)], 0),
         vec!["alpha", "beta"]
     );
+    // Mixed NaN/finite: partial_cmp is *also* None here, so the path
+    // tie-break still decides. Guards against a future switch to
+    // total_cmp, which orders NaN as max/min and would reorder this.
+    assert_eq!(
+        ranked(vec![("finite", 1.0), ("nanny", f64::NAN)], 0),
+        vec!["finite", "nanny"]
+    );
 }

--- a/src/vcs/mod_tests.rs
+++ b/src/vcs/mod_tests.rs
@@ -1,0 +1,113 @@
+use super::*;
+use std::path::{Path, PathBuf};
+
+fn index_with(workdir: Option<&str>, files: &[&str]) -> HistoryIndex {
+    let map: HashMap<PathBuf, Stats> = files
+        .iter()
+        .map(|f| (PathBuf::from(f), Stats::default()))
+        .collect();
+    HistoryIndex::new(map, workdir.map(PathBuf::from), false)
+}
+
+#[test]
+fn accessors_reflect_construction() {
+    let idx = index_with(Some("/repo"), &["a.rs", "b.rs"]);
+    assert_eq!(idx.len(), 2);
+    assert!(!idx.is_empty());
+    assert!(idx.get(Path::new("a.rs")).is_some());
+    assert!(idx.get(Path::new("missing.rs")).is_none());
+    assert_eq!(idx.workdir(), Some(Path::new("/repo")));
+    assert!(!idx.truncated_shallow_clone());
+}
+
+#[test]
+fn default_index_is_empty() {
+    let idx = HistoryIndex::default();
+    assert_eq!(idx.len(), 0);
+    assert!(idx.is_empty());
+    assert!(idx.workdir().is_none());
+    assert!(!idx.truncated_shallow_clone());
+}
+
+#[test]
+fn get_for_path_strips_the_workdir_prefix() {
+    let idx = index_with(Some("/repo"), &["src/a.rs"]);
+    // Absolute path inside the work tree resolves to its relative entry.
+    assert!(idx.get_for_path(Path::new("/repo/src/a.rs")).is_some());
+    // A path outside the work tree cannot be made relative → None.
+    assert!(idx.get_for_path(Path::new("/elsewhere/src/a.rs")).is_none());
+}
+
+#[test]
+fn get_for_path_returns_none_for_a_bare_repo() {
+    // No work tree (bare repo) → an absolute path can never be resolved.
+    let idx = index_with(None, &["src/a.rs"]);
+    assert!(idx.get_for_path(Path::new("/repo/src/a.rs")).is_none());
+}
+
+#[test]
+fn iter_and_into_files_expose_the_map() {
+    let idx = index_with(Some("/repo"), &["a.rs", "b.rs"]);
+    let mut seen: Vec<_> = idx.iter().map(|(p, _)| p.clone()).collect();
+    seen.sort();
+    assert_eq!(seen, vec![PathBuf::from("a.rs"), PathBuf::from("b.rs")]);
+    assert_eq!(idx.into_files().len(), 2);
+}
+
+#[derive(Debug)]
+struct Entry {
+    path: String,
+    risk: f64,
+}
+
+fn ranked(entries: Vec<(&str, f64)>, top: usize) -> Vec<String> {
+    let mut entries: Vec<Entry> = entries
+        .into_iter()
+        .map(|(path, risk)| Entry {
+            path: path.to_owned(),
+            risk,
+        })
+        .collect();
+    rank_by_risk(&mut entries, top, |e| (e.path.as_str(), e.risk));
+    entries.into_iter().map(|e| e.path).collect()
+}
+
+#[test]
+fn rank_orders_by_descending_risk() {
+    assert_eq!(
+        ranked(vec![("low", 1.0), ("high", 9.0), ("mid", 5.0)], 0),
+        vec!["high", "mid", "low"]
+    );
+}
+
+#[test]
+fn rank_breaks_ties_on_path_ascending() {
+    // Equal risk must yield a deterministic, path-ordered result.
+    assert_eq!(
+        ranked(vec![("zeta", 5.0), ("alpha", 5.0)], 0),
+        vec!["alpha", "zeta"]
+    );
+}
+
+#[test]
+fn rank_truncates_to_top_n() {
+    assert_eq!(
+        ranked(vec![("a", 1.0), ("b", 2.0), ("c", 3.0)], 2),
+        vec!["c", "b"]
+    );
+}
+
+#[test]
+fn rank_top_zero_keeps_all() {
+    assert_eq!(ranked(vec![("a", 1.0), ("b", 2.0)], 0).len(), 2);
+}
+
+#[test]
+fn rank_nan_risk_falls_back_to_path_order() {
+    // NaN never occurs in production, but the `unwrap_or(Equal)` branch
+    // must still produce a stable path-ordered result, not a panic.
+    assert_eq!(
+        ranked(vec![("beta", f64::NAN), ("alpha", f64::NAN)], 0),
+        vec!["alpha", "beta"]
+    );
+}

--- a/src/vcs/options.rs
+++ b/src/vcs/options.rs
@@ -1,0 +1,274 @@
+// bca: suppress-file(halstead, nargs, exit)
+// File-level halstead/nargs/exit are many-fn aggregation artifacts (the
+// window parser's unit branches + the Options builder), not
+// per-function logic complexity (cognitive/cyclomatic stay enforced).
+
+//! Configuration for a change-history walk.
+//!
+//! [`Options`] is a plain data struct: the CLI / web / Python layers
+//! fill it in from user input, and [`build_history_index`](crate::vcs::build_history_index)
+//! consumes it. Time windows are stored already resolved to seconds so
+//! the generic core never re-parses user duration strings; the
+//! [`parse_window`] helper is exposed for those front ends to perform
+//! that resolution (and to surface a typed [`Error`] on bad input).
+
+use super::error::Error;
+
+/// Seconds in a day.
+pub(crate) const SECONDS_PER_DAY: i64 = 86_400;
+/// Seconds in a week.
+const SECONDS_PER_WEEK: i64 = 7 * SECONDS_PER_DAY;
+/// Seconds in an average Gregorian month (30.436875 days). Months and
+/// years are inherently approximate; the average keeps `12mo` and `1y`
+/// numerically identical (both 365.2425 days → 365 days), matching the
+/// `long_window_days: 365` shown in the issue's output sample.
+const SECONDS_PER_MONTH: i64 = 2_629_746;
+/// Seconds in an average Gregorian year (365.2425 days).
+const SECONDS_PER_YEAR: i64 = 31_556_952;
+
+/// Default long window (`12mo` ≈ 365 days).
+pub const DEFAULT_LONG_WINDOW: &str = "12mo";
+/// Default recent window (`90d`).
+pub const DEFAULT_RECENT_WINDOW: &str = "90d";
+
+/// Default bot-author exclusion pattern (case-insensitive, matched as a
+/// substring against both the canonical author name and email). The
+/// `[bot]` suffixes are regex-escaped. Mirrors the well-known automation
+/// identities called out in issue #328.
+pub const DEFAULT_BOT_PATTERN: &str = r"dependabot\[bot\]|renovate\[bot\]|github-actions\[bot\]|pre-commit-ci\[bot\]|mergify\[bot\]|pyup-bot";
+
+/// Which composite risk-score formula to apply.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum RiskFormula {
+    /// Log-scaled weighted sum with categorical bumps (the `v1`
+    /// formula documented in [`score`](crate::vcs::score)).
+    #[default]
+    Weighted,
+    /// Each signal re-ranked to its percentile within the analyzed
+    /// set, then averaged. The literature recommends relative triggers
+    /// over hard thresholds for cross-project robustness.
+    Percentile,
+}
+
+impl std::str::FromStr for RiskFormula {
+    type Err = Error;
+
+    /// Parse the user-facing formula name. The single source of truth
+    /// shared by the web (`POST /vcs`) and Python (`vcs_metrics`) front
+    /// ends; the CLI uses a clap `ValueEnum` instead.
+    fn from_str(s: &str) -> Result<Self, Error> {
+        match s {
+            "weighted" => Ok(Self::Weighted),
+            "percentile" => Ok(Self::Percentile),
+            other => Err(Error::InvalidFormula(other.to_owned())),
+        }
+    }
+}
+
+/// Configuration for a single change-history walk.
+// The booleans are independent on/off CLI toggles (`--full-history`,
+// `--include-merges`, …); packing them into a flags newtype would hide
+// each one's meaning at construction sites for no real gain.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Clone, Debug)]
+pub struct Options {
+    /// Long observation window, in seconds (default ≈ 365 days).
+    pub long_window_secs: i64,
+    /// Recent observation window, in seconds (default 90 days).
+    pub recent_window_secs: i64,
+    /// Revision to start the walk from (default `HEAD`).
+    pub reference: String,
+    /// Walk the full commit DAG rather than first-parent only.
+    pub full_history: bool,
+    /// Include merge commits (default: skip them).
+    pub include_merges: bool,
+    /// Follow file renames across history (default: on).
+    pub follow_renames: bool,
+    /// Exclude bot author identities (default: on).
+    pub exclude_bots: bool,
+    /// Regex matched against author name/email to detect bots.
+    pub bot_pattern: String,
+    /// Reference "now" as a Unix timestamp for reproducible snapshots
+    /// (`--as-of`). `None` means wall-clock time at walk start.
+    pub as_of: Option<i64>,
+    /// Which composite score to compute.
+    pub risk_formula: RiskFormula,
+    /// Emit SHA-256-hashed canonical author identities (default: off —
+    /// author identities never leave the process otherwise).
+    pub emit_author_details: bool,
+    /// Emit stats for files deleted at the target ref (default: off).
+    pub include_deleted: bool,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            // The default-window constants are valid by construction;
+            // `expect` documents the invariant (AGENTS.md permits it
+            // for provably-unreachable cases). A unit test pins it.
+            long_window_secs: parse_window(DEFAULT_LONG_WINDOW)
+                .expect("DEFAULT_LONG_WINDOW parses"),
+            recent_window_secs: parse_window(DEFAULT_RECENT_WINDOW)
+                .expect("DEFAULT_RECENT_WINDOW parses"),
+            reference: "HEAD".to_owned(),
+            full_history: false,
+            include_merges: false,
+            follow_renames: true,
+            exclude_bots: true,
+            bot_pattern: DEFAULT_BOT_PATTERN.to_owned(),
+            as_of: None,
+            risk_formula: RiskFormula::Weighted,
+            emit_author_details: false,
+            include_deleted: false,
+        }
+    }
+}
+
+impl Options {
+    /// Long window expressed in whole days (for the serialized
+    /// `long_window_days` field and the `new_file`/age cap).
+    #[must_use]
+    pub fn long_window_days(&self) -> u32 {
+        secs_to_days(self.long_window_secs)
+    }
+
+    /// Recent window expressed in whole days.
+    #[must_use]
+    pub fn recent_window_days(&self) -> u32 {
+        secs_to_days(self.recent_window_secs)
+    }
+}
+
+/// Round a second count to the nearest whole day, saturating into
+/// `u32`. Window lengths never approach `u32::MAX` days in practice,
+/// but the saturation keeps the conversion total and lint-clean.
+fn secs_to_days(secs: i64) -> u32 {
+    let days = (secs + SECONDS_PER_DAY / 2) / SECONDS_PER_DAY;
+    u32::try_from(days.max(0)).unwrap_or(u32::MAX)
+}
+
+/// Parse a human time-window string into seconds.
+///
+/// Accepts a suffix form — `<number><unit>` with unit `d` (days),
+/// `w` (weeks), `mo` (months), or `y` (years) — or an ISO 8601 duration
+/// (`P12M`, `P90D`, `P2Y`, `P8W`). Months and years use the average
+/// Gregorian length, so `12mo`, `1y`, and `P1Y` all resolve to
+/// 365 days.
+///
+/// # Errors
+///
+/// Returns [`Error::InvalidWindow`] when the input is empty, carries an
+/// unrecognised unit, or has a non-numeric magnitude.
+pub fn parse_window(spec: &str) -> Result<i64, Error> {
+    let trimmed = spec.trim();
+    if trimmed.is_empty() {
+        return Err(Error::InvalidWindow("window is empty".to_owned()));
+    }
+    if let Some(rest) = trimmed.strip_prefix(['P', 'p']) {
+        return parse_iso8601(rest, spec);
+    }
+    // Suffix form: split the trailing alphabetic unit from the leading
+    // numeric magnitude.
+    let split = trimmed
+        .find(|c: char| c.is_ascii_alphabetic())
+        .ok_or_else(|| Error::InvalidWindow(format!("{spec:?} has no unit")))?;
+    let (number, unit) = trimmed.split_at(split);
+    let magnitude: i64 = number
+        .trim()
+        .parse()
+        .map_err(|_| Error::InvalidWindow(format!("{number:?} is not a whole number")))?;
+    let factor = unit_factor(unit)
+        .ok_or_else(|| Error::InvalidWindow(format!("unknown unit {unit:?} in {spec:?}")))?;
+    checked_window(magnitude, factor, spec)
+}
+
+/// Seconds-per-unit for the suffix form. `mo` is months (the bare `m`
+/// is intentionally rejected as ambiguous between minutes and months).
+fn unit_factor(unit: &str) -> Option<i64> {
+    match unit {
+        "d" => Some(SECONDS_PER_DAY),
+        "w" => Some(SECONDS_PER_WEEK),
+        "mo" => Some(SECONDS_PER_MONTH),
+        "y" => Some(SECONDS_PER_YEAR),
+        _ => None,
+    }
+}
+
+/// Parse the post-`P` body of an ISO 8601 duration. Only the date
+/// portion is meaningful for a history window; a `T` time section is
+/// rejected rather than silently ignored.
+fn parse_iso8601(body: &str, original: &str) -> Result<i64, Error> {
+    if body.is_empty() {
+        return Err(Error::InvalidWindow(format!("{original:?} has no fields")));
+    }
+    let mut total: i64 = 0;
+    let mut digits = String::new();
+    for ch in body.chars() {
+        if ch.is_ascii_digit() {
+            digits.push(ch);
+            continue;
+        }
+        if digits.is_empty() {
+            return Err(Error::InvalidWindow(format!(
+                "{original:?} field {ch:?} has no magnitude"
+            )));
+        }
+        let magnitude: i64 = digits
+            .parse()
+            .map_err(|_| Error::InvalidWindow(format!("{digits:?} is not a whole number")))?;
+        digits.clear();
+        // Date designators only: Y, M (months — date context), W, D.
+        let factor = match ch {
+            'Y' => SECONDS_PER_YEAR,
+            'M' => SECONDS_PER_MONTH,
+            'W' => SECONDS_PER_WEEK,
+            'D' => SECONDS_PER_DAY,
+            _ => {
+                return Err(Error::InvalidWindow(format!(
+                    "unsupported ISO 8601 designator {ch:?} in {original:?}"
+                )));
+            }
+        };
+        total = total
+            .checked_add(
+                magnitude
+                    .checked_mul(factor)
+                    .ok_or_else(|| Error::InvalidWindow(format!("{original:?} overflows")))?,
+            )
+            .ok_or_else(|| Error::InvalidWindow(format!("{original:?} overflows")))?;
+    }
+    if !digits.is_empty() {
+        return Err(Error::InvalidWindow(format!(
+            "{original:?} ends with a magnitude {digits:?} lacking a designator"
+        )));
+    }
+    reject_non_positive(total, original)
+}
+
+/// Multiply a magnitude by its unit factor, rejecting negatives and
+/// overflow.
+fn checked_window(magnitude: i64, factor: i64, spec: &str) -> Result<i64, Error> {
+    if magnitude < 0 {
+        return Err(Error::InvalidWindow(format!("{spec:?} is negative")));
+    }
+    let product = magnitude
+        .checked_mul(factor)
+        .ok_or_else(|| Error::InvalidWindow(format!("{spec:?} overflows")))?;
+    reject_non_positive(product, spec)
+}
+
+/// A zero-length window degenerates the walk (its boundary collapses
+/// onto `now`, admitting no history), so reject it rather than silently
+/// producing an empty result.
+fn reject_non_positive(seconds: i64, spec: &str) -> Result<i64, Error> {
+    if seconds <= 0 {
+        return Err(Error::InvalidWindow(format!(
+            "{spec:?} is not a positive duration"
+        )));
+    }
+    Ok(seconds)
+}
+
+#[cfg(test)]
+#[path = "options_tests.rs"]
+mod tests;

--- a/src/vcs/options_tests.rs
+++ b/src/vcs/options_tests.rs
@@ -62,3 +62,57 @@ fn default_bot_pattern_is_a_valid_regex() {
     // Guards the `expect` documented in `Options::default` / `BotFilter`.
     assert!(regex::Regex::new(DEFAULT_BOT_PATTERN).is_ok());
 }
+
+#[test]
+fn risk_formula_parses_known_names() {
+    assert_eq!(
+        "weighted".parse::<RiskFormula>().expect("weighted"),
+        RiskFormula::Weighted
+    );
+    assert_eq!(
+        "percentile".parse::<RiskFormula>().expect("percentile"),
+        RiskFormula::Percentile
+    );
+}
+
+#[test]
+fn risk_formula_rejects_unknown_name() {
+    assert!(
+        matches!("bogus".parse::<RiskFormula>(), Err(Error::InvalidFormula(name)) if name == "bogus")
+    );
+}
+
+#[test]
+fn iso8601_unsupported_designator_is_rejected() {
+    // 'X' is not a date designator (Y/M/W/D). Distinct from the
+    // no-magnitude path (`PT5S`): here a magnitude precedes a bad unit.
+    assert!(matches!(parse_window("P5X"), Err(Error::InvalidWindow(_))));
+}
+
+#[test]
+fn iso8601_trailing_magnitude_without_designator_is_rejected() {
+    // "P5" carries a magnitude with no unit designator to close it.
+    assert!(matches!(parse_window("P5"), Err(Error::InvalidWindow(_))));
+}
+
+#[test]
+fn overflowing_windows_are_rejected_not_wrapped() {
+    // Magnitudes large enough to overflow i64 seconds must surface a
+    // clean InvalidWindow, never a wrapped (and possibly negative)
+    // duration. Covers the `checked_mul` guards in both forms.
+    for bad in ["999999999999y", "P999999999999Y"] {
+        assert!(
+            matches!(parse_window(bad), Err(Error::InvalidWindow(_))),
+            "expected {bad:?} to be rejected as overflow"
+        );
+    }
+}
+
+#[test]
+fn secs_to_days_saturates_huge_and_floors_negative() {
+    // The conversion is total: a span past u32::MAX days saturates
+    // rather than wrapping, and a negative second-count floors to 0.
+    let huge = (i64::from(u32::MAX) + 10) * SECONDS_PER_DAY;
+    assert_eq!(secs_to_days(huge), u32::MAX);
+    assert_eq!(secs_to_days(-10 * SECONDS_PER_DAY), 0);
+}

--- a/src/vcs/options_tests.rs
+++ b/src/vcs/options_tests.rs
@@ -1,0 +1,64 @@
+use super::*;
+
+const DAY: i64 = 86_400;
+
+#[test]
+fn suffix_units_resolve_to_seconds() {
+    assert_eq!(parse_window("90d").expect("90d"), 90 * DAY);
+    assert_eq!(parse_window("8w").expect("8w"), 8 * 7 * DAY);
+    // Months and years use the average Gregorian length.
+    assert_eq!(parse_window("1y").expect("1y"), SECONDS_PER_YEAR);
+    assert_eq!(parse_window("12mo").expect("12mo"), 12 * SECONDS_PER_MONTH);
+}
+
+#[test]
+fn twelve_months_and_one_year_both_round_to_365_days() {
+    assert_eq!(secs_to_days(parse_window("12mo").expect("12mo")), 365);
+    assert_eq!(secs_to_days(parse_window("1y").expect("1y")), 365);
+    assert_eq!(secs_to_days(parse_window("90d").expect("90d")), 90);
+}
+
+#[test]
+fn iso8601_durations_parse() {
+    assert_eq!(parse_window("P90D").expect("P90D"), 90 * DAY);
+    assert_eq!(parse_window("P8W").expect("P8W"), 8 * 7 * DAY);
+    assert_eq!(parse_window("P1Y").expect("P1Y"), SECONDS_PER_YEAR);
+    assert_eq!(parse_window("P12M").expect("P12M"), 12 * SECONDS_PER_MONTH);
+    // Combined fields sum.
+    assert_eq!(
+        parse_window("P1Y6M").expect("P1Y6M"),
+        SECONDS_PER_YEAR + 6 * SECONDS_PER_MONTH
+    );
+}
+
+#[test]
+fn bad_windows_are_rejected() {
+    // A zero-length window degenerates the walk, so it is rejected too.
+    for bad in [
+        "", "  ", "12", "10x", "-5d", "P", "PT5S", "12m", "abc", "0d", "P0D", "0w",
+    ] {
+        assert!(
+            matches!(parse_window(bad), Err(Error::InvalidWindow(_))),
+            "expected {bad:?} to be rejected"
+        );
+    }
+}
+
+#[test]
+fn defaults_match_the_issue_sample() {
+    let options = Options::default();
+    assert_eq!(options.long_window_days(), 365);
+    assert_eq!(options.recent_window_days(), 90);
+    assert_eq!(options.reference, "HEAD");
+    assert!(options.follow_renames);
+    assert!(options.exclude_bots);
+    assert!(!options.full_history);
+    assert!(!options.include_merges);
+    assert_eq!(options.risk_formula, RiskFormula::Weighted);
+}
+
+#[test]
+fn default_bot_pattern_is_a_valid_regex() {
+    // Guards the `expect` documented in `Options::default` / `BotFilter`.
+    assert!(regex::Regex::new(DEFAULT_BOT_PATTERN).is_ok());
+}

--- a/src/vcs/options_tests.rs
+++ b/src/vcs/options_tests.rs
@@ -101,8 +101,10 @@ fn overflowing_windows_are_rejected_not_wrapped() {
     // clean InvalidWindow, never a wrapped (and possibly negative)
     // duration. Covers the `checked_mul` guards in both forms.
     for bad in ["999999999999y", "P999999999999Y"] {
+        // Match the message, not just the variant, so the test pins the
+        // `checked_mul` overflow guard rather than any InvalidWindow path.
         assert!(
-            matches!(parse_window(bad), Err(Error::InvalidWindow(_))),
+            matches!(parse_window(bad), Err(Error::InvalidWindow(msg)) if msg.contains("overflows")),
             "expected {bad:?} to be rejected as overflow"
         );
     }

--- a/src/vcs/score.rs
+++ b/src/vcs/score.rs
@@ -1,0 +1,206 @@
+// bca: suppress-file(halstead, nargs)
+// File-level halstead/nargs are many-fn aggregation artifacts (the
+// formula's many log/weight terms + the percentile extractor table),
+// not per-function logic complexity (cognitive/cyclomatic stay enforced).
+
+//! Composite risk-score formulas.
+//!
+//! Two scores are offered. The default **weighted** score is a
+//! log-scaled weighted sum with categorical multiplicative bumps; the
+//! **percentile** score re-ranks every signal to its position within
+//! the analyzed set and averages. Both are *ordinal*: only relative
+//! ranks carry meaning, never the absolute magnitude.
+//!
+//! # Literature
+//!
+//! The term weights and thresholds are grounded in the defect- and
+//! vulnerability-prediction literature synthesised on issue #328:
+//!
+//! - Recent churn and recent commit count carry the highest weight —
+//!   Nagappan & Ball's relative-churn measures and the just-in-time
+//!   defect-prediction line both find recent change activity the
+//!   strongest single signal (Firefox `LinesChanged` PD 85,
+//!   `NumChanges` PD 86).
+//! - The author factor is multiplied by an ownership-dilution term
+//!   `(1 - ownership_top_share)`: diffuse ownership predicts defects
+//!   (Avelino DoA / truck-factor; Bird et al.).
+//! - Categorical developer-count bumps encode the RHEL4 finding that
+//!   files touched by ≥9 developers were ~16× more likely to harbour a
+//!   vulnerability, with a softer bump at the 6-developer mark.
+//! - A new-file bump reflects the Chromium observation that newly
+//!   added features carry elevated risk.
+//! - Bug-fix and security-fix commit counts feed a log-scaled additive
+//!   term, security fixes double-weighted (Sentence-Level VFC studies;
+//!   PySecDB).
+//! - File size is a deliberately tiny tie-breaker — large files are
+//!   weakly correlated with defects but the signal saturates fast.
+//!
+//! Bumping the formula in any way **must** increment
+//! [`RISK_SCORE_VERSION`] so downstream consumers can detect the
+//! change.
+
+use super::stats::Stats;
+
+/// Version of the weighted composite formula. Increment on any change
+/// to the term set, weights, or bumps below.
+pub const RISK_SCORE_VERSION: u32 = 1;
+
+/// RHEL4 high-developer-count threshold (~16× vulnerability likelihood).
+const HIGH_DEV_THRESHOLD: u32 = 9;
+/// RHEL4 softer developer-count threshold.
+const MID_DEV_THRESHOLD: u32 = 6;
+/// Multiplicative bump applied at or above [`HIGH_DEV_THRESHOLD`].
+const HIGH_DEV_BONUS: f64 = 0.35;
+/// Multiplicative bump applied at or above [`MID_DEV_THRESHOLD`].
+const MID_DEV_BONUS: f64 = 0.15;
+/// Multiplicative bump for a file first seen within the recent window.
+const NEW_FILE_BONUS: f64 = 0.15;
+/// Absolute tolerance for treating two percentile signals as tied. All
+/// signals are integer counts or ratios in `[0, 1]`, so `1e-9` is far
+/// below any meaningful difference yet absorbs floating-point ratio drift.
+const TIE_TOLERANCE: f64 = 1e-9;
+
+/// Raw signals consumed by the weighted formula. Decoupled from
+/// [`Stats`] so the formula is unit-testable on synthetic inputs
+/// without constructing a full stats record.
+#[derive(Clone, Copy, Debug)]
+pub struct ScoreInput {
+    /// Lines added + deleted in the recent window.
+    pub churn_recent: u64,
+    /// Lines added + deleted in the long window.
+    pub churn_long: u64,
+    /// Distinct commits in the recent window.
+    pub commits_recent: u32,
+    /// Distinct commits in the long window.
+    pub commits_long: u32,
+    /// Distinct authors in the long window.
+    pub authors_long: u32,
+    /// Top-author share of edits in `[0, 1]`.
+    pub ownership_top_share: f64,
+    /// Long-window bug-fix commit count.
+    pub bug_fix_commits: u32,
+    /// Long-window security-fix commit count.
+    pub security_fix_commits: u32,
+    /// Source lines of the file at the target ref (tie-breaker).
+    pub sloc: u64,
+    /// Days since the file's first in-window commit (capped at window).
+    pub age_days: u32,
+    /// Recent-window length in days (new-file threshold).
+    pub recent_window_days: u32,
+}
+
+/// Compute the weighted composite risk score for one file.
+///
+/// See the module docs for the term-by-term literature grounding. The
+/// `f64` casts of count fields are exact for every realistic input
+/// (counts never exceed 2^53) and the score is ordinal, so the lints
+/// are allowed locally with that justification.
+#[must_use]
+#[allow(clippy::cast_precision_loss)]
+pub fn weighted(input: &ScoreInput) -> f64 {
+    let recency_churn = ln1p(input.churn_recent as f64);
+    let long_churn = ln1p(input.churn_long as f64);
+    let recency_count = ln1p(f64::from(input.commits_recent));
+    let long_count = ln1p(f64::from(input.commits_long));
+    let author_factor = ln1p(f64::from(input.authors_long));
+    let dilution = (1.0 - input.ownership_top_share).clamp(0.0, 1.0);
+    let fix_factor =
+        ln1p(f64::from(input.bug_fix_commits) + 2.0 * f64::from(input.security_fix_commits));
+    // Size is a tiny tie-breaker: squared log over 100 keeps even a
+    // 10k-line file contributing well under one churn-point.
+    let size_factor = ln1p(input.sloc as f64).powi(2) / 100.0;
+
+    let new_file_bonus = if input.age_days < input.recent_window_days {
+        NEW_FILE_BONUS
+    } else {
+        0.0
+    };
+    let dev_bonus = if input.authors_long >= HIGH_DEV_THRESHOLD {
+        HIGH_DEV_BONUS
+    } else if input.authors_long >= MID_DEV_THRESHOLD {
+        MID_DEV_BONUS
+    } else {
+        0.0
+    };
+
+    let base = 0.30 * recency_churn
+        + 0.25 * recency_count
+        + 0.15 * long_count
+        + 0.15 * author_factor * (1.0 + dilution)
+        + 0.10 * fix_factor
+        + 0.05 * long_churn
+        + size_factor;
+
+    base * (1.0 + dev_bonus + new_file_bonus)
+}
+
+/// `ln(1 + x)` guarding against a negative argument from clock skew or
+/// an upstream miscount; the domain of every caller is non-negative, so
+/// the clamp is purely defensive.
+fn ln1p(x: f64) -> f64 {
+    (1.0 + x.max(0.0)).ln()
+}
+
+/// Recompute every file's `risk_score` as the mean percentile rank of
+/// its signals within the analyzed set (the `--risk-formula percentile`
+/// mode).
+///
+/// Each signal is ranked independently using the *mid-rank* of ties
+/// (so identical values share a percentile), scaled to `[0, 100]`, and
+/// the per-file mean across signals becomes the score. With fewer than
+/// two files percentiles are undefined, so the weighted score is left
+/// in place.
+///
+/// The `u64 → f64` signal casts are exact for every realistic churn
+/// count (well under 2^53) and the result is ordinal, so the precision
+/// lint is allowed for the whole pass.
+#[allow(clippy::cast_precision_loss)]
+pub fn apply_percentile(stats: &mut [Stats]) {
+    if stats.len() < 2 {
+        return;
+    }
+    // Signals contributing to the percentile blend. Ownership enters as
+    // its dilution `(1 - share)` so "more diffuse" ranks higher, matching
+    // the weighted formula's direction.
+    let extractors: [fn(&Stats) -> f64; 8] = [
+        |s| s.churn_recent as f64,
+        |s| s.churn_long as f64,
+        |s| f64::from(s.commits_recent),
+        |s| f64::from(s.commits_long),
+        |s| f64::from(s.authors_long),
+        |s| 1.0 - s.ownership_top_share,
+        |s| f64::from(s.bug_fix_commits),
+        |s| f64::from(s.security_fix_commits),
+    ];
+
+    let n = stats.len();
+    let mut blended = vec![0.0_f64; n];
+    for extract in extractors {
+        let values: Vec<f64> = stats.iter().map(extract).collect();
+        for (i, &v) in values.iter().enumerate() {
+            // Tie tolerance: integer-derived signals compare bit-exact,
+            // but the dilution signal `1 - top/total` can land ~1 ULP
+            // apart for mathematically-equal ratios (e.g. 2/6 vs 1/3).
+            // `f64::EPSILON` is the ULP at magnitude 1.0 (too tight here),
+            // so use a small absolute tolerance — and apply it to BOTH
+            // filters so a near-equal value is counted as tied, never as
+            // both "less" and "equal" (which could push `pct` past 1.0).
+            let less = values.iter().filter(|&&o| o < v - TIE_TOLERANCE).count();
+            let equal = values
+                .iter()
+                .filter(|&&o| (o - v).abs() < TIE_TOLERANCE)
+                .count();
+            // Mid-rank: average position among equal values, in [0, 1].
+            let pct = (less as f64 + (equal as f64 - 1.0) / 2.0) / (n as f64 - 1.0);
+            blended[i] += pct.clamp(0.0, 1.0);
+        }
+    }
+    let signal_count = extractors.len() as f64;
+    for (s, blend) in stats.iter_mut().zip(blended) {
+        s.risk_score = (blend / signal_count) * 100.0;
+    }
+}
+
+#[cfg(test)]
+#[path = "score_tests.rs"]
+mod tests;

--- a/src/vcs/score_tests.rs
+++ b/src/vcs/score_tests.rs
@@ -1,0 +1,206 @@
+// The percentile no-op test compares an exactly-representable f64
+// literal (42.0); `float_cmp` is a false positive there.
+#![allow(clippy::float_cmp)]
+
+use super::*;
+
+/// A neutral baseline input; tests tweak one axis and assert the score
+/// moves in the expected direction. Comparative only — never asserts an
+/// exact float (the score is ordinal).
+fn baseline() -> ScoreInput {
+    ScoreInput {
+        churn_recent: 50,
+        churn_long: 200,
+        commits_recent: 3,
+        commits_long: 10,
+        authors_long: 3,
+        ownership_top_share: 0.8,
+        bug_fix_commits: 1,
+        security_fix_commits: 0,
+        sloc: 300,
+        age_days: 200,
+        recent_window_days: 90,
+    }
+}
+
+#[test]
+fn version_is_one() {
+    assert_eq!(RISK_SCORE_VERSION, 1);
+}
+
+#[test]
+fn more_recent_churn_scores_higher() {
+    let low = weighted(&baseline());
+    let high = weighted(&ScoreInput {
+        churn_recent: 5_000,
+        ..baseline()
+    });
+    assert!(
+        high > low,
+        "high recent churn should outrank low: {high} vs {low}"
+    );
+}
+
+#[test]
+fn diluted_ownership_scores_higher_than_concentrated() {
+    let concentrated = weighted(&ScoreInput {
+        ownership_top_share: 1.0,
+        ..baseline()
+    });
+    let diluted = weighted(&ScoreInput {
+        ownership_top_share: 0.2,
+        ..baseline()
+    });
+    assert!(diluted > concentrated, "{diluted} vs {concentrated}");
+}
+
+#[test]
+fn more_authors_scores_higher() {
+    let few = weighted(&ScoreInput {
+        authors_long: 2,
+        ..baseline()
+    });
+    let many = weighted(&ScoreInput {
+        authors_long: 12,
+        ..baseline()
+    });
+    assert!(many > few, "{many} vs {few}");
+}
+
+#[test]
+fn dev_count_thresholds_bump_the_score() {
+    // Ownership pinned to 1.0 zeroes the dilution term so only the
+    // author count varies.
+    let at = |authors_long| {
+        weighted(&ScoreInput {
+            authors_long,
+            ownership_top_share: 1.0,
+            ..baseline()
+        })
+    };
+    // Crossing the 6- and 9-developer thresholds applies a
+    // multiplicative bump (0.15, then a further jump to 0.35) that
+    // dwarfs the smooth ln(author) growth: each *crossing* step lifts
+    // the score by far more than an adjacent *within-band* step. The
+    // 1.10 ratios sit above the bump (~1.15×/~1.17×) and well above
+    // smooth growth (~1.005×), so this fails if MID_DEV_BONUS /
+    // HIGH_DEV_BONUS are removed — unlike a bare `six > five` monotonic
+    // check, which the strictly-increasing author factor passes anyway.
+    assert!(
+        at(6) > at(5) * 1.10,
+        "6-dev crossing: {} vs {}",
+        at(6),
+        at(5)
+    );
+    assert!(
+        at(9) > at(8) * 1.10,
+        "9-dev crossing: {} vs {}",
+        at(9),
+        at(8)
+    );
+    // A within-band step (7→8, both in the mid band) does NOT jump by
+    // that ratio — this is what distinguishes the categorical bump from
+    // monotone author growth.
+    assert!(at(8) < at(7) * 1.10, "within-band step is smooth");
+}
+
+#[test]
+fn recent_churn_outweighs_long_churn() {
+    // Same churn magnitude, but recent churn is weighted 0.30 and long
+    // churn only 0.05, so concentrating it in the recent window must
+    // score strictly higher. Pins the weight *ordering* (not merely
+    // "churn matters"), so a formula that swapped the two coefficients
+    // fails.
+    let recent_heavy = weighted(&ScoreInput {
+        churn_recent: 1_000,
+        churn_long: 1_000,
+        ..baseline()
+    });
+    let long_heavy = weighted(&ScoreInput {
+        churn_recent: 0,
+        churn_long: 1_000,
+        ..baseline()
+    });
+    assert!(
+        recent_heavy > long_heavy,
+        "recent churn weighted higher: {recent_heavy} vs {long_heavy}"
+    );
+}
+
+#[test]
+fn security_fixes_weigh_double_bug_fixes() {
+    let bugs = weighted(&ScoreInput {
+        bug_fix_commits: 4,
+        security_fix_commits: 0,
+        ..baseline()
+    });
+    let security = weighted(&ScoreInput {
+        bug_fix_commits: 0,
+        security_fix_commits: 4,
+        ..baseline()
+    });
+    assert!(
+        security > bugs,
+        "security fixes double-weighted: {security} vs {bugs}"
+    );
+}
+
+#[test]
+fn new_file_bump_applies_below_recent_window() {
+    let old = weighted(&ScoreInput {
+        age_days: 200,
+        ..baseline()
+    });
+    let new = weighted(&ScoreInput {
+        age_days: 10,
+        ..baseline()
+    });
+    assert!(
+        new > old,
+        "a new file gets the new-file bump: {new} vs {old}"
+    );
+}
+
+#[test]
+fn percentile_ranks_busiest_file_highest() {
+    let mut stats = vec![
+        Stats {
+            churn_recent: 10,
+            commits_recent: 1,
+            commits_long: 1,
+            authors_long: 1,
+            ..Stats::default()
+        },
+        Stats {
+            churn_recent: 100,
+            commits_recent: 5,
+            commits_long: 8,
+            authors_long: 4,
+            ..Stats::default()
+        },
+        Stats {
+            churn_recent: 1_000,
+            commits_recent: 20,
+            commits_long: 40,
+            authors_long: 10,
+            ..Stats::default()
+        },
+    ];
+    apply_percentile(&mut stats);
+    assert!(stats[2].risk_score > stats[1].risk_score);
+    assert!(stats[1].risk_score > stats[0].risk_score);
+    // Percentile scores are bounded to [0, 100].
+    for s in &stats {
+        assert!((0.0..=100.0).contains(&s.risk_score));
+    }
+}
+
+#[test]
+fn percentile_is_a_noop_below_two_files() {
+    let mut one = vec![Stats {
+        risk_score: 42.0,
+        ..Stats::default()
+    }];
+    apply_percentile(&mut one);
+    assert_eq!(one[0].risk_score, 42.0, "single-file set is left untouched");
+}

--- a/src/vcs/stats.rs
+++ b/src/vcs/stats.rs
@@ -1,0 +1,252 @@
+// bca: suppress-file(halstead, nargs)
+// File-level halstead/nargs are many-fn aggregation artifacts (the
+// 20-field Stats assembly in `finalize`), not per-function logic
+// complexity (cognitive/cyclomatic stay enforced).
+
+//! Per-file change-history statistics: the public [`Stats`] output and
+//! the internal [`Accumulator`] that the backend feeds during a walk.
+
+use std::collections::{HashMap, HashSet};
+
+use super::classify::Classification;
+use super::identity::AuthorId;
+use super::options::{Options, SECONDS_PER_DAY};
+use super::score::{self, RISK_SCORE_VERSION, ScoreInput};
+
+/// Output-shape version for the `vcs` block. Bump on any change to the
+/// serialized field set.
+pub const VCS_SCHEMA_VERSION: u32 = 1;
+
+/// Per-file change-history metrics.
+///
+/// One record per tracked, non-binary, non-symlink file present at the
+/// target ref. A tracked file with no activity in the window is emitted
+/// with zero counts — distinct from an untracked file, which has no
+/// `vcs` block at all.
+///
+/// All scores are *ordinal*: rank files by them, do not read absolute
+/// magnitudes. The serialized shape lives in [`crate::wire::Vcs`]; this
+/// struct is the compute-side source the wire form is projected from.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Stats {
+    /// Output-shape version ([`VCS_SCHEMA_VERSION`]).
+    pub vcs_schema_version: u32,
+    /// Composite-formula version ([`RISK_SCORE_VERSION`]).
+    pub risk_score_version: u32,
+    /// Long window length, in days.
+    pub long_window_days: u32,
+    /// Recent window length, in days.
+    pub recent_window_days: u32,
+    /// Distinct commits touching the file in the long window.
+    pub commits_long: u32,
+    /// Distinct commits touching the file in the recent window.
+    pub commits_recent: u32,
+    /// Σ(added + deleted) lines in the long window.
+    pub churn_long: u64,
+    /// Σ(added + deleted) lines in the recent window.
+    pub churn_recent: u64,
+    /// Distinct canonical author identities in the long window.
+    pub authors_long: u32,
+    /// Distinct canonical author identities in the recent window.
+    pub authors_recent: u32,
+    /// Top-author share of edits in the long window, in `[0, 1]`.
+    pub ownership_top_share: f64,
+    /// `commits_recent / commits_long`, clamped to `[0, 1]`.
+    pub burst: f64,
+    /// Long-window commits whose message matched a bug-fix keyword.
+    pub bug_fix_commits: u32,
+    /// Long-window commits whose message matched a security keyword.
+    pub security_fix_commits: u32,
+    /// Long-window commits whose subject is a revert / rollback.
+    pub revert_commits: u32,
+    /// Days since the file's first in-window commit (capped at window).
+    pub age_days: u32,
+    /// Days since the file's most recent in-window commit.
+    pub last_modified_days: u32,
+    /// Composite risk score (weighted or percentile, per options).
+    pub risk_score: f64,
+    /// Complexity × recent-churn hotspot score; `Some` only when AST
+    /// metrics were computed alongside the history.
+    pub hotspot_score: Option<f64>,
+    /// SHA-256-hashed canonical author identities, sorted; `Some` only
+    /// under `--emit-author-details`.
+    pub author_ids: Option<Vec<String>>,
+}
+
+/// Mutable per-file accumulator threaded through the history walk.
+///
+/// Holds the raw sets and counters; [`Accumulator::finalize`] collapses
+/// them into a [`Stats`]. Author *edits* credit every participant of a
+/// touching commit (author plus `Co-authored-by` trailers) one edit, so
+/// the distinct-author count and the ownership ratio both account for
+/// co-authorship.
+#[derive(Clone, Debug, Default)]
+pub struct Accumulator {
+    sloc: u64,
+    commits_long: u32,
+    commits_recent: u32,
+    churn_long: u64,
+    churn_recent: u64,
+    /// Per-identity edit credits in the long window (ownership + count).
+    author_edits_long: HashMap<AuthorId, u32>,
+    /// Identities credited within the recent window (count only).
+    authors_recent: HashSet<AuthorId>,
+    bug_fix_commits: u32,
+    security_fix_commits: u32,
+    revert_commits: u32,
+    oldest_touch: Option<i64>,
+    newest_touch: Option<i64>,
+}
+
+/// One commit's effect on one file, as handed to [`Accumulator::record`].
+pub struct ChangeRecord<'a> {
+    /// Added + deleted lines this commit applied to the file.
+    pub churn: u64,
+    /// Commit timestamp (Unix seconds, clamped to `now` for skew).
+    pub commit_time: i64,
+    /// Whether the commit falls inside the recent window.
+    pub in_recent: bool,
+    /// Keyword classification of the commit message.
+    pub class: Classification,
+    /// Non-empty, bot-filtered participant identities for this commit.
+    pub authors: &'a [AuthorId],
+}
+
+impl Accumulator {
+    /// Start an accumulator for a file of `sloc` source lines.
+    #[must_use]
+    pub fn new(sloc: u64) -> Self {
+        Self {
+            sloc,
+            ..Self::default()
+        }
+    }
+
+    /// Fold one commit's effect on this file into the running totals.
+    pub fn record(&mut self, change: &ChangeRecord<'_>) {
+        self.commits_long += 1;
+        self.churn_long += change.churn;
+        self.bug_fix_commits += u32::from(change.class.bug_fix);
+        self.security_fix_commits += u32::from(change.class.security_fix);
+        self.revert_commits += u32::from(change.class.revert);
+        for id in change.authors {
+            // Avoid cloning the identity on the common repeat-author path;
+            // only a first-seen author allocates a map key.
+            if let Some(count) = self.author_edits_long.get_mut(id) {
+                *count += 1;
+            } else {
+                self.author_edits_long.insert(id.clone(), 1);
+            }
+        }
+        self.oldest_touch = Some(match self.oldest_touch {
+            Some(t) => t.min(change.commit_time),
+            None => change.commit_time,
+        });
+        self.newest_touch = Some(match self.newest_touch {
+            Some(t) => t.max(change.commit_time),
+            None => change.commit_time,
+        });
+        if change.in_recent {
+            self.commits_recent += 1;
+            self.churn_recent += change.churn;
+            self.authors_recent.extend(change.authors.iter().cloned());
+        }
+    }
+
+    /// Collapse the accumulator into the serializable [`Stats`].
+    ///
+    /// `now` is the reference timestamp (wall clock or `--as-of`). The
+    /// resulting risk score uses the weighted formula; percentile
+    /// re-ranking is a whole-set pass applied later by the backend.
+    #[must_use]
+    pub fn finalize(&self, now: i64, options: &Options) -> Stats {
+        let long_window_days = options.long_window_days();
+        let authors_long = u32::try_from(self.author_edits_long.len()).unwrap_or(u32::MAX);
+        let authors_recent = u32::try_from(self.authors_recent.len()).unwrap_or(u32::MAX);
+
+        let total_edits: u32 = self.author_edits_long.values().copied().sum();
+        let top_edits = self.author_edits_long.values().copied().max().unwrap_or(0);
+        let ownership_top_share = if total_edits > 0 {
+            f64::from(top_edits) / f64::from(total_edits)
+        } else {
+            0.0
+        };
+
+        let burst = if self.commits_long > 0 {
+            (f64::from(self.commits_recent) / f64::from(self.commits_long)).clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
+
+        // Age is capped at the long window: the walk only observes
+        // in-window commits, so a file older than the window reports
+        // the window length rather than its true creation date (true
+        // first-commit detection is the per-function/full-history
+        // follow-up, #329).
+        let age_days = self.oldest_touch.map_or(long_window_days, |t| {
+            days_between(t, now).min(long_window_days)
+        });
+        let last_modified_days = self
+            .newest_touch
+            .map_or(long_window_days, |t| days_between(t, now));
+
+        let risk_score = score::weighted(&ScoreInput {
+            churn_recent: self.churn_recent,
+            churn_long: self.churn_long,
+            commits_recent: self.commits_recent,
+            commits_long: self.commits_long,
+            authors_long,
+            ownership_top_share,
+            bug_fix_commits: self.bug_fix_commits,
+            security_fix_commits: self.security_fix_commits,
+            sloc: self.sloc,
+            age_days,
+            recent_window_days: options.recent_window_days(),
+        });
+
+        let author_ids = options.emit_author_details.then(|| {
+            let mut ids: Vec<String> = self
+                .author_edits_long
+                .keys()
+                .map(AuthorId::hashed)
+                .collect();
+            ids.sort_unstable();
+            ids
+        });
+
+        Stats {
+            vcs_schema_version: VCS_SCHEMA_VERSION,
+            risk_score_version: RISK_SCORE_VERSION,
+            long_window_days,
+            recent_window_days: options.recent_window_days(),
+            commits_long: self.commits_long,
+            commits_recent: self.commits_recent,
+            churn_long: self.churn_long,
+            churn_recent: self.churn_recent,
+            authors_long,
+            authors_recent,
+            ownership_top_share,
+            burst,
+            bug_fix_commits: self.bug_fix_commits,
+            security_fix_commits: self.security_fix_commits,
+            revert_commits: self.revert_commits,
+            age_days,
+            last_modified_days,
+            risk_score,
+            hotspot_score: None,
+            author_ids,
+        }
+    }
+}
+
+/// Whole days between an earlier timestamp and `now`, clamped at zero so
+/// a future-dated commit (clock skew) reads as "today" rather than a
+/// negative age.
+fn days_between(earlier: i64, now: i64) -> u32 {
+    let delta = (now - earlier).max(0);
+    u32::try_from(delta / SECONDS_PER_DAY).unwrap_or(u32::MAX)
+}
+
+#[cfg(test)]
+#[path = "stats_tests.rs"]
+mod tests;

--- a/src/vcs/stats_tests.rs
+++ b/src/vcs/stats_tests.rs
@@ -1,0 +1,182 @@
+// Exact-equality on f64 is intentional here: every compared value is
+// an exactly-representable literal (0.0, 0.5, 0.75, 1.0) produced by
+// exact integer ratios, so `float_cmp` is a false positive in tests.
+#![allow(clippy::float_cmp)]
+
+use super::*;
+use crate::vcs::options::Options;
+
+const DAY: i64 = 86_400;
+const NOW: i64 = 1_700_000_000;
+
+fn author(email: &str) -> AuthorId {
+    AuthorId::new(b"Someone", email.as_bytes())
+}
+
+fn change(
+    churn: u64,
+    days_ago: i64,
+    authors: &[AuthorId],
+    class: Classification,
+) -> ChangeRecord<'_> {
+    ChangeRecord {
+        churn,
+        commit_time: NOW - days_ago * DAY,
+        in_recent: days_ago <= 90,
+        class,
+        authors,
+    }
+}
+
+#[test]
+fn empty_accumulator_finalizes_to_zeros() {
+    let stats = Accumulator::new(120).finalize(NOW, &Options::default());
+    assert_eq!(stats.commits_long, 0);
+    assert_eq!(stats.churn_long, 0);
+    assert_eq!(stats.authors_long, 0);
+    assert_eq!(stats.ownership_top_share, 0.0);
+    assert_eq!(stats.burst, 0.0);
+    // A tracked-but-untouched file caps age/last-modified at the window.
+    assert_eq!(stats.age_days, 365);
+    assert_eq!(stats.last_modified_days, 365);
+    assert_eq!(stats.vcs_schema_version, VCS_SCHEMA_VERSION);
+    assert_eq!(stats.risk_score_version, RISK_SCORE_VERSION);
+    assert!(stats.risk_score.is_finite());
+}
+
+#[test]
+fn single_commit_counts_once_with_full_ownership() {
+    let mut acc = Accumulator::new(100);
+    let ada = [author("ada@example.com")];
+    acc.record(&change(40, 10, &ada, Classification::default()));
+    let stats = acc.finalize(NOW, &Options::default());
+
+    assert_eq!(stats.commits_long, 1);
+    assert_eq!(stats.commits_recent, 1);
+    assert_eq!(stats.churn_long, 40);
+    assert_eq!(stats.churn_recent, 40);
+    assert_eq!(stats.authors_long, 1);
+    assert_eq!(stats.authors_recent, 1);
+    assert_eq!(stats.ownership_top_share, 1.0);
+    assert_eq!(stats.burst, 1.0);
+    assert_eq!(stats.age_days, 10);
+    assert_eq!(stats.last_modified_days, 10);
+}
+
+#[test]
+fn classification_flags_accumulate() {
+    let mut acc = Accumulator::new(100);
+    let ada = [author("ada@example.com")];
+    acc.record(&change(
+        10,
+        5,
+        &ada,
+        Classification {
+            bug_fix: true,
+            security_fix: false,
+            revert: false,
+        },
+    ));
+    acc.record(&change(
+        10,
+        6,
+        &ada,
+        Classification {
+            bug_fix: true,
+            security_fix: true,
+            revert: false,
+        },
+    ));
+    acc.record(&change(
+        10,
+        7,
+        &ada,
+        Classification {
+            bug_fix: false,
+            security_fix: false,
+            revert: true,
+        },
+    ));
+    let stats = acc.finalize(NOW, &Options::default());
+    assert_eq!(stats.bug_fix_commits, 2);
+    assert_eq!(stats.security_fix_commits, 1);
+    assert_eq!(stats.revert_commits, 1);
+}
+
+#[test]
+fn ownership_reflects_edit_split() {
+    let mut acc = Accumulator::new(100);
+    let ada = [author("ada@example.com")];
+    let grace = [author("grace@example.com")];
+    // Ada edits three times, Grace once → top share 3/4.
+    for days in [10, 20, 30] {
+        acc.record(&change(10, days, &ada, Classification::default()));
+    }
+    acc.record(&change(10, 40, &grace, Classification::default()));
+    let stats = acc.finalize(NOW, &Options::default());
+    assert_eq!(stats.authors_long, 2);
+    assert!((stats.ownership_top_share - 0.75).abs() < 1e-9);
+}
+
+#[test]
+fn coauthors_count_toward_distinct_authors() {
+    let mut acc = Accumulator::new(100);
+    let pair = [author("ada@example.com"), author("grace@example.com")];
+    acc.record(&change(10, 10, &pair, Classification::default()));
+    let stats = acc.finalize(NOW, &Options::default());
+    // One commit, two participants.
+    assert_eq!(stats.commits_long, 1);
+    assert_eq!(stats.authors_long, 2);
+    // Each credited one edit → 1/2 top share.
+    assert!((stats.ownership_top_share - 0.5).abs() < 1e-9);
+}
+
+#[test]
+fn recent_window_excludes_old_commits() {
+    let mut acc = Accumulator::new(100);
+    let ada = [author("ada@example.com")];
+    acc.record(&change(10, 30, &ada, Classification::default())); // recent
+    acc.record(&change(10, 200, &ada, Classification::default())); // long only
+    let stats = acc.finalize(NOW, &Options::default());
+    assert_eq!(stats.commits_long, 2);
+    assert_eq!(stats.commits_recent, 1);
+    assert_eq!(stats.churn_long, 20);
+    assert_eq!(stats.churn_recent, 10);
+    assert_eq!(stats.age_days, 200);
+    assert_eq!(stats.last_modified_days, 30);
+    assert!((stats.burst - 0.5).abs() < 1e-9);
+}
+
+#[test]
+fn emit_author_details_adds_sorted_hashes() {
+    let mut acc = Accumulator::new(100);
+    let pair = [author("grace@example.com"), author("ada@example.com")];
+    acc.record(&change(10, 10, &pair, Classification::default()));
+
+    let options = Options {
+        emit_author_details: true,
+        ..Options::default()
+    };
+    let stats = acc.finalize(NOW, &options);
+
+    let ids = stats.author_ids.expect("author_ids present");
+    assert_eq!(ids.len(), 2);
+    let mut sorted = ids.clone();
+    sorted.sort_unstable();
+    assert_eq!(ids, sorted, "hashed ids are emitted sorted");
+
+    // Off by default.
+    let without = acc.finalize(NOW, &Options::default());
+    assert!(without.author_ids.is_none());
+}
+
+#[test]
+fn future_dated_commit_clamps_age_to_zero() {
+    let mut acc = Accumulator::new(100);
+    let ada = [author("ada@example.com")];
+    // A commit 5 days in the "future" (clock skew); days_ago negative.
+    acc.record(&change(10, -5, &ada, Classification::default()));
+    let stats = acc.finalize(NOW, &Options::default());
+    assert_eq!(stats.age_days, 0);
+    assert_eq!(stats.last_modified_days, 0);
+}

--- a/src/wire.rs
+++ b/src/wire.rs
@@ -639,6 +639,89 @@ impl From<&wmc::Stats> for Wmc {
 // Container wire structs.
 // ---------------------------------------------------------------------------
 
+/// Wire form of [`crate::vcs::Stats`] — per-file change-history metrics.
+///
+/// Flat by design: the field names are the JSON output keys verbatim.
+/// All scores are ordinal. `hotspot_score` and `author_ids` are elided
+/// when absent (no AST metrics alongside, and `--emit-author-details`
+/// off, respectively). Gated behind the `vcs-git` backend feature.
+#[cfg(feature = "vcs-git")]
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct Vcs {
+    /// Output-shape version.
+    pub vcs_schema_version: u32,
+    /// Composite-formula version.
+    pub risk_score_version: u32,
+    /// Long window length, in days.
+    pub long_window_days: u32,
+    /// Recent window length, in days.
+    pub recent_window_days: u32,
+    /// Distinct commits in the long window.
+    pub commits_long: u32,
+    /// Distinct commits in the recent window.
+    pub commits_recent: u32,
+    /// Σ(added + deleted) lines in the long window.
+    pub churn_long: u64,
+    /// Σ(added + deleted) lines in the recent window.
+    pub churn_recent: u64,
+    /// Distinct authors in the long window.
+    pub authors_long: u32,
+    /// Distinct authors in the recent window.
+    pub authors_recent: u32,
+    /// Top-author edit share in `[0, 1]`.
+    pub ownership_top_share: f64,
+    /// `commits_recent / commits_long`, clamped to `[0, 1]`.
+    pub burst: f64,
+    /// Long-window bug-fix commit count.
+    pub bug_fix_commits: u32,
+    /// Long-window security-fix commit count.
+    pub security_fix_commits: u32,
+    /// Long-window revert commit count.
+    pub revert_commits: u32,
+    /// Days since the file's first in-window commit (capped at window).
+    pub age_days: u32,
+    /// Days since the file's most recent in-window commit.
+    pub last_modified_days: u32,
+    /// Ordinal composite risk score.
+    pub risk_score: f64,
+    /// Complexity × recent-churn hotspot score, when AST metrics were
+    /// computed alongside the history.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hotspot_score: Option<f64>,
+    /// SHA-256-hashed canonical author identities, under
+    /// `--emit-author-details`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub author_ids: Option<Vec<String>>,
+}
+
+#[cfg(feature = "vcs-git")]
+impl From<&crate::vcs::Stats> for Vcs {
+    fn from(s: &crate::vcs::Stats) -> Self {
+        Self {
+            vcs_schema_version: s.vcs_schema_version,
+            risk_score_version: s.risk_score_version,
+            long_window_days: s.long_window_days,
+            recent_window_days: s.recent_window_days,
+            commits_long: s.commits_long,
+            commits_recent: s.commits_recent,
+            churn_long: s.churn_long,
+            churn_recent: s.churn_recent,
+            authors_long: s.authors_long,
+            authors_recent: s.authors_recent,
+            ownership_top_share: s.ownership_top_share,
+            burst: s.burst,
+            bug_fix_commits: s.bug_fix_commits,
+            security_fix_commits: s.security_fix_commits,
+            revert_commits: s.revert_commits,
+            age_days: s.age_days,
+            last_modified_days: s.last_modified_days,
+            risk_score: s.risk_score,
+            hotspot_score: s.hotspot_score,
+            author_ids: s.author_ids.clone(),
+        }
+    }
+}
+
 /// Wire form of [`crate::spaces::CodeMetrics`].
 ///
 /// Each metric is an `Option` skipped when `None`: an unselected metric
@@ -689,6 +772,11 @@ pub struct CodeMetrics {
     /// `Npa` metric, if selected and not disabled.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub npa: Option<Npa>,
+    /// Change-history (VCS) metrics, present only for the file-level
+    /// space when a history walk supplied them. Gated behind `vcs-git`.
+    #[cfg(feature = "vcs-git")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vcs: Option<Vcs>,
 }
 
 impl From<&crate::spaces::CodeMetrics> for CodeMetrics {
@@ -712,6 +800,10 @@ impl From<&crate::spaces::CodeMetrics> for CodeMetrics {
             wmc: (on(Metric::Wmc) && !c.wmc.is_disabled()).then(|| Wmc::from(&c.wmc)),
             npm: (on(Metric::Npm) && !c.npm.is_disabled()).then(|| Npm::from(&c.npm)),
             npa: (on(Metric::Npa) && !c.npa.is_disabled()).then(|| Npa::from(&c.npa)),
+            // VCS data is injected post-analysis, so its presence — not
+            // the selection mask — governs emission.
+            #[cfg(feature = "vcs-git")]
+            vcs: c.vcs.as_ref().map(Vcs::from),
         }
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -25,6 +25,12 @@ pub mod fixtures;
 #[allow(dead_code)]
 pub mod validators;
 
+/// Deterministic git-repo builder for change-history (VCS) tests.
+/// Gated behind the backend feature it exercises.
+#[cfg(feature = "vcs-git")]
+#[allow(dead_code)]
+pub mod vcs_fixture;
+
 #[allow(dead_code)]
 const REPO: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/", "repositories");
 const SNAPSHOT_PATH: &str = concat!(

--- a/tests/common/vcs_fixture.rs
+++ b/tests/common/vcs_fixture.rs
@@ -31,6 +31,10 @@ impl Repo {
         // Keep commits hermetic regardless of the host's global config.
         run_git(dir.path(), &["config", "commit.gpgsign", "false"], &[]);
         run_git(dir.path(), &["config", "gc.auto", "0"], &[]);
+        // Pin line endings so churn line-counts are identical on a
+        // contributor with `core.autocrlf=true` (the Git-for-Windows
+        // default) — the integration tests assert exact churn values.
+        run_git(dir.path(), &["config", "core.autocrlf", "false"], &[]);
         Self { dir }
     }
 
@@ -94,7 +98,16 @@ impl Repo {
         ];
         run_git(
             self.dir.path(),
-            &["commit", "-q", "--allow-empty", "-m", message],
+            // `--no-verify` skips any commit/commit-msg hook a
+            // contributor's global `core.hooksPath` might install.
+            &[
+                "commit",
+                "-q",
+                "--no-verify",
+                "--allow-empty",
+                "-m",
+                message,
+            ],
             &env,
         );
     }

--- a/tests/common/vcs_fixture.rs
+++ b/tests/common/vcs_fixture.rs
@@ -1,0 +1,112 @@
+//! Deterministic temp git-repo builder for change-history (VCS) tests.
+//!
+//! Commits are made through the `git` CLI with fixed author / committer
+//! identities and explicit UNIX timestamps (`GIT_AUTHOR_DATE` /
+//! `GIT_COMMITTER_DATE`), so windows, ages, and ordering are fully
+//! reproducible. Pair with [`big_code_analysis::vcs::Options::as_of`]
+//! pinned to [`FIXED_NOW`] for snapshot-stable runs.
+
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+/// Reference "now" for every VCS fixture test. Commit timestamps are
+/// expressed as offsets before this instant.
+pub const FIXED_NOW: i64 = 1_700_000_000;
+
+/// One day in seconds, for expressing commit ages.
+pub const DAY: i64 = 86_400;
+
+/// A throwaway git repository under a `TempDir` (auto-removed on drop).
+pub struct Repo {
+    dir: TempDir,
+}
+
+impl Repo {
+    /// Initialise an empty repo on a `main` branch with signing off.
+    pub fn init() -> Self {
+        let dir = tempfile::tempdir().expect("tempdir");
+        run_git(dir.path(), &["init", "-q", "-b", "main"], &[]);
+        // Keep commits hermetic regardless of the host's global config.
+        run_git(dir.path(), &["config", "commit.gpgsign", "false"], &[]);
+        run_git(dir.path(), &["config", "gc.auto", "0"], &[]);
+        Self { dir }
+    }
+
+    /// Repository root.
+    pub fn path(&self) -> &Path {
+        self.dir.path()
+    }
+
+    /// Write (or overwrite) a file relative to the repo root, creating
+    /// parent directories.
+    pub fn write(&self, rel: &str, contents: &str) {
+        let path = self.dir.path().join(rel);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("mkdir -p");
+        }
+        std::fs::write(path, contents).expect("write file");
+    }
+
+    /// Stage everything and commit as `(name, email)` at `secs`
+    /// (UNIX seconds) with `message`.
+    pub fn commit(&self, name: &str, email: &str, secs: i64, message: &str) {
+        self.commit_inner(name, email, secs, message);
+    }
+
+    /// Run an arbitrary `git` subcommand (e.g. `mv`) in the repo.
+    pub fn git(&self, args: &[&str]) {
+        run_git(self.dir.path(), args, &[]);
+    }
+
+    /// Run an arbitrary `git` subcommand with the fixed identity and a
+    /// controlled author/committer date (for commands that create a
+    /// commit, e.g. `merge --no-ff`).
+    pub fn git_at(&self, name: &str, email: &str, secs: i64, args: &[&str]) {
+        let date = format!("@{secs} +0000");
+        let env = [
+            ("GIT_AUTHOR_NAME", name),
+            ("GIT_AUTHOR_EMAIL", email),
+            ("GIT_AUTHOR_DATE", date.as_str()),
+            ("GIT_COMMITTER_NAME", name),
+            ("GIT_COMMITTER_EMAIL", email),
+            ("GIT_COMMITTER_DATE", date.as_str()),
+        ];
+        run_git(self.dir.path(), args, &env);
+    }
+
+    /// Write a `.mailmap` mapping canonical identities.
+    pub fn mailmap(&self, contents: &str) {
+        self.write(".mailmap", contents);
+    }
+
+    fn commit_inner(&self, name: &str, email: &str, secs: i64, message: &str) {
+        run_git(self.dir.path(), &["add", "-A"], &[]);
+        let date = format!("@{secs} +0000");
+        let env = [
+            ("GIT_AUTHOR_NAME", name),
+            ("GIT_AUTHOR_EMAIL", email),
+            ("GIT_AUTHOR_DATE", date.as_str()),
+            ("GIT_COMMITTER_NAME", name),
+            ("GIT_COMMITTER_EMAIL", email),
+            ("GIT_COMMITTER_DATE", date.as_str()),
+        ];
+        run_git(
+            self.dir.path(),
+            &["commit", "-q", "--allow-empty", "-m", message],
+            &env,
+        );
+    }
+}
+
+/// Run `git <args>` in `dir` with extra environment, asserting success.
+fn run_git(dir: &Path, args: &[&str], env: &[(&str, &str)]) {
+    let mut cmd = Command::new("git");
+    cmd.args(args).current_dir(dir);
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+    let status = cmd.status().expect("spawn git");
+    assert!(status.success(), "git {args:?} failed");
+}

--- a/tests/vcs_history.rs
+++ b/tests/vcs_history.rs
@@ -450,6 +450,43 @@ fn first_parent_merges_and_full_history_count_branch_work() {
 }
 
 #[test]
+fn shallow_clone_degrades_gracefully() {
+    use std::process::Command;
+    // Source repo with two commits so the shallow tip has a parent that
+    // the depth-1 clone will not fetch (a grafted, absent boundary).
+    let src = Repo::init();
+    src.write("f.rs", "fn a() {}\n");
+    src.commit("Ada", "ada@example.com", FIXED_NOW - 30 * DAY, "first");
+    src.write("f.rs", "fn a() {}\nfn b() {}\n");
+    src.commit("Ada", "ada@example.com", FIXED_NOW - 10 * DAY, "second");
+
+    // `file://` forces the non-local transport so `--depth` actually
+    // produces a shallow clone (a bare path clone ignores `--depth`).
+    let dest = tempfile::tempdir().expect("tempdir");
+    let url = format!("file://{}", src.path().display());
+    let clone_ok = Command::new("git")
+        .args(["clone", "--quiet", "--depth", "1", &url])
+        .arg(dest.path())
+        .status()
+        .expect("spawn git clone")
+        .success();
+    assert!(clone_ok, "shallow clone failed");
+
+    // Must NOT abort on the missing grafted parent: it is treated as a
+    // boundary (diff against the empty tree) and the result is flagged
+    // truncated rather than erroring out — the graceful path that was
+    // previously dead because the walk aborted before finalizing.
+    let index = build_history_index(dest.path(), &opts()).expect("shallow walk completes");
+    assert!(index.truncated_shallow_clone(), "shallow clone is flagged");
+    let stats = stats_for(&index, "f.rs");
+    assert_eq!(stats.commits_long, 1, "only the shallow tip is present");
+    assert!(
+        stats.churn_long >= 1,
+        "the tip's content counts as additions"
+    );
+}
+
+#[test]
 fn not_a_repository_errors_clearly() {
     let dir = tempfile::tempdir().expect("tempdir");
     let err = build_history_index(dir.path(), &opts()).expect_err("must error outside a repo");

--- a/tests/vcs_history.rs
+++ b/tests/vcs_history.rs
@@ -1,0 +1,460 @@
+//! End-to-end change-history (VCS) tests against real, deterministic
+//! git repositories built through the `git` CLI (issue #328).
+//!
+//! Every commit carries a fixed identity and UNIX timestamp, and every
+//! walk pins `as_of` to [`vcs_fixture::FIXED_NOW`], so per-signal counts
+//! are exact and reproducible. The whole file is gated behind the
+//! `vcs-git` backend feature.
+#![cfg(feature = "vcs-git")]
+// Exact-equality on f64 is intentional: the compared values are
+// exactly-representable literals (1.0) from exact integer ratios.
+#![allow(clippy::float_cmp)]
+
+use std::path::Path;
+
+use big_code_analysis::vcs::{self, Options, build_history_index};
+
+mod common;
+use common::vcs_fixture::{DAY, FIXED_NOW, Repo};
+
+/// Options pinned to the fixture clock; tweak fields per test.
+fn opts() -> Options {
+    Options {
+        as_of: Some(FIXED_NOW),
+        ..Options::default()
+    }
+}
+
+fn stats_for<'a>(index: &'a vcs::HistoryIndex, rel: &str) -> &'a vcs::Stats {
+    index
+        .get(Path::new(rel))
+        .unwrap_or_else(|| panic!("expected stats for {rel}; index has {} files", index.len()))
+}
+
+#[test]
+fn single_commit_one_file() {
+    let repo = Repo::init();
+    repo.write("src/work.rs", "fn a() {}\nfn b() {}\nfn c() {}\n");
+    repo.commit("Ada", "ada@example.com", FIXED_NOW - 10 * DAY, "initial");
+
+    let index = build_history_index(repo.path(), &opts()).expect("walk");
+    let stats = stats_for(&index, "src/work.rs");
+
+    assert_eq!(stats.commits_long, 1);
+    assert_eq!(stats.commits_recent, 1);
+    assert_eq!(stats.authors_long, 1);
+    assert_eq!(stats.authors_recent, 1);
+    assert_eq!(stats.churn_long, 3, "three lines added");
+    assert_eq!(stats.churn_recent, 3);
+    assert_eq!(stats.ownership_top_share, 1.0);
+    assert_eq!(stats.age_days, 10);
+    assert_eq!(stats.last_modified_days, 10);
+    assert_eq!(stats.bug_fix_commits, 0);
+}
+
+#[test]
+fn two_authors_counted_distinctly() {
+    let repo = Repo::init();
+    repo.write("f.rs", "one\n");
+    repo.commit("Ada", "ada@example.com", FIXED_NOW - 20 * DAY, "a");
+    repo.write("f.rs", "one\ntwo\n");
+    repo.commit("Grace", "grace@example.com", FIXED_NOW - 10 * DAY, "b");
+
+    let index = build_history_index(repo.path(), &opts()).expect("walk");
+    let stats = stats_for(&index, "f.rs");
+    assert_eq!(stats.commits_long, 2);
+    assert_eq!(stats.authors_long, 2);
+    assert!((stats.ownership_top_share - 0.5).abs() < 1e-9);
+}
+
+#[test]
+fn bots_excluded_by_default_then_included() {
+    let build = |exclude_bots: bool| {
+        let repo = Repo::init();
+        repo.write("f.rs", "x\n");
+        repo.commit("Ada", "ada@example.com", FIXED_NOW - 20 * DAY, "human");
+        repo.write("f.rs", "x\ny\n");
+        repo.commit(
+            "dependabot[bot]",
+            "49699333+dependabot[bot]@users.noreply.github.com",
+            FIXED_NOW - 10 * DAY,
+            "bump dep",
+        );
+        let options = Options {
+            exclude_bots,
+            ..opts()
+        };
+        let index = build_history_index(repo.path(), &options).expect("walk");
+        let stats = stats_for(&index, "f.rs");
+        (stats.commits_long, stats.authors_long)
+    };
+
+    // Default: the bot-only commit is dropped entirely.
+    assert_eq!(build(true), (1, 1));
+    // Opt-in: both commits and both authors count.
+    assert_eq!(build(false), (2, 2));
+}
+
+#[test]
+fn renames_followed_by_default() {
+    let build = |follow_renames: bool| {
+        let repo = Repo::init();
+        repo.write("a.rs", "line\n");
+        repo.commit("Ada", "ada@example.com", FIXED_NOW - 20 * DAY, "create a");
+        repo.git(&["mv", "a.rs", "b.rs"]);
+        repo.commit(
+            "Ada",
+            "ada@example.com",
+            FIXED_NOW - 10 * DAY,
+            "rename to b",
+        );
+        let options = Options {
+            follow_renames,
+            ..opts()
+        };
+        let index = build_history_index(repo.path(), &options).expect("walk");
+        stats_for(&index, "b.rs").commits_long
+    };
+
+    // Following renames sees both the create (under a.rs) and the move.
+    assert_eq!(build(true), 2);
+    // Not following stops at the move commit.
+    assert_eq!(build(false), 1);
+}
+
+#[test]
+fn recent_window_excludes_old_commits() {
+    let repo = Repo::init();
+    repo.write("f.rs", "1\n");
+    repo.commit("Ada", "ada@example.com", FIXED_NOW - 200 * DAY, "old");
+    repo.write("f.rs", "1\n2\n");
+    repo.commit("Ada", "ada@example.com", FIXED_NOW - 5 * DAY, "fresh");
+
+    let index = build_history_index(repo.path(), &opts()).expect("walk");
+    let stats = stats_for(&index, "f.rs");
+    assert_eq!(stats.commits_long, 2);
+    assert_eq!(
+        stats.commits_recent, 1,
+        "only the 5-day-old commit is recent"
+    );
+    assert_eq!(stats.last_modified_days, 5);
+    assert_eq!(stats.age_days, 200);
+}
+
+#[test]
+fn long_window_excludes_commits_beyond_the_boundary() {
+    let repo = Repo::init();
+    repo.write("f.rs", "1\n");
+    // Well outside the 365-day long window.
+    repo.commit("Ada", "ada@example.com", FIXED_NOW - 800 * DAY, "ancient");
+    repo.write("f.rs", "1\n2\n");
+    repo.commit("Ada", "ada@example.com", FIXED_NOW - 30 * DAY, "recent");
+
+    let index = build_history_index(repo.path(), &opts()).expect("walk");
+    let stats = stats_for(&index, "f.rs");
+    assert_eq!(
+        stats.commits_long, 1,
+        "the 800-day-old commit is outside the window"
+    );
+}
+
+#[test]
+fn bug_and_security_fixes_classified() {
+    let repo = Repo::init();
+    repo.write("f.rs", "1\n");
+    repo.commit(
+        "Ada",
+        "ada@example.com",
+        FIXED_NOW - 30 * DAY,
+        "fix crash on resize",
+    );
+    repo.write("f.rs", "1\n2\n");
+    repo.commit(
+        "Ada",
+        "ada@example.com",
+        FIXED_NOW - 20 * DAY,
+        "patch CVE-2021-44228 in parser",
+    );
+    repo.write("f.rs", "1\n2\n3\n");
+    repo.commit("Ada", "ada@example.com", FIXED_NOW - 10 * DAY, "add docs");
+
+    let index = build_history_index(repo.path(), &opts()).expect("walk");
+    let stats = stats_for(&index, "f.rs");
+    assert_eq!(stats.bug_fix_commits, 1);
+    assert_eq!(stats.security_fix_commits, 1);
+}
+
+#[test]
+fn mailmap_canonicalizes_one_author() {
+    let repo = Repo::init();
+    repo.mailmap("Ada Lovelace <ada@example.com> <ada@old.example.com>\n");
+    repo.write("f.rs", "1\n");
+    repo.commit("Ada", "ada@old.example.com", FIXED_NOW - 20 * DAY, "a");
+    repo.write("f.rs", "1\n2\n");
+    repo.commit("Ada Lovelace", "ada@example.com", FIXED_NOW - 10 * DAY, "b");
+
+    let index = build_history_index(repo.path(), &opts()).expect("walk");
+    let stats = stats_for(&index, "f.rs");
+    assert_eq!(stats.commits_long, 2);
+    assert_eq!(
+        stats.authors_long, 1,
+        "two emails canonicalize to one identity"
+    );
+}
+
+#[test]
+fn coauthored_by_trailer_counts_extra_author() {
+    let repo = Repo::init();
+    repo.write("f.rs", "1\n");
+    repo.commit(
+        "Ada",
+        "ada@example.com",
+        FIXED_NOW - 10 * DAY,
+        "pair work\n\nCo-authored-by: Grace Hopper <grace@example.com>\n",
+    );
+
+    let index = build_history_index(repo.path(), &opts()).expect("walk");
+    let stats = stats_for(&index, "f.rs");
+    assert_eq!(stats.commits_long, 1);
+    assert_eq!(stats.authors_long, 2, "author + co-author");
+}
+
+#[test]
+fn untracked_file_has_no_stats() {
+    let repo = Repo::init();
+    repo.write("tracked.rs", "1\n");
+    repo.commit("Ada", "ada@example.com", FIXED_NOW - 10 * DAY, "a");
+    // An untracked working-tree file is absent from the index entirely,
+    // distinct from a tracked file with zero counts.
+    std::fs::write(repo.path().join("untracked.rs"), "2\n").expect("write");
+
+    let index = build_history_index(repo.path(), &opts()).expect("walk");
+    assert!(index.get(Path::new("tracked.rs")).is_some());
+    assert!(index.get(Path::new("untracked.rs")).is_none());
+}
+
+#[test]
+fn revert_commit_classified_end_to_end() {
+    let repo = Repo::init();
+    repo.write("f.rs", "1\n");
+    repo.commit(
+        "Ada",
+        "ada@example.com",
+        FIXED_NOW - 20 * DAY,
+        "add feature",
+    );
+    repo.write("f.rs", "1\n2\n");
+    // git's auto-generated revert subject.
+    repo.commit(
+        "Ada",
+        "ada@example.com",
+        FIXED_NOW - 10 * DAY,
+        "Revert \"add feature\"",
+    );
+    let index = build_history_index(repo.path(), &opts()).expect("walk");
+    let stats = stats_for(&index, "f.rs");
+    assert_eq!(
+        stats.revert_commits, 1,
+        "revert classified through the real walk"
+    );
+    assert_eq!(stats.bug_fix_commits, 0);
+}
+
+#[test]
+fn risk_score_ranks_busy_above_quiet() {
+    let repo = Repo::init();
+    // A quiet file: one tiny commit, long ago.
+    repo.write("quiet.rs", "fn q() {}\n");
+    repo.commit("Ada", "ada@example.com", FIXED_NOW - 300 * DAY, "add quiet");
+    // A busy file: large recent churn across several commits and authors.
+    for step in 0..6_i64 {
+        let who = if step % 2 == 0 {
+            ("Ada", "ada@example.com")
+        } else {
+            ("Grace", "grace@example.com")
+        };
+        let line_count = usize::try_from(step * 10 + 1).expect("fits usize");
+        repo.write("busy.rs", &"fn f() {}\n".repeat(line_count));
+        repo.commit(who.0, who.1, FIXED_NOW - (30 - step) * DAY, "edit busy");
+    }
+    let index = build_history_index(repo.path(), &opts()).expect("walk");
+    // End-to-end: the score wiring (finalize → ScoreInput → weighted)
+    // must rank the high-churn, multi-author, recently-edited file above
+    // the quiet one. A miscabled score field would flip or flatten this.
+    assert!(
+        stats_for(&index, "busy.rs").risk_score > stats_for(&index, "quiet.rs").risk_score,
+        "busy file outranks quiet file"
+    );
+}
+
+#[test]
+fn empty_repo_errors_on_unborn_head() {
+    // A freshly-initialised repo (no commits) has an unborn HEAD; the
+    // ref cannot resolve, so the walk reports ResolveRef rather than
+    // panicking or hanging.
+    let repo = Repo::init();
+    let err = build_history_index(repo.path(), &opts()).expect_err("unborn HEAD must error");
+    assert!(matches!(err, vcs::Error::ResolveRef { .. }), "got {err:?}");
+}
+
+#[test]
+fn parse_timestamp_accepts_formats_and_rejects_garbage() {
+    assert!(vcs::parse_timestamp("2023-11-14T00:00:00Z").is_ok());
+    assert_eq!(
+        vcs::parse_timestamp("@1700000000").expect("epoch form"),
+        1_700_000_000
+    );
+    assert!(matches!(
+        vcs::parse_timestamp("not-a-date"),
+        Err(vcs::Error::InvalidTimestamp(_))
+    ));
+}
+
+#[test]
+fn percentile_formula_reranks_end_to_end() {
+    let repo = Repo::init();
+    repo.write("quiet.rs", "fn q() {}\n");
+    repo.commit("Ada", "ada@example.com", FIXED_NOW - 300 * DAY, "quiet");
+    for step in 0..5_i64 {
+        let lines = usize::try_from(step * 8 + 1).expect("fits usize");
+        repo.write("busy.rs", &"fn f() {}\n".repeat(lines));
+        repo.commit(
+            "Ada",
+            "ada@example.com",
+            FIXED_NOW - (20 - step) * DAY,
+            "busy",
+        );
+    }
+    let options = Options {
+        risk_formula: vcs::RiskFormula::Percentile,
+        ..opts()
+    };
+    let index = build_history_index(repo.path(), &options).expect("walk");
+    let busy = stats_for(&index, "busy.rs").risk_score;
+    let quiet = stats_for(&index, "quiet.rs").risk_score;
+    assert!(
+        busy > quiet,
+        "percentile ranks busy above quiet: {busy} vs {quiet}"
+    );
+    assert!((0.0..=100.0).contains(&busy), "percentile score in [0,100]");
+}
+
+#[test]
+fn include_deleted_surfaces_a_removed_file() {
+    let repo = Repo::init();
+    repo.write("gone.rs", "fn g() {}\n");
+    repo.commit("Ada", "ada@example.com", FIXED_NOW - 30 * DAY, "add gone");
+    repo.git(&["rm", "-q", "gone.rs"]);
+    repo.write("kept.rs", "fn k() {}\n");
+    repo.commit(
+        "Ada",
+        "ada@example.com",
+        FIXED_NOW - 10 * DAY,
+        "remove gone",
+    );
+
+    // Default: a file deleted at the target ref is absent from the index.
+    let default = build_history_index(repo.path(), &opts()).expect("walk");
+    assert!(default.get(Path::new("gone.rs")).is_none());
+    // Opt-in: the deleted file is surfaced with its in-window history.
+    let with_deleted = build_history_index(
+        repo.path(),
+        &Options {
+            include_deleted: true,
+            ..opts()
+        },
+    )
+    .expect("walk");
+    let gone = with_deleted
+        .get(Path::new("gone.rs"))
+        .expect("deleted file surfaced under include_deleted");
+    // Both the "add gone" commit and the "remove gone" deletion commit
+    // touch the file (a deletion is a churn-bearing change), so exactly
+    // two commits attribute — a regression dropping the deletion-commit
+    // attribution would fail this where `>= 1` would not.
+    assert_eq!(gone.commits_long, 2);
+}
+
+#[test]
+fn first_parent_merges_and_full_history_count_branch_work() {
+    let repo = Repo::init();
+    repo.write("base.rs", "fn b() {}\n");
+    repo.commit(
+        "Ada",
+        "ada@example.com",
+        FIXED_NOW - 40 * DAY,
+        "base on main",
+    );
+    repo.git(&["checkout", "-q", "-b", "feature"]);
+    repo.write("f.rs", "fn f() {}\n");
+    repo.commit(
+        "Grace",
+        "grace@example.com",
+        FIXED_NOW - 30 * DAY,
+        "feature work",
+    );
+    repo.git(&["checkout", "-q", "main"]);
+    repo.git_at(
+        "Ada",
+        "ada@example.com",
+        FIXED_NOW - 10 * DAY,
+        &["merge", "--no-ff", "-m", "merge feature", "feature"],
+    );
+
+    let commits_long = |options: &Options| {
+        build_history_index(repo.path(), options)
+            .expect("walk")
+            .get(Path::new("f.rs"))
+            .expect("f.rs is present at the merged HEAD")
+            .commits_long
+    };
+
+    // Default (first-parent, skip merges): the branch-side commit is on
+    // the second parent and the merge is skipped, so f.rs is unattributed.
+    assert_eq!(commits_long(&opts()), 0, "first-parent skips branch work");
+    // Including merges: the merge commit's diff against its first parent
+    // introduces f.rs, so it is counted once.
+    assert_eq!(
+        commits_long(&Options {
+            include_merges: true,
+            ..opts()
+        }),
+        1,
+        "the merge commit introduces f.rs"
+    );
+    // Full history walks the second parent, counting the branch commit.
+    // The merge is still skipped (full_history does not imply
+    // include_merges), so it is exactly one.
+    assert_eq!(
+        commits_long(&Options {
+            full_history: true,
+            ..opts()
+        }),
+        1,
+        "full history reaches the branch commit"
+    );
+    // Both flags together count the file twice — once on the branch
+    // commit (C2) and once on the merge's diff against its first parent
+    // (M). This double-count is the documented consequence of walking
+    // the full DAG *and* attributing merges; pinned so it cannot change
+    // silently.
+    assert_eq!(
+        commits_long(&Options {
+            full_history: true,
+            include_merges: true,
+            ..opts()
+        }),
+        2,
+        "full DAG + merges attributes both the branch and merge commits"
+    );
+}
+
+#[test]
+fn not_a_repository_errors_clearly() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let err = build_history_index(dir.path(), &opts()).expect_err("must error outside a repo");
+    assert!(
+        matches!(err, vcs::Error::NotARepository(_)),
+        "expected NotARepository, got {err:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Implements epic #328 — change-history (VCS) metrics with a git backend.
`big-code-analysis` can now rank a repository's files by a composite
change-history **risk score** (log-scaled weighted sum of churn, author
spread, recency, and a complexity×churn hotspot signal), surfaced across
all four crates and dogfooded in this repo's own CI.

Closes #328.

## What ships

- **Library** — `src/vcs/` generic modules + `src/vcs/git/` backend behind
  the `vcs` / `vcs-git` Cargo features. Rename-following, mailmap identity
  canonicalisation, bot filtering, percentile and weighted risk formulas,
  shallow-clone-aware history walk. `CodeMetrics.vcs` + `wire::Vcs` for the
  serialized shape.
- **CLI** — `bca vcs` (ranked table / JSON / CSV) and `bca metrics --vcs`
  (attaches a per-file vcs block to a metrics run).
- **Web** — `POST /vcs` walks a server-side working tree and returns files
  ranked by risk (same parse-timeout / blocking-pool guards as the other
  endpoints; localhost-bind security note in the module docs).
- **Python** — `vcs_metrics(repo_path, ...)` (analogue of `bca vcs`) and
  `analyze(..., vcs=True)`, both fully typed in `_native.pyi`.
- **Docs / packaging** — book chapter, `STABILITY.md`, `CHANGELOG.md`,
  `man/bca-vcs.1`, deb/rpm asset lists, and a CI step that publishes a VCS
  risk report alongside the metrics pages.

## Design note (deviates from the issue)

The issue proposed a `Metric::Vcs` variant selected via `--metrics vcs`.
VCS metrics are file-level — no per-function threshold, not suppressible —
so they don't fit the AST `Metric` bitfield (its guard tests resist it).
Delivered instead via a dedicated `--vcs` flag, keeping `bca metrics --vcs`
simple with default windows and pointing power users at `bca vcs`.

## Testing

~60 Rust tests across the crates + 6 Python tests. `make pre-commit` is
green: cargo fmt/clippy (default + all-features), `cargo test --workspace
--all-features`, doc, udeps, self-scan hard + headroom gates, man-page
drift, all lint families, and the Python ruff/mypy/pytest stages. The two
`POST /vcs` 415/405 fallback tests were verified via test-via-revert (each
fails against the pre-fix code).

## Follow-ups (out of scope)

- #573 — make the VCS report a first-class rendered HTML page (report.html-style).
- #329–#334 — deferred enhancements tracked separately.
