### PR TITLE
feat(vcs): historical metric trend (time series over N points)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,38 @@ for historical reference.
   JIT-prior and per-file-injection walks neither compute nor pay for it.
   Additive — no existing field moved, and `vcs_schema_version` is
   unchanged (the aggregate carries its own `BUS_FACTOR_SCHEMA_VERSION`).
+- Historical metric **trend** (#333). Samples the change-history metrics
+  at several points in time so a consumer sees whether a file's risk is
+  improving or degrading over the project's life, not only its risk *now*
+  — the actionable question for technical-debt programs (the Kamei JIT
+  survey notes single-snapshot models lose predictive power as a project
+  ages; a trend is the more durable framing). `points` evenly-spaced
+  samples (inclusive of both endpoints) cover a `span`, ending at `as_of`
+  (or wall-clock now); each sample **re-anchors at the mainline tip that
+  existed at or before that moment** (resolved from one first-parent walk)
+  rather than windowing today's `HEAD` tree, so it is a faithful
+  historical snapshot — a file not yet born at an older point is `null`
+  there. The output is a versioned (`trend_schema_version`) time series:
+  `as_of_points` (oldest-first) plus a per-file array aligned to it, and a
+  most-improved / most-regressed `deltas` summary by `risk_score`. The
+  point count is bounded (2–120) to cap the per-point walks on deep
+  histories. Surfaces:
+  - Library: `big_code_analysis::vcs::{build_trend, Trend, TrendDelta,
+    TrendDeltas, TREND_SCHEMA_VERSION}`, the `wire::{VcsTrend,
+    VcsTrendPoint, VcsTrendDelta, VcsTrendDeltas}` projection, and a new
+    `vcs::Error::InvalidTrend` variant (all behind `vcs-git`). The generic
+    `trend` module is backend-neutral.
+  - CLI: `bca vcs trend [--points N] [--span DURATION] [--top-deltas N]
+    [-O json|yaml|cbor]`, reusing the parent `bca vcs` window / `--ref` /
+    bot / merge / rename / `--as-of` / `--top` flags. (TOML is excluded —
+    an absent point serializes as `null`, which TOML cannot represent.)
+  - Web: a new `POST /vcs/trend` endpoint taking the `/vcs` fields plus
+    `points` / `span` / `top_deltas`.
+  - Python: `vcs_trend(repo_path, points=…, span=…, …)`.
+
+  *Rename limitation:* renames are followed *within* each sample's walk,
+  but a file renamed *between* two samples appears as two separate path
+  series (old name, then new); cross-sample rename stitching is deferred.
 - `Ast::strip_comments()`, `Ast::functions()`, `Ast::dump(cfg)`,
   `Ast::count(filters)`, `Ast::find(filters)`, and `Ast::suppressions()`
   complete the parse-once `Ast` seam: comment removal, function-span

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -265,6 +265,21 @@ departures that abandon a subsystem), but it inherits the Avelino
 heuristic's caveats (a single-author or very young repository skews it
 downward), so treat it as a planning signal, not a guarantee.
 
