### PR TITLE
chore: source review & audit sweep — inline behaviour-preserving fixes

### DIFF
--- a/.claude/skills/audit-file/SKILL.md
+++ b/.claude/skills/audit-file/SKILL.md
@@ -1,0 +1,599 @@
+---
+name: audit-file
+description: Audit a single Rust source file in the big-code-analysis workspace for logic errors, complexity, bugs, security issues, and code smells. Use when asked to audit or review a specific file.
+---
+
+# Audit File
+
+Audit the single Rust source file `$ARGUMENTS` for logic errors, unnecessary
+complexity, bugs, security issues, incorrect comments, and code smells.
+
+`$ARGUMENTS` must be a path to a single file — absolute, or relative to the
+repository root (e.g., `src/metrics/halstead.rs`,
+`big-code-analysis-cli/src/main.rs`).
+
+**Resolve `$ARGUMENTS` to a canonical repo-relative path once at the very
+start of the run** and use the resolved value for every subsequent reference
+(memory keys, issue titles). Canonicalize with:
+
+```bash
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+FILE_PATH="$(realpath --relative-to="$PROJECT_ROOT" "$PROJECT_ROOT/$ARGUMENTS" 2>/dev/null \
+  || realpath --relative-to="$PROJECT_ROOT" "$ARGUMENTS")"
+```
+
+**Memory-key sanitization**: replace `/` with `-` in `$FILE_PATH` before
+composing Serena memory keys so the key is a single flat token (e.g.,
+`audit-state-src-metrics-halstead-rs`, not
+`audit-state-src/metrics/halstead.rs`). Apply this rule to every
+`audit-state-$FILE_PATH` reference below.
+
+## ABSOLUTE CONSTRAINTS
+
+**This skill is READ-ONLY. It MUST NOT leave any trace on the filesystem.**
+
+- **NEVER commit code.** No `git commit`, no `git add`, no staging. Zero commits.
+- **NEVER leave uncommitted files.** No new files, no modified files, no temp files
+  in the worktree. If you accidentally create or modify a file, revert it
+  immediately with `git checkout -- .`.
+- **NEVER modify source files.** Not even "harmless" formatting or comment fixes.
+- **NEVER push branches.** The isolation branch is disposable and local-only.
+- The ONLY side effects of this skill are: GitHub issues filed, Serena memories
+  updated, and terminal output printed.
+
+---
+
+## Before Starting
+
+Check existing open GitHub issues (`gh issue list`) to avoid filing duplicates.
+Note any relevant open issues as context, but do NOT let them constrain the audit.
+
+---
+
+## Step 0: Launch isolated agent
+
+**This step is MANDATORY and must be the very first action.**
+
+The audit runs in isolation to guarantee the main working tree is never touched.
+
+### Environment detection
+
+Determine the isolation mode:
+
+```bash
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+if [[ "$PROJECT_ROOT" == *".claude/worktrees/"* ]]; then
+  ISOLATION_MODE="worktree"
+else
+  ISOLATION_MODE="branch"
+fi
+```
+
+- **Worktree mode**: You are already inside a worktree. Keep all existing
+  behavior (agent launched with `isolation: "worktree"`).
+- **Branch mode**: You are in the main project directory. Agents run without
+  worktree isolation. Serena LSP works correctly in this mode.
+
+### Branch mode prerequisites
+
+In branch mode, verify the working tree is completely clean before proceeding:
+
+```bash
+if [[ "$ISOLATION_MODE" == "branch" ]]; then
+  DIRTY="$(git status --porcelain)"
+  if [[ -n "$DIRTY" ]]; then
+    echo "Error: branch mode requires a clean repository (no uncommitted or untracked files)." >&2
+    echo "$DIRTY" >&2
+    exit 1
+  fi
+fi
+```
+
+### Launch the agent
+
+If you are the top-level orchestrator (invoked by the user), immediately launch
+a single Agent that executes Steps 1-9. Pass the resolved file path and any
+prior context. Do NOT perform any audit work directly.
+
+- **Worktree mode**: Launch the Agent with `isolation: "worktree"`. This creates
+  an isolated worktree automatically.
+- **Branch mode**: Launch the Agent WITHOUT `isolation: "worktree"`. The agent
+  runs in the main project directory (safe because the audit is read-only).
+
+**CRITICAL**: In worktree mode, the Agent tool call MUST include
+`isolation: "worktree"` as a required parameter. Double-check before sending.
+In branch mode, do NOT include `isolation: "worktree"`.
+
+### Agent verification (MANDATORY)
+
+Every agent must verify its environment before doing any work:
+
+```bash
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+if [[ "$PROJECT_ROOT" == *".claude/worktrees/"* ]]; then
+  ISOLATION_MODE="worktree"
+else
+  ISOLATION_MODE="branch"
+fi
+echo "ISOLATION_MODE=$ISOLATION_MODE PROJECT_ROOT=$PROJECT_ROOT"
+```
+
+**In worktree mode**: Confirm `PROJECT_ROOT` contains `.claude/worktrees/`.
+If not, abort:
+"ABORTED: Agent expected worktree isolation but PROJECT_ROOT=\<path\>"
+
+**In branch mode**: Confirm the working tree is clean (`git status --porcelain`
+returns empty output). If dirty, abort:
+"ABORTED: Branch mode requires a clean working tree."
+
+In worktree mode, all file operations must be within `PROJECT_ROOT`.
+
+**Worktree cleanup**: Worktrees are automatically cleaned up by the Claude Code
+runtime. NEVER run `git worktree remove` or `git worktree prune`.
+
+---
+
+## Step 1: Load audit history
+
+Read the Serena memory keyed on `$FILE_PATH` (with `/` replaced by `-`) to
+check for prior audit state. Invoke the Serena MCP tool `serena:read_memory`
+directly with `memory_name: "audit-state-<sanitized-FILE_PATH>"`. If the Serena MCP
+server is not active for this session, call `serena:activate_project` first.
+
+If the memory exists, it contains a single-file coverage record in this format:
+
+```
+# Audit State: <file path>
+last_audit: YYYY-MM-DD
+last_model: <model-id>
+
+## File Coverage
+<relative_path> | <depth> | <date> | <findings_count> findings | <model-id>
+```
+
+Where `<depth>` is one of: `full`, `partial`, `skimmed`, `none`.
+
+Use the recorded depth to calibrate effort:
+
+| Prior depth | Age | Action |
+|-------------|-----|--------|
+| `none` | any | Deep audit required |
+| `skimmed` | any | Deep audit required |
+| `partial` | > 30 days | Audit uncovered areas at `full` depth |
+| `partial` | recent | Spot-check; focus on sections not previously covered |
+| `full` | < 3 days | Skip unless file changed since last audit (`git log -1 -- <file>`) |
+| `full` | > 3 days | Re-audit — code may have drifted |
+
+If the memory does not exist, treat the file as never audited (priority 1, full
+depth required).
+
+---
+
+## Step 2: Establish context
+
+### 2a: Identify the containing crate
+
+Walk up from the file to find its `Cargo.toml` and extract the crate name:
+
+```bash
+FILE_ABS="$PROJECT_ROOT/$FILE_PATH"
+CRATE_DIR="$(dirname "$FILE_ABS")"
+while true; do
+  [[ -f "$CRATE_DIR/Cargo.toml" ]] && break
+  [[ "$CRATE_DIR" == "$PROJECT_ROOT" || "$CRATE_DIR" == "/" ]] && break
+  CRATE_DIR="$(dirname "$CRATE_DIR")"
+done
+CRATE_NAME="$(cargo metadata --format-version 1 --no-deps \
+  | jq -r --arg dir "$CRATE_DIR/" \
+    '.packages[] | select(.manifest_path | startswith($dir)) | .name' \
+  | head -1)"
+echo "CRATE_DIR=$CRATE_DIR CRATE_NAME=$CRATE_NAME"
+if [[ -z "$CRATE_NAME" ]]; then
+  echo "error: could not identify a Cargo.toml containing $FILE_ABS" >&2
+  exit 1
+fi
+```
+
+### 2b: Build baseline
+
+Run build, tests, and clippy scoped to the containing crate to establish
+the pre-audit baseline. These commands serve two purposes: (1) confirm the
+crate compiles and tests pass so you know what was already broken before the
+audit, and (2) surface any existing clippy findings that are in scope.
+
+```bash
+cargo build -p "$CRATE_NAME" 2>&1 | tail -5
+cargo test  -p "$CRATE_NAME" 2>&1 | tail -20
+cargo clippy -p "$CRATE_NAME" -- -W clippy::all 2>&1 | tail -20
+```
+
+Record: passing test count, existing warnings, existing clippy findings.
+Anything already broken is NOT your problem to fix — note it as context only.
+
+### 2c: Collect code metrics for the file
+
+Use the project's own CLI to measure the target file. The output highlights
+cyclomatic / cognitive complexity hotspots, Halstead defect estimates,
+function-size outliers, and maintainability-index scores — all of which direct
+the audit to the highest-risk functions.
+
+```bash
+if cargo build -p big-code-analysis-cli >/dev/null 2>&1; then
+  ./target/debug/big-code-analysis-cli -m -O json -p "$FILE_ABS" > /tmp/audit-metrics.json || true
+fi
+```
+
+Parse the output (when available) and extract per-function metrics:
+
+- **Halstead estimated bugs > 0.5**: These functions have the highest
+  probability of containing defects. Audit them first.
+- **Cyclomatic complexity > 10**: Complex branching increases the chance of
+  missed edge cases. Cross-reference with checklist questions 1-7.
+- **Cognitive complexity > 15**: Hard-to-understand code is where incorrect
+  comments and swallowed errors hide.
+- **Functions > 100 SLOC or > 3 parameters**: Code smell candidates for
+  checklist questions 18-23.
+- **Maintainability Index < 10**: The entire file warrants deep review.
+
+Carry this data forward to Step 3. When applying the audit checklist, start
+with the functions flagged by metrics.
+
+If the metrics tool is unavailable, skip this substep and proceed.
+
+### 2d: Understand the file's role
+
+Read the target file entirely. Then briefly establish:
+
+- What module / public surface does this file implement?
+- Does it export items re-exported from `lib.rs`? (If so, public-API
+  stability rules apply — see checklist Q28.)
+- Does it belong to a family that mirrors other language modules under
+  `src/languages/`? (If so, cross-language consistency rules apply —
+  see checklist Q27.)
+- Does it contain metric computation or AST traversal? (If so, security
+  checklist items Q7-Q10 apply with higher weight.)
+
+This context shapes which checklist questions are most relevant in Step 3.
+
+---
+
+## Step 3: Audit checklist
+
+Read the entire file, then apply every applicable question below. **Start
+with functions flagged by code metrics** (Step 2c) — these have the highest
+defect probability.
+
+Record each finding as:
+
+```
+FINDING: <short title>
+FILE: <path>:<line range>
+CHECKLIST: <question number(s)>
+EVIDENCE: <what is wrong and why, with code snippet>
+CATEGORY: bug | security | enhancement | documentation
+```
+
+Use exactly these four category names — they are the GitHub labels Step 5
+will apply. Mapping rules:
+
+- **bug** — incorrect behavior, off-by-one, swallowed errors, broken contracts
+- **security** — anything in the Security checklist (Q8-Q13)
+- **enhancement** — code smells, refactors, complexity, dependency hygiene
+- **documentation** — incorrect or stale comments, doc-tests, missing docs
+
+### Logic and Correctness
+
+1. Does every code path produce the correct output for its documented contract?
+2. Are there off-by-one errors in ranges, indexes, or boundary checks?
+3. Are there match arms, if-else branches, or rule bodies that are unreachable
+   or logically dead?
+4. Are error cases handled, or silently swallowed (`continue`, `_ => {}`,
+   `Err(_)` arms, ignored `Result`)?
+5. Are there false positives on valid inputs, or false negatives on invalid
+   inputs?
+6. Are all edge cases handled: empty input, max-size input, non-UTF-8 paths,
+   missing files, deeply nested ASTs?
+7. Is recursion bounded? AST traversal and tree-sitter walks must not blow
+   the stack on pathological input.
+
+### Security
+
+8. Can a malicious or pathological input (e.g., a deliberately deep or
+   recursive source file) cause stack overflow, infinite loop, or OOM?
+9. Is there path traversal risk in any directory-walking or file-loading
+   logic?
+10. Are symlinks handled safely?
+11. Is `to_string_lossy()` safe for all file path handling, or could non-UTF-8
+    paths cause silent corruption? Never use `to_string_lossy()` for paths
+    used as identifiers (map keys, JSON output, error correlation).
+12. Does any feature or API allow user-supplied content to execute arbitrary
+    code or make network calls?
+13. Are there hardcoded secrets, tokens, or environment-specific paths?
+
+### Incorrect Comments and Documentation
+
+14. Do doc comments on public items accurately describe behavior, parameters,
+    return values, and errors?
+15. Are inline comments factually correct and not stale (old architectures,
+    wrong line numbers, removed features)?
+16. Do doc-test examples compile and run correctly?
+17. Are there TODO/FIXME/HACK comments indicating known tech debt?
+
+### Code Smells and Unnecessary Complexity
+
+18. Are there duplicated helper functions across test files that should be in
+    a shared module?
+19. Are there overly verbose patterns that could be simplified (unnecessary
+    clones, verbose match arms)?
+20. Are there unused imports, functions, or struct fields?
+21. Are there functions longer than ~50 lines of logic that should be
+    decomposed?
+22. Are there hardcoded strings that should be named constants?
+23. Are any hardcoded lists a maintenance hazard (e.g., per-language node
+    type lists that must stay in sync with the upstream tree-sitter grammar)?
+
+### Dependency and Build Concerns
+
+24. Are all `Cargo.toml` dependencies necessary? Are any runtime dependencies
+    only used by a binary or optional feature?
+25. Are feature flags on dependencies minimal and appropriate?
+26. Is `default-features = false` used where the full default feature set is
+    not needed?
+
+### Project-Specific (big-code-analysis)
+
+27. Per-language modules under `src/languages/` deliberately mirror each
+    other. Does any change introduce a discrepancy that one language exhibits
+    and another does not (different metric formula, different node-type
+    handling, different operator/operand classification) without justification?
+28. The crate is published on crates.io. Does any change break the public API
+    (`lib.rs` re-exports, public traits, `Metrics` / `FuncSpace` / language
+    enum shapes) without an intentional version bump?
+29. Tree-sitter grammar versions are pinned with `=X.Y.Z` in the root
+    `Cargo.toml`. Does any change loosen these pins, or use grammar features
+    that were not available in the pinned version?
+30. Are there `unwrap()`, `expect()`, `assert!()`, or `panic!()` calls in
+    non-test code? `expect()` / `assert!()` are acceptable in tests;
+    production code should propagate with `?`. Document any non-test
+    `expect()` with the invariant that makes the panic unreachable.
+
+---
+
+## Step 4: Deduplicate and validate
+
+For each finding:
+
+1. Re-read and confirm the evidence is concrete (file + line + reasoning).
+2. Cross-check against existing open issues (`gh issue list`). Drop exact duplicates.
+3. Confirm the category from Step 3 (`bug`, `security`, `enhancement`, or
+   `documentation`) — this is the GitHub label Step 5 will apply.
+
+---
+
+## Step 5: File GitHub issues
+
+### 5a: Ensure category labels exist
+
+Before filing the first issue, ensure every label the audit may use exists in
+the repo. `gh issue create` rejects unknown labels. Of the four categories,
+`bug`, `documentation`, and `enhancement` already exist on most GitHub repos;
+`security` may need to be created on first use:
+
+```bash
+ensure_label() {
+  local name="$1" color="$2" desc="$3"
+  if ! gh label list --limit 200 --json name --jq '.[].name' | grep -qx "$name"; then
+    gh label create "$name" --color "$color" --description "$desc"
+  fi
+}
+
+ensure_label security          "ee0701" "Security-relevant finding"
+ensure_label upstream-grammar  "fbca04" "Cannot be fixed locally; needs upstream tree-sitter grammar change"
+```
+
+### 5b: Create the issue
+
+For each surviving finding, create one issue. Template:
+
+```markdown
+## Summary
+
+<One-sentence description of the problem>
+
+## Location
+
+- `<file path>:<line numbers>`
+
+## Evidence
+
+<Code snippet or reasoning showing the problem>
+
+## Expected Behavior
+
+<What should happen instead>
+
+## Actual Behavior
+
+<What currently happens>
+
+## Impact
+
+<Who is affected and how>
+```
+
+Write the body to a temp file and use `gh issue create --body-file`:
+
+```bash
+cat > /tmp/issue-body.md <<'EOF'
+...body here...
+EOF
+gh issue create --title "scope: short description" --label "bug" --body-file /tmp/issue-body.md
+```
+
+### Upstream-grammar findings
+
+Some findings cannot be fixed in this repository because the bug lives in an
+upstream tree-sitter grammar (`tree-sitter-rust`, `tree-sitter-python`,
+`tree-sitter-java`, `tree-sitter-typescript`, `tree-sitter-javascript`,
+`tree-sitter-kotlin-ng`, etc.) rather than in our wrapper. The grammar version
+is pinned in `Cargo.toml`, so the fix requires either a workaround locally,
+an upstream patch, or both.
+
+When a finding falls into this category:
+
+1. **Still file the issue** — the problem is real and should be tracked.
+2. Add the `upstream-grammar` label alongside the normal category label
+   (`bug`, `enhancement`, etc.).
+3. In the issue body, add an `## Upstream Grammar` section that names the
+   grammar crate and version and explains why a local fix is partial or
+   impossible.
+4. Do NOT add a fix plan in Step 6 that assumes a local-only fix; instead,
+   the fix-plan comment should describe the upstream coordination required
+   (file an issue against the grammar repository, document any local
+   workaround, plan the version bump that picks up the upstream fix).
+
+Example:
+
+```bash
+gh issue create \
+  --title "python: function metrics misclassify lambda as expression" \
+  --label "bug" \
+  --label "upstream-grammar" \
+  --body-file /tmp/issue-body.md
+```
+
+Signals that an upstream-grammar block applies include:
+
+- Finding depends on a node type or field name produced by the grammar.
+- Reproducer requires source that the grammar parses incorrectly.
+- Fix would require teaching tree-sitter to emit different nodes.
+
+---
+
+## Step 6: Add fix-plan comments
+
+For each issue filed, add a comment:
+
+```markdown
+## General Plan for Fix
+
+### Root Cause
+
+<Why the problem exists>
+
+### Implementation Steps
+
+1. <Smallest change that fixes the problem>
+2. <Next step if needed>
+
+### Tests to Add/Update
+
+- <Test 1>
+- <Test 2>
+
+### Verification
+
+- [ ] `cargo test -p <crate-name>` passes
+- [ ] `cargo clippy -p <crate-name>` clean
+- [ ] Manual verification: <specific scenario>
+```
+
+```bash
+cat > /tmp/fix-plan.md <<'EOF'
+...plan here...
+EOF
+gh issue comment <NUMBER> --body-file /tmp/fix-plan.md
+```
+
+---
+
+## Step 7: Summary table
+
+Print to the terminal:
+
+```
+| # | Title | Category | File | Issue |
+|---|-------|----------|------|-------|
+```
+
+Also list any findings dropped as duplicates of existing issues.
+
+---
+
+## Step 8: Save audit state
+
+After completing the audit, persist the coverage state to Serena memory by
+invoking the Serena MCP tool `serena:write_memory` directly with
+`memory_name: "audit-state-<sanitized-FILE_PATH>"` (i.e., `$FILE_PATH` with
+`/` replaced by `-`) and the merged content as `content`.
+
+Build the memory content by **merging** the previous state (from Step 1) with
+the current session's coverage. Rules for merging:
+
+- Update depth, date, model, and findings count for this session's audit
+- If the file no longer exists in the repository, remove the record
+- Preserve any other fields from the previous memory verbatim
+
+Format the memory as:
+
+```
+# Audit State: <file path>
+last_audit: YYYY-MM-DD
+last_model: <model-id>
+
+## File Coverage
+<relative_path> | <depth> | <date> | <findings_count> findings | <model-id>
+```
+
+Each line: `<relative_path> | <depth> | <date> | <findings_count> findings | <model-id>`
+
+Where:
+
+- `<relative_path>` is relative to the repository root
+- `<depth>` is `full`, `partial`, `skimmed`, or `none`
+- `<date>` is YYYY-MM-DD of this audit
+- `<findings_count>` is the number of issues filed
+- `<model-id>` is the AI model that performed the audit
+
+The `last_model` header records the model used in the most recent audit session.
+
+---
+
+## Step 9: Verify clean working tree
+
+**This step is MANDATORY and must be the last action before returning.**
+
+Confirm that the working tree has zero modifications and zero new files:
+
+```bash
+git status --porcelain
+```
+
+If any output is shown, something went wrong — the audit was supposed to be
+read-only.
+
+- For **modifications to tracked files** (`M ` / ` M` lines), revert with
+  `git checkout -- <path>` per file. Do NOT use a blanket `git checkout -- .`
+  in worktree mode without first verifying every listed path belongs to the
+  audit (other agents may share the worktree).
+- For **untracked files** (`??` lines), do NOT delete them automatically.
+  Untracked output means the audit wrote a file it should not have. Surface
+  the path(s) verbatim in the final summary so the user can decide whether
+  to keep or remove them. Never run `git clean` from this skill.
+
+Report the anomaly (which files, which step likely produced them) in your
+final summary output.
+
+---
+
+## Guardrails
+
+All ABSOLUTE CONSTRAINTS (top of this document) apply. Additionally:
+
+- **NEVER delete worktrees.** Only the Claude Code runtime may do that.
+- Do NOT implement fixes. This is audit-only.
+- Do NOT file findings without concrete evidence (file + line + reasoning).
+- Do NOT file duplicate issues. Always check `gh issue list` first.
+- Use `--body-file` for all `gh issue create` and `gh issue comment` calls.
+- In worktree mode, all audit work MUST happen inside the isolated worktree.
+- In branch mode, audit work runs in the main directory (read-only, verified clean).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ destroys other agents' in-progress work:
 | `review` | Read-only review of a diff, branch, PR, or commit range |
 | `audit-tests` | Finding tests that pass for the wrong reason |
 | `audit-crate` | Read-only crate-level audit that files GitHub issues for findings |