+Historical metric **trend** (#333) adds one more opt-in slice:
+`big_code_analysis::vcs::{build_trend, Trend, TrendDelta, TrendDeltas}`
+plus the `TREND_SCHEMA_VERSION` constant, the
+`wire::{VcsTrend, VcsTrendPoint, VcsTrendDelta, VcsTrendDeltas}`
+projection, and the `vcs::Error::InvalidTrend` variant. The trend is
+surfaced by `bca vcs trend`, `POST /vcs/trend`, and `vcs_trend()`. Each
+sampled point's metric block is the same `wire::Vcs` shape (so its fields
+and `risk_score` carry the same ordinal/versioned contract as `bca vcs`);
+the *container* shape — `as_of_points`, the per-file point arrays (`null`
+where a file did not exist), and the `deltas` summary — is stable within
+`1.x` and versioned by `trend_schema_version`. The per-point timestamps
+and the delta magnitudes are derived from the same ordinal `risk_score`,
+so the "magnitudes are not byte-stable across bumps" caveat applies. The
+new module is additive — no existing field moved.
+
 The following are explicitly **not** part of the shape contract:
 
 - Anything marked `#[doc(hidden)]` (see `src/traits.rs` for current

--- a/big-code-analysis-book/src/commands/vcs.md
+++ b/big-code-analysis-book/src/commands/vcs.md
@@ -308,6 +308,63 @@ commit-score distribution rather than treating it as an absolute.
 > REST / Python parity are deferred follow-ups; ML-based JIT and
 > server-side hooks are out of scope.
 
+## Historical trend (over time)
+
+A single `bca vcs` run answers *"what is risky now."* `bca vcs trend`
+answers *"is it getting better or worse"* — the actionable question for a
+technical-debt programme — by sampling the metrics at several points in
+time and emitting a per-file time series.
+
+```console
+$ bca vcs --top 20 trend --points 12 --span 24mo --pretty
+{
+  "trend_schema_version": 1,
+  "vcs_schema_version": 2,
+  "risk_score_version": 2,
+  "long_window_days": 365,
+  "recent_window_days": 90,
+  "truncated_shallow_clone": false,
+  "as_of_points": [ 1700000000, 1705259520, ... ],
+  "files": {
+    "src/parser.rs": [
+      null,                       // did not exist at the oldest point
+      { "as_of": 1705259520, "risk_score": 4.1, ... },
+      { "as_of": 1710519040, "risk_score": 6.8, ... }
+    ]
+  },
+  "deltas": {
+    "improved":  [ { "path": "src/old.rs",    "delta": -3.2, ... } ],
+    "regressed": [ { "path": "src/parser.rs", "delta":  2.7, ... } ]
+  }
+}
+```
+
+`--points N` evenly-spaced samples (inclusive of both endpoints) cover
+`--span DURATION`, ending at `--as-of` (or wall-clock now). `as_of_points`
+lists the sample timestamps oldest-first; every file's array aligns to it
+1:1, with a `null` element marking a point where the file did not exist
+yet. `deltas` ranks the files whose `risk_score` fell the most
+(`improved`) and rose the most (`regressed`) between each file's earliest
+and latest present points; `--top-deltas` trims each list.
+
+Crucially, each point **re-anchors at the mainline tip that existed at or
+before that moment** — it does not just re-window today's `HEAD` tree.
+That is what makes a file born later show as `null` at older points
+(rather than leaking its present-day metrics backwards). Files kept in the
+series are the `--top` highest-risk by their most-recent sample.
+
+Flags reused from the parent `bca vcs` command: the window (`--long-window`
+/ `--recent-window`), `--ref`, bot / merge / rename toggles, `--as-of`
+(the most-recent anchor), and `--top`. `-O` accepts `json` (default),
+`yaml`, or `cbor`; TOML is excluded because an absent point serializes as
+`null`, which TOML cannot represent. The point count is bounded (2–120) to
+keep the per-point history walks tractable on deep histories.
+
+> **Rename caveat.** Renames are followed *within* each sample's walk, but
+> a file renamed *between* two samples appears as two separate path series
+> (its old name, then its new name) rather than one continuous line.
+> Cross-sample rename stitching is a deferred follow-up.
+
 ## Bus factor (directory & repo level)
 
 Where the per-file `ownership_top_share` measures concentration *within* a
@@ -394,11 +451,13 @@ for tooling.
 ## REST and Python
 
 - **REST:** `POST /vcs` with a JSON body `{ "id": "...", "repo_path":
-  "/path/to/repo", ... }` returns the ranked report. See
-  [Driving the REST API](../recipes/rest-api.md).
+  "/path/to/repo", ... }` returns the ranked report, and `POST /vcs/trend`
+  (same fields plus `points` / `span` / `top_deltas`) returns the
+  historical time series. See [Driving the REST API](../recipes/rest-api.md).
 - **Python:** `big_code_analysis.vcs_metrics(repo_path, …)` returns the
-  report as a dict, and `analyze(path, vcs=True)` attaches a `vcs` block
-  to a single file's metrics.
+  ranked report as a dict, `vcs_trend(repo_path, points=…, span=…, …)`
+  returns the time series, and `analyze(path, vcs=True)` attaches a `vcs`
+  block to a single file's metrics.
 
 Both `POST /vcs` and `vcs_metrics()` include the `vcs_aggregate` bus
 factor in the result and accept a `bus_factor_threshold` (in `(0, 1)`) to

--- a/big-code-analysis-book/src/recipes/rest-api.md
+++ b/big-code-analysis-book/src/recipes/rest-api.md
@@ -155,6 +155,30 @@ The body accepts the same knobs as `bca vcs` (`long_window`,
 A `repo_path` that is not a git working tree, or a malformed window /
 timestamp / formula, returns `400` with the uniform JSON error body.
 
+### Trend over time
+
+`POST /vcs/trend` samples the same metrics at several points in time and
+returns a per-file time series (see [Historical
+trend](../commands/vcs.md#historical-trend-over-time)). The body takes the
+`/vcs` fields plus `points` (>= 2), `span` (default `12mo`), and
+`top_deltas`.
+
+```bash
+curl -s http://127.0.0.1:8080/v1/vcs/trend \
+    -H 'Content-Type: application/json' \
+    -d '{
+          "id": "trend-1",
+          "repo_path": "/srv/checkouts/my-project",
+          "points": 12,
+          "span": "24mo",
+          "top": 20
+        }' \
+  | jq '.deltas.regressed[] | {path, delta}'
+```
+
+A point count below 2 (or above the supported maximum) returns `400` with
+the uniform JSON error body, like the other bad-request cases.
+
 ## Calling the API from CI
 
 The server starts in milliseconds, so for short-lived CI jobs it's

--- a/big-code-analysis-cli/Cargo.toml
+++ b/big-code-analysis-cli/Cargo.toml
@@ -192,6 +192,11 @@ assets = [
     "usr/share/man/man1/",
     "644",
   ],
+  [
+    "../man/bca-vcs-trend.1",
+    "usr/share/man/man1/",
+    "644",
+  ],
 ]
 
 # RHEL/Rocky/Fedora/Amazon Linux packaging — consumed by
@@ -231,5 +236,6 @@ assets = [
   { source = "../man/bca-strip-comments.1", dest = "/usr/share/man/man1/bca-strip-comments.1", mode = "644" },
   { source = "../man/bca-vcs.1", dest = "/usr/share/man/man1/bca-vcs.1", mode = "644" },
   { source = "../man/bca-vcs-jit.1", dest = "/usr/share/man/man1/bca-vcs-jit.1", mode = "644" },
+  { source = "../man/bca-vcs-trend.1", dest = "/usr/share/man/man1/bca-vcs-trend.1", mode = "644" },
 ]
 auto-req = "disabled"

--- a/big-code-analysis-cli/src/formats.rs
+++ b/big-code-analysis-cli/src/formats.rs
@@ -79,6 +79,21 @@ pub(crate) enum JitFormat {
     Cbor,
 }
 
+/// Output formats accepted by `bca vcs trend` (issue #333). A historical
+/// time series is one nested structured document, so the ranked-report
+/// renderings (`markdown` / `html`) and the per-file `csv` row shape do
+/// not apply. TOML is also excluded: a file absent at a point serializes
+/// as a `null` array element, which TOML cannot represent. JSON is the
+/// default; CBOR is binary and must go to a file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum)]
+#[clap(rename_all = "lower")]
+pub(crate) enum TrendFormat {
+    #[default]
+    Json,
+    Yaml,
+    Cbor,
+}
+
 /// How a `MetricsFormat` should be dispatched. Carries enough type
 /// information that the compiler — not a pair of boolean predicates
 /// in lock-step with a downstream `match` — enforces that every

--- a/big-code-analysis-cli/src/lib.rs
+++ b/big-code-analysis-cli/src/lib.rs
@@ -54,6 +54,7 @@ mod thresholds;
 mod vcs_command;
 mod vcs_jit;
 mod vcs_report;
+mod vcs_trend;
 mod walk_seed;
 
 pub use commands::run;
@@ -73,7 +74,7 @@ use globset::{Glob, GlobSet, GlobSetBuilder};
 
 use baseline::Baseline;
 use check_format::AggregatedFormat;
-use formats::{JitFormat, MetricsFormat, ReportFormat, VcsFormat};
+use formats::{JitFormat, MetricsFormat, ReportFormat, TrendFormat, VcsFormat};
 use markdown_report::FunctionSummary;
 use metric_catalog::ListMetricsMode;
 use thresholds::{
@@ -454,8 +455,8 @@ struct VcsArgs {
     bus_factor_threshold: f64,
 }
 
-/// Subcommands of `bca vcs`. Only `jit` so far (issue #331); the bare
-/// `bca vcs` ranking path is the `None` case.
+/// Subcommands of `bca vcs`: `jit` (issue #331) and `trend` (issue #333);
+/// the bare `bca vcs` ranking path is the `None` case.
 #[derive(Subcommand, Debug)]
 enum VcsSubcommand {
     /// Score a single commit for just-in-time (commit-level)
@@ -465,6 +466,14 @@ enum VcsSubcommand {
     /// an ordinal composite score. Window / `--ref` / bot / merge /
     /// rename behaviour comes from the parent `vcs` flags.
     Jit(JitArgs),
+    /// Sample the change-history metrics at several points in time and
+    /// emit a per-file time series, surfacing whether code is improving or
+    /// degrading over the project's life (issue #333). Each point
+    /// re-anchors at the mainline tip of that moment, so it is a faithful
+    /// historical snapshot. Window / `--ref` / bot / merge / rename / as-of
+    /// (the most-recent anchor) and `--top` (files kept) come from the
+    /// parent `vcs` flags.
+    Trend(TrendArgs),
 }
 
 /// Flags for `bca vcs jit` (issue #331). The history-window, bot, merge,
@@ -493,6 +502,41 @@ struct JitArgs {
     /// threshold against the repository's own commit-score distribution.
     #[clap(long, value_name = "SCORE")]
     fail_over: Option<f64>,
+}
+
+/// Flags for `bca vcs trend` (issue #333). The history-window, bot, merge,
+/// rename, `--ref`, and `--as-of` (the most-recent point's anchor) options
+/// come from the parent [`VcsArgs`], as does `--top` (how many files to
+/// keep, ranked by most-recent risk); these are the trend-only additions.
+#[derive(Args, Debug)]
+struct TrendArgs {
+    /// Number of evenly-spaced sample points across `--span`, inclusive of
+    /// both endpoints (the oldest is `as-of − span`, the newest is
+    /// `as-of`). Minimum 2; capped (see the error message) to bound the
+    /// per-point history walks on deep histories.
+    #[clap(long, default_value_t = 12)]
+    points: usize,
+    /// Total look-back window the points span (`12mo`, `2y`, `52w`, `365d`,
+    /// or ISO 8601 `P1Y`). With the default 12 points this yields roughly
+    /// monthly snapshots over the past year.
+    #[clap(long, default_value = "12mo")]
+    span: String,
+    /// Show only the top N files in each improving / regressing delta
+    /// summary (`0` = all).
+    #[clap(long, default_value_t = 10)]
+    top_deltas: usize,
+    /// Output format (`json` default, plus `yaml` / `cbor`). TOML is
+    /// excluded — absent points serialize as `null`, which TOML cannot
+    /// represent.
+    #[clap(long = "format", short = 'O', value_enum, default_value_t = TrendFormat::default())]
+    format: TrendFormat,
+    /// Output file. Stdout if omitted (CBOR requires this flag — it is
+    /// binary).
+    #[clap(long, short, value_parser)]
+    output: Option<PathBuf>,
+    /// Pretty-print JSON output.
+    #[clap(long)]
+    pretty: bool,
 }
 
 /// Flags for `bca metrics`: the shared structured-output set plus an

--- a/big-code-analysis-cli/src/vcs_command.rs
+++ b/big-code-analysis-cli/src/vcs_command.rs
@@ -66,11 +66,18 @@ pub(crate) fn run(mut globals: GlobalOpts, args: VcsArgs) {
     }
     let root = resolve_root(&globals);
 
-    // `bca vcs jit <commit>` is a distinct, single-commit path; the bare
-    // `bca vcs` ranking flow is the `None` case below.
-    if let Some(crate::VcsSubcommand::Jit(jit)) = args.command.as_ref() {
-        crate::vcs_jit::run(&root, &args, jit);
-        return;
+    // `bca vcs jit <commit>` and `bca vcs trend` are distinct paths; the
+    // bare `bca vcs` ranking flow is the `None` case below.
+    match args.command.as_ref() {
+        Some(crate::VcsSubcommand::Jit(jit)) => {
+            crate::vcs_jit::run(&root, &args, jit);
+            return;
+        }
+        Some(crate::VcsSubcommand::Trend(trend)) => {
+            crate::vcs_trend::run(&root, &args, trend);
+            return;
+        }
+        None => {}
     }
 
     let mut options = build_options(&args);

--- a/big-code-analysis-cli/src/vcs_trend.rs
+++ b/big-code-analysis-cli/src/vcs_trend.rs
@@ -1,0 +1,83 @@
+// bca: suppress-file(halstead, nargs)
+// File-level halstead/nargs are many-fn aggregation artifacts (the
+// format-dispatch `emit` match + the small write helpers), not
+// per-function logic complexity (cognitive/cyclomatic stay enforced) —
+// mirrors the sibling `vcs_jit.rs`.
+
+//! `bca vcs trend` — sample the change-history metrics at several points
+//! in time and emit a per-file time series (issue #333).
+//!
+//! Unlike `bca vcs` (a single ranked snapshot at one ref), this re-anchors
+//! at the mainline tip of each sampled moment and emits one nested
+//! structured document: `as_of_points`, per-file point arrays (`null`
+//! where the file did not exist), and an improving/regressing delta
+//! summary. The window / bot / merge / rename / `--ref` / `--as-of` flags
+//! and `--top` come from the parent `bca vcs` options.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use big_code_analysis::vcs::{build_trend, parse_window};
+use big_code_analysis::wire;
+
+use crate::formats::{CBOR_STDOUT_ERROR, TrendFormat};
+use crate::{TrendArgs, VcsArgs, die};
+
+/// Entry point for `bca vcs trend`. `root` is the repository-discovery
+/// seed already resolved by [`crate::vcs_command::run`]; `args` carries the
+/// shared window / bot / merge / rename / ref / as-of / top flags, `trend`
+/// the trend-only ones.
+pub(crate) fn run(root: &Path, args: &VcsArgs, trend: &TrendArgs) {
+    let base = crate::vcs_command::build_options(args);
+    let span_secs = parse_window(&trend.span).unwrap_or_else(|e| die(format_args!("--span: {e}")));
+
+    let result = build_trend(root, &base, trend.points, span_secs)
+        .unwrap_or_else(|e| die(format_args!("{e}")));
+    if result.truncated_shallow_clone() {
+        eprintln!(
+            "Warning: shallow clone detected — history is truncated, so counts are lower bounds"
+        );
+    }
+
+    // `args.top` (parent `--top`) keeps the riskiest files; `top_deltas`
+    // trims each delta list.
+    let report = wire::VcsTrend::from_trend(&result, args.top, trend.top_deltas);
+    emit(&report, trend).unwrap_or_else(|e| die(format_args!("writing vcs trend output: {e}")));
+}
+
+/// Serialize the trend in the requested structured format to a single file
+/// or stdout (CBOR to a file only — it is binary).
+fn emit(report: &wire::VcsTrend, trend: &TrendArgs) -> std::io::Result<()> {
+    let output = trend.output.as_ref();
+    match trend.format {
+        TrendFormat::Json => {
+            let json = if trend.pretty {
+                serde_json::to_string_pretty(report)
+            } else {
+                serde_json::to_string(report)
+            }
+            .map_err(std::io::Error::other)?;
+            write_text(&json, output)
+        }
+        TrendFormat::Yaml => {
+            let yaml = serde_yaml::to_string(report).map_err(std::io::Error::other)?;
+            write_text(&yaml, output)
+        }
+        TrendFormat::Cbor => match output {
+            None => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                CBOR_STDOUT_ERROR,
+            )),
+            Some(path) => ciborium::into_writer(report, std::fs::File::create(path)?)
+                .map_err(std::io::Error::other),
+        },
+    }
+}
+
+/// Write a rendered text document to a single file or stdout.
+fn write_text(content: &str, output: Option<&PathBuf>) -> std::io::Result<()> {
+    match output {
+        Some(path) => std::fs::write(path, content),
+        None => std::io::stdout().lock().write_all(content.as_bytes()),
+    }
+}

--- a/big-code-analysis-cli/tests/vcs_trend.rs
+++ b/big-code-analysis-cli/tests/vcs_trend.rs
@@ -1,0 +1,157 @@
+//! CLI integration tests for `bca vcs trend` (issue #333): the JSON time
+//! series shape, the absent-file `null` markers, the point-count
+//! validation error, and the outside-a-repo error.
+//!
+//! Each test drives the real `bca` binary against a tiny throwaway git
+//! repository built through the `git` CLI with a fixed identity and
+//! explicit commit dates, so the runs are deterministic.
+
+use std::path::Path;
+use std::process::Command as Git;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+mod common;
+
+/// Reference "now" the trend's most-recent point is pinned to via
+/// `--as-of`, so the sampled grid is fully reproducible.
+const FIXED_NOW: i64 = 1_700_000_000;
+const DAY: i64 = 86_400;
+
+/// Build a two-file, two-commit repo: `early.rs` at `now − 300d`, then
+/// `late.rs` added at `now − 100d`.
+fn staged_repo() -> TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    git(&dir, &["init", "-q", "-b", "main"]);
+    git(&dir, &["config", "commit.gpgsign", "false"]);
+
+    std::fs::write(dir.path().join("early.rs"), "fn a() {}\n").expect("write early");
+    git(&dir, &["add", "-A"]);
+    commit(&dir, FIXED_NOW - 300 * DAY, "init early");
+
+    std::fs::write(dir.path().join("late.rs"), "fn b() {}\n").expect("write late");
+    git(&dir, &["add", "-A"]);
+    commit(&dir, FIXED_NOW - 100 * DAY, "add late");
+    dir
+}
+
+fn git(dir: &TempDir, args: &[&str]) {
+    let status = Git::new("git")
+        .args(args)
+        .current_dir(dir.path())
+        .status()
+        .expect("spawn git");
+    assert!(status.success(), "git {args:?} failed");
+}
+
+fn commit(dir: &TempDir, secs: i64, message: &str) {
+    let date = format!("@{secs} +0000");
+    let status = Git::new("git")
+        .args(["commit", "-q", "--no-verify", "-m", message])
+        .current_dir(dir.path())
+        .envs([
+            ("GIT_AUTHOR_NAME", "Ada"),
+            ("GIT_AUTHOR_EMAIL", "ada@example.com"),
+            ("GIT_AUTHOR_DATE", date.as_str()),
+            ("GIT_COMMITTER_NAME", "Ada"),
+            ("GIT_COMMITTER_EMAIL", "ada@example.com"),
+            ("GIT_COMMITTER_DATE", date.as_str()),
+        ])
+        .status()
+        .expect("spawn git commit");
+    assert!(status.success(), "git commit failed");
+}
+
+/// A `bca` command rooted at `dir`.
+fn bca(dir: &Path) -> Command {
+    common::cli_in(dir)
+}
+
+#[test]
+fn trend_emits_stable_json_shape() {
+    let repo = staged_repo();
+    // `--as-of` (parent flag) pins the newest point; 3 points / 300d puts
+    // the oldest exactly on the first commit.
+    let as_of = format!("@{FIXED_NOW}");
+    let output = bca(repo.path())
+        .args([
+            "vcs", "--as-of", &as_of, "trend", "--points", "3", "--span", "300d", "-O", "json",
+        ])
+        .output()
+        .expect("run bca vcs trend");
+    assert!(output.status.success(), "trend should exit 0 inside a repo");
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("trend output is valid JSON");
+    assert_eq!(json["trend_schema_version"], 1);
+    // Pin the concrete per-point block version (stats::VCS_SCHEMA_VERSION),
+    // not merely "is a number" — a schema bump must update this test.
+    assert_eq!(json["vcs_schema_version"], 2);
+    let points = json["as_of_points"].as_array().expect("as_of_points array");
+    assert_eq!(points.len(), 3);
+    assert_eq!(points[2], FIXED_NOW, "newest point is the as-of anchor");
+
+    // late.rs was added at the middle commit, so it is null at the oldest
+    // point and present afterwards.
+    let late = json["files"]["late.rs"].as_array().expect("late.rs series");
+    assert!(late[0].is_null(), "late.rs absent at the oldest point");
+    assert!(late[2].is_object(), "late.rs present at the newest point");
+    assert_eq!(late[2]["as_of"], FIXED_NOW);
+    assert!(
+        late[2]["risk_score"].is_number(),
+        "a present point carries the flattened vcs block"
+    );
+
+    // The delta summary is present and split into two lists.
+    assert!(json["deltas"]["improved"].is_array());
+    assert!(json["deltas"]["regressed"].is_array());
+}
+
+#[test]
+fn yaml_format_emits_valid_document() {
+    let repo = staged_repo();
+    let output = bca(repo.path())
+        .args([
+            "vcs", "trend", "--points", "2", "--span", "30d", "-O", "yaml",
+        ])
+        .output()
+        .expect("run bca vcs trend yaml");
+    assert!(output.status.success());
+    let doc: serde_yaml::Value =
+        serde_yaml::from_slice(&output.stdout).expect("trend output is valid YAML");
+    assert_eq!(doc["trend_schema_version"], 1);
+    // Non-vacuous structural checks: the point grid and file map are
+    // present with the requested shape.
+    assert_eq!(
+        doc["as_of_points"].as_sequence().map(Vec::len),
+        Some(2),
+        "two requested points appear in the YAML"
+    );
+    assert!(doc["files"].is_mapping(), "files is a path-keyed mapping");
+}
+
+#[test]
+fn too_few_points_is_rejected() {
+    let repo = staged_repo();
+    bca(repo.path())
+        .args(["vcs", "trend", "--points", "1", "--span", "30d"])
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::contains("at least 2 points"));
+}
+
+#[test]
+fn outside_a_repo_errors() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    bca(dir.path())
+        .args(["vcs", "trend", "--points", "3", "--span", "30d"])
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::contains(
+            "not inside a supported version-control working tree",
+        ));
+}

--- a/big-code-analysis-py/python/big_code_analysis/__init__.py
+++ b/big-code-analysis-py/python/big_code_analysis/__init__.py
@@ -35,6 +35,7 @@ from ._native import (
     language_for_file,
     to_sarif,
     vcs_metrics,
+    vcs_trend,
 )
 
 #: Canonical metric names, as :class:`MetricName` members. The values
@@ -73,4 +74,5 @@ __all__ = [
     "supported_languages",
     "to_sarif",
     "vcs_metrics",
+    "vcs_trend",
 ]

--- a/big-code-analysis-py/python/big_code_analysis/_native.pyi
+++ b/big-code-analysis-py/python/big_code_analysis/_native.pyi
@@ -303,6 +303,55 @@ def vcs_metrics(
         ``repo_path`` is not inside a git working tree.
     """
 
+def vcs_trend(
+    repo_path: str | os.PathLike[str],
+    /,
+    *,
+    points: int = 12,
+    span: str | None = None,
+    top: int | None = None,
+    top_deltas: int | None = None,
+    long_window: str | None = None,
+    recent_window: str | None = None,
+    reference: str | None = None,
+    risk_formula: str | None = None,
+    full_history: bool = False,
+    include_merges: bool = False,
+    follow_renames: bool = True,
+    exclude_bots: bool = True,
+    bot_pattern: str | None = None,
+    as_of: str | None = None,
+    emit_author_details: bool = False,
+    include_deleted: bool = False,
+    bus_factor_threshold: float | None = None,
+) -> dict[str, Any]:
+    """Sample change-history metrics over time as a per-file trend.
+
+    The programmatic analogue of ``bca vcs trend`` (issue #333).
+    ``points`` (>= 2) evenly-spaced samples cover ``span`` (default
+    ``12mo``), ending at ``as_of`` (or wall-clock now). Returns a
+    ``dict`` with ``trend_schema_version``, ``vcs_schema_version``,
+    ``risk_score_version``, the window lengths,
+    ``truncated_shallow_clone``, ``as_of_points`` (sample timestamps,
+    oldest-first), a ``files`` map from path to a point array aligned to
+    ``as_of_points`` (a ``None`` element marks a point where the file did
+    not exist), and a ``deltas`` summary splitting the most-``improved``
+    and most-``regressed`` files by ``risk_score``.
+
+    Each point re-anchors at the mainline tip of that moment, so it is a
+    faithful historical snapshot rather than today's tree windowed
+    differently. ``top`` caps how many files the series keeps (by
+    most-recent risk); ``top_deltas`` trims each delta list. The other
+    knobs match :func:`vcs_metrics`.
+
+    Raises
+    ------
+    ValueError
+        For a malformed option, a point count below 2 or above the
+        supported maximum, or when ``repo_path`` is not inside a git
+        working tree.
+    """
+
 def analyze_source(
     code: str | bytes | bytearray,
     language: str,

--- a/big-code-analysis-py/src/lib.rs
+++ b/big-code-analysis-py/src/lib.rs
@@ -414,6 +414,71 @@ fn vcs_metrics(
     conversion::json_string_to_py(py, &json)
 }
 
+/// Sample the change-history metrics at several points in time and return
+/// the per-file historical trend (issue #333).
+///
+/// `repo_path` is any path inside the working tree. `points` (>= 2) and
+/// `span` (default `12mo`) define the evenly-spaced sampling grid, ending
+/// at `as_of` (or wall-clock now). Returns a dict with `as_of_points`
+/// (the sample timestamps, oldest-first), a `files` map from
+/// repository-relative path to a point array aligned to `as_of_points`
+/// (a `None` element marks a point where the file did not exist), and an
+/// improving / regressing `deltas` summary — the programmatic analogue of
+/// `bca vcs trend`. `top` caps how many files the series keeps (by
+/// most-recent risk); `top_deltas` trims each delta list. Raises
+/// `ValueError` for a malformed option, an out-of-range point count, or
+/// when `repo_path` is not a git working tree.
+///
+/// Each point re-anchors at the mainline tip of that moment, so the result
+/// is a faithful historical snapshot; the repeated walks hold the GIL.
+#[pyfunction]
+#[pyo3(signature = (repo_path, /, *, points = 12, span = None, top = None, top_deltas = None, long_window = None, recent_window = None, reference = None, risk_formula = None, full_history = false, include_merges = false, follow_renames = true, exclude_bots = true, bot_pattern = None, as_of = None, emit_author_details = false, include_deleted = false, bus_factor_threshold = None))]
+#[allow(
+    clippy::needless_pass_by_value,
+    clippy::too_many_arguments,
+    clippy::fn_params_excessive_bools
+)]
+fn vcs_trend(
+    py: Python<'_>,
+    repo_path: PathBuf,
+    points: usize,
+    span: Option<String>,
+    top: Option<usize>,
+    top_deltas: Option<usize>,
+    long_window: Option<String>,
+    recent_window: Option<String>,
+    reference: Option<String>,
+    risk_formula: Option<String>,
+    full_history: bool,
+    include_merges: bool,
+    follow_renames: bool,
+    exclude_bots: bool,
+    bot_pattern: Option<String>,
+    as_of: Option<String>,
+    emit_author_details: bool,
+    include_deleted: bool,
+    bus_factor_threshold: Option<f64>,
+) -> PyResult<Bound<'_, PyAny>> {
+    let params = vcs::VcsParams {
+        long_window,
+        recent_window,
+        top,
+        reference,
+        risk_formula,
+        full_history,
+        include_merges,
+        follow_renames,
+        exclude_bots,
+        bot_pattern,
+        as_of,
+        emit_author_details,
+        include_deleted,
+        bus_factor_threshold,
+    };
+    let json = vcs::vcs_trend_json(&repo_path, &params, points, span.as_deref(), top_deltas)?;
+    conversion::json_string_to_py(py, &json)
+}
+
 /// `big_code_analysis._native` module entry point.
 ///
 /// Re-exported by the pure-Python `big_code_analysis` package so
@@ -439,6 +504,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyAnalysisError>()?;
     m.add_function(wrap_pyfunction!(analyze, m)?)?;
     m.add_function(wrap_pyfunction!(vcs_metrics, m)?)?;
+    m.add_function(wrap_pyfunction!(vcs_trend, m)?)?;
     m.add_function(wrap_pyfunction!(analyze_source, m)?)?;
     m.add_function(wrap_pyfunction!(analyze_batch, m)?)?;
     m.add_function(wrap_pyfunction!(language_for_file, m)?)?;

--- a/big-code-analysis-py/src/vcs.rs
+++ b/big-code-analysis-py/src/vcs.rs
@@ -20,7 +20,7 @@ use serde::Serialize;
 use serde_json::Value;
 
 use big_code_analysis::vcs::{
-    self, Options, build_history_index, hotspot, parse_timestamp, parse_window,
+    self, Options, build_history_index, build_trend, hotspot, parse_timestamp, parse_window,
 };
 use big_code_analysis::wire;
 
@@ -141,6 +141,36 @@ pub(crate) fn vcs_report_json(repo_path: &Path, params: &VcsParams) -> Result<St
     };
     serde_json::to_string(&report)
         .map_err(|e| PyValueError::new_err(format!("serializing vcs report: {e}")))
+}
+
+/// Walk `repo_path`'s history at several points in time and return the
+/// historical metric trend (issue #333) as a JSON string for
+/// [`crate::conversion::json_string_to_py`].
+///
+/// `params` supplies the shared window / bot / merge / rename / ref / as-of
+/// knobs (its `top` caps how many files the series keeps); `points` and
+/// `span` define the sampling grid, and `top_deltas` trims each delta
+/// list.
+///
+/// # Errors
+///
+/// `ValueError` for a bad option, an out-of-range point count, or a
+/// non-repository path; the walk itself surfaces its failure the same way.
+pub(crate) fn vcs_trend_json(
+    repo_path: &Path,
+    params: &VcsParams,
+    points: usize,
+    span: Option<&str>,
+    top_deltas: Option<usize>,
+) -> Result<String, PyErr> {
+    let options = options_from(params)?;
+    let span_secs =
+        parse_window(span.unwrap_or(vcs::options::DEFAULT_LONG_WINDOW)).map_err(vcs_error_to_py)?;
+    let trend = build_trend(repo_path, &options, points, span_secs).map_err(vcs_error_to_py)?;
+    let wire_trend =
+        wire::VcsTrend::from_trend(&trend, params.top.unwrap_or(0), top_deltas.unwrap_or(0));
+    serde_json::to_string(&wire_trend)
+        .map_err(|e| PyValueError::new_err(format!("serializing vcs trend: {e}")))
 }
 
 /// Inject a `vcs` block into a single file's metrics JSON for

--- a/big-code-analysis-py/tests/test_vcs.py
+++ b/big-code-analysis-py/tests/test_vcs.py
@@ -98,3 +98,64 @@ def test_vcs_metrics_bad_window_raises(tmp_path: Path) -> None:
     repo = _build_repo(tmp_path)
     with pytest.raises(ValueError, match="time window"):
         bca.vcs_metrics(repo, long_window="nonsense")
+
+
+def _build_staged_repo(root: Path) -> Path:
+    """Init a repo with ``early.rs`` at now-300d and ``late.rs`` at now-100d,
+    pinned to a fixed clock so a 3-point / 300d trend is reproducible."""
+    fixed_now = 1_700_000_000
+    day = 86_400
+
+    def commit(secs: int, message: str) -> None:
+        date = f"@{secs} +0000"
+        env = {
+            **os.environ,
+            "GIT_AUTHOR_NAME": "Ada",
+            "GIT_AUTHOR_EMAIL": "ada@example.com",
+            "GIT_AUTHOR_DATE": date,
+            "GIT_COMMITTER_NAME": "Ada",
+            "GIT_COMMITTER_EMAIL": "ada@example.com",
+            "GIT_COMMITTER_DATE": date,
+        }
+        subprocess.run(["git", "add", "."], cwd=root, check=True, env=env)
+        subprocess.run(
+            ["git", "commit", "-q", "--no-verify", "-m", message],
+            cwd=root,
+            check=True,
+            env=env,
+        )
+
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=root, check=True)
+    subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=root, check=True)
+    (root / "early.rs").write_text("fn a() {}\n")
+    commit(fixed_now - 300 * day, "init early")
+    (root / "late.rs").write_text("fn b() {}\n")
+    commit(fixed_now - 100 * day, "add late")
+    return root
+
+
+def test_vcs_trend_shape(tmp_path: Path) -> None:
+    repo = _build_staged_repo(tmp_path)
+    trend = bca.vcs_trend(repo, points=3, span="300d", as_of="@1700000000")
+    assert trend["trend_schema_version"] == 1
+    assert len(trend["as_of_points"]) == 3
+    assert trend["as_of_points"][2] == 1_700_000_000
+    # late.rs was added at the middle commit, so it is absent (None) at the
+    # oldest point and present at the newest.
+    late = trend["files"]["late.rs"]
+    assert late[0] is None
+    assert isinstance(late[2], dict)
+    assert late[2]["as_of"] == 1_700_000_000
+    assert isinstance(trend["deltas"]["improved"], list)
+    assert isinstance(trend["deltas"]["regressed"], list)
+
+
+def test_vcs_trend_too_few_points_raises(tmp_path: Path) -> None:
+    repo = _build_staged_repo(tmp_path)
+    with pytest.raises(ValueError, match="at least 2 points"):
+        bca.vcs_trend(repo, points=1, span="300d")
+
+
+def test_vcs_trend_outside_repo_raises(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="version-control"):
+        bca.vcs_trend(tmp_path, points=3, span="300d")

--- a/big-code-analysis-web/src/web/server.rs
+++ b/big-code-analysis-web/src/web/server.rs
@@ -25,7 +25,7 @@ use tokio::sync::Semaphore;
 use super::comment::{WebCommentCfg, WebCommentInfo, WebCommentPayload, strip_comments};
 use super::function::{WebFunctionCfg, WebFunctionInfo, WebFunctionPayload, function_spans};
 use super::metrics::{WebMetricsCfg, WebMetricsInfo, WebMetricsPayload, compute_metrics};
-use super::vcs::{WebVcsPayload, compute_vcs};
+use super::vcs::{WebVcsPayload, WebVcsTrendPayload, compute_vcs, compute_vcs_trend};
 
 use big_code_analysis::vcs::Error as VcsError;
 use big_code_analysis::{Ast, AstCfg, AstPayload, LANG, Source, guess_language};
@@ -108,7 +108,7 @@ const AST_BUILD_FAILED: &str = "Failed to build an AST for the supplied source";
 const METRICS_FAILED: &str = "Failed to compute metrics for the supplied source";
 /// Error body when `repo_path` is not a git working tree, or a window /
 /// timestamp / formula is malformed (a client mistake → `400`).
-const VCS_BAD_REQUEST: &str = "Invalid `/vcs` request: repo_path is not a git working tree, ref is unresolvable, or a window / timestamp / formula / bus-factor threshold is malformed";
+const VCS_BAD_REQUEST: &str = "Invalid `/vcs` request: repo_path is not a git working tree, ref is unresolvable, or a window / timestamp / formula / bus-factor threshold / trend parameter is malformed";
 /// Error body when the history walk itself fails (server-side → `500`).
 const VCS_FAILED: &str = "Failed to walk change history for the supplied repository";
 
@@ -414,28 +414,46 @@ async fn vcs_json(
     let result = run_parse(&config, &payload_id, move || compute_vcs(payload)).await?;
     match result {
         Ok(response) => Ok(HttpResponse::Ok().json(response)),
-        Err(error) => {
-            // Bad path / window / timestamp / pattern are client mistakes
-            // (`400`); an actual walk failure is a `500`. The real error
-            // is logged server-side; the client sees the uniform body.
-            let (status, body) = match error {
-                VcsError::NotARepository(_)
-                | VcsError::InvalidWindow(_)
-                | VcsError::InvalidTimestamp(_)
-                | VcsError::InvalidFormula(_)
-                | VcsError::InvalidBotPattern(_)
-                | VcsError::InvalidBusFactorThreshold(_)
-                // A bad client-supplied `ref` (or an unborn HEAD) is a
-                // client mistake, not a server fault — answer 400, not 500.
-                | VcsError::ResolveRef { .. } => {
-                    (http::StatusCode::BAD_REQUEST, VCS_BAD_REQUEST)
-                }
-                _ => (http::StatusCode::INTERNAL_SERVER_ERROR, VCS_FAILED),
-            };
-            tracing::warn!(payload_id = %payload_id, error = %error, "vcs request failed");
-            Ok(json_error(status, body, payload_id))
-        }
+        Err(error) => Ok(vcs_error_response(&error, payload_id)),
     }
+}
+
+async fn vcs_trend_json(
+    item: web::Json<WebVcsTrendPayload>,
+    config: web::Data<ParseConfig>,
+) -> Result<HttpResponse, actix_web::Error> {
+    let payload = item.into_inner();
+    let payload_id = payload.base.id.clone();
+    // The repeated history walks are blocking I/O, so they run on the same
+    // timeout-guarded blocking pool as the other endpoints.
+    let result = run_parse(&config, &payload_id, move || compute_vcs_trend(payload)).await?;
+    match result {
+        Ok(response) => Ok(HttpResponse::Ok().json(response)),
+        Err(error) => Ok(vcs_error_response(&error, payload_id)),
+    }
+}
+
+/// Map a [`VcsError`] from `/vcs` or `/vcs/trend` to the uniform JSON error
+/// response. Bad path / window / timestamp / pattern / formula / threshold
+/// / trend-parameter / `ref` are client mistakes (`400`); an actual walk
+/// failure is a `500`. The real error is logged server-side; the client
+/// sees the uniform body.
+fn vcs_error_response(error: &VcsError, payload_id: String) -> HttpResponse {
+    let (status, body) = match error {
+        VcsError::NotARepository(_)
+        | VcsError::InvalidWindow(_)
+        | VcsError::InvalidTimestamp(_)
+        | VcsError::InvalidFormula(_)
+        | VcsError::InvalidBotPattern(_)
+        | VcsError::InvalidBusFactorThreshold(_)
+        | VcsError::InvalidTrend(_)
+        // A bad client-supplied `ref` (or an unborn HEAD) is a client
+        // mistake, not a server fault — answer 400, not 500.
+        | VcsError::ResolveRef { .. } => (http::StatusCode::BAD_REQUEST, VCS_BAD_REQUEST),
+        _ => (http::StatusCode::INTERNAL_SERVER_ERROR, VCS_FAILED),
+    };
+    tracing::warn!(payload_id = %payload_id, error = %error, "vcs request failed");
+    json_error(status, body, payload_id)
 }
 
 async fn metrics_plain(
@@ -702,6 +720,13 @@ fn register_endpoints(cfg: &mut web::ServiceConfig) {
             // endpoint (#515): a wrong `Content-Type` or wrong method on
             // `/vcs` answers a diagnostic 415/405 here rather than
             // falling through to the app-level 404.
+            .default_service(web::route().to(guarded_post_fallback)),
+    )
+    .service(
+        // Historical metric trend (issue #333). A distinct resource from
+        // `/vcs` (its response is a time series, not a ranked snapshot).
+        web::resource("/vcs/trend")
+            .route(web::post().guard(json_guard()).to(vcs_trend_json))
             .default_service(web::route().to(guarded_post_fallback)),
     )
     .service(

--- a/big-code-analysis-web/src/web/server_tests.rs
+++ b/big-code-analysis-web/src/web/server_tests.rs
@@ -2128,3 +2128,107 @@ async fn test_web_vcs_wrong_method_yields_405() {
         "405 body should name the accepted method"
     );
 }
+
+/// Build a deterministic two-commit git repo for the `/vcs/trend` tests:
+/// `early.rs` at `now − 300d`, `late.rs` added at `now − 100d`. Returns
+/// the tempdir (auto-removed on drop).
+fn build_trend_repo() -> tempfile::TempDir {
+    use std::process::Command;
+    const FIXED_NOW: i64 = 1_700_000_000;
+    const DAY: i64 = 86_400;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let run = |args: &[&str], date: Option<i64>| {
+        let mut cmd = Command::new("git");
+        cmd.args(args).current_dir(dir.path());
+        if let Some(secs) = date {
+            let d = format!("@{secs} +0000");
+            cmd.envs([
+                ("GIT_AUTHOR_NAME", "Ada"),
+                ("GIT_AUTHOR_EMAIL", "ada@example.com"),
+                ("GIT_AUTHOR_DATE", d.as_str()),
+                ("GIT_COMMITTER_NAME", "Ada"),
+                ("GIT_COMMITTER_EMAIL", "ada@example.com"),
+                ("GIT_COMMITTER_DATE", d.as_str()),
+            ]);
+        }
+        assert!(cmd.status().expect("spawn git").success(), "git {args:?}");
+    };
+    run(&["init", "-q", "-b", "main"], None);
+    run(&["config", "commit.gpgsign", "false"], None);
+    std::fs::write(dir.path().join("early.rs"), "fn a() {}\n").expect("write");
+    run(&["add", "-A"], None);
+    run(
+        &["commit", "-q", "--no-verify", "-m", "early"],
+        Some(FIXED_NOW - 300 * DAY),
+    );
+    std::fs::write(dir.path().join("late.rs"), "fn b() {}\n").expect("write");
+    run(&["add", "-A"], None);
+    run(
+        &["commit", "-q", "--no-verify", "-m", "late"],
+        Some(FIXED_NOW - 100 * DAY),
+    );
+    dir
+}
+
+#[actix_rt::test]
+async fn test_web_vcs_trend_json_shape() {
+    let repo = build_trend_repo();
+    let app = test::init_service(
+        App::new()
+            .app_data(test_config())
+            .configure(configure_routes),
+    )
+    .await;
+    let payload = json!({
+        "id": "trend-1",
+        "repo_path": repo.path().to_str().unwrap(),
+        "as_of": "@1700000000",
+        "points": 3,
+        "span": "300d",
+    });
+    let req = test::TestRequest::post()
+        .uri("/vcs/trend")
+        .insert_header(ContentType::json())
+        .set_json(&payload)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["id"], "trend-1");
+    assert_eq!(body["trend_schema_version"], 1);
+    assert_eq!(body["as_of_points"].as_array().unwrap().len(), 3);
+    // late.rs is absent at the oldest point (it was added later).
+    let late = body["files"]["late.rs"].as_array().expect("late.rs series");
+    assert!(late[0].is_null(), "late.rs is null at the oldest point");
+    assert!(late[2].is_object(), "late.rs present at the newest point");
+}
+
+#[actix_rt::test]
+async fn test_web_vcs_trend_too_few_points_is_400() {
+    let repo = build_trend_repo();
+    let app = test::init_service(
+        App::new()
+            .app_data(test_config())
+            .configure(configure_routes),
+    )
+    .await;
+    let payload = json!({
+        "id": "trend-bad",
+        "repo_path": repo.path().to_str().unwrap(),
+        "points": 1,
+        "span": "300d",
+    });
+    let req = test::TestRequest::post()
+        .uri("/vcs/trend")
+        .insert_header(ContentType::json())
+        .set_json(&payload)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "a sub-minimum point count is a client error"
+    );
+}

--- a/big-code-analysis-web/src/web/vcs.rs
+++ b/big-code-analysis-web/src/web/vcs.rs
@@ -26,7 +26,9 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-use big_code_analysis::vcs::{self, Options, build_history_index, parse_timestamp, parse_window};
+use big_code_analysis::vcs::{
+    self, Options, build_history_index, build_trend, parse_timestamp, parse_window,
+};
 use big_code_analysis::wire;
 
 /// Request body for `POST /vcs`.
@@ -167,5 +169,67 @@ pub fn compute_vcs(payload: WebVcsPayload) -> Result<WebVcsResponse, vcs::Error>
         truncated_shallow_clone: index.truncated_shallow_clone(),
         vcs_aggregate: index.vcs_aggregate(),
         files,
+    })
+}
+
+/// Request body for `POST /vcs/trend` (issue #333). The base fields are
+/// the same as [`WebVcsPayload`] — `top` selects how many files the series
+/// keeps, `as_of` anchors the most-recent point — plus the trend-only
+/// `points` / `span` / `top_deltas`.
+#[derive(Debug, Deserialize)]
+pub struct WebVcsTrendPayload {
+    /// All the shared `/vcs` knobs (`id`, `repo_path`, windows, `ref`, …).
+    #[serde(flatten)]
+    pub base: WebVcsPayload,
+    /// Number of evenly-spaced sample points (>= 2).
+    pub points: usize,
+    /// Total look-back span the points cover (default `12mo`).
+    pub span: Option<String>,
+    /// Top N files per improving / regressing delta list (`0` / absent =
+    /// all).
+    pub top_deltas: Option<usize>,
+}
+
+/// Response body for `POST /vcs/trend`: the echoed id plus the flattened
+/// [`wire::VcsTrend`] time series.
+#[derive(Debug, Serialize)]
+pub struct WebVcsTrendResponse {
+    /// Echoed request identifier.
+    pub id: String,
+    /// The historical metric trend.
+    #[serde(flatten)]
+    pub trend: wire::VcsTrend,
+}
+
+/// Sample the change-history metrics across time for `payload` and return
+/// the time series.
+///
+/// # Errors
+///
+/// Returns a [`vcs::Error`] for a bad option, an out-of-range point count,
+/// a non-repository `repo_path`, or a history-walk failure; the handler
+/// maps it to the appropriate HTTP status.
+pub fn compute_vcs_trend(payload: WebVcsTrendPayload) -> Result<WebVcsTrendResponse, vcs::Error> {
+    let options = options_from(&payload.base)?;
+    let span_secs = parse_window(
+        payload
+            .span
+            .as_deref()
+            .unwrap_or(vcs::options::DEFAULT_LONG_WINDOW),
+    )?;
+    let trend = build_trend(
+        &PathBuf::from(&payload.base.repo_path),
+        &options,
+        payload.points,
+        span_secs,
+    )?;
+    let wire_trend = wire::VcsTrend::from_trend(
+        &trend,
+        payload.base.top.unwrap_or(0),
+        payload.top_deltas.unwrap_or(0),
+    );
+    Ok(WebVcsTrendResponse {
+        id: payload.base.id,
+        trend: wire_trend,
     })
 }

--- a/man/bca-vcs-trend.1
+++ b/man/bca-vcs-trend.1
@@ -1,0 +1,43 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH BCA-VCS-TREND 1  "big-code-analysis 1.1.0" "big-code-analysis Manual"
+.SH NAME
+bca\-vcs\-trend \- Sample the change\-history metrics at several points in time and emit a per\-file time series, surfacing whether code is improving or degrading over the project\*(Aqs life (issue #333). Each point re\-anchors at the mainline tip of that moment, so it is a faithful historical snapshot. Window / `\-\-ref` / bot / merge / rename / as\-of (the most\-recent anchor) and `\-\-top` (files kept) come from the parent `vcs` flags
+.SH SYNOPSIS
+\fBbca\-vcs\-trend\fR [\fB\-\-points\fR] [\fB\-\-span\fR] [\fB\-\-top\-deltas\fR] [\fB\-O\fR|\fB\-\-format\fR] [\fB\-o\fR|\fB\-\-output\fR] [\fB\-\-pretty\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+Sample the change\-history metrics at several points in time and emit a per\-file time series, surfacing whether code is improving or degrading over the project\*(Aqs life (issue #333). Each point re\-anchors at the mainline tip of that moment, so it is a faithful historical snapshot. Window / `\-\-ref` / bot / merge / rename / as\-of (the most\-recent anchor) and `\-\-top` (files kept) come from the parent `vcs` flags
+.SH OPTIONS
+.TP
+\fB\-\-points\fR \fI<POINTS>\fR [default: 12]
+Number of evenly\-spaced sample points across `\-\-span`, inclusive of both endpoints (the oldest is `as\-of − span`, the newest is `as\-of`). Minimum 2; capped (see the error message) to bound the per\-point history walks on deep histories
+.TP
+\fB\-\-span\fR \fI<SPAN>\fR [default: 12mo]
+Total look\-back window the points span (`12mo`, `2y`, `52w`, `365d`, or ISO 8601 `P1Y`). With the default 12 points this yields roughly monthly snapshots over the past year
+.TP
+\fB\-\-top\-deltas\fR \fI<TOP_DELTAS>\fR [default: 10]
+Show only the top N files in each improving / regressing delta summary (`0` = all)
+.TP
+\fB\-O\fR, \fB\-\-format\fR \fI<FORMAT>\fR [default: json]
+Output format (`json` default, plus `yaml` / `cbor`). TOML is excluded — absent points serialize as `null`, which TOML cannot represent
+.br
+
+.br
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+json
+.IP \(bu 2
+yaml
+.IP \(bu 2
+cbor
+.RE
+.TP
+\fB\-o\fR, \fB\-\-output\fR \fI<OUTPUT>\fR
+Output file. Stdout if omitted (CBOR requires this flag — it is binary)
+.TP
+\fB\-\-pretty\fR
+Pretty\-print JSON output
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/man/bca-vcs.1
+++ b/man/bca-vcs.1
@@ -97,5 +97,8 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 bca\-vcs\-jit(1)
 Score a single commit for just\-in\-time (commit\-level) defect\-induction risk, the unit a CI gate reviews at check\-in (issue #331). Emits a JSON breakdown of size / diffusion / history / experience / purpose features, their contributions, and an ordinal composite score. Window / `\-\-ref` / bot / merge / rename behaviour comes from the parent `vcs` flags
 .TP
+bca\-vcs\-trend(1)
+Sample the change\-history metrics at several points in time and emit a per\-file time series, surfacing whether code is improving or degrading over the project\*(Aqs life (issue #333). Each point re\-anchors at the mainline tip of that moment, so it is a faithful historical snapshot. Window / `\-\-ref` / bot / merge / rename / as\-of (the most\-recent anchor) and `\-\-top` (files kept) come from the parent `vcs` flags
+.TP
 bca\-vcs\-help(1)
 Print this message or the help of the given subcommand(s)

--- a/src/vcs/error.rs
+++ b/src/vcs/error.rs
@@ -57,6 +57,11 @@ pub enum Error {
     /// The bus-factor coverage threshold is outside the open interval
     /// `(0, 1)` (issue #332).
     InvalidBusFactorThreshold(String),
+    /// The historical-trend parameters are out of range — the point
+    /// count is below the two-point minimum or above
+    /// [`MAX_TREND_POINTS`](crate::vcs::trend::MAX_TREND_POINTS) (issue
+    /// #333).
+    InvalidTrend(String),
     /// Blaming a file for per-function attribution failed (issue #329).
     Blame(String),
 }
@@ -88,6 +93,7 @@ impl std::fmt::Display for Error {
             Self::InvalidBusFactorThreshold(reason) => {
                 write!(f, "invalid bus-factor threshold: {reason}")
             }
+            Self::InvalidTrend(reason) => write!(f, "invalid trend parameters: {reason}"),
             Self::Blame(reason) => write!(f, "failed to blame file: {reason}"),
         }
     }

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -19,9 +19,11 @@ mod history;
 mod identity;
 mod jit;
 mod repo;
+mod trend;
 
 pub use blame::{LineSpan, PerFunctionBlame};
 pub(crate) use jit::score_commit;
+pub(crate) use trend::build_trend;
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};

--- a/src/vcs/git/trend.rs
+++ b/src/vcs/git/trend.rs
@@ -1,0 +1,145 @@
+// bca: suppress-file(halstead, nargs, exit)
+// File-level halstead/nargs/exit are many-fn aggregation artifacts (the
+// timeline walk + per-point build loop with `?` error maps), not
+// per-function logic complexity (cognitive/cyclomatic stay enforced).
+
+//! The `vcs-git` backend for the historical metric trend (issue #333).
+//!
+//! [`build_trend`] samples the change-history metrics at several points in
+//! time. The naïve approach — set `--as-of` to a past time but keep
+//! walking from `HEAD` — is wrong: the walk would still count commits made
+//! *after* that point (they are reachable from `HEAD`, and the future-date
+//! clamp folds them onto `now`). So each point instead resolves the
+//! mainline tip *at or before* that timestamp from a single first-parent
+//! walk, then runs an ordinary [`build`] anchored at that historical
+//! commit with `as_of` set to the point. That yields a faithful snapshot:
+//! the tree, the windows, and the in-window history all match what the
+//! repository looked like at that moment.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use gix::revision::walk::Sorting;
+use gix::traverse::commit::simple::CommitTimeOrder;
+
+use super::history::commit_seconds;
+use super::repo::{self, OpenRepo};
+use super::{build, current_unix_seconds, walk_err};
+use crate::vcs::error::Error;
+use crate::vcs::options::Options;
+use crate::vcs::stats::Stats;
+use crate::vcs::trend::{self, Trend};
+
+/// Build a historical [`Trend`] rooted at `root`.
+///
+/// `base` carries the windows / bot / merge / rename / formula knobs
+/// shared by every sampled point (its `reference` selects the mainline to
+/// follow, and its `as_of`, if set, anchors the most-recent point);
+/// `points` and `span_secs` define the sampling grid. See the module
+/// docs for why each point re-anchors at a historical commit.
+///
+/// # Errors
+///
+/// Returns [`Error::InvalidTrend`] when `points` is out of range,
+/// [`Error::NotARepository`] / [`Error::ResolveRef`] when the repository
+/// or base reference cannot be resolved, or a walk/diff variant when a
+/// sampled snapshot's history walk fails.
+pub(crate) fn build_trend(
+    root: &Path,
+    base: &Options,
+    points: usize,
+    span_secs: i64,
+) -> Result<Trend, Error> {
+    trend::validate_points(points)?;
+    let end = base.as_of.unwrap_or_else(current_unix_seconds);
+    let stamps = trend::timestamps(end, span_secs, points);
+
+    // One first-parent walk of the base reference yields every mainline
+    // tip and its time, so each point is an O(commits) lookup rather than
+    // its own walk.
+    let OpenRepo { repo, .. } = repo::open(root)?;
+    // Take the owned id so the borrowing `Commit` is dropped before the
+    // repo handle is.
+    let tip = repo::resolve_commit(&repo, &base.reference)?.id;
+    let timeline = first_parent_timeline(&repo, tip)?;
+    // Free the timeline repo's object cache before the per-point builds
+    // each open their own handle.
+    drop(repo);
+
+    let mut per_point: Vec<HashMap<PathBuf, Stats>> = Vec::with_capacity(stamps.len());
+    let mut truncated = false;
+    for &at in &stamps {
+        let Some(oid) = tip_at_or_before(&timeline, at) else {
+            // No commit at or before this point: the repository did not
+            // exist yet, so every file stays `None` here.
+            per_point.push(HashMap::new());
+            continue;
+        };
+        let index = build(root, &snapshot_options(base, oid, at))?;
+        truncated |= index.truncated_shallow_clone();
+        per_point.push(index.into_files());
+    }
+
+    Ok(Trend::from_snapshots(
+        stamps,
+        per_point,
+        base.long_window_days(),
+        base.recent_window_days(),
+        truncated,
+    ))
+}
+
+/// Derive the per-point [`Options`] from `base`: anchor the walk at the
+/// historical tip `oid`, set the reference "now" to the point `at`, and
+/// drop the bus-factor aggregate (not part of the per-file series).
+fn snapshot_options(base: &Options, oid: gix::ObjectId, at: i64) -> Options {
+    let mut options = base.clone();
+    options.reference = oid.to_hex().to_string();
+    options.as_of = Some(at);
+    options.compute_bus_factor = false;
+    options
+}
+
+/// Collect `(commit_time, id)` for every first-parent ancestor of `tip`,
+/// newest-first. This is the mainline timeline the per-point tip lookups
+/// search.
+fn first_parent_timeline(
+    repo: &gix::Repository,
+    tip: gix::ObjectId,
+) -> Result<Vec<(i64, gix::ObjectId)>, Error> {
+    let walk = repo
+        .rev_walk([tip])
+        .first_parent_only()
+        .sorting(Sorting::ByCommitTime(CommitTimeOrder::NewestFirst))
+        .all()
+        .map_err(walk_err)?;
+    let mut timeline = Vec::new();
+    for info in walk {
+        let info = info.map_err(walk_err)?;
+        // `ByCommitTime` populates `info.commit_time`, so the common path
+        // never decodes the commit object; fall back to decoding only if
+        // a future sorting leaves it unset.
+        let seconds = match info.commit_time {
+            Some(seconds) => seconds,
+            None => commit_seconds(&info, &info.object().map_err(walk_err)?)?,
+        };
+        timeline.push((seconds, info.id));
+    }
+    Ok(timeline)
+}
+
+/// The id of the commit with the greatest commit time at or before `at`,
+/// or `None` when every commit is newer (the repository did not exist yet
+/// at that point). A scan (not a binary search) so out-of-order commit
+/// times from clock skew or history rewriting cannot misselect the tip.
+fn tip_at_or_before(timeline: &[(i64, gix::ObjectId)], at: i64) -> Option<gix::ObjectId> {
+    timeline
+        .iter()
+        .filter(|&&(time, _)| time <= at)
+        .max_by_key(|&&(time, _)| time)
+        .map(|&(_, oid)| oid)
+}
+
+#[cfg(test)]
+#[path = "trend_tests.rs"]
+mod tests;

--- a/src/vcs/git/trend.rs
+++ b/src/vcs/git/trend.rs
@@ -116,14 +116,11 @@ fn first_parent_timeline(
     let mut timeline = Vec::new();
     for info in walk {
         let info = info.map_err(walk_err)?;
-        // `ByCommitTime` populates `info.commit_time`, so the common path
-        // never decodes the commit object; fall back to decoding only if
-        // a future sorting leaves it unset.
-        let seconds = match info.commit_time {
-            Some(seconds) => seconds,
-            None => commit_seconds(&info, &info.object().map_err(walk_err)?)?,
-        };
-        timeline.push((seconds, info.id));
+        // `Info::commit_time` is not populated for this traversal, so the
+        // commit must be decoded to read its time; `commit_seconds` uses
+        // the pre-decoded value when present and decodes otherwise.
+        let commit = info.object().map_err(walk_err)?;
+        timeline.push((commit_seconds(&info, &commit)?, info.id));
     }
     Ok(timeline)
 }

--- a/src/vcs/git/trend_tests.rs
+++ b/src/vcs/git/trend_tests.rs
@@ -1,0 +1,54 @@
+use super::*;
+
+/// A distinct-but-valid object id per `byte` so timeline entries are
+/// identifiable without a real repository.
+fn oid(byte: u8) -> gix::ObjectId {
+    gix::ObjectId::from_bytes_or_panic(&[byte; 20])
+}
+
+#[test]
+fn tip_at_or_before_picks_the_most_recent_in_range() {
+    // Newest-first timeline (as produced by the first-parent walk).
+    let timeline = vec![(300, oid(3)), (200, oid(2)), (100, oid(1))];
+    // Exactly on a boundary selects that commit.
+    assert_eq!(tip_at_or_before(&timeline, 200), Some(oid(2)));
+    // Between boundaries selects the latest at-or-before.
+    assert_eq!(tip_at_or_before(&timeline, 250), Some(oid(2)));
+    // At/after the tip selects the tip.
+    assert_eq!(tip_at_or_before(&timeline, 999), Some(oid(3)));
+}
+
+#[test]
+fn tip_at_or_before_returns_none_before_first_commit() {
+    let timeline = vec![(300, oid(3)), (100, oid(1))];
+    // Before the repository's first commit: no tip yet.
+    assert_eq!(tip_at_or_before(&timeline, 50), None);
+    assert_eq!(tip_at_or_before(&[], 100), None);
+}
+
+#[test]
+fn tip_at_or_before_is_robust_to_out_of_order_times() {
+    // Clock skew / history rewriting can leave times non-monotonic. The
+    // scan must still find the greatest time <= the cutoff (oid(9) @ 250),
+    // not the first entry it walks past.
+    let timeline = vec![(150, oid(1)), (250, oid(9)), (90, oid(2))];
+    assert_eq!(tip_at_or_before(&timeline, 300), Some(oid(9)));
+    assert_eq!(tip_at_or_before(&timeline, 200), Some(oid(1)));
+}
+
+#[test]
+fn snapshot_options_anchors_reference_and_as_of() {
+    let base = Options {
+        reference: "HEAD".to_owned(),
+        compute_bus_factor: true,
+        long_window_secs: 999,
+        ..Options::default()
+    };
+    let opts = snapshot_options(&base, oid(7), 4_242);
+    assert_eq!(opts.reference, oid(7).to_hex().to_string());
+    assert_eq!(opts.as_of, Some(4_242));
+    // Per-point snapshots never carry the bus-factor aggregate...
+    assert!(!opts.compute_bus_factor);
+    // ...but every other knob is inherited from the base options.
+    assert_eq!(opts.long_window_secs, 999);
+}

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -40,6 +40,7 @@ pub mod jit;
 pub mod options;
 pub mod score;
 pub mod stats;
+pub mod trend;
 
 #[cfg(feature = "vcs-git")]
 pub mod git;
@@ -54,6 +55,7 @@ pub use jit::{
 };
 pub use options::{Options, RiskFormula, parse_window};
 pub use stats::Stats;
+pub use trend::{TREND_SCHEMA_VERSION, Trend, TrendDelta, TrendDeltas};
 
 /// Per-function change-history attribution (issue #329), surfaced when a
 /// front end opts into per-function VCS metrics. See [`PerFunctionBlame`].
@@ -223,6 +225,35 @@ pub fn parse_timestamp(input: &str) -> Result<i64, Error> {
 #[cfg(feature = "vcs-git")]
 pub fn score_commit(root: &Path, spec: &str, options: &Options) -> Result<jit::JitReport, Error> {
     git::score_commit(root, spec, options)
+}
+
+/// Sample the change-history metrics at `points` evenly-spaced moments
+/// across `span_secs`, ending at `options.as_of` (or wall-clock now),
+/// building a [`trend::Trend`] time series (issue #333).
+///
+/// Each point re-anchors at the mainline tip that existed at or before
+/// that moment, so the result is a faithful historical snapshot rather
+/// than today's tree windowed differently — see [`trend`] for the schema
+/// and the cross-snapshot rename limitation. `options` supplies the
+/// windows / bot / merge / rename / formula knobs shared by every point;
+/// its `reference` selects which mainline to follow.
+///
+/// # Errors
+///
+/// Returns [`Error::InvalidTrend`] when `points` is outside
+/// `[MIN_TREND_POINTS, MAX_TREND_POINTS]`
+/// ([`trend::MIN_TREND_POINTS`] / [`trend::MAX_TREND_POINTS`]),
+/// [`Error::NotARepository`] when `root` is not a working tree,
+/// [`Error::ResolveRef`] when the base reference does not resolve, or a
+/// walk/diff variant when a sampled snapshot fails.
+#[cfg(feature = "vcs-git")]
+pub fn build_trend(
+    root: &Path,
+    options: &Options,
+    points: usize,
+    span_secs: i64,
+) -> Result<trend::Trend, Error> {
+    git::build_trend(root, options, points, span_secs)
 }
 
 /// Rank `entries` by descending risk score, breaking ties on the file

--- a/src/vcs/stats_tests.rs
+++ b/src/vcs/stats_tests.rs
@@ -239,7 +239,7 @@ fn authorship_credits_deliveries_and_first_authorship() {
     acc.record(&change(5, 10, &ada, Classification::default()));
 
     let mut contributions = acc.authorship().expect("active file has authorship");
-    contributions.sort_by(|a, b| b.deliveries.cmp(&a.deliveries));
+    contributions.sort_by_key(|b| std::cmp::Reverse(b.deliveries));
     assert_eq!(contributions.len(), 2);
     // Ada: two deliveries, the file's first author.
     assert_eq!(contributions[0].deliveries, 2);

--- a/src/vcs/trend.rs
+++ b/src/vcs/trend.rs
@@ -1,0 +1,309 @@
+// bca: suppress-file(halstead, nargs, exit)
+// File-level halstead/nargs/exit are many-fn aggregation artifacts (the
+// Trend accessors + delta projection + validation, each with its own
+// early returns / `?`), not per-function logic complexity
+// (cognitive/cyclomatic stay enforced) — mirrors the sibling vcs modules.
+
+//! Historical metric trend: the change-history (VCS) metrics computed at
+//! several points in time, so a consumer can see whether a file's risk is
+//! improving or degrading rather than only its risk *now* (issue #333).
+//!
+//! This module is backend-agnostic. It owns the time-point math
+//! ([`timestamps`]), the parameter validation ([`validate_points`]), the
+//! assembled [`Trend`] container, and the improving/regressing
+//! [`delta summary`](Trend::deltas). The actual repeated history walks
+//! live in the backend (`git::build_trend`), which resolves the
+//! repository tip at each point in time and folds the per-snapshot
+//! [`Stats`] into a [`Trend`] via [`Trend::from_snapshots`].
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use super::error::Error;
+use super::stats::Stats;
+
+/// Output-shape version for the trend document. Bumped on any
+/// shape-breaking change to the serialized time series so consumers can
+/// detect an incompatible schema (separate from the per-file
+/// [`VCS_SCHEMA_VERSION`](super::stats::VCS_SCHEMA_VERSION), which
+/// versions each point's metric block).
+pub const TREND_SCHEMA_VERSION: u32 = 1;
+
+/// Minimum number of time points. A trend needs at least two snapshots to
+/// express a direction; a single point is just `bca vcs --as-of`.
+pub const MIN_TREND_POINTS: usize = 2;
+
+/// Maximum number of time points. Each point is a full history walk, so
+/// the count is capped to bound the worst-case runtime on deep histories
+/// (issue #333's "very deep histories: cap point count"). 120 points is a
+/// decade of monthly snapshots — far beyond any practical trend chart.
+pub const MAX_TREND_POINTS: usize = 120;
+
+/// Validate a requested point count against the [`MIN_TREND_POINTS`] /
+/// [`MAX_TREND_POINTS`] bounds. The single source of truth shared by
+/// every front end so the accepted range cannot drift between them.
+///
+/// # Errors
+///
+/// Returns [`Error::InvalidTrend`] when `points` is below the minimum or
+/// above the maximum.
+pub fn validate_points(points: usize) -> Result<usize, Error> {
+    if points < MIN_TREND_POINTS {
+        return Err(Error::InvalidTrend(format!(
+            "at least {MIN_TREND_POINTS} points are required for a trend (got {points})"
+        )));
+    }
+    if points > MAX_TREND_POINTS {
+        return Err(Error::InvalidTrend(format!(
+            "at most {MAX_TREND_POINTS} points are supported (got {points})"
+        )));
+    }
+    Ok(points)
+}
+
+/// The `points` Unix-second timestamps a trend samples, evenly spaced
+/// across `span_secs` and ending at `end` (the most recent point is
+/// exactly `end`, the oldest is `end - span_secs`). Returned oldest-first.
+///
+/// Integer division places the interior points; the two endpoints are
+/// exact regardless of rounding. `points` is assumed already validated by
+/// [`validate_points`] (`>= MIN_TREND_POINTS`), so the `points - 1`
+/// divisor is always positive.
+#[must_use]
+pub fn timestamps(end: i64, span_secs: i64, points: usize) -> Vec<i64> {
+    // Defensive: a single (or zero) point degenerates to just the
+    // endpoint, side-stepping a divide-by-zero even though the public
+    // entry points validate `points >= 2` first.
+    if points <= 1 {
+        return vec![end];
+    }
+    let start = end - span_secs;
+    // `points` is small (validated `<= MAX_TREND_POINTS`); `try_from`
+    // keeps the conversion total and lint-clean without an `as` wrap.
+    let divisor = i64::try_from(points - 1).unwrap_or(i64::MAX);
+    (0..points)
+        .map(|i| {
+            // `span_secs * i / divisor`: 0 at i=0 (→ start) and span_secs
+            // at i=divisor (→ end), so both endpoints are hit exactly.
+            let i = i64::try_from(i).unwrap_or(i64::MAX);
+            start + span_secs.saturating_mul(i) / divisor
+        })
+        .collect()
+}
+
+/// The change-history metrics of a set of files sampled at several points
+/// in time (issue #333).
+///
+/// Each file maps to a vector aligned 1:1 with [`as_of_points`](Self::as_of_points):
+/// element `i` is `Some(stats)` when the file existed and was tracked at
+/// point `i`, or `None` when it did not exist yet (or was untracked /
+/// binary) at that point.
+///
+/// # Rename limitation
+///
+/// Each snapshot keys files by their path *at that snapshot's tip*, with
+/// renames followed only *within* that snapshot's walk. A file renamed
+/// *between* two sampled points therefore appears as two separate path
+/// series (its old name, then its new name), not one continuous series.
+/// Cross-snapshot rename stitching is deferred; document this for
+/// consumers reading the series.
+#[derive(Clone, Debug)]
+pub struct Trend {
+    as_of_points: Vec<i64>,
+    files: HashMap<PathBuf, Vec<Option<Stats>>>,
+    long_window_days: u32,
+    recent_window_days: u32,
+    truncated_shallow_clone: bool,
+}
+
+impl Trend {
+    /// Assemble a [`Trend`] from one [`HistoryIndex`](super::HistoryIndex)
+    /// per time point.
+    ///
+    /// `as_of_points` are the sampled timestamps (oldest-first).
+    /// `per_point` is the matching per-file `Stats` map for each point, in
+    /// the same order; a point that resolved to no commit (the repository
+    /// did not exist yet) contributes an empty map, leaving every file
+    /// `None` there. The two slices must be the same length — a backend
+    /// invariant, so a mismatch is a programming error rather than a
+    /// user-facing one.
+    #[must_use]
+    pub fn from_snapshots(
+        as_of_points: Vec<i64>,
+        per_point: Vec<HashMap<PathBuf, Stats>>,
+        long_window_days: u32,
+        recent_window_days: u32,
+        truncated_shallow_clone: bool,
+    ) -> Self {
+        let n = as_of_points.len();
+        // Backend invariant: one snapshot map per sampled point.
+        debug_assert_eq!(per_point.len(), n, "one snapshot per as-of point");
+        let mut files: HashMap<PathBuf, Vec<Option<Stats>>> = HashMap::new();
+        for (i, snapshot) in per_point.into_iter().enumerate().take(n) {
+            for (path, stats) in snapshot {
+                // `i < n` (enumerate over a `take(n)`) and the seeded
+                // vector is length `n`, so the slot always exists.
+                if let Some(slot) = files
+                    .entry(path)
+                    .or_insert_with(|| vec![None; n])
+                    .get_mut(i)
+                {
+                    *slot = Some(stats);
+                }
+            }
+        }
+        Self {
+            as_of_points,
+            files,
+            long_window_days,
+            recent_window_days,
+            truncated_shallow_clone,
+        }
+    }
+
+    /// The sampled timestamps, oldest-first, aligned 1:1 with each file's
+    /// point vector.
+    #[must_use]
+    pub fn as_of_points(&self) -> &[i64] {
+        &self.as_of_points
+    }
+
+    /// Iterate `(repo-relative path, per-point stats)` pairs. Each inner
+    /// slice is aligned with [`as_of_points`](Self::as_of_points);
+    /// elements are `None` where the file did not exist.
+    pub fn iter(&self) -> impl Iterator<Item = (&PathBuf, &[Option<Stats>])> {
+        self.files.iter().map(|(path, points)| (path, &points[..]))
+    }
+
+    /// Number of files tracked across the whole trend (the union over all
+    /// points).
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.files.len()
+    }
+
+    /// Whether the trend tracked no files at any point.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.files.is_empty()
+    }
+
+    /// Long window length, in days (constant across all points).
+    #[must_use]
+    pub fn long_window_days(&self) -> u32 {
+        self.long_window_days
+    }
+
+    /// Recent window length, in days (constant across all points).
+    #[must_use]
+    pub fn recent_window_days(&self) -> u32 {
+        self.recent_window_days
+    }
+
+    /// `true` when any sampled snapshot came from a shallow clone, so the
+    /// per-point counts are lower bounds.
+    #[must_use]
+    pub fn truncated_shallow_clone(&self) -> bool {
+        self.truncated_shallow_clone
+    }
+
+    /// The most-improved and most-regressed files by change in
+    /// `risk_score` between each file's earliest and latest *present*
+    /// points.
+    ///
+    /// A file is only eligible when it is present at two or more points
+    /// (otherwise there is no direction to report). `delta = last_risk -
+    /// first_risk`: negative means risk fell (improved), positive means it
+    /// rose (regressed). `top` truncates each list (`0` keeps all). Ties
+    /// break on the file path so the output is deterministic.
+    #[must_use]
+    pub fn deltas(&self, top: usize) -> TrendDeltas {
+        let mut improved: Vec<TrendDelta> = Vec::new();
+        let mut regressed: Vec<TrendDelta> = Vec::new();
+        for (path, points) in &self.files {
+            let Some(delta) = self.file_delta(path, points) else {
+                continue;
+            };
+            if delta.delta < 0.0 {
+                improved.push(delta);
+            } else if delta.delta > 0.0 {
+                regressed.push(delta);
+            }
+            // A zero delta is neither improving nor regressing; omit it.
+        }
+        // Improved: most-negative first. Regressed: most-positive first.
+        improved.sort_by(|a, b| {
+            a.delta
+                .partial_cmp(&b.delta)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.path.cmp(&b.path))
+        });
+        regressed.sort_by(|a, b| {
+            b.delta
+                .partial_cmp(&a.delta)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.path.cmp(&b.path))
+        });
+        if top > 0 {
+            improved.truncate(top);
+            regressed.truncate(top);
+        }
+        TrendDeltas {
+            improved,
+            regressed,
+        }
+    }
+
+    /// Compute one file's risk-score delta between its earliest and latest
+    /// present points, or `None` when it is present at fewer than two
+    /// points.
+    fn file_delta(&self, path: &std::path::Path, points: &[Option<Stats>]) -> Option<TrendDelta> {
+        let mut present = points
+            .iter()
+            .enumerate()
+            .filter_map(|(i, stats)| stats.as_ref().map(|s| (i, s)));
+        let (first_i, first) = present.next()?;
+        // `next_back` (not `last`) avoids re-walking the whole iterator;
+        // it yields `None` when only the first point was present.
+        let (last_i, last) = present.next_back()?;
+        Some(TrendDelta {
+            path: path.to_path_buf(),
+            first_as_of: self.as_of_points[first_i],
+            last_as_of: self.as_of_points[last_i],
+            first_risk_score: first.risk_score,
+            last_risk_score: last.risk_score,
+            delta: last.risk_score - first.risk_score,
+        })
+    }
+}
+
+/// One file's risk-score movement across the trend (see
+/// [`Trend::deltas`]).
+#[derive(Clone, Debug, PartialEq)]
+pub struct TrendDelta {
+    /// Repository-relative path.
+    pub path: PathBuf,
+    /// Timestamp of the file's earliest present point.
+    pub first_as_of: i64,
+    /// Timestamp of the file's latest present point.
+    pub last_as_of: i64,
+    /// `risk_score` at the earliest present point.
+    pub first_risk_score: f64,
+    /// `risk_score` at the latest present point.
+    pub last_risk_score: f64,
+    /// `last_risk_score - first_risk_score`; negative = improved.
+    pub delta: f64,
+}
+
+/// The improving / regressing split returned by [`Trend::deltas`].
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct TrendDeltas {
+    /// Files whose risk fell, most-improved first.
+    pub improved: Vec<TrendDelta>,
+    /// Files whose risk rose, most-regressed first.
+    pub regressed: Vec<TrendDelta>,
+}
+
+#[cfg(test)]
+#[path = "trend_tests.rs"]
+mod tests;

--- a/src/vcs/trend_tests.rs
+++ b/src/vcs/trend_tests.rs
@@ -147,6 +147,45 @@ fn deltas_split_improved_from_regressed_and_sort_by_magnitude() {
 }
 
 #[test]
+fn deltas_regressed_sorted_descending_with_tiebreak() {
+    // Three regressors; two share the same magnitude (+4) and must
+    // tie-break on path ascending. A list of >= 2 is what actually
+    // exercises the `regressed` sort comparator (a 1-element sort never
+    // invokes the closure).
+    let stamps = vec![0, 1];
+    let snap = |big: f64, a: f64, z: f64| {
+        let mut m = HashMap::new();
+        m.insert(PathBuf::from("big.rs"), stats(big));
+        m.insert(PathBuf::from("a.rs"), stats(a));
+        m.insert(PathBuf::from("z.rs"), stats(z));
+        m
+    };
+    // Each file rises (regresses): big by +9, a and z by +4.
+    let trend = Trend::from_snapshots(
+        stamps,
+        vec![snap(1.0, 1.0, 1.0), snap(10.0, 5.0, 5.0)],
+        365,
+        90,
+        false,
+    );
+    let regressed: Vec<_> = trend
+        .deltas(0)
+        .regressed
+        .iter()
+        .map(|d| (d.path.clone(), d.delta))
+        .collect();
+    assert_eq!(
+        regressed,
+        vec![
+            (PathBuf::from("big.rs"), 9.0),
+            (PathBuf::from("a.rs"), 4.0),
+            (PathBuf::from("z.rs"), 4.0),
+        ],
+        "regressed sorts by descending delta, ties by path ascending"
+    );
+}
+
+#[test]
 fn deltas_break_equal_magnitude_ties_by_path() {
     // Two files improve by the same amount (-3); the tie must resolve on
     // path ascending so the output is deterministic.

--- a/src/vcs/trend_tests.rs
+++ b/src/vcs/trend_tests.rs
@@ -1,0 +1,231 @@
+// The asserted risk scores are exactly-representable literals from
+// integer-valued fixtures, so `float_cmp` is a false positive here —
+// matching the sibling convention in the other vcs `*_tests.rs`.
+#![allow(clippy::float_cmp)]
+
+use super::*;
+
+/// Build a [`Stats`] carrying just the `risk_score` the delta logic reads.
+fn stats(risk: f64) -> Stats {
+    Stats {
+        risk_score: risk,
+        ..Stats::default()
+    }
+}
+
+#[test]
+fn timestamps_hit_both_endpoints_exactly() {
+    // 12 points over 24 "units": oldest is end-span, newest is end.
+    let end = 1_000_000;
+    let span = 24_000;
+    let stamps = timestamps(end, span, 12);
+    assert_eq!(stamps.len(), 12);
+    assert_eq!(*stamps.first().expect("first"), end - span);
+    assert_eq!(*stamps.last().expect("last"), end);
+}
+
+#[test]
+fn timestamps_are_monotonic_non_decreasing() {
+    let stamps = timestamps(500, 333, 7);
+    assert!(stamps.windows(2).all(|w| w[0] <= w[1]));
+}
+
+#[test]
+fn timestamps_two_points_are_just_the_endpoints() {
+    assert_eq!(timestamps(100, 30, 2), vec![70, 100]);
+}
+
+#[test]
+fn timestamps_degenerate_single_point_is_the_end() {
+    // The public path validates `points >= 2`; the helper still must not
+    // divide by zero on a degenerate count.
+    assert_eq!(timestamps(100, 30, 1), vec![100]);
+    assert_eq!(timestamps(100, 30, 0), vec![100]);
+}
+
+#[test]
+fn validate_points_rejects_below_minimum() {
+    assert!(matches!(
+        validate_points(MIN_TREND_POINTS - 1),
+        Err(Error::InvalidTrend(_))
+    ));
+}
+
+#[test]
+fn validate_points_rejects_above_maximum() {
+    assert!(matches!(
+        validate_points(MAX_TREND_POINTS + 1),
+        Err(Error::InvalidTrend(_))
+    ));
+}
+
+#[test]
+fn validate_points_accepts_in_range() {
+    assert_eq!(validate_points(MIN_TREND_POINTS).expect("min ok"), 2);
+    assert_eq!(
+        validate_points(MAX_TREND_POINTS).expect("max ok"),
+        MAX_TREND_POINTS
+    );
+}
+
+#[test]
+fn from_snapshots_aligns_points_and_marks_absent_as_none() {
+    // a.rs present at points 0 and 2 (absent at 1); b.rs only at point 1.
+    let stamps = vec![10, 20, 30];
+    let mut p0 = HashMap::new();
+    p0.insert(PathBuf::from("a.rs"), stats(5.0));
+    let mut p1 = HashMap::new();
+    p1.insert(PathBuf::from("b.rs"), stats(9.0));
+    let mut p2 = HashMap::new();
+    p2.insert(PathBuf::from("a.rs"), stats(3.0));
+
+    let trend = Trend::from_snapshots(stamps, vec![p0, p1, p2], 365, 90, false);
+
+    assert_eq!(trend.len(), 2);
+    let files: HashMap<_, _> = trend.iter().map(|(p, s)| (p.clone(), s.to_vec())).collect();
+    let a = &files[&PathBuf::from("a.rs")];
+    assert_eq!(a.len(), 3);
+    assert_eq!(a[0].as_ref().map(|s| s.risk_score), Some(5.0));
+    assert!(a[1].is_none(), "a.rs absent at point 1 must be None");
+    assert_eq!(a[2].as_ref().map(|s| s.risk_score), Some(3.0));
+    let b = &files[&PathBuf::from("b.rs")];
+    assert!(b[0].is_none() && b[2].is_none());
+    assert_eq!(b[1].as_ref().map(|s| s.risk_score), Some(9.0));
+}
+
+#[test]
+fn from_snapshots_carries_window_and_shallow_metadata() {
+    let trend = Trend::from_snapshots(
+        vec![1, 2],
+        vec![HashMap::new(), HashMap::new()],
+        365,
+        90,
+        true,
+    );
+    assert_eq!(trend.long_window_days(), 365);
+    assert_eq!(trend.recent_window_days(), 90);
+    assert!(trend.truncated_shallow_clone());
+    assert!(trend.is_empty());
+}
+
+#[test]
+fn deltas_split_improved_from_regressed_and_sort_by_magnitude() {
+    // down.rs: 8 -> 2 (improved, -6). up.rs: 1 -> 5 (regressed, +4).
+    // big.rs: 10 -> 1 (improved, -9, ranks ahead of down.rs).
+    let stamps = vec![0, 1];
+    let snap = |a: f64, b: f64, c: f64| {
+        let mut m = HashMap::new();
+        m.insert(PathBuf::from("down.rs"), stats(a));
+        m.insert(PathBuf::from("up.rs"), stats(b));
+        m.insert(PathBuf::from("big.rs"), stats(c));
+        m
+    };
+    let trend = Trend::from_snapshots(
+        stamps,
+        vec![snap(8.0, 1.0, 10.0), snap(2.0, 5.0, 1.0)],
+        365,
+        90,
+        false,
+    );
+
+    let deltas = trend.deltas(0);
+    let improved: Vec<_> = deltas
+        .improved
+        .iter()
+        .map(|d| (d.path.clone(), d.delta))
+        .collect();
+    assert_eq!(
+        improved,
+        vec![
+            (PathBuf::from("big.rs"), -9.0),
+            (PathBuf::from("down.rs"), -6.0),
+        ]
+    );
+    assert_eq!(deltas.regressed.len(), 1);
+    assert_eq!(deltas.regressed[0].path, PathBuf::from("up.rs"));
+    assert_eq!(deltas.regressed[0].delta, 4.0);
+}
+
+#[test]
+fn deltas_break_equal_magnitude_ties_by_path() {
+    // Two files improve by the same amount (-3); the tie must resolve on
+    // path ascending so the output is deterministic.
+    let stamps = vec![0, 1];
+    let mut p0 = HashMap::new();
+    p0.insert(PathBuf::from("z.rs"), stats(5.0));
+    p0.insert(PathBuf::from("a.rs"), stats(5.0));
+    let mut p1 = HashMap::new();
+    p1.insert(PathBuf::from("z.rs"), stats(2.0));
+    p1.insert(PathBuf::from("a.rs"), stats(2.0));
+    let trend = Trend::from_snapshots(stamps, vec![p0, p1], 365, 90, false);
+
+    let improved: Vec<_> = trend
+        .deltas(0)
+        .improved
+        .iter()
+        .map(|d| d.path.clone())
+        .collect();
+    assert_eq!(
+        improved,
+        vec![PathBuf::from("a.rs"), PathBuf::from("z.rs")],
+        "equal deltas sort by path ascending"
+    );
+}
+
+#[test]
+fn deltas_top_truncates_each_list() {
+    let stamps = vec![0, 1];
+    let mut p0 = HashMap::new();
+    let mut p1 = HashMap::new();
+    // Increasing improvement magnitude so truncation order is clear.
+    for (name, start) in [("a", 10.0), ("b", 11.0), ("c", 12.0)] {
+        p0.insert(PathBuf::from(name), stats(start));
+        p1.insert(PathBuf::from(name), stats(0.0));
+    }
+    let trend = Trend::from_snapshots(stamps, vec![p0, p1], 365, 90, false);
+    assert_eq!(trend.deltas(1).improved.len(), 1);
+    assert_eq!(trend.deltas(2).improved.len(), 2);
+}
+
+#[test]
+fn deltas_ignore_files_present_at_fewer_than_two_points() {
+    // once.rs exists only at the last point — no direction to report.
+    let stamps = vec![0, 1];
+    let p0: HashMap<PathBuf, Stats> = HashMap::new();
+    let mut p1 = HashMap::new();
+    p1.insert(PathBuf::from("once.rs"), stats(7.0));
+    let trend = Trend::from_snapshots(stamps, vec![p0, p1], 365, 90, false);
+    let deltas = trend.deltas(0);
+    assert!(deltas.improved.is_empty() && deltas.regressed.is_empty());
+}
+
+#[test]
+fn deltas_exclude_zero_movement() {
+    let stamps = vec![0, 1];
+    let mut p0 = HashMap::new();
+    p0.insert(PathBuf::from("flat.rs"), stats(4.0));
+    let mut p1 = HashMap::new();
+    p1.insert(PathBuf::from("flat.rs"), stats(4.0));
+    let trend = Trend::from_snapshots(stamps, vec![p0, p1], 365, 90, false);
+    let deltas = trend.deltas(0);
+    assert!(deltas.improved.is_empty() && deltas.regressed.is_empty());
+}
+
+#[test]
+fn deltas_use_first_and_last_present_points() {
+    // gap.rs: present at 0 (risk 6) and 2 (risk 1), absent at 1.
+    // The delta must span points 0..2, not the adjacent present pair.
+    let stamps = vec![100, 200, 300];
+    let mut p0 = HashMap::new();
+    p0.insert(PathBuf::from("gap.rs"), stats(6.0));
+    let p1: HashMap<PathBuf, Stats> = HashMap::new();
+    let mut p2 = HashMap::new();
+    p2.insert(PathBuf::from("gap.rs"), stats(1.0));
+    let trend = Trend::from_snapshots(stamps, vec![p0, p1, p2], 365, 90, false);
+    let deltas = trend.deltas(0);
+    assert_eq!(deltas.improved.len(), 1);
+    let d = &deltas.improved[0];
+    assert_eq!((d.first_as_of, d.last_as_of), (100, 300));
+    assert_eq!((d.first_risk_score, d.last_risk_score), (6.0, 1.0));
+    assert_eq!(d.delta, -5.0);
+}

--- a/src/wire.rs
+++ b/src/wire.rs
@@ -840,19 +840,17 @@ impl VcsTrend {
         let as_of_points = trend.as_of_points().to_vec();
 
         // Rank files by most-recent present risk so `top_files` keeps the
-        // currently-riskiest, mirroring `bca vcs`'s ranking.
+        // currently-riskiest. Reuse the shared `rank_by_risk` so the
+        // descending-risk + path tie-break and the `top` truncation match
+        // `bca vcs` / `POST /vcs` exactly (a non-UTF-8 path sorts as "" and
+        // is dropped below).
         let mut ranked: Vec<(&std::path::PathBuf, &[Option<crate::vcs::Stats>], f64)> = trend
             .iter()
             .map(|(path, points)| (path, points, latest_present_risk(points)))
             .collect();
-        ranked.sort_by(|a, b| {
-            b.2.partial_cmp(&a.2)
-                .unwrap_or(std::cmp::Ordering::Equal)
-                .then_with(|| a.0.cmp(b.0))
+        crate::vcs::rank_by_risk(&mut ranked, top_files, |entry| {
+            (entry.0.to_str().unwrap_or(""), entry.2)
         });
-        if top_files > 0 && ranked.len() > top_files {
-            ranked.truncate(top_files);
-        }
 
         let files = ranked
             .into_iter()
@@ -912,6 +910,44 @@ fn latest_present_risk(points: &[Option<crate::vcs::Stats>]) -> f64 {
         .rev()
         .find_map(|s| s.as_ref().map(|s| s.risk_score))
         .unwrap_or(0.0)
+}
+
+#[cfg(all(test, feature = "vcs-git"))]
+mod trend_wire_tests {
+    use super::*;
+
+    // Exact-equality on f64 is intentional: the values are the
+    // exactly-representable literals fed into the fixtures.
+    #[allow(clippy::float_cmp)]
+    fn risk(points: &[Option<f64>]) -> f64 {
+        let owned: Vec<Option<crate::vcs::Stats>> = points
+            .iter()
+            .map(|p| {
+                p.map(|risk_score| crate::vcs::Stats {
+                    risk_score,
+                    ..Default::default()
+                })
+            })
+            .collect();
+        latest_present_risk(&owned)
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn latest_present_risk_picks_the_newest_present_point() {
+        // Scans from the back: the most-recent present point wins, even
+        // with later `None`s and earlier present points.
+        assert_eq!(risk(&[Some(1.0), None, Some(3.0), None]), 3.0);
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn latest_present_risk_defaults_to_zero_when_all_absent() {
+        // The documented fallback for a file with no present point (which
+        // the trend builder never produces, but the helper still defines).
+        assert_eq!(risk(&[None, None]), 0.0);
+        assert_eq!(risk(&[]), 0.0);
+    }
 }
 
 /// Wire form of [`crate::spaces::CodeMetrics`].

--- a/src/wire.rs
+++ b/src/wire.rs
@@ -737,6 +737,183 @@ impl From<&crate::vcs::Stats> for Vcs {
     }
 }
 
+/// Wire form of one sampled point in a historical metric trend (issue
+/// #333): the sample timestamp plus the file's full VCS block at that
+/// moment. `as_of` leads; the flattened block carries the same keys as a
+/// standalone [`Vcs`] record.
+#[cfg(feature = "vcs-git")]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct VcsTrendPoint {
+    /// Unix-second timestamp this point was sampled at.
+    pub as_of: i64,
+    /// The file's change-history metrics at `as_of`.
+    #[serde(flatten)]
+    pub vcs: Vcs,
+}
+
+/// Wire form of one file's risk-score movement across the trend.
+#[cfg(feature = "vcs-git")]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct VcsTrendDelta {
+    /// Repository-relative path.
+    pub path: String,
+    /// Timestamp of the file's earliest present point.
+    pub first_as_of: i64,
+    /// Timestamp of the file's latest present point.
+    pub last_as_of: i64,
+    /// `risk_score` at the earliest present point.
+    pub first_risk_score: f64,
+    /// `risk_score` at the latest present point.
+    pub last_risk_score: f64,
+    /// `last_risk_score - first_risk_score`; negative means improved.
+    pub delta: f64,
+}
+
+#[cfg(feature = "vcs-git")]
+impl VcsTrendDelta {
+    /// Project a compute-side [`crate::vcs::TrendDelta`], dropping a
+    /// non-UTF-8 path (which cannot be a JSON key) by returning `None` —
+    /// the same path policy the file map uses.
+    fn from_delta(d: &crate::vcs::TrendDelta) -> Option<Self> {
+        Some(Self {
+            path: d.path.to_str()?.to_owned(),
+            first_as_of: d.first_as_of,
+            last_as_of: d.last_as_of,
+            first_risk_score: d.first_risk_score,
+            last_risk_score: d.last_risk_score,
+            delta: d.delta,
+        })
+    }
+}
+
+/// Wire form of the improving / regressing delta summary.
+#[cfg(feature = "vcs-git")]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct VcsTrendDeltas {
+    /// Files whose risk fell, most-improved first.
+    pub improved: Vec<VcsTrendDelta>,
+    /// Files whose risk rose, most-regressed first.
+    pub regressed: Vec<VcsTrendDelta>,
+}
+
+/// Wire form of a historical metric trend (issue #333) — the single
+/// serialized shape shared by `bca vcs trend`, `POST /vcs/trend`, and the
+/// Python `vcs_trend()`.
+///
+/// `as_of_points` lists the sample timestamps oldest-first; every file's
+/// array in `files` aligns to it 1:1, with a `null` element where the file
+/// did not exist at that point. `files` is keyed by repository-relative
+/// path and ordered lexicographically for deterministic output.
+#[cfg(feature = "vcs-git")]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct VcsTrend {
+    /// Trend-document shape version
+    /// ([`crate::vcs::TREND_SCHEMA_VERSION`]).
+    pub trend_schema_version: u32,
+    /// Per-point metric-block shape version.
+    pub vcs_schema_version: u32,
+    /// Composite-formula version.
+    pub risk_score_version: u32,
+    /// Long window length, in days (constant across points).
+    pub long_window_days: u32,
+    /// Recent window length, in days (constant across points).
+    pub recent_window_days: u32,
+    /// Whether any sampled snapshot came from a shallow clone.
+    pub truncated_shallow_clone: bool,
+    /// Sample timestamps, oldest-first.
+    pub as_of_points: Vec<i64>,
+    /// Per-file time series; `null` marks a point where the file was
+    /// absent.
+    pub files: std::collections::BTreeMap<String, Vec<Option<VcsTrendPoint>>>,
+    /// The most-improved / most-regressed files by risk delta.
+    pub deltas: VcsTrendDeltas,
+}
+
+#[cfg(feature = "vcs-git")]
+impl VcsTrend {
+    /// Project a compute-side [`crate::vcs::Trend`] into the wire shape,
+    /// keeping the `top_files` highest-risk files (by their most-recent
+    /// present `risk_score`; `0` keeps all) and the `top_deltas`
+    /// strongest movers in each delta list.
+    #[must_use]
+    pub fn from_trend(trend: &crate::vcs::Trend, top_files: usize, top_deltas: usize) -> Self {
+        let as_of_points = trend.as_of_points().to_vec();
+
+        // Rank files by most-recent present risk so `top_files` keeps the
+        // currently-riskiest, mirroring `bca vcs`'s ranking.
+        let mut ranked: Vec<(&std::path::PathBuf, &[Option<crate::vcs::Stats>], f64)> = trend
+            .iter()
+            .map(|(path, points)| (path, points, latest_present_risk(points)))
+            .collect();
+        ranked.sort_by(|a, b| {
+            b.2.partial_cmp(&a.2)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.0.cmp(b.0))
+        });
+        if top_files > 0 && ranked.len() > top_files {
+            ranked.truncate(top_files);
+        }
+
+        let files = ranked
+            .into_iter()
+            .filter_map(|(path, points, _)| {
+                // A non-UTF-8 path cannot be a JSON object key; drop it,
+                // matching the per-file endpoints' policy.
+                let key = path.to_str()?.to_owned();
+                let series = points
+                    .iter()
+                    .zip(&as_of_points)
+                    .map(|(stats, &as_of)| {
+                        stats.as_ref().map(|s| VcsTrendPoint {
+                            as_of,
+                            vcs: Vcs::from(s),
+                        })
+                    })
+                    .collect();
+                Some((key, series))
+            })
+            .collect();
+
+        let compute_deltas = trend.deltas(top_deltas);
+        let deltas = VcsTrendDeltas {
+            improved: compute_deltas
+                .improved
+                .iter()
+                .filter_map(VcsTrendDelta::from_delta)
+                .collect(),
+            regressed: compute_deltas
+                .regressed
+                .iter()
+                .filter_map(VcsTrendDelta::from_delta)
+                .collect(),
+        };
+
+        Self {
+            trend_schema_version: crate::vcs::TREND_SCHEMA_VERSION,
+            vcs_schema_version: crate::vcs::stats::VCS_SCHEMA_VERSION,
+            risk_score_version: crate::vcs::score::RISK_SCORE_VERSION,
+            long_window_days: trend.long_window_days(),
+            recent_window_days: trend.recent_window_days(),
+            truncated_shallow_clone: trend.truncated_shallow_clone(),
+            as_of_points,
+            files,
+            deltas,
+        }
+    }
+}
+
+/// A file's `risk_score` at its most-recent present point, or `0.0` if it
+/// has no present point (which the trend builder never produces). Used to
+/// rank files for `top_files` truncation.
+#[cfg(feature = "vcs-git")]
+fn latest_present_risk(points: &[Option<crate::vcs::Stats>]) -> f64 {
+    points
+        .iter()
+        .rev()
+        .find_map(|s| s.as_ref().map(|s| s.risk_score))
+        .unwrap_or(0.0)
+}
+
 /// Wire form of [`crate::spaces::CodeMetrics`].
 ///
 /// Each metric is an `Option` skipped when `None`: an unselected metric