+| `audit-file` | Read-only single-file audit that files GitHub issues for findings |
 | `audit-naming` | Read-only crate-level audit of naming quality |
 | `scan-project` | Workspace-wide scan for logic errors, security issues, and metrics calculation bugs (6 parallel agents, 50-question checklist) |
 | `cleanup-crate` | Removing dead code, unused imports, and unreachable paths from one crate |
@@ -62,6 +63,6 @@ destroys other agents' in-progress work:
 | `lessons-learned` | Drafting entries for `docs/development/lessons_learned.md` |
 | `doc-author` | Writing / revising / de-slopping a prose doc against `docs/conventions/documentation.md` |
 
-The `audit-crate`, `audit-naming`, `scan-project`, `issue-triage`, and
+The `audit-crate`, `audit-file`, `audit-naming`, `scan-project`, `issue-triage`, and
 `review` skills are read-only and must not modify the working tree; all
 other skills may edit code as part of their workflow.

--- a/big-code-analysis-cli/src/check_format.rs
+++ b/big-code-analysis-cli/src/check_format.rs
@@ -462,8 +462,10 @@ fn orphan_splice_end(existing: &str, begin: usize) -> usize {
     }
     existing.len()
 }
-/// (by ratio), worst value, worst limit. Sorted by count desc, then
-/// path asc.
+
+/// "Per-file rollup" GFM table: one row per file with its violation
+/// count, worst metric (by ratio), worst value, worst limit. Sorted by
+/// count desc, then path asc.
 fn write_per_file_rollup(out: &mut String, pairs: &[(Violation, Option<Coverage>)]) {
     use std::fmt::Write as _;
     out.push_str("### Per-file rollup\n\n");

--- a/big-code-analysis-cli/src/commands.rs
+++ b/big-code-analysis-cli/src/commands.rs
@@ -1079,8 +1079,10 @@ fn classify_check_outcome(
         match coverage {
             Some(Coverage::Regressed { .. }) => has_regression = true,
             // `Coverage::New`, or `None` when no `--baseline` was given.
-            // `Coverage::Covered` never reaches here — `filter_by_baseline`
-            // drops it before the kept set is built.
+            // `Coverage::Covered` never reaches here: by default
+            // `filter_by_baseline` drops it, and under `--report-suppressed`
+            // `run_check` partitions it into the `suppressed` set — so the
+            // `active` slice this fn classifies is always Covered-free.
             _ => has_new = true,
         }
     }

--- a/big-code-analysis-cli/src/exemptions.rs
+++ b/big-code-analysis-cli/src/exemptions.rs
@@ -34,6 +34,7 @@ use big_code_analysis::{
 
 use crate::OutputFormat;
 use crate::baseline::DiffEntry;
+use crate::check_format::escape_gfm_cell;
 use crate::format_util::{MetricScalar, strip_path_prefix};
 
 /// Per-file marker batch streamed from the walk worker pool to the
@@ -161,14 +162,21 @@ impl ExemptionsReport {
                 for row in rows {
                     let m = &row.marker;
                     let path = strip_path_prefix(&row.path, strip_prefix);
+                    // Cells go through `escape_gfm_cell` for the same reason
+                    // the crate's other two GFM emitters do (check_format /
+                    // markdown_report, unified in #439): a path or symbol
+                    // containing `|` or a newline would otherwise inject a
+                    // spurious column break and corrupt the table. The
+                    // marker label is a fixed ASCII literal, so it is safe
+                    // un-escaped inside the code span.
                     let _ = writeln!(
                         out,
                         "| {} | {} | `{}` | {} | {} |",
-                        path,
+                        escape_gfm_cell(path),
                         m.line,
                         marker_label(m.target, m.dialect),
-                        scope_metrics(&m.scope),
-                        function_cell(m),
+                        escape_gfm_cell(&scope_metrics(&m.scope)),
+                        escape_gfm_cell(&function_cell(m)),
                     );
                 }
             }
@@ -195,10 +203,10 @@ impl ExemptionsReport {
                     let _ = writeln!(
                         out,
                         "| {} | {} | {} | {} | {} |",
-                        path,
+                        escape_gfm_cell(path),
                         e.start_line,
-                        e.qualified,
-                        e.metric,
+                        escape_gfm_cell(&e.qualified),
+                        escape_gfm_cell(&e.metric),
                         MetricScalar(e.value),
                     );
                 }
@@ -280,10 +288,18 @@ fn render_marker_rows_tty(out: &mut String, rows: &[MarkerRow], strip_prefix: &s
             )
         })
         .collect();