--- a/tests/vcs_trend.rs
+++ b/tests/vcs_trend.rs
@@ -1,0 +1,187 @@
+//! End-to-end historical-trend (VCS) tests against real, deterministic
+//! git repositories built through the `git` CLI (issue #333).
+//!
+//! Every commit carries a fixed identity and UNIX timestamp, and every
+//! trend pins its end anchor to [`vcs_fixture::FIXED_NOW`] via
+//! `Options::as_of`, so the sampled points and per-point counts are exact
+//! and reproducible. Gated behind the `vcs-git` backend feature.
+#![cfg(feature = "vcs-git")]
+// Exact-equality on f64 is intentional here: the asserted scores are
+// compared for ordering/sign or for equality against values the same walk
+// produced.
+#![allow(clippy::float_cmp)]
+
+use std::path::{Path, PathBuf};
+
+use big_code_analysis::vcs::{self, Options, build_trend};
+use big_code_analysis::wire;
+
+mod common;
+use common::vcs_fixture::{DAY, FIXED_NOW, Repo};
+
+/// Base options pinned to the fixture clock; the trend's most-recent point
+/// lands exactly on `FIXED_NOW`.
+fn opts() -> Options {
+    Options {
+        as_of: Some(FIXED_NOW),
+        ..Options::default()
+    }
+}
+
+/// A three-commit history: `early.rs` is born first and edited twice;
+/// `late.rs` only appears at the middle commit. The timestamps are spaced
+/// so a 3-point / 300-day trend samples one commit per point.
+fn staged_repo() -> Repo {
+    let repo = Repo::init();
+    repo.write("early.rs", "one\n");
+    repo.commit(
+        "Ada",
+        "ada@example.com",
+        FIXED_NOW - 300 * DAY,
+        "init early",
+    );
+
+    repo.write("early.rs", "one\ntwo\n");
+    repo.write("late.rs", "x\n");
+    repo.commit("Ada", "ada@example.com", FIXED_NOW - 150 * DAY, "add late");
+
+    repo.write("early.rs", "one\ntwo\nthree\n");
+    repo.commit("Ada", "ada@example.com", FIXED_NOW - 10 * DAY, "edit early");
+    repo
+}
+
+fn series<'a>(trend: &'a vcs::Trend, rel: &str) -> Vec<Option<&'a vcs::Stats>> {
+    let target = PathBuf::from(rel);
+    let Some((_, points)) = trend.iter().find(|(path, _)| **path == target) else {
+        panic!("no series for {rel}");
+    };
+    points.iter().map(Option::as_ref).collect()
+}
+
+#[test]
+fn samples_span_endpoints_oldest_first() {
+    let repo = staged_repo();
+    let trend = build_trend(repo.path(), &opts(), 3, 300 * DAY).expect("trend");
+    let points = trend.as_of_points();
+    assert_eq!(points.len(), 3);
+    assert_eq!(points[0], FIXED_NOW - 300 * DAY, "oldest is end - span");
+    assert_eq!(points[2], FIXED_NOW, "newest is the end anchor");
+    assert!(points[0] < points[1] && points[1] < points[2]);
+}
+
+#[test]
+fn a_file_born_later_is_absent_at_earlier_points() {
+    // Load-bearing for the historical-tip resolution: a naïve `--as-of`
+    // walk anchored at HEAD would count `late.rs` (it is in today's tree)
+    // at the oldest point. Re-anchoring at the historical tip leaves it
+    // `None` until the commit that actually introduced it.
+    let repo = staged_repo();
+    let trend = build_trend(repo.path(), &opts(), 3, 300 * DAY).expect("trend");
+
+    let late = series(&trend, "late.rs");
+    assert!(
+        late[0].is_none(),
+        "late.rs did not exist at the oldest point"
+    );
+    assert!(late[1].is_some(), "late.rs exists from the middle commit");
+    assert!(late[2].is_some());
+
+    // early.rs exists at every point.
+    let early = series(&trend, "early.rs");
+    assert!(
+        early.iter().all(Option::is_some),
+        "early.rs present throughout"
+    );
+}
+
+#[test]
+fn per_point_commit_counts_grow_with_history() {
+    let repo = staged_repo();
+    let trend = build_trend(repo.path(), &opts(), 3, 300 * DAY).expect("trend");
+    let early = series(&trend, "early.rs");
+    // One commit accumulated by the oldest point, two by the middle, three
+    // by HEAD (all within the 365-day long window).
+    assert_eq!(early[0].expect("p0").commits_long, 1);
+    assert_eq!(early[1].expect("p1").commits_long, 2);
+    assert_eq!(early[2].expect("p2").commits_long, 3);
+}
+
+#[test]
+fn points_before_first_commit_are_all_absent() {
+    let repo = Repo::init();
+    repo.write("only.rs", "a\n");
+    repo.commit("Ada", "ada@example.com", FIXED_NOW - 5 * DAY, "init");
+
+    // Span reaches back to before the single commit; the two oldest points
+    // predate the repository and must be empty.
+    let trend = build_trend(repo.path(), &opts(), 3, 100 * DAY).expect("trend");
+    let only = series(&trend, "only.rs");
+    assert!(
+        only[0].is_none() && only[1].is_none(),
+        "predate first commit"
+    );
+    assert!(only[2].is_some(), "HEAD point sees the file");
+}
+
+#[test]
+fn invalid_point_count_is_rejected() {
+    let repo = staged_repo();
+    assert!(matches!(
+        build_trend(repo.path(), &opts(), 1, 300 * DAY),
+        Err(vcs::Error::InvalidTrend(_))
+    ));
+}
+
+#[test]
+fn wire_projection_keeps_alignment_and_marks_absent_as_null() {
+    let repo = staged_repo();
+    let trend = build_trend(repo.path(), &opts(), 3, 300 * DAY).expect("trend");
+    let wire = wire::VcsTrend::from_trend(&trend, 0, 0);
+
+    assert_eq!(wire.trend_schema_version, vcs::TREND_SCHEMA_VERSION);
+    assert_eq!(wire.as_of_points.len(), 3);
+    let late = &wire.files["late.rs"];
+    assert!(late[0].is_none(), "absent point serializes as null");
+    let point1 = late[1].as_ref().expect("present point");
+    assert_eq!(
+        point1.as_of, wire.as_of_points[1],
+        "point carries its as_of"
+    );
+
+    // The whole document round-trips through JSON unchanged.
+    let json = serde_json::to_string(&wire).expect("serialize");
+    let back: wire::VcsTrend = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(wire, back);
+}
+
+#[test]
+fn wire_top_files_keeps_the_riskiest() {
+    let repo = staged_repo();
+    let trend = build_trend(repo.path(), &opts(), 3, 300 * DAY).expect("trend");
+    let full = wire::VcsTrend::from_trend(&trend, 0, 0);
+    assert_eq!(full.files.len(), 2);
+    let one = wire::VcsTrend::from_trend(&trend, 1, 0);
+    assert_eq!(one.files.len(), 1, "top_files = 1 keeps a single series");
+}
+
+#[test]
+fn deltas_flag_a_file_whose_risk_moved() {
+    // early.rs is edited across all three points; whichever direction its
+    // risk moved, it must land in exactly one delta list (its endpoints
+    // differ), and never in both.
+    let repo = staged_repo();
+    let trend = build_trend(repo.path(), &opts(), 3, 300 * DAY).expect("trend");
+    let deltas = trend.deltas(0);
+    let in_improved = deltas
+        .improved
+        .iter()
+        .any(|d| d.path == Path::new("early.rs"));
+    let in_regressed = deltas
+        .regressed
+        .iter()
+        .any(|d| d.path == Path::new("early.rs"));
+    assert!(
+        in_improved ^ in_regressed,
+        "early.rs risk moved, so it belongs to exactly one list"
+    );
+}

--- a/tests/vcs_trend.rs
+++ b/tests/vcs_trend.rs
@@ -160,8 +160,68 @@ fn wire_top_files_keeps_the_riskiest() {
     let trend = build_trend(repo.path(), &opts(), 3, 300 * DAY).expect("trend");
     let full = wire::VcsTrend::from_trend(&trend, 0, 0);
     assert_eq!(full.files.len(), 2);
+
+    // Identify the file `top_files = 1` must retain, ranking with the same
+    // contract as the projection (descending most-recent risk, ties broken
+    // by path ascending) so a tie can't make this assertion ambiguous.
+    let mut ranked: Vec<(String, f64)> = full
+        .files
+        .iter()
+        .map(|(path, points)| {
+            let last_risk = points
+                .iter()
+                .rev()
+                .find_map(|p| p.as_ref().map(|pt| pt.vcs.risk_score))
+                .expect("each kept file has a present point");
+            (path.clone(), last_risk)
+        })
+        .collect();
+    ranked.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .expect("finite risk scores")
+            .then_with(|| a.0.cmp(&b.0))
+    });
+    let riskiest = ranked[0].0.clone();
+
     let one = wire::VcsTrend::from_trend(&trend, 1, 0);
     assert_eq!(one.files.len(), 1, "top_files = 1 keeps a single series");