-    let loc_w = locs.iter().map(String::len).max().unwrap_or(0);
+    // Measure widths in `char`s, not bytes: `{:width$}` pads to a
+    // char count, so a byte-length budget over-pads a multi-byte path.
+    // Matches the crate's alignment convention (markdown_report,
+    // metric_diff).
+    let loc_w = locs.iter().map(|l| l.chars().count()).max().unwrap_or(0);
     let label_w = rows
         .iter()
-        .map(|r| marker_label(r.marker.target, r.marker.dialect).len())
+        .map(|r| {
+            marker_label(r.marker.target, r.marker.dialect)
+                .chars()
+                .count()
+        })
         .max()
         .unwrap_or(0);
     for (loc, row) in locs.iter().zip(rows) {

--- a/big-code-analysis-cli/src/exemptions_tests.rs
+++ b/big-code-analysis-cli/src/exemptions_tests.rs
@@ -132,6 +132,63 @@ fn markdown_uses_tables_and_marker_syntax() {
 }
 
 #[test]
+fn markdown_escapes_pipe_in_path_symbol_and_function_cells() {
+    // A path (legal on Unix), function name, or symbol containing `|`
+    // must be escaped as `\|` so it cannot inject a spurious GFM column
+    // break and corrupt the rendered table. Mirrors the shared escaping
+    // policy the crate's other two GFM emitters follow (#439).
+    let report = ExemptionsReport {
+        markers: Some(vec![MarkerRow {
+            path: "src/a|b.rs".to_owned(),
+            marker: marker(
+                10,
+                SuppressionTarget::Function,
+                SuppressionDialect::Native,
+                SuppressionScope::All,
+                Some("weird|fn"),
+            ),
+        }]),
+        excludes: None,
+        baseline: Some(BaselineSection {
+            path: ".bca-baseline.toml".to_owned(),
+            entries: vec![BaselineRow {
+                path: "src/c|d.rs".to_owned(),
+                qualified: "Mod::sym|bol".to_owned(),
+                metric: "cognitive".to_owned(),
+                value: 12.0,
+                start_line: 7,
+            }],
+        }),
+    };
+    let out = report
+        .render(OutputFormat::Markdown, "")
+        .expect("markdown render");
+    // Pipes inside cells are escaped, not emitted raw.
+    assert!(
+        out.contains(r"src/a\|b.rs"),
+        "path pipe not escaped, got:\n{out}"
+    );
+    assert!(
+        out.contains(r"weird\|fn"),
+        "function pipe not escaped, got:\n{out}"
+    );
+    assert!(
+        out.contains(r"Mod::sym\|bol"),
+        "symbol pipe not escaped, got:\n{out}"
+    );
+    assert!(
+        out.contains(r"src/c\|d.rs"),
+        "baseline path pipe not escaped, got:\n{out}"
+    );
+    // The raw, unescaped `src/a|b.rs` must not survive (it would split
+    // the File column). This is the assertion that fails pre-fix.
+    assert!(
+        !out.contains("src/a|b.rs"),
+        "raw unescaped path present, got:\n{out}"
+    );
+}
+
+#[test]
 fn json_nests_three_sections_under_suppressions_envelope() {
     let out = sample_report()
         .render(OutputFormat::Json, "")

--- a/big-code-analysis-cli/src/markdown_report.rs
+++ b/big-code-analysis-cli/src/markdown_report.rs
@@ -369,18 +369,16 @@ pub(crate) fn write_table(
     }
 }
 
-/// Append a `### Legend` section: a definition-list-style bullet per
-/// `(header, definition)` pair, so a Markdown reader (a PR comment, a
-/// pasted issue) can learn what each column abbreviation means — the
-/// same definitions the HTML report shows as hover tooltips, drawn from
-/// the shared column specs so the two formats cannot drift (issue #611).
-/// The header abbreviation is wrapped in backticks (it is a code-like
-/// token) and the definition is GFM-escaped. Renders nothing when
-/// `entries` is empty.
 /// Append a "Legend" subsection at the given heading `level` (number of
-/// `#`). Threaded rather than hardcoded so an embedding page can keep its
-/// document outline gap-free — a standalone VCS page (`#` title) needs an
-/// `##` legend, an embedded one (`##` section) needs `###` (issue #618).
+/// leading `#`): a definition-list-style bullet per `(header, definition)`
+/// pair, so a Markdown reader (a PR comment, a pasted issue) can learn what
+/// each column abbreviation means — the same definitions the HTML report
+/// shows as hover tooltips, drawn from the shared column specs so the two
+/// formats cannot drift (issue #611). The header is emitted in bold and the
+/// definition is GFM-escaped. The heading level is threaded rather than
+/// hardcoded so an embedding page keeps its outline gap-free — a standalone
+/// VCS page (`#` title) needs an `##` legend, an embedded one (`##` section)
+/// needs `###` (issue #618). Renders nothing when `entries` is empty.
 pub(crate) fn write_legend(out: &mut String, level: usize, entries: &[(&str, &str)]) {
     if entries.is_empty() {
         return;

--- a/big-code-analysis-cli/src/vcs_command.rs
+++ b/big-code-analysis-cli/src/vcs_command.rs
@@ -248,10 +248,9 @@ pub(crate) fn build_options(args: &VcsArgs) -> Options {
     options.risk_formula = args.risk_formula.into();
     options.emit_author_details = args.emit_author_details;
     options.include_deleted = args.include_deleted;
-    // `build_options` is the shared builder, so it leaves `compute_bus_factor`
-    // at its `Default` (`false`) — the `jit` subcommand never wants the
-    // aggregate. The ranking callers (`run`, `default_aggregate_index`) set it
-    // `true` explicitly, so no assignment is needed here.
+    // `build_options` (the shared builder) leaves `compute_bus_factor` at its
+    // `Default` (`false`); the ranking callers `run` / `default_aggregate_index`
+    // set it `true`, so no explicit assignment is needed here.
     options.bus_factor_threshold =
         vcs::options::validate_bus_factor_threshold(args.bus_factor_threshold)
             .unwrap_or_else(|e| die(format_args!("--bus-factor-threshold: {e}")));

--- a/big-code-analysis-cli/src/vcs_command.rs
+++ b/big-code-analysis-cli/src/vcs_command.rs
@@ -248,9 +248,10 @@ pub(crate) fn build_options(args: &VcsArgs) -> Options {
     options.risk_formula = args.risk_formula.into();
     options.emit_author_details = args.emit_author_details;
     options.include_deleted = args.include_deleted;
-    // The shared builder leaves the aggregate off (the `jit` subcommand never
-    // wants it); the ranking flow turns it on below. `Default` already sets it
-    // `false`, so no explicit assignment is needed here.
+    // `build_options` is the shared builder, so it leaves `compute_bus_factor`
+    // at its `Default` (`false`) — the `jit` subcommand never wants the
+    // aggregate. The ranking callers (`run`, `default_aggregate_index`) set it
+    // `true` explicitly, so no assignment is needed here.
     options.bus_factor_threshold =
         vcs::options::validate_bus_factor_threshold(args.bus_factor_threshold)
             .unwrap_or_else(|e| die(format_args!("--bus-factor-threshold: {e}")));

--- a/big-code-analysis-cli/src/vcs_report.rs
+++ b/big-code-analysis-cli/src/vcs_report.rs
@@ -208,9 +208,11 @@ const VCS_SPECS: &[VcsColumn] = &[
     VcsColumn {
         header: HOTSPOT_HEADER,
         align: Align::Right,
-        // Rendered only when some row carries a score (see `active_specs`);
-        // the `unwrap_or_default` is a defensive blank for the unreachable
-        // mixed case where the column survives but a single row is `None`.
+        // Rendered only when some row carries a score (see `active_specs`).
+        // In a mixed report — the normal `report --vcs` join, where some
+        // files have AST-derived scores and others do not — the column
+        // survives on the scored rows and `unwrap_or_default` emits a blank
+        // cell for each unscored (`None`) row.
         cell: |_, e| {
             Cell::Num(
                 e.vcs

--- a/big-code-analysis-cli/src/vcs_report.rs
+++ b/big-code-analysis-cli/src/vcs_report.rs
@@ -208,11 +208,9 @@ const VCS_SPECS: &[VcsColumn] = &[
     VcsColumn {
         header: HOTSPOT_HEADER,
         align: Align::Right,
-        // Rendered only when some row carries a score (see `active_specs`).
-        // In a mixed report — the normal `report --vcs` join, where some
-        // files have AST-derived scores and others do not — the column
-        // survives on the scored rows and `unwrap_or_default` emits a blank
-        // cell for each unscored (`None`) row.
+        // Rendered only when some row carries a score (see `active_specs`); in a
+        // mixed report (the normal `report --vcs` join) the column survives on the
+        // scored rows and `unwrap_or_default` blanks each unscored (`None`) row.
         cell: |_, e| {
             Cell::Num(
                 e.vcs

--- a/big-code-analysis-py/src/batch.rs
+++ b/big-code-analysis-py/src/batch.rs
@@ -318,9 +318,12 @@ const _: fn() = || {
 /// `paths` is any Python iterable of `str | os.PathLike[str]`;
 /// generators work because iteration is done lazily via `PyO3`'s
 /// `try_iter` (which calls Python's `iter()` builtin under the hood).
-/// The output list has the same length as the input iterable and
-/// preserves order one-to-one, so callers can `zip(inputs, results)`
-/// without losing the pairing.
+/// With `skip_generated=false` the output list has the same length as
+/// the input iterable and preserves order one-to-one, so callers can
+/// `zip(inputs, results)` without losing the pairing. Under the default
+/// `skip_generated=true` a skipped file yields no slot (see below), so
+/// the list can be shorter — `zip(inputs, results)` would then silently
+/// mis-pair every entry after the first skip.
 ///
 /// `metrics=` selects which metrics to compute (#268). `None` (the
 /// default) preserves the full suite; an empty list raises

--- a/big-code-analysis-py/tests/test_vcs.py
+++ b/big-code-analysis-py/tests/test_vcs.py
@@ -481,7 +481,13 @@ def test_vcs_metrics_file_types_sequence_matches_comma_string(tmp_path: Path) ->
         ["git", "commit", "-q", "-m", "add py"],
         cwd=repo,
         check=True,
-        env={**os.environ},
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "Ada",
+            "GIT_AUTHOR_EMAIL": "ada@example.com",
+            "GIT_COMMITTER_NAME": "Ada",
+            "GIT_COMMITTER_EMAIL": "ada@example.com",
+        },
     )
     from_seq = bca.vcs_metrics(repo, file_types=["rs", "py"])
     from_str = bca.vcs_metrics(repo, file_types="rs,py")

--- a/check-grammar-marker-sync.py
+++ b/check-grammar-marker-sync.py
@@ -226,9 +226,9 @@ def _coerce_baseline_value(
 def load_baseline() -> dict[str, dict[str, str]] | None:
     """Parse the baseline file.
 
-    Returns None when the baseline is missing (caller renders the
-    "run --update to create it" hint — but `--update` itself
-    refuses this case; see `write_baseline`). Exits with code 2
+    Returns None when the baseline is missing (caller renders a
+    "restore it from git history" hint; `--update` refuses to
+    create a missing baseline — see `write_baseline`). Exits with code 2
     on malformed TOML. Non-string scalars trip a warning and are
     coerced so the drift message remains informative; non-scalar
     values (lists, tables) trip a warning and are treated as

--- a/src/count.rs
+++ b/src/count.rs
@@ -21,8 +21,6 @@
 // function so the per-language impl blocks stay readable.
 #![allow(clippy::wildcard_imports, clippy::enum_glob_use)]
 
-extern crate num_format;
-
 use num_format::{Locale, ToFormattedString};
 use std::fmt;
 use std::sync::{Arc, Mutex};

--- a/src/langs.rs
+++ b/src/langs.rs
@@ -50,7 +50,7 @@ mk_langs!(
     // `cpp` (and `mozcpp`) pull in. `Tsx` rides `typescript` because
     // both variants resolve to the `tree-sitter-typescript` crate
     // (TSX vs TypeScript is a per-grammar `LANGUAGE_*` constant
-    // inside that one crate, see `get_language!` in `src/macros.rs`).
+    // inside that one crate, see `get_language!` in `src/macros/mod.rs`).
     (
         "javascript",
         Javascript,

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -135,6 +135,14 @@ impl fmt::Display for Stats {
 }
 
 impl Stats {
+    // Intentionally a no-op. Halstead distinct-counts (`u_operators` /
+    // `u_operands`) cannot be summed across sibling spaces without
+    // double-counting operators/operands they share. Cross-space
+    // aggregation is instead done by unioning the occurrence maps
+    // (`HalsteadMaps::merge`) and re-running `finalize` on the parent
+    // (see `spaces.rs`). Summing the finalized fields here — mirroring
+    // the sibling metrics' `merge` — would silently inflate every parent
+    // space's n1/n2/N1/N2.
     pub(crate) fn merge(&mut self, _other: &Stats) {}
 
     /// Returns `η1`, the number of distinct operators

--- a/src/metrics/mi.rs
+++ b/src/metrics/mi.rs
@@ -54,6 +54,12 @@ impl fmt::Display for Stats {
 }
 
 impl Stats {
+    // Intentionally a no-op. MI is a derived metric: the parent space
+    // recomputes it from its merged Loc / Cyclomatic / Halstead inputs
+    // (`compute_halstead_mi_and_wmc` in `spaces.rs`), so there is nothing
+    // to roll up from a child's finalized `Stats`. Combining the fields
+    // here would double-apply inputs already captured by the parent's
+    // recompute. (Same rationale as `halstead::Stats::merge`.)
     pub(crate) fn merge(&mut self, _other: &Stats) {}
 
     #[inline]

--- a/src/metrics/wmc.rs
+++ b/src/metrics/wmc.rs
@@ -390,10 +390,11 @@ impl Wmc for ElixirCode {
 }
 
 // Default no-op `Wmc` impls. Audited in #188. See the rationale block
-// on `implement_metric_trait!(Npa, …)` in `src/metrics/npa.rs` — Wmc
-// classification mirrors Npa one-for-one (Wmc = sum-of-cyclomatic-
-// per-method, so it requires the same per-language class / method
-// detection plumbing).
+// on `implement_metric_trait!(Npa, …)` in `src/metrics/npa.rs`. Wmc needs
+// the same per-language class / method detection plumbing (Wmc =
+// sum-of-cyclomatic-per-method), and mirrors Npa's set EXCEPT Go: Npa/Npm
+// implement Go but Wmc no-ops it because Go's flat space model cannot
+// attribute methods to a receiver class (see the Go rationale block above).
 implement_metric_trait!(
     Wmc,
     PreprocCode,

--- a/src/suppression.rs
+++ b/src/suppression.rs
@@ -358,8 +358,8 @@ fn parse_lizard(trimmed: &str) -> Option<Suppression> {
     // `#lizard forgive global` — file-scoped, all metrics.
     //
     // Lizard's own scanner tolerates a single space after `#` and
-    // around the verb, but is otherwise exact. We mirror that:
-    // canonicalize whitespace inside the marker, then match literals.
+    // around the verb, but is otherwise exact. We mirror that by
+    // trimming the ends and matching the verb phrase verbatim.
     let s = trimmed.strip_prefix('#')?.trim_start();
     let s = s.strip_prefix("lizard")?;
     let rest = s.trim();

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -530,6 +530,9 @@ pub(crate) fn normalize_path<P: AsRef<Path>>(path: P) -> PathBuf {
 
     for component in components {
         match component {
+            // A `Prefix` (Windows drive / UNC) component only ever
+            // appears first; the leading peek+next above already
+            // consumed it, so it cannot recur in this loop.
             Component::Prefix(..) => unreachable!(),
             Component::RootDir => {
                 ret.push(component.as_os_str());

--- a/src/vcs/cache.rs
+++ b/src/vcs/cache.rs
@@ -218,7 +218,10 @@ impl HistoryCache {
 /// [`head_sha`]: HistoryCache::head_sha
 ///
 /// `DefaultHasher` is created with fixed keys, so the digest is stable
-/// across processes; [`CACHE_SCHEMA_VERSION`] guards the *meaning* of the
+/// across processes built with the same toolchain (its `SipHasher13`
+/// algorithm is not guaranteed stable across Rust releases — a bump
+/// shifts every fingerprint, which costs a benign cold walk, never a
+/// wrong hit). [`CACHE_SCHEMA_VERSION`] guards the *meaning* of the
 /// inputs, so the fingerprint need only be self-consistent within one
 /// format version.
 #[must_use]

--- a/src/vcs/jit.rs
+++ b/src/vcs/jit.rs
@@ -271,7 +271,7 @@ pub fn score(features: &JitFeatures, purpose: JitPurpose) -> (f64, JitContributi
     let h = &features.history;
     let e = &features.experience;
 
-    let churn = ln1p((s.lines_added + s.lines_deleted) as f64);
+    let churn = ln1p(s.lines_added.saturating_add(s.lines_deleted) as f64);
     let size =
         0.30 * churn + 0.15 * ln1p(f64::from(s.files_touched)) + 0.05 * ln1p(f64::from(s.hunks));
 

--- a/src/vcs/score.rs
+++ b/src/vcs/score.rs
@@ -192,8 +192,8 @@ pub fn apply_percentile(stats: &mut [Stats]) {
         |s| 1.0 - s.ownership_top_share,
         |s| f64::from(s.bug_fix_commits),
         |s| f64::from(s.security_fix_commits),
-        |s| s.change_entropy_recent,
-        |s| s.cochange_entropy_recent,
+        |s| s.change_entropy_recent.max(0.0),
+        |s| s.cochange_entropy_recent.max(0.0),
     ];
 
     let n = stats.len();

--- a/src/vcs/trend.rs
+++ b/src/vcs/trend.rs
@@ -77,7 +77,7 @@ pub fn timestamps(end: i64, span_secs: i64, points: usize) -> Vec<i64> {
     if points <= 1 {
         return vec![end];
     }
-    let start = end - span_secs;
+    let start = end.saturating_sub(span_secs);
     // `points` is small (validated `<= MAX_TREND_POINTS`); `try_from`
     // keeps the conversion total and lint-clean without an `as` wrap.
     let divisor = i64::try_from(points - 1).unwrap_or(i64::MAX);


### PR DESCRIPTION
## Source review & audit sweep (176-file pass)

A systematic per-file review + audit of **every non-test `.rs`/`.py` file** in the workspace (176 files). Each file was checked for logic/metric-computation bugs, per-language consistency, panic-safety, determinism, security, and test quality.

This PR carries only the **behaviour-preserving inline fixes**. All **behaviour-changing findings** (anything that would move a metric snapshot or needs a design decision) were collected and filed as grouped issues under the tracking issue **#710** (≈160 findings across #695–#709) — nothing actionable was dropped.

### Inline fixes in this PR (20 commits)

**Bug fixes:**
- `fix(cli): escape GFM cells in exemptions markdown report` — `|`/newlines in a function name broke the Markdown table; added `escape_gfm_cell` + regression test.
- `fix(vcs): saturate churn sum in pub score formula` — unchecked `u64 + u64` in the `pub` `score()` could debug-panic via a direct API caller; `saturating_add` (behaviour-identical for real inputs).
- `fix(vcs): saturate trend start subtraction in pub timestamps` — same class, the public `timestamps()` start subtraction.
- `fix(vcs): clamp entropy in percentile path for parity with weighted` — the percentile risk path read entropy raw while the weighted path clamps `.max(0.0)`; behaviour-preserving (entropy ≥ 0 today), restores symmetry + future-proofs.

**Cleanup:**
- `chore(lib): drop redundant extern crate num_format` — edition-2024 leftover (matches prior `extern crate` cleanup).

**Doc / comment corrections (stale or misleading):**
- truncated `write_per_file_rollup` doc; stale "Covered"-routing comment; contradictory `write_legend` doc blocks; stale `compute_bus_factor` builder comment; hotspot mixed-case comment; `analyze_batch` zip-guarantee scope; stale `load_baseline` missing-baseline hint; stale `src/macros.rs` path after the dir split; Halstead/MI `Stats::merge` no-op rationale; WMC-vs-Npa "one-for-one" claim (Go diverges); Lizard whitespace-handling comment; `normalize_path` Prefix-unreachable invariant; cache fingerprint cross-toolchain stability.
- `style(cli): keep vcs doc-comment fixes within SLOC budget` — kept two corrected comments net-zero-line so the baselined `loc.sloc` self-scan gate stays green.

Every change kept `make pre-commit` green (cargo fmt/clippy/test, doc, udeps, man-page drift, self-scan hard+headroom, Python ruff/mypy/pytest) — the gate was re-run after every 10th file and at the end.

### Process
- Behaviour-preserving only on this branch — no metric/snapshot changes, so the `big-code-analysis-output` submodule is untouched.
- Findings grouped by theme (per-language consistency, direction-awareness, dump recursion, VCS bit-identity, output-format robustness, …) rather than filed per-file, to keep the tracker actionable.

Closes nothing directly; tracked by #710.