+    assert!(
+        one.files.contains_key(&riskiest),
+        "top_files = 1 keeps the highest most-recent-risk file ({riskiest})"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn wire_drops_non_utf8_paths() {
+    // A non-UTF-8 path cannot be a JSON object key, so `from_trend` (and
+    // the delta projection) must drop it rather than mangle it. Build a
+    // `Trend` directly with such a path present at two points (so it would
+    // otherwise be both a file series and a delta entry).
+    use std::collections::HashMap;
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+
+    let bad = PathBuf::from(OsStr::from_bytes(b"bad\xffname.rs"));
+    let stat = |risk: f64| vcs::Stats {
+        risk_score: risk,
+        ..Default::default()
+    };
+    let mut p0 = HashMap::new();
+    p0.insert(bad.clone(), stat(5.0));
+    let mut p1 = HashMap::new();
+    p1.insert(bad.clone(), stat(9.0)); // risk moved → eligible for a delta
+    let trend = vcs::Trend::from_snapshots(vec![0, 1], vec![p0, p1], 365, 90, false);
+
+    // Compute-side keeps the path (it is a `PathBuf`); the wire projection
+    // drops it from both the file map and the delta lists.
+    assert_eq!(trend.len(), 1, "compute-side trend retains the bad path");
+    let wire = wire::VcsTrend::from_trend(&trend, 0, 0);
+    assert!(wire.files.is_empty(), "non-UTF-8 path dropped from files");
+    assert!(
+        wire.deltas.improved.is_empty() && wire.deltas.regressed.is_empty(),
+        "non-UTF-8 path dropped from deltas"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds **historical metric trend** support (issue #333): sample the
change-history (VCS) metrics at N points in time so a consumer can see
whether a file's risk is *improving or degrading* over the project's life,
not only its risk *now*. Surfaced across all three front ends — CLI, web,
and Python — each point carrying the full per-file VCS block.

## Why the naïve approach is wrong

Setting `Options::as_of` to a past time does **not** produce a faithful
historical snapshot: `git::build` seeds accumulators from today's `HEAD`
tree and `walk_history` only clamps *future-dated* commits to `now`, so
commits made **after** a past `as_of` (still reachable from `HEAD`) keep
counting. Each trend point therefore resolves the mainline tip that
existed **at or before** that timestamp (from one first-parent walk,
scanned for the max commit-time ≤ t so clock skew can't misselect) and
re-anchors an ordinary history walk there with `as_of` set to the point.
A file not yet born at an older point is `null` there — pinned by a
revert-verified, load-bearing test.

## Surfaces

- **Library:** `vcs::{build_trend, Trend, TrendDelta, TrendDeltas, TREND_SCHEMA_VERSION}`,
  `wire::{VcsTrend, VcsTrendPoint, VcsTrendDelta, VcsTrendDeltas}`, and
  `Error::InvalidTrend` (all behind `vcs-git`). The generic `trend` module
  is backend-neutral.
- **CLI:** `bca vcs trend --points N --span DURATION --top-deltas N`
  (`-O json|yaml|cbor`), reusing the parent `bca vcs` window / `--ref` /
  bot / merge / rename / `--as-of` / `--top` flags.
- **Web:** `POST /vcs/trend`.
- **Python:** `vcs_trend(repo_path, points=…, span=…, …)`.

## Output schema

```json
{ "trend_schema_version": 1,
  "as_of_points": [t0, t1, ...],
  "files": { "path": [ { "as_of": t, "...vcs block..." } | null, ... ] },
  "deltas": { "improved": [...], "regressed": [...] } }
```

`as_of_points` is oldest-first; every file's array aligns to it 1:1 with a
`null` where the file was absent. `deltas` ranks the biggest movers by
`risk_score` between each file's earliest and latest present points.

## Decisions / edge cases

- Point count bounded `[2, 120]` → `Error::InvalidTrend` (HTTP 400 / Python
  `ValueError`); empty repo / unborn HEAD → `ResolveRef`; points before the
  first commit → all-`null`.
- TOML excluded from trend output — an absent point serializes as `null`,
  which TOML cannot represent (JSON/YAML/CBOR handle it).
- **Rename limitation (deferred):** renames are followed *within* each
  sample's walk, but a file renamed *between* samples appears as two
  separate path series.

## Acceptance criteria

- [x] Time-series output schema is stable and versioned (`trend_schema_version`).
- [x] Performance: one windowed walk per point + one first-parent timeline
      walk; 12 points / 1k commits completes well under 60 s.

## Testing & docs

Tests at every layer (lib unit + integration, CLI, web route, Python).
Quality reviews run (code-review: no bugs; audit-tests strengthenings
applied). Docs updated: mdBook VCS chapter + REST recipe, `CHANGELOG`,
`STABILITY`, and a generated `bca-vcs-trend.1` man page. Full
`make pre-commit` is green; clippy clean (`-D warnings`, default + all
features).

## Incidental

Includes one isolated commit fixing a pre-existing clippy-1.95
`unnecessary_sort_by` failure in `stats_tests.rs` that was blocking the
shared gate (filed as #581).

Fixes #333
Fixes #581
