### PR TITLE
fix(cli): make bare-relative and ./-prefixed globs equivalent

### DIFF
--- a/.bca-baseline.toml
+++ b/.bca-baseline.toml
@@ -96,27 +96,6 @@ metric = "loc.sloc"
 value = 1440.0
 
 [[entry]]
-path = "big-code-analysis-cli/src/walk_seed.rs"
-qualified = "<file>"
-start_line = 1
-metric = "halstead.effort"
-value = 118415.26919508257
-
-[[entry]]
-path = "big-code-analysis-cli/src/walk_seed.rs"
-qualified = "<file>"
-start_line = 1
-metric = "nargs"
-value = 12.0
-
-[[entry]]
-path = "big-code-analysis-cli/src/walk_seed.rs"
-qualified = "<file>"
-start_line = 1
-metric = "nexits"
-value = 5.0
-
-[[entry]]
 path = "big-code-analysis-py/src/batch.rs"
 qualified = "<file>"
 start_line = 1

--- a/.bca-baseline.toml
+++ b/.bca-baseline.toml
@@ -42,7 +42,7 @@ value = 30.0
 [[entry]]
 path = "big-code-analysis-cli/src/lib.rs"
 qualified = "expand_seed_paths"
-start_line = 2734
+start_line = 2756
 metric = "cognitive"
 value = 24.0
 
@@ -100,7 +100,14 @@ path = "big-code-analysis-cli/src/walk_seed.rs"
 qualified = "<file>"
 start_line = 1
 metric = "halstead.effort"
-value = 51592.32760686371
+value = 66503.44629824138
+
+[[entry]]
+path = "big-code-analysis-cli/src/walk_seed.rs"
+qualified = "<file>"
+start_line = 1
+metric = "nargs"
+value = 8.0
 
 [[entry]]
 path = "big-code-analysis-py/src/batch.rs"

--- a/.bca-baseline.toml
+++ b/.bca-baseline.toml
@@ -42,7 +42,7 @@ value = 30.0
 [[entry]]
 path = "big-code-analysis-cli/src/lib.rs"
 qualified = "expand_seed_paths"
-start_line = 2756
+start_line = 2758
 metric = "cognitive"
 value = 24.0
 
@@ -100,14 +100,21 @@ path = "big-code-analysis-cli/src/walk_seed.rs"
 qualified = "<file>"
 start_line = 1
 metric = "halstead.effort"
-value = 66503.44629824138
+value = 118415.26919508257
 
 [[entry]]
 path = "big-code-analysis-cli/src/walk_seed.rs"
 qualified = "<file>"
 start_line = 1
 metric = "nargs"
-value = 8.0
+value = 12.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/walk_seed.rs"
+qualified = "<file>"
+start_line = 1
+metric = "nexits"
+value = 5.0
 
 [[entry]]
 path = "big-code-analysis-py/src/batch.rs"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2279,6 +2279,24 @@ for historical reference.
 
 ### Fixed
 
+- Bare-relative glob patterns now match the same files as their `./`-prefixed
+  equivalents: `--exclude 'dir/**'` is identical to `--exclude './dir/**'`
+  (#726). The walker matches discovered files against a `./`-anchored
+  walk-root path, but patterns were compiled verbatim, so a bare `dir/**`
+  silently matched nothing while `./dir/**` worked — affecting `--include`,
+  `--exclude`, `--exclude-from`, `.bcaignore`, and the `[check.exclude]`
+  gate-exemption set. A leading `./` is now stripped symmetrically from both
+  the pattern and the match path. `**/`-prefixed, `*`, and absolute patterns
+  were unaffected and remain unchanged.
+- A file named directly via `--paths` (or `--paths-from` / manifest `paths`)
+  is now always analyzed regardless of the project's exclude deny-set
+  (`.bcaignore`, `--exclude`, manifest `exclude`), matching the
+  `ripgrep`/`fd`/`git` convention that an explicitly-named path overrides
+  ignore rules (#726). Previously an exclude that matched the named file
+  silently produced "0 files matched"; this was masked for `./`-anchored
+  project patterns by the glob bug above, and surfaced once that was fixed.
+  Directory-walk excludes are unchanged, and an `--include` allow-list still
+  narrows which explicitly-named files are analyzed.
 - CLI `--help` text sweep (#608): relocated 80+ issue-tracker references
   (`#539`, `issue #328`, `pre-#182`, …) out of the user-facing clap
   doc-comments into adjacent `//` maintainer comments; the `bca check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2287,7 +2287,10 @@ for historical reference.
   `--exclude`, `--exclude-from`, `.bcaignore`, and the `[check.exclude]`
   gate-exemption set. A leading `./` is now stripped symmetrically from both
   the pattern and the match path. `**/`-prefixed, `*`, and absolute patterns
-  were unaffected and remain unchanged.
+  were unaffected and remain unchanged. The Python bindings' `analyze_paths`
+  walker had the mirror-image bug — it matched bare seed-relative paths, so
+  `./dir/**` silently matched nothing there — and now accepts both spellings
+  identically as well.
 - A file named directly via `--paths` (or `--paths-from` / manifest `paths`)
   is now always analyzed regardless of the project's exclude deny-set
   (`.bcaignore`, `--exclude`, manifest `exclude`), matching the
@@ -2296,7 +2299,12 @@ for historical reference.
   silently produced "0 files matched"; this was masked for `./`-anchored
   project patterns by the glob bug above, and surfaced once that was fixed.
   Directory-walk excludes are unchanged, and an `--include` allow-list still
-  narrows which explicitly-named files are analyzed.
+  narrows which explicitly-named files are analyzed — matched against the
+  seed's CWD-relative form, so `--include 'src/**'` now accepts
+  `--paths "$PWD/src/f.rs"` exactly like `--paths src/f.rs` (the emitted
+  `name` keeps the as-spelled form). The Python bindings' `analyze_paths`
+  applies the same rule: a file seed bypasses `exclude`, and `include`
+  still narrows it by basename.
 - CLI `--help` text sweep (#608): relocated 80+ issue-tracker references
   (`#539`, `issue #328`, `pre-#182`, …) out of the user-facing clap
   doc-comments into adjacent `//` maintainer comments; the `bca check

--- a/big-code-analysis-book/src/python/batch.md
+++ b/big-code-analysis-book/src/python/batch.md
@@ -46,8 +46,12 @@ results = bca.analyze_paths("path/to/repo", include="*.py")
 
 Each positional seed may be a file or a directory; directories are
 walked honouring `.gitignore`, the `include` / `exclude` globs (a
-single glob string or a sequence), and the generated-file filter.
-`respect_gitignore=False` opts into walking ignored files. The
+single glob string or a sequence; a leading `./` is optional, so
+`dir/**` ≡ `./dir/**`), and the generated-file filter. A seed naming
+a file directly is always analysed regardless of `exclude` — an
+explicit request overrides ignore-style rules — while `include`
+still narrows it by basename. `respect_gitignore=False` opts into
+walking ignored files. The
 result is the same `list[FuncSpaceDict | AnalysisFailure]` shape and
 never-raise contract as `analyze_batch`, and it forwards the same
 `exclude_tests` / `allow_lossy_path` / `skip_generated` / `metrics` /

--- a/big-code-analysis-book/src/recipes/quality-reports.md
+++ b/big-code-analysis-book/src/recipes/quality-reports.md
@@ -78,6 +78,12 @@ bca report \
 > **Flag arity.** `--include` and `--exclude` take exactly one glob per
 > occurrence; repeat the flag for additional patterns. The `=` form
 > works the same way: `--include="*.rs" --exclude="**/target/**"`.
+>
+> **Leading `./` is optional.** A bare-relative pattern and its
+> `./`-prefixed spelling are equivalent: `--exclude "vendor/**"` matches
+> exactly what `--exclude "./vendor/**"` does. This holds for every glob
+> surface — `--include`, `--exclude`, `--exclude-from`, `.bcaignore`, and
+> the `[check.exclude]` gate-exemption set.
 
 For a stable repo-wide deny-set, keep the patterns in a file at the
 repo root (a `.bcaignore` by convention) and load it with

--- a/big-code-analysis-cli/src/commands.rs
+++ b/big-code-analysis-cli/src/commands.rs
@@ -707,7 +707,13 @@ fn apply_check_exclude(
     let before = violations.len();
     let kept: Vec<Violation> = violations
         .into_iter()
-        .filter(|v| !globset.is_match(crate::walk_seed::anchor_against_seeds(&seeds, &v.path)))
+        .filter(|v| {
+            // Anchor to the `./`-relative walk-root form, then strip the
+            // leading `./` so bare-relative `[check.exclude]` patterns match
+            // it just like `./`-prefixed ones (#726).
+            let anchored = crate::walk_seed::anchor_against_seeds(&seeds, &v.path);
+            !globset.is_match(crate::walk_seed::strip_cur_dir(&anchored))
+        })
         .collect();
     let skipped = before - kept.len();
     if skipped > 0 {

--- a/big-code-analysis-cli/src/lib.rs
+++ b/big-code-analysis-cli/src/lib.rs
@@ -283,11 +283,13 @@ struct WalkSelectionArgs {
     /// Glob to include files. Repeat the flag to add multiple globs
     /// (`-I '*.rs' -I '*.toml'`); each occurrence takes exactly one
     /// value, so a positional argument that follows is never swallowed.
+    /// A leading `./` is optional: `dir/**` and `./dir/**` are equivalent.
     #[clap(long, short = 'I', num_args(1), action = clap::ArgAction::Append, help_heading = "Input selection")]
     include: Vec<String>,
     /// Glob to exclude files. Repeat the flag to add multiple globs
     /// (`-X '*.tmp' -X '*.bak'`); each occurrence takes exactly one
     /// value, so a positional argument that follows is never swallowed.
+    /// A leading `./` is optional: `dir/**` and `./dir/**` are equivalent.
     /// CLI values are *merged with* (unioned, not a replacement for) any
     /// `bca.toml` `exclude` list and any `--exclude-from` patterns, so a
     /// CLI `--exclude` never silently un-excludes a directory the
@@ -2371,7 +2373,13 @@ fn mk_globset(elems: Vec<String>) -> Result<GlobSet, String> {
         if e.is_empty() {
             continue;
         }
-        globset.add(Glob::new(e).map_err(|err| format!("invalid glob pattern {e:?}: {err}"))?);
+        // Normalise the optional leading `./` so `dir/**` and `./dir/**`
+        // compile to the same glob; the match-path side is stripped
+        // symmetrically in `WalkFilters::passes` / the `[check.exclude]`
+        // filter (#726).
+        let pattern = walk_seed::strip_dot_slash(e);
+        globset
+            .add(Glob::new(pattern).map_err(|err| format!("invalid glob pattern {e:?}: {err}"))?);
     }
     globset
         .build()
@@ -2669,8 +2677,22 @@ impl WalkFilters<'_> {
     /// walk root (#489), so `./`-anchored patterns match regardless of
     /// how the seed was spelled.
     fn passes(&self, match_path: &Path) -> bool {
+        // Strip a leading `./` so bare-relative patterns (`dir/**`) match
+        // the `./`-anchored walk-root form just like `./dir/**` does (#726).
+        let match_path = walk_seed::strip_cur_dir(match_path);
         (self.include.is_empty() || self.include.is_match(match_path))
             && (self.exclude.is_empty() || !self.exclude.is_match(match_path))
+    }
+
+    /// Does `match_path` satisfy only the include allow-list (empty =
+    /// "all")? Used for explicitly-named file seeds, which bypass the
+    /// exclude deny-set: a project's ignore rules shape *directory-walk*
+    /// scope and must not silently drop a file the user named on the
+    /// command line (#726). The include allow-list still narrows which
+    /// named files are analyzed.
+    fn includes(&self, match_path: &Path) -> bool {
+        let match_path = walk_seed::strip_cur_dir(match_path);
+        self.include.is_empty() || self.include.is_match(match_path)
     }
 }
 
@@ -2783,9 +2805,14 @@ fn expand_seed_paths(
         if kind.is_file() {
             // A single explicit file seed keeps the form the caller
             // spelled (its emitted `name` must match the single-file
-            // `bca.analyze()` API), and is matched against the globs
-            // as-is — the historical single-file filter behaviour.
-            if filters.passes(&seed) && seen.insert(seed.clone()) {
+            // `bca.analyze()` API). It bypasses the exclude deny-set: a
+            // file named directly on the command line is a direct request
+            // that a project's directory-walk ignore rules (`.bcaignore`,
+            // `--exclude`, manifest `exclude`) must not silently drop
+            // (#726), matching the ripgrep/fd convention that an explicit
+            // path overrides ignore rules. An `--include` allow-list still
+            // narrows which named files are analyzed.
+            if filters.includes(&seed) && seen.insert(seed.clone()) {
                 // Record the explicit seed (in its emitted form) so the
                 // per-file dispatch can distinguish it from a
                 // directory-expansion product: an explicitly-named file

--- a/big-code-analysis-cli/src/lib.rs
+++ b/big-code-analysis-cli/src/lib.rs
@@ -2370,14 +2370,16 @@ fn mk_globset(elems: Vec<String>) -> Result<GlobSet, String> {
 
     let mut globset = GlobSetBuilder::new();
     for e in &elems {
-        if e.is_empty() {
-            continue;
-        }
         // Normalise the optional leading `./` so `dir/**` and `./dir/**`
         // compile to the same glob; the match-path side is stripped
         // symmetrically in `WalkFilters::passes` / the `[check.exclude]`
-        // filter (#726).
+        // filter (#726). The emptiness skip runs *after* the strip so a
+        // bare `./` (empty once normalised) is skipped like an empty
+        // pattern instead of compiling an empty glob.
         let pattern = walk_seed::strip_dot_slash(e);
+        if pattern.is_empty() {
+            continue;
+        }
         globset
             .add(Glob::new(pattern).map_err(|err| format!("invalid glob pattern {e:?}: {err}"))?);
     }
@@ -2811,8 +2813,11 @@ fn expand_seed_paths(
             // `--exclude`, manifest `exclude`) must not silently drop
             // (#726), matching the ripgrep/fd convention that an explicit
             // path overrides ignore rules. An `--include` allow-list still
-            // narrows which named files are analyzed.
-            if filters.includes(&seed) && seen.insert(seed.clone()) {
+            // narrows which named files are analyzed, matched against the
+            // seed's CWD-relative form so `--include 'src/**'` treats
+            // `--paths "$PWD/src/f.rs"` and `--paths src/f.rs` alike.
+            let include_form = walk_seed::file_seed_match_path(&seed);
+            if filters.includes(&include_form) && seen.insert(seed.clone()) {
                 // Record the explicit seed (in its emitted form) so the
                 // per-file dispatch can distinguish it from a
                 // directory-expansion product: an explicitly-named file

--- a/big-code-analysis-cli/src/walk_seed.rs
+++ b/big-code-analysis-cli/src/walk_seed.rs
@@ -91,6 +91,35 @@ pub(crate) fn reanchor_seed(seed: PathBuf) -> PathBuf {
     }
 }
 
+/// Strip a single leading `./` from a glob pattern so the bare-relative
+/// spelling (`dir/**`) and the explicit-CWD spelling (`./dir/**`) compile
+/// to the identical glob (#726).
+///
+/// `globset` matches are whole-path anchored, so before this strip
+/// `./dir/**` matched the `./`-prefixed walk-root form (see
+/// [`match_path_for`]) while `dir/**` required the path to *start with*
+/// `dir` and silently matched nothing. Normalising the pattern side here
+/// and the match-path side in [`strip_cur_dir`] makes the two spellings
+/// exactly equivalent. `**/`, `*`, and absolute (`/…`) patterns have no
+/// leading `./` and are returned untouched.
+pub(crate) fn strip_dot_slash(pattern: &str) -> &str {
+    pattern.strip_prefix("./").unwrap_or(pattern)
+}
+
+/// Strip a single leading `CurDir` (`.`) component from a match path so it
+/// compares in the same no-`./` space as a [`strip_dot_slash`]-normalised
+/// pattern (#726).
+///
+/// `strip_prefix(".")` is purely lexical: it removes only a leading
+/// `CurDir` component and leaves absolute or already-bare paths unchanged,
+/// so `./dir/foo` becomes `dir/foo` while `/abs/foo` and `dir/foo` pass
+/// through verbatim. Applied immediately before `is_match` at both match
+/// sites; the emitted output path (baseline keys, report names) derives
+/// from the real file path, not this match form, so it is unaffected.
+pub(crate) fn strip_cur_dir(match_path: &std::path::Path) -> &std::path::Path {
+    match_path.strip_prefix(".").unwrap_or(match_path)
+}
+
 /// Compute the path to match exclude/include globs against for a file
 /// `path` discovered under the directory walk `seed`.
 ///

--- a/big-code-analysis-cli/src/walk_seed.rs
+++ b/big-code-analysis-cli/src/walk_seed.rs
@@ -1,3 +1,11 @@
+// bca: suppress-file(halstead, nargs, nexits)
+// File-level halstead/nargs/nexits are aggregation artifacts: this
+// module is many small path-normalisation helpers (strip, anchor,
+// reanchor, match-form) whose early returns and parameters sum at the
+// file level without any one function being complex
+// (cognitive/cyclomatic stay enforced) — the same posture as
+// big-code-analysis-py/src/walk.rs.
+
 //! Walk-seed re-anchoring.
 //!
 //! Keeps the walker's emitted path form independent of how the user
@@ -88,17 +96,26 @@ pub(crate) fn reanchor_seed(seed: PathBuf) -> PathBuf {
 /// lexically nor canonically under `cwd`. The lexical strip is tried
 /// first (no syscall on the common at/under-CWD case); the canonical
 /// retry covers a seed spelled through a symlinked ancestor (the macOS
-/// `/tmp` → `/private/tmp` default). Shared by [`reanchor_seed`] and
-/// [`file_seed_match_path`], which differ only in what they do with the
-/// remainder.
+/// `/tmp` → `/private/tmp` default); the final canonical-`cwd` retry
+/// covers Windows, where `canonicalize` yields a `\\?\`-verbatim path
+/// while `current_dir` is typically non-verbatim, so the first two
+/// strips never share a prefix — canonicalizing both sides puts them in
+/// the same form (it also rescues a Unix `cwd` reached through a
+/// symlink). Shared by [`reanchor_seed`] and [`file_seed_match_path`],
+/// which differ only in what they do with the remainder.
 fn cwd_relative_tail(path: &std::path::Path, cwd: &std::path::Path) -> Option<PathBuf> {
-    match path.strip_prefix(cwd) {
-        Ok(rel) => Some(rel.to_path_buf()),
-        Err(_) => match path.canonicalize() {
-            Ok(canonical) => canonical.strip_prefix(cwd).ok().map(PathBuf::from),
-            Err(_) => None,
-        },
+    if let Ok(rel) = path.strip_prefix(cwd) {
+        return Some(rel.to_path_buf());
     }
+    let canonical = path.canonicalize().ok()?;
+    if let Ok(rel) = canonical.strip_prefix(cwd) {
+        return Some(rel.to_path_buf());
+    }
+    let canonical_cwd = cwd.canonicalize().ok()?;
+    canonical
+        .strip_prefix(&canonical_cwd)
+        .ok()
+        .map(PathBuf::from)
 }
 
 /// The path to match `--include` globs against for an *explicitly named

--- a/big-code-analysis-cli/src/walk_seed.rs
+++ b/big-code-analysis-cli/src/walk_seed.rs
@@ -74,20 +74,59 @@ pub(crate) fn reanchor_seed(seed: PathBuf) -> PathBuf {
     // failure path, so the common at/under-CWD seed pays no extra syscall); an
     // unresolvable or genuinely-outside seed keeps its as-spelled absolute
     // form, the only stable identity for it.
-    let stripped = match seed.strip_prefix(&cwd) {
-        Ok(rel) => Some(rel.to_path_buf()),
-        Err(_) => match seed.canonicalize() {
-            Ok(canonical) => canonical.strip_prefix(&cwd).ok().map(PathBuf::from),
-            Err(_) => None,
-        },
-    };
-    match stripped {
+    match cwd_relative_tail(&seed, &cwd) {
         Some(rel) if rel.as_os_str().is_empty() => PathBuf::from("."),
         Some(rel) => rel,
         // Neither lexically nor canonically under the CWD (an unresolvable or
         // genuinely-outside seed). Keep the as-spelled absolute seed; its
         // emitted paths keep that form, the only stable identity for them.
         None => seed,
+    }
+}
+
+/// The CWD-relative remainder of `path`, or `None` when it is neither
+/// lexically nor canonically under `cwd`. The lexical strip is tried
+/// first (no syscall on the common at/under-CWD case); the canonical
+/// retry covers a seed spelled through a symlinked ancestor (the macOS
+/// `/tmp` → `/private/tmp` default). Shared by [`reanchor_seed`] and
+/// [`file_seed_match_path`], which differ only in what they do with the
+/// remainder.
+fn cwd_relative_tail(path: &std::path::Path, cwd: &std::path::Path) -> Option<PathBuf> {
+    match path.strip_prefix(cwd) {
+        Ok(rel) => Some(rel.to_path_buf()),
+        Err(_) => match path.canonicalize() {
+            Ok(canonical) => canonical.strip_prefix(cwd).ok().map(PathBuf::from),
+            Err(_) => None,
+        },
+    }
+}
+
+/// The path to match `--include` globs against for an *explicitly named
+/// file seed*: its CWD-relative tail when the file lies under the CWD,
+/// otherwise the seed as spelled.
+///
+/// [`reanchor_seed`] deliberately leaves file seeds untouched because it
+/// rewrites the *emitted* `name` (which must echo the caller's spelling
+/// for single-file API parity, #488). This helper exists for the *match*
+/// form only — the same emit/match separation `match_path_for` draws for
+/// directory walks (#489) — so `--paths "$PWD/src/foo.rs" --include
+/// 'src/**'` matches exactly like `--paths src/foo.rs` does, without
+/// changing what the run emits (#726). A relative seed already is its
+/// own match form; a file outside the CWD has no relative identity and
+/// is matched as spelled (a `**/`-prefixed or `*`-style include still
+/// applies to it).
+pub(crate) fn file_seed_match_path(seed: &std::path::Path) -> PathBuf {
+    if seed.is_relative() {
+        return seed.to_path_buf();
+    }
+    let Ok(cwd) = std::env::current_dir() else {
+        return seed.to_path_buf();
+    };
+    match cwd_relative_tail(seed, &cwd) {
+        // A file seed can never *be* the CWD, so a non-empty remainder is
+        // the only Some shape reachable here; guard anyway.
+        Some(rel) if !rel.as_os_str().is_empty() => rel,
+        _ => seed.to_path_buf(),
     }
 }
 
@@ -101,9 +140,15 @@ pub(crate) fn reanchor_seed(seed: PathBuf) -> PathBuf {
 /// `dir` and silently matched nothing. Normalising the pattern side here
 /// and the match-path side in [`strip_cur_dir`] makes the two spellings
 /// exactly equivalent. `**/`, `*`, and absolute (`/…`) patterns have no
-/// leading `./` and are returned untouched.
+/// leading `./` and are returned untouched. A doubled-slash spelling
+/// (`.//x`) is also returned untouched: stripping it would leave `/x`,
+/// silently turning a (malformed) relative pattern into an
+/// absolute-anchored one.
 pub(crate) fn strip_dot_slash(pattern: &str) -> &str {
-    pattern.strip_prefix("./").unwrap_or(pattern)
+    pattern
+        .strip_prefix("./")
+        .filter(|rest| !rest.starts_with('/'))
+        .unwrap_or(pattern)
 }
 
 /// Strip a single leading `CurDir` (`.`) component from a match path so it

--- a/big-code-analysis-cli/src/walk_seed_tests.rs
+++ b/big-code-analysis-cli/src/walk_seed_tests.rs
@@ -1,5 +1,36 @@
-use super::{anchor_against_seeds, match_path_for, reanchor_seed, strip_cur_dir, strip_dot_slash};
+use super::{
+    anchor_against_seeds, file_seed_match_path, match_path_for, reanchor_seed, strip_cur_dir,
+    strip_dot_slash,
+};
 use std::path::{Path, PathBuf};
+
+#[test]
+fn file_seed_match_path_anchors_absolute_file_under_cwd_to_relative_tail() {
+    // #726 include-side: `--paths "$PWD/src/lib.rs" --include 'src/**'`
+    // must match like `--paths src/lib.rs`. The match form (not the
+    // emitted name) becomes the CWD-relative tail.
+    let mut seed = std::env::current_dir().expect("cwd available in test");
+    seed.push("src");
+    seed.push("lib.rs");
+    assert!(seed.is_file(), "crate src/lib.rs must exist for this test");
+    assert_eq!(file_seed_match_path(&seed), Path::new("src/lib.rs"));
+}
+
+#[test]
+fn file_seed_match_path_leaves_relative_and_outside_cwd_seeds_as_spelled() {
+    // A relative seed already is its own match form.
+    assert_eq!(
+        file_seed_match_path(Path::new("vendor/drop.py")),
+        Path::new("vendor/drop.py")
+    );
+    // A file outside the CWD has no relative identity: as spelled.
+    let outside = if cfg!(windows) {
+        PathBuf::from(r"C:\definitely\not\under\cwd\f.rs")
+    } else {
+        PathBuf::from("/definitely/not/under/cwd/f.rs")
+    };
+    assert_eq!(file_seed_match_path(&outside), outside);
+}
 
 #[test]
 fn strip_dot_slash_normalises_only_a_single_leading_dot_slash() {
@@ -12,8 +43,12 @@ fn strip_dot_slash_normalises_only_a_single_leading_dot_slash() {
     assert_eq!(strip_dot_slash("/abs/dir/**"), "/abs/dir/**");
     // A lone `.` (no slash) is not a `./` prefix and is left as-is.
     assert_eq!(strip_dot_slash("."), ".");
-    // Only one `./` is stripped, never a `.//` double prefix.
-    assert_eq!(strip_dot_slash(".//x"), "/x");
+    // A doubled-slash spelling is NOT stripped: `.//x` minus `./` would
+    // be the absolute-anchored `/x`, silently changing the pattern's
+    // meaning. Malformed input keeps its (non-matching) form.
+    assert_eq!(strip_dot_slash(".//x"), ".//x");
+    // A bare `./` strips to empty; `mk_globset` skips it post-strip.
+    assert_eq!(strip_dot_slash("./"), "");
 }
 
 #[test]

--- a/big-code-analysis-cli/src/walk_seed_tests.rs
+++ b/big-code-analysis-cli/src/walk_seed_tests.rs
@@ -1,8 +1,36 @@
 use super::{
-    anchor_against_seeds, file_seed_match_path, match_path_for, reanchor_seed, strip_cur_dir,
-    strip_dot_slash,
+    anchor_against_seeds, cwd_relative_tail, file_seed_match_path, match_path_for, reanchor_seed,
+    strip_cur_dir, strip_dot_slash,
 };
 use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+#[test]
+fn cwd_relative_tail_canonicalizes_both_sides_when_forms_diverge() {
+    // The third fallback: when `path` and `cwd` are spelled in forms that
+    // share no lexical prefix even after canonicalizing `path` (on Windows
+    // a `\\?\`-verbatim canonical path vs a non-verbatim CWD; simulated
+    // here with a symlinked `cwd`), canonicalizing BOTH sides must still
+    // recover the relative tail. Pre-fix this returned `None` and the
+    // explicit-file include anchoring silently fell back to the absolute
+    // as-spelled form on Windows CI.
+    let td = tempfile::tempdir().expect("tempdir");
+    let real_root = td.path().canonicalize().expect("canonical tempdir");
+    let sub = real_root.join("sub");
+    std::fs::create_dir(&sub).expect("create subdir");
+    std::fs::write(sub.join("f.rs"), "fn f() {}\n").expect("write fixture");
+    let link = real_root.join("root-link");
+    std::os::unix::fs::symlink(&real_root, &link).expect("create symlink");
+
+    // `path` is canonical; `cwd` is spelled through the symlink, so the
+    // lexical strip and the canonical-`path` strip both fail — only the
+    // canonical-`cwd` retry succeeds.
+    assert_eq!(
+        cwd_relative_tail(&sub.join("f.rs"), &link),
+        Some(PathBuf::from("sub/f.rs")),
+        "diverging path/cwd spellings must still yield the relative tail"
+    );
+}
 
 #[test]
 fn file_seed_match_path_anchors_absolute_file_under_cwd_to_relative_tail() {

--- a/big-code-analysis-cli/src/walk_seed_tests.rs
+++ b/big-code-analysis-cli/src/walk_seed_tests.rs
@@ -1,12 +1,15 @@
 use super::{
-    anchor_against_seeds, cwd_relative_tail, file_seed_match_path, match_path_for, reanchor_seed,
-    strip_cur_dir, strip_dot_slash,
+    anchor_against_seeds, file_seed_match_path, match_path_for, reanchor_seed, strip_cur_dir,
+    strip_dot_slash,
 };
 use std::path::{Path, PathBuf};
 
 #[cfg(unix)]
 #[test]
 fn cwd_relative_tail_canonicalizes_both_sides_when_forms_diverge() {
+    // Imported here (not at module scope) so the symbol is not "unused"
+    // on non-unix targets, where this is the only caller in tests.
+    use super::cwd_relative_tail;
     // The third fallback: when `path` and `cwd` are spelled in forms that
     // share no lexical prefix even after canonicalizing `path` (on Windows
     // a `\\?\`-verbatim canonical path vs a non-verbatim CWD; simulated

--- a/big-code-analysis-cli/src/walk_seed_tests.rs
+++ b/big-code-analysis-cli/src/walk_seed_tests.rs
@@ -1,5 +1,93 @@
-use super::{anchor_against_seeds, match_path_for, reanchor_seed};
+use super::{anchor_against_seeds, match_path_for, reanchor_seed, strip_cur_dir, strip_dot_slash};
 use std::path::{Path, PathBuf};
+
+#[test]
+fn strip_dot_slash_normalises_only_a_single_leading_dot_slash() {
+    // #726: `dir/**` and `./dir/**` must compile to the identical glob.
+    assert_eq!(strip_dot_slash("./cve-corpus/**"), "cve-corpus/**");
+    assert_eq!(strip_dot_slash("cve-corpus/**"), "cve-corpus/**");
+    // Forms that already work are untouched: `**/`, `*`, and absolute.
+    assert_eq!(strip_dot_slash("**/cve-corpus/**"), "**/cve-corpus/**");
+    assert_eq!(strip_dot_slash("*.rs"), "*.rs");
+    assert_eq!(strip_dot_slash("/abs/dir/**"), "/abs/dir/**");
+    // A lone `.` (no slash) is not a `./` prefix and is left as-is.
+    assert_eq!(strip_dot_slash("."), ".");
+    // Only one `./` is stripped, never a `.//` double prefix.
+    assert_eq!(strip_dot_slash(".//x"), "/x");
+}
+
+#[test]
+fn strip_cur_dir_strips_only_a_leading_curdir_component() {
+    // #726: the match-path side drops a leading `./` so it compares in the
+    // same no-`./` space as a `strip_dot_slash`-normalised pattern.
+    assert_eq!(
+        strip_cur_dir(Path::new("./cve-corpus/foo.c")),
+        Path::new("cve-corpus/foo.c")
+    );
+    // Bare-relative and absolute paths have no leading `CurDir`: untouched.
+    assert_eq!(
+        strip_cur_dir(Path::new("cve-corpus/foo.c")),
+        Path::new("cve-corpus/foo.c")
+    );
+    assert_eq!(
+        strip_cur_dir(Path::new("/abs/cve-corpus/foo.c")),
+        Path::new("/abs/cve-corpus/foo.c")
+    );
+}
+
+#[test]
+fn bare_relative_pattern_matches_match_path_for_every_seed_form() {
+    // #726 core parity: a globset built from the bare-relative `cve-corpus/**`
+    // must exclude the `match_path_for(seed, file)` form for every seed
+    // spelling, exactly as the `./cve-corpus/**` spelling already did.
+    use globset::{Glob, GlobSet, GlobSetBuilder};
+
+    fn globset_of(pattern: &str) -> GlobSet {
+        let mut b = GlobSetBuilder::new();
+        b.add(Glob::new(strip_dot_slash(pattern)).expect("valid glob"));
+        b.build().expect("valid globset")
+    }
+
+    let bare = globset_of("cve-corpus/**");
+    let dotted = globset_of("./cve-corpus/**");
+
+    // Absolute walk root, `.` walk root, and bare-relative subdir seed all
+    // emit a `./`-prefixed match path that the bare pattern must now match.
+    let cases = [
+        (
+            PathBuf::from("/repo"),
+            PathBuf::from("/repo/cve-corpus/x.c"),
+        ),
+        (PathBuf::from("."), PathBuf::from("./cve-corpus/x.c")),
+        (PathBuf::from("src"), PathBuf::from("src/cve-corpus/x.c")),
+    ];
+    for (seed, file) in cases {
+        let match_path = match_path_for(&seed, &file);
+        let stripped = strip_cur_dir(&match_path);
+        assert!(
+            bare.is_match(stripped),
+            "bare `cve-corpus/**` must match {match_path:?} (seed {seed:?})"
+        );
+        assert_eq!(
+            bare.is_match(stripped),
+            dotted.is_match(stripped),
+            "`cve-corpus/**` and `./cve-corpus/**` must agree for {match_path:?}"
+        );
+    }
+
+    // A sibling directory must NOT be excluded by either spelling — guards
+    // against the strip widening the match.
+    let keep = match_path_for(&PathBuf::from("/repo"), &PathBuf::from("/repo/src/x.c"));
+    let keep = strip_cur_dir(&keep);
+    assert!(
+        !bare.is_match(keep),
+        "bare pattern must not match a sibling dir"
+    );
+    assert!(
+        !dotted.is_match(keep),
+        "dotted pattern must not match a sibling dir"
+    );
+}
 
 #[test]
 fn relative_seed_is_unchanged() {

--- a/big-code-analysis-cli/tests/check_exclude.rs
+++ b/big-code-analysis-cli/tests/check_exclude.rs
@@ -70,6 +70,35 @@ fn check_exclude_flag_drops_matching_offenders_only() {
         ));
 }
 
+/// #726: a *bare-relative* `[check.exclude]` glob (no `**/`, no `./`)
+/// must match the `./`-anchored violation path just like a `./`-prefixed
+/// one. Pre-fix `excluded.rs` never matched the emitted `./excluded.rs`
+/// form, so the offender leaked past the gate. The existing tests all use
+/// `**/excluded.rs`, whose `**` absorbs the leading `./` and hides the
+/// bug; this case exercises the surface that actually regressed.
+#[test]
+fn check_exclude_bare_relative_glob_drops_matching_offenders() {
+    let dir = two_file_fixture();
+
+    cli(dir.path())
+        .args([
+            "check",
+            "--paths",
+            dir.path().to_str().unwrap(),
+            "--threshold",
+            "cyclomatic=1",
+            "--check-exclude",
+            "excluded.rs",
+        ])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("kept_offender"))
+        .stderr(predicate::str::contains("excluded_offender").not())
+        .stderr(predicate::str::contains(
+            "skipped 1 violations via [check.exclude]",
+        ));
+}
+
 /// When the glob covers the *only* offender, the gate passes clean
 /// (exit 0). The file is still walked (so the "no input files matched"
 /// tool error does not fire) — its violation is simply dropped.

--- a/big-code-analysis-cli/tests/exclude_path_form.rs
+++ b/big-code-analysis-cli/tests/exclude_path_form.rs
@@ -293,6 +293,149 @@ fn include_glob_is_anchored_to_walk_root_from_subdir() {
     );
 }
 
+/// Run `bca metrics` with an inline `--exclude <pattern>` (one per
+/// pattern) for the given `--paths` seed, returning the emitted JSON
+/// basenames. Unlike `walked_with_seed` this exercises the inline
+/// `--exclude` → `mk_globset` path, the surface #726 reported.
+fn walked_with_inline_excludes(
+    fixture: &Path,
+    cwd: &Path,
+    seed: &str,
+    excludes: &[&str],
+) -> Vec<String> {
+    let out = TempDir::new().unwrap();
+    let mut cmd = cli(fixture);
+    cmd.current_dir(cwd).args(["metrics", "--paths", seed]);
+    for pat in excludes {
+        cmd.args(["--exclude", pat]);
+    }
+    cmd.args(["-O", "json", "--output-dir", out.path().to_str().unwrap()])
+        .assert()
+        .success();
+    emitted_json(out.path())
+}
+
+#[test]
+fn bare_relative_exclude_matches_dot_prefixed_exclude() {
+    // #726: `--exclude 'vendor/**'` (bare-relative) must exclude the same
+    // files as `--exclude './vendor/**'`. Pre-fix the bare spelling never
+    // matched the `./`-prefixed walk-root form, so vendor/ and tests/ leaked
+    // straight back into the analysed set. Run both the `--paths .` and the
+    // absolute-seed form so the fix is pinned for every match-path shape.
+    let dir = TempDir::new().unwrap();
+    let fixture = dir.path().canonicalize().unwrap();
+    make_tree(&fixture);
+
+    let expected = vec!["keep.py.json".to_string()];
+
+    for seed in [".", fixture.to_str().unwrap()] {
+        let bare =
+            walked_with_inline_excludes(&fixture, &fixture, seed, &["vendor/**", "tests/**"]);
+        let dotted =
+            walked_with_inline_excludes(&fixture, &fixture, seed, &["./vendor/**", "./tests/**"]);
+        assert_eq!(
+            bare, expected,
+            "bare `vendor/**`/`tests/**` must exclude both dirs (seed {seed:?})"
+        );
+        assert_eq!(
+            dotted, expected,
+            "dotted `./vendor/**`/`./tests/**` must exclude both dirs (seed {seed:?})"
+        );
+        assert_eq!(
+            bare, dotted,
+            "bare and `./`-prefixed excludes must be identical (seed {seed:?})"
+        );
+    }
+}
+
+#[test]
+fn bare_relative_include_matches_dot_prefixed_include() {
+    // #726 mirror for the include surface: `--include 'src/**'` must keep
+    // the same files as `--include './src/**'`. Pre-fix the bare include
+    // matched the `./`-prefixed form nowhere and dropped every file.
+    let dir = TempDir::new().unwrap();
+    let fixture = dir.path().canonicalize().unwrap();
+    make_tree(&fixture);
+    let out_bare = TempDir::new().unwrap();
+    cli(&fixture)
+        .current_dir(&fixture)
+        .args([
+            "metrics",
+            "--paths",
+            ".",
+            "--include",
+            "src/**",
+            "-O",
+            "json",
+            "--output-dir",
+            out_bare.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    assert_eq!(
+        emitted_json(out_bare.path()),
+        vec!["keep.py.json".to_string()],
+        "bare `src/**` include must keep only src/keep.py (#726)"
+    );
+}
+
+#[test]
+fn explicit_file_seed_bypasses_exclude_but_honors_include() {
+    // #726 UX: a file named directly on the command line is a direct
+    // request and must not be dropped by a directory-walk exclude (the
+    // ripgrep/fd convention that an explicit path overrides ignore rules).
+    // The same exclude still drops the file in a *directory* walk, and an
+    // `--include` allow-list still narrows an explicitly-named file.
+    let dir = TempDir::new().unwrap();
+    let fixture = dir.path().canonicalize().unwrap();
+    make_tree(&fixture);
+    let vendored = fixture.join("vendor").join("drop.py");
+
+    // Directory walk: `--exclude vendor/** tests/**` leaves only keep.py.
+    let walked = walked_with_inline_excludes(&fixture, &fixture, ".", &["vendor/**", "tests/**"]);
+    assert_eq!(
+        walked,
+        vec!["keep.py.json".to_string()],
+        "directory walk must still honor the excludes"
+    );
+
+    // Explicit file seed under the excluded vendor/ dir, spelled
+    // *relative* so the bare `vendor/**` exclude would match it under the
+    // old `passes` gate — the exact form that test-via-revert perturbs.
+    // It must still be analyzed: the explicit request overrides the
+    // exclude deny-set.
+    let explicit =
+        walked_with_inline_excludes(&fixture, &fixture, "vendor/drop.py", &["vendor/**"]);
+    assert_eq!(
+        explicit,
+        vec!["drop.py.json".to_string()],
+        "an explicitly-named file must bypass the exclude deny-set (#726)"
+    );
+
+    // An `--include` allow-list still narrows it: include only *.rs drops
+    // the explicitly-named .py file.
+    let out = TempDir::new().unwrap();
+    cli(&fixture)
+        .current_dir(&fixture)
+        .args([
+            "metrics",
+            "--paths",
+            vendored.to_str().unwrap(),
+            "--include",
+            "*.rs",
+            "-O",
+            "json",
+            "--output-dir",
+            out.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    assert!(
+        emitted_json(out.path()).is_empty(),
+        "an explicitly-named file must still honor the --include allow-list"
+    );
+}
+
 #[test]
 fn absolute_subdir_seed_still_excludes() {
     // A seed that is an absolute path to a *subdirectory* of the walk

--- a/big-code-analysis-cli/tests/exclude_path_form.rs
+++ b/big-code-analysis-cli/tests/exclude_path_form.rs
@@ -348,6 +348,28 @@ fn bare_relative_exclude_matches_dot_prefixed_exclude() {
     }
 }
 
+/// Run `bca metrics --paths . --include <pattern>` from the fixture root
+/// and return the emitted JSON basenames.
+fn walked_with_include(fixture: &Path, include: &str) -> Vec<String> {
+    let out = TempDir::new().unwrap();
+    cli(fixture)
+        .current_dir(fixture)
+        .args([
+            "metrics",
+            "--paths",
+            ".",
+            "--include",
+            include,
+            "-O",
+            "json",
+            "--output-dir",
+            out.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    emitted_json(out.path())
+}
+
 #[test]
 fn bare_relative_include_matches_dot_prefixed_include() {
     // #726 mirror for the include surface: `--include 'src/**'` must keep
@@ -356,26 +378,21 @@ fn bare_relative_include_matches_dot_prefixed_include() {
     let dir = TempDir::new().unwrap();
     let fixture = dir.path().canonicalize().unwrap();
     make_tree(&fixture);
-    let out_bare = TempDir::new().unwrap();
-    cli(&fixture)
-        .current_dir(&fixture)
-        .args([
-            "metrics",
-            "--paths",
-            ".",
-            "--include",
-            "src/**",
-            "-O",
-            "json",
-            "--output-dir",
-            out_bare.path().to_str().unwrap(),
-        ])
-        .assert()
-        .success();
+
+    let expected = vec!["keep.py.json".to_string()];
+    let bare = walked_with_include(&fixture, "src/**");
+    let dotted = walked_with_include(&fixture, "./src/**");
     assert_eq!(
-        emitted_json(out_bare.path()),
-        vec!["keep.py.json".to_string()],
+        bare, expected,
         "bare `src/**` include must keep only src/keep.py (#726)"
+    );
+    assert_eq!(
+        dotted, expected,
+        "dotted `./src/**` include must keep only src/keep.py"
+    );
+    assert_eq!(
+        bare, dotted,
+        "bare and `./`-prefixed includes must be identical (#726)"
     );
 }
 
@@ -433,6 +450,41 @@ fn explicit_file_seed_bypasses_exclude_but_honors_include() {
     assert!(
         emitted_json(out.path()).is_empty(),
         "an explicitly-named file must still honor the --include allow-list"
+    );
+}
+
+#[test]
+fn explicit_absolute_file_seed_include_matches_cwd_relative_form() {
+    // #726 include-side anchoring: a dir-prefixed include (`vendor/**`)
+    // must accept an explicitly named *absolute* file under the CWD the
+    // same way it accepts the relative spelling — the include is matched
+    // against the seed's CWD-relative tail, not the raw absolute string.
+    let dir = TempDir::new().unwrap();
+    let fixture = dir.path().canonicalize().unwrap();
+    make_tree(&fixture);
+    let vendored = fixture.join("vendor").join("drop.py");
+
+    let out = TempDir::new().unwrap();
+    cli(&fixture)
+        .current_dir(&fixture)
+        .args([
+            "metrics",
+            "--paths",
+            vendored.to_str().unwrap(),
+            "--include",
+            "vendor/**",
+            "-O",
+            "json",
+            "--output-dir",
+            out.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    assert_eq!(
+        emitted_json(out.path()),
+        vec!["drop.py.json".to_string()],
+        "an absolute explicit file under the CWD must match a dir-prefixed \
+         include via its CWD-relative tail (#726)"
     );
 }
 

--- a/big-code-analysis-py/python/big_code_analysis/_native.pyi
+++ b/big-code-analysis-py/python/big_code_analysis/_native.pyi
@@ -512,7 +512,12 @@ def analyze_paths(
     ``include`` / ``exclude`` accept a single glob string or a sequence
     of them; globs are matched against each file's path relative to its
     walk seed (so ``include="*.rs"`` matches ``src/lib.rs`` by its
-    basename). Pass ``respect_gitignore=False`` to walk ignored files
+    basename), and a leading ``./`` on a pattern is optional —
+    ``dir/**`` and ``./dir/**`` are equivalent. A seed that names a
+    *file* directly is always analysed regardless of ``exclude`` (an
+    explicit request overrides ignore-style rules); ``include`` still
+    narrows it, matched on its basename.
+    Pass ``respect_gitignore=False`` to walk ignored files
     too. The remaining kwargs (``exclude_tests`` / ``allow_lossy_path``
     / ``skip_generated`` / ``metrics`` / ``vcs`` / ``vcs_per_function``)
     forward to per-file analysis exactly as on :func:`analyze` /

--- a/big-code-analysis-py/src/batch.rs
+++ b/big-code-analysis-py/src/batch.rs
@@ -573,8 +573,8 @@ impl VcsRepoCache {
 /// the [`analyze_batch`] result shape (issue #658).
 ///
 /// Each positional `path` may be a file or a directory; directories are
-/// walked with `.gitignore` awareness (the same [`ignore`](crate::walk)
-/// crate the CLI walker uses), honouring the `include` / `exclude` globs.
+/// walked with `.gitignore` awareness honouring `include` / `exclude` —
+/// see [`crate::walk`] for the glob and file-seed semantics (#726).
 /// The walk is the discovery step `analyze_batch` lacks; per-file analysis,
 /// the never-raise contract (failures become `AnalysisFailure` elements),
 /// the generated-file filter, and language inference are identical to

--- a/big-code-analysis-py/src/walk.rs
+++ b/big-code-analysis-py/src/walk.rs
@@ -11,8 +11,16 @@
 //! rather than reimplementing the walk in Python. The CLI's own walker is
 //! binary-private, so this is a focused re-expression of the same
 //! behaviour against the underlying crates: `.gitignore` / `.ignore` /
-//! parent-ignore awareness, root-relative include/exclude globs, and a
-//! per-seed walk where each seed may be a file or a directory.
+//! parent-ignore awareness, root-relative include/exclude globs (a
+//! leading `./` on a pattern is optional — `dir/**` ≡ `./dir/**`, #726),
+//! and a per-seed walk where each seed may be a file or a directory.
+//! An explicitly named *file* seed bypasses the exclude deny-set
+//! (mirroring the CLI, #726): naming a file is a direct request that
+//! ignore-style rules must not silently drop; the include allow-list
+//! still narrows it, matched on its basename (the root-relative form of
+//! a file that is its own walk root — the CLI instead matches an
+//! explicit file's include against its CWD-relative spelling, a
+//! deliberate difference since these walks are not CWD-scoped).
 //!
 //! Language inference and the generated-file filter are *not* applied
 //! here — they run per file inside [`crate::analysis::analyze_path`]
@@ -33,7 +41,9 @@ use pyo3::exceptions::PyValueError;
 /// Both are matched against each file's path *relative to the walk seed*
 /// (mirroring the CLI's walk-root-relative anchoring), so `include=["*.rs"]`
 /// matches `src/lib.rs` by its basename glob without the caller spelling out
-/// the directory prefix. An empty include set means "no include filter"
+/// the directory prefix. A pattern's leading `./` is optional — it is
+/// stripped at compile time so `dir/**` and `./dir/**` are equivalent,
+/// matching the CLI (#726). An empty include set means "no include filter"
 /// (every file passes); an empty exclude set excludes nothing.
 pub(crate) struct WalkFilters {
     include: GlobSet,
@@ -55,10 +65,14 @@ impl WalkFilters {
     /// match the include set (when non-empty) and must not match the
     /// exclude set.
     fn accepts(&self, rel: &Path) -> bool {
-        if !self.include.is_empty() && !self.include.is_match(rel) {
-            return false;
-        }
-        !self.exclude.is_match(rel)
+        self.includes(rel) && !self.exclude.is_match(rel)
+    }
+
+    /// Whether `rel` satisfies only the include allow-list (empty =
+    /// "all"). Used for explicitly named file seeds, which bypass the
+    /// exclude deny-set (#726) — see the module docs.
+    fn includes(&self, rel: &Path) -> bool {
+        self.include.is_empty() || self.include.is_match(rel)
     }
 }
 
@@ -67,7 +81,22 @@ impl WalkFilters {
 fn build_globset(patterns: Vec<String>, flag: &str) -> PyResult<GlobSet> {
     let mut builder = GlobSetBuilder::new();
     for pattern in patterns {
-        let glob = Glob::new(&pattern)
+        // Strip a single optional leading `./` so `dir/**` and `./dir/**`
+        // compile to the identical glob (#726) — matched paths here are
+        // already bare seed-relative, so only the pattern side needs the
+        // strip. Keep in sync with the CLI's `walk_seed::strip_dot_slash`
+        // (binary-private, hence this small duplicate): a doubled-slash
+        // spelling (`.//x`) is left untouched so a malformed relative
+        // pattern cannot silently become an absolute-anchored one, and a
+        // pattern empty after the strip is skipped.
+        let normalized = pattern
+            .strip_prefix("./")
+            .filter(|rest| !rest.starts_with('/'))
+            .unwrap_or(&pattern);
+        if normalized.is_empty() {
+            continue;
+        }
+        let glob = Glob::new(normalized)
             .map_err(|e| PyValueError::new_err(format!("invalid {flag} glob {pattern:?}: {e}")))?;
         builder.add(glob);
     }
@@ -79,11 +108,12 @@ fn build_globset(patterns: Vec<String>, flag: &str) -> PyResult<GlobSet> {
 /// Walk every seed in `paths`, returning the discovered files in a stable
 /// order.
 ///
-/// Each seed may be a file (emitted directly, still subject to the glob
-/// filters relative to its own basename) or a directory (walked with
-/// gitignore awareness when `respect_gitignore` is true). Files are
-/// de-duplicated across seeds while preserving first-seen order, so
-/// overlapping seeds do not double-analyse a file.
+/// Each seed may be a file (emitted directly; the include allow-list is
+/// matched on its basename, the exclude deny-set does not apply — an
+/// explicitly named file is a direct request, #726) or a directory
+/// (walked with gitignore awareness when `respect_gitignore` is true).
+/// Files are de-duplicated across seeds while preserving first-seen
+/// order, so overlapping seeds do not double-analyse a file.
 pub(crate) fn walk_paths(
     paths: &[PathBuf],
     filters: &WalkFilters,
@@ -92,6 +122,13 @@ pub(crate) fn walk_paths(
     let mut out: Vec<PathBuf> = Vec::new();
     let mut seen: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
     for seed in paths {
+        if seed.is_file() {
+            let name = seed.file_name().map_or(seed.as_path(), Path::new);
+            if filters.includes(name) && seen.insert(seed.clone()) {
+                out.push(seed.clone());
+            }
+            continue;
+        }
         walk_seed(seed, filters, respect_gitignore, &mut out, &mut seen);
     }
     out
@@ -105,9 +142,11 @@ fn walk_seed(
     out: &mut Vec<PathBuf>,
     seen: &mut std::collections::HashSet<PathBuf>,
 ) {
-    // `WalkBuilder` rooted at the seed: a file seed yields just that file,
-    // a directory seed yields its tree. Gitignore handling mirrors the CLI
-    // walker's default-on posture; `respect_gitignore=false` is the
+    // `WalkBuilder` rooted at the seed: a directory seed yields its tree
+    // (file seeds are emitted directly by `walk_paths` and never reach
+    // here; a nonexistent seed yields one Err entry, skipped below).
+    // Gitignore handling mirrors the CLI walker's default-on posture;
+    // `respect_gitignore=false` is the
     // `analyze_paths(..., respect_gitignore=False)` opt-out.
     let mut builder = WalkBuilder::new(root);
     builder
@@ -146,14 +185,10 @@ fn walk_seed(
         let path = entry.path();
         // Match the glob filters against the seed-relative path so a
         // basename glob (`*.rs`) matches without a directory prefix; fall
-        // back to the full path when the strip fails (a file seed strips to
-        // the empty path, so match on its file name instead).
+        // back to the full path when the strip fails (defensive — a
+        // directory walk only yields files strictly under `root`; file
+        // seeds are emitted by `walk_paths` and never reach this loop).
         let rel = path.strip_prefix(root).unwrap_or(path);
-        let rel = if rel.as_os_str().is_empty() {
-            Path::new(path.file_name().unwrap_or(path.as_os_str()))
-        } else {
-            rel
-        };
         if !filters.accepts(rel) {
             continue;
         }
@@ -161,5 +196,115 @@ fn walk_seed(
         if seen.insert(owned.clone()) {
             out.push(owned);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{WalkFilters, walk_paths};
+    use std::path::{Path, PathBuf};
+
+    /// Fixture tree: `src/keep.rs`, `vendor/drop.rs`.
+    fn make_tree(dir: &Path) {
+        for (sub, name) in [("src", "keep.rs"), ("vendor", "drop.rs")] {
+            let d = dir.join(sub);
+            std::fs::create_dir_all(&d).expect("create fixture dir");
+            std::fs::write(d.join(name), "fn f() {}\n").expect("write fixture");
+        }
+    }
+
+    fn filters(include: &[&str], exclude: &[&str]) -> WalkFilters {
+        WalkFilters::compile(
+            include.iter().map(|s| (*s).to_owned()).collect(),
+            exclude.iter().map(|s| (*s).to_owned()).collect(),
+        )
+        .expect("valid globs")
+    }
+
+    fn walked(root: &Path, f: &WalkFilters) -> Vec<PathBuf> {
+        let mut found = walk_paths(&[root.to_path_buf()], f, true);
+        found.sort();
+        found
+    }
+
+    #[test]
+    fn bare_relative_and_dot_prefixed_excludes_are_equivalent() {
+        // #726 parity: `vendor/**` and `./vendor/**` must drop the same
+        // files. Pre-fix the `./`-prefixed spelling silently matched
+        // nothing here (the mirror image of the CLI bug: this walker
+        // matches bare seed-relative paths).
+        let dir = tempfile::tempdir().expect("tempdir");
+        make_tree(dir.path());
+
+        let bare = walked(dir.path(), &filters(&[], &["vendor/**"]));
+        let dotted = walked(dir.path(), &filters(&[], &["./vendor/**"]));
+        assert_eq!(
+            bare,
+            vec![dir.path().join("src/keep.rs")],
+            "bare `vendor/**` must drop the vendored file"
+        );
+        assert_eq!(
+            bare, dotted,
+            "`vendor/**` and `./vendor/**` must drop the same files (#726)"
+        );
+    }
+
+    #[test]
+    fn bare_relative_and_dot_prefixed_includes_are_equivalent() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        make_tree(dir.path());
+
+        let bare = walked(dir.path(), &filters(&["src/**"], &[]));
+        let dotted = walked(dir.path(), &filters(&["./src/**"], &[]));
+        assert_eq!(
+            bare,
+            vec![dir.path().join("src/keep.rs")],
+            "bare `src/**` include must keep only src/"
+        );
+        assert_eq!(
+            bare, dotted,
+            "`src/**` and `./src/**` must keep the same files (#726)"
+        );
+    }
+
+    #[test]
+    fn explicit_file_seed_bypasses_exclude_but_honors_include() {
+        // #726 CLI parity: an explicitly named file seed is analyzed even
+        // when an exclude glob matches it; the include allow-list still
+        // narrows it, matched on its basename.
+        let dir = tempfile::tempdir().expect("tempdir");
+        make_tree(dir.path());
+        let vendored = dir.path().join("vendor/drop.rs");
+
+        let kept = walk_paths(
+            std::slice::from_ref(&vendored),
+            &filters(&[], &["*.rs"]),
+            true,
+        );
+        assert_eq!(
+            kept,
+            vec![vendored.clone()],
+            "an explicitly named file must bypass the exclude deny-set (#726)"
+        );
+
+        let narrowed = walk_paths(
+            std::slice::from_ref(&vendored),
+            &filters(&["*.py"], &[]),
+            true,
+        );
+        assert!(
+            narrowed.is_empty(),
+            "the include allow-list must still narrow an explicit file seed"
+        );
+        let included = walk_paths(
+            std::slice::from_ref(&vendored),
+            &filters(&["*.rs"], &[]),
+            true,
+        );
+        assert_eq!(
+            included,
+            vec![vendored],
+            "a basename include must accept a matching explicit file seed"
+        );
     }
 }

--- a/big-code-analysis-py/tests/test_discovery.py
+++ b/big-code-analysis-py/tests/test_discovery.py
@@ -143,6 +143,29 @@ def test_analyze_paths_include_exclude_globs(tmp_path: Path) -> None:
     assert _names(no_py) == {"a.rs"}
 
 
+def test_analyze_paths_dot_slash_glob_equivalence(tmp_path: Path) -> None:
+    """#726: a leading ``./`` on a glob is optional — ``dir/**`` and
+    ``./dir/**`` filter identically (the ``./`` spelling silently matched
+    nothing before the fix)."""
+    _write(tmp_path, "src/keep.rs", "fn keep() {}\n")
+    _write(tmp_path, "vendor/drop.rs", "fn drop_it() {}\n")
+    bare = bca.analyze_paths(tmp_path, exclude="vendor/**")
+    dotted = bca.analyze_paths(tmp_path, exclude="./vendor/**")
+    assert _names(bare) == {"keep.rs"}
+    assert _names(bare) == _names(dotted)
+
+
+def test_analyze_paths_file_seed_bypasses_exclude(tmp_path: Path) -> None:
+    """#726: a seed naming a file directly is analysed even when an
+    ``exclude`` glob matches it (explicit request overrides ignore-style
+    rules, CLI parity); ``include`` still narrows it by basename."""
+    vendored = _write(tmp_path, "vendor/drop.rs", "fn drop_it() {}\n")
+    kept = bca.analyze_paths(vendored, exclude="*.rs")
+    assert _names(kept) == {"drop.rs"}
+    narrowed = bca.analyze_paths(vendored, include="*.py")
+    assert _names(narrowed) == set()
+
+
 def test_analyze_paths_multiple_seeds(tmp_path: Path) -> None:
     """#658: multiple positional seeds are each walked (file or dir)."""
     d1 = tmp_path / "d1"

--- a/docs/development/lessons_learned.md
+++ b/docs/development/lessons_learned.md
@@ -3800,3 +3800,48 @@ after each fix, re-grep with a pattern derived from what you just fixed,
 not from the original symbol name.
 
 ---
+
+## 73. A filter that silently matches nothing is load-bearing — fixing it re-decides every consumer
+
+A pattern or predicate that silently matches nothing does not just
+fail its own feature: the surrounding system equilibrates around the
+bug. Other consumers of the shared mechanism, the test suite, and
+even the project's own config come to depend on the non-matching.
+Fixing the match un-masks all of it at once, and the fallout
+presents as unrelated failures far from the changed line.
+
+**The bare-relative glob fix changed explicit-file-seed semantics**
+(#726, `1a2c5f29`). `mk_globset` compiles one globset consumed by
+two sites: the directory-walk filter (matching `./`-anchored
+walk-root paths) and the explicit-file-seed filter (matching the
+seed as spelled). Stripping the leading `./` so `dir/**` finally
+worked for walks also made the repo's own `.bcaignore`
+(`./**/tests/**`) match the absolute fixture path `cli_smoke` names
+directly via `--paths` — seven tests went red with "0 files
+matched". Those tests had passed only because the bug kept
+`./`-anchored patterns from matching anything; the fix forced a
+genuine design decision the bug had been hiding (explicit file
+seeds now bypass the exclude deny-set, the ripgrep/fd convention
+that an explicitly named path overrides ignore rules).
+
+**Two overlapping causes made the failures look environmental**
+(#726). The first failure in the fresh worktree *was* environmental
+— uninitialized submodules ("path does not exist"). After
+`git submodule update --init`, the same seven tests still failed,
+now with "0 files matched": a second, distinct cause behind the
+same test names. The misattribution was only broken by bisecting
+against the pre-fix binary: stash the fix, rebuild, re-run the
+exact failing command, restore. The clean binary analyzed the file;
+the fixed one refused — proof the fix, not the environment, changed
+behavior.
+
+**Lesson:** Before fixing a predicate or pattern that silently
+matched nothing, enumerate every consumer of the shared mechanism
+(the globset, the checker predicate, the dispatch arm) and ask what
+each consumer's behavior becomes once the match starts working —
+the answer may be a design decision to surface, not a mechanical
+fix. When tests fail after such a fix, bisect against the pre-fix
+binary before blaming the environment, and treat "this test only
+passed because of the bug" as an expected finding, not a surprise.
+
+---

--- a/man/bca-check.1
+++ b/man/bca-check.1
@@ -155,10 +155,10 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 Input files or directories to analyze. Unioned with any positional `[PATHS]`. Defaults to the current directory (`.`) when omitted and no manifest `paths` is set; an explicitly\-given path that does not exist is an error (exit 1)
 .TP
 \fB\-I\fR, \fB\-\-include\fR \fI<INCLUDE>\fR
-Glob to include files. Repeat the flag to add multiple globs (`\-I \*(Aq*.rs\*(Aq \-I \*(Aq*.toml\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed
+Glob to include files. Repeat the flag to add multiple globs (`\-I \*(Aq*.rs\*(Aq \-I \*(Aq*.toml\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. A leading `./` is optional: `dir/**` and `./dir/**` are equivalent
 .TP
 \fB\-X\fR, \fB\-\-exclude\fR \fI<EXCLUDE>\fR
-Glob to exclude files. Repeat the flag to add multiple globs (`\-X \*(Aq*.tmp\*(Aq \-X \*(Aq*.bak\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. CLI values are *merged with* (unioned, not a replacement for) any `bca.toml` `exclude` list and any `\-\-exclude\-from` patterns, so a CLI `\-\-exclude` never silently un\-excludes a directory the project config deliberately skipped. Pass `\-\-no\-config` to ignore the manifest entirely
+Glob to exclude files. Repeat the flag to add multiple globs (`\-X \*(Aq*.tmp\*(Aq \-X \*(Aq*.bak\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. A leading `./` is optional: `dir/**` and `./dir/**` are equivalent. CLI values are *merged with* (unioned, not a replacement for) any `bca.toml` `exclude` list and any `\-\-exclude\-from` patterns, so a CLI `\-\-exclude` never silently un\-excludes a directory the project config deliberately skipped. Pass `\-\-no\-config` to ignore the manifest entirely
 .TP
 \fB\-l\fR, \fB\-\-language\fR \fI<LANGUAGE>\fR
 Force a language instead of inferring from extension. Accepts a canonical language name (`rust`, `python`, `cpp`, …) or a file extension (`rs`, `py`, …). An unrecognized value is a hard error

--- a/man/bca-count.1
+++ b/man/bca-count.1
@@ -20,10 +20,10 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 Input files or directories to analyze. Unioned with any positional `[PATHS]`. Defaults to the current directory (`.`) when omitted and no manifest `paths` is set; an explicitly\-given path that does not exist is an error (exit 1)
 .TP
 \fB\-I\fR, \fB\-\-include\fR \fI<INCLUDE>\fR
-Glob to include files. Repeat the flag to add multiple globs (`\-I \*(Aq*.rs\*(Aq \-I \*(Aq*.toml\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed
+Glob to include files. Repeat the flag to add multiple globs (`\-I \*(Aq*.rs\*(Aq \-I \*(Aq*.toml\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. A leading `./` is optional: `dir/**` and `./dir/**` are equivalent
 .TP
 \fB\-X\fR, \fB\-\-exclude\fR \fI<EXCLUDE>\fR
-Glob to exclude files. Repeat the flag to add multiple globs (`\-X \*(Aq*.tmp\*(Aq \-X \*(Aq*.bak\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. CLI values are *merged with* (unioned, not a replacement for) any `bca.toml` `exclude` list and any `\-\-exclude\-from` patterns, so a CLI `\-\-exclude` never silently un\-excludes a directory the project config deliberately skipped. Pass `\-\-no\-config` to ignore the manifest entirely
+Glob to exclude files. Repeat the flag to add multiple globs (`\-X \*(Aq*.tmp\*(Aq \-X \*(Aq*.bak\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. A leading `./` is optional: `dir/**` and `./dir/**` are equivalent. CLI values are *merged with* (unioned, not a replacement for) any `bca.toml` `exclude` list and any `\-\-exclude\-from` patterns, so a CLI `\-\-exclude` never silently un\-excludes a directory the project config deliberately skipped. Pass `\-\-no\-config` to ignore the manifest entirely
 .TP
 \fB\-l\fR, \fB\-\-language\fR \fI<LANGUAGE>\fR
 Force a language instead of inferring from extension. Accepts a canonical language name (`rust`, `python`, `cpp`, …) or a file extension (`rs`, `py`, …). An unrecognized value is a hard error

--- a/man/bca-diff.1
+++ b/man/bca-diff.1
@@ -58,10 +58,10 @@ In file/dir mode: the new (after) metric output (a per\-file JSON file or a dire
 Input files or directories to analyze. Unioned with any positional `[PATHS]`. Defaults to the current directory (`.`) when omitted and no manifest `paths` is set; an explicitly\-given path that does not exist is an error (exit 1)
 .TP
 \fB\-I\fR, \fB\-\-include\fR \fI<INCLUDE>\fR
-Glob to include files. Repeat the flag to add multiple globs (`\-I \*(Aq*.rs\*(Aq \-I \*(Aq*.toml\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed
+Glob to include files. Repeat the flag to add multiple globs (`\-I \*(Aq*.rs\*(Aq \-I \*(Aq*.toml\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. A leading `./` is optional: `dir/**` and `./dir/**` are equivalent
 .TP
 \fB\-X\fR, \fB\-\-exclude\fR \fI<EXCLUDE>\fR
-Glob to exclude files. Repeat the flag to add multiple globs (`\-X \*(Aq*.tmp\*(Aq \-X \*(Aq*.bak\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. CLI values are *merged with* (unioned, not a replacement for) any `bca.toml` `exclude` list and any `\-\-exclude\-from` patterns, so a CLI `\-\-exclude` never silently un\-excludes a directory the project config deliberately skipped. Pass `\-\-no\-config` to ignore the manifest entirely
+Glob to exclude files. Repeat the flag to add multiple globs (`\-X \*(Aq*.tmp\*(Aq \-X \*(Aq*.bak\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. A leading `./` is optional: `dir/**` and `./dir/**` are equivalent. CLI values are *merged with* (unioned, not a replacement for) any `bca.toml` `exclude` list and any `\-\-exclude\-from` patterns, so a CLI `\-\-exclude` never silently un\-excludes a directory the project config deliberately skipped. Pass `\-\-no\-config` to ignore the manifest entirely
 .TP
 \fB\-l\fR, \fB\-\-language\fR \fI<LANGUAGE>\fR
 Force a language instead of inferring from extension. Accepts a canonical language name (`rust`, `python`, `cpp`, …) or a file extension (`rs`, `py`, …). An unrecognized value is a hard error

--- a/man/bca-dump.1
+++ b/man/bca-dump.1
@@ -23,10 +23,10 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 Input files or directories to analyze. Unioned with any positional `[PATHS]`. Defaults to the current directory (`.`) when omitted and no manifest `paths` is set; an explicitly\-given path that does not exist is an error (exit 1)
 .TP
 \fB\-I\fR, \fB\-\-include\fR \fI<INCLUDE>\fR
-Glob to include files. Repeat the flag to add multiple globs (`\-I \*(Aq*.rs\*(Aq \-I \*(Aq*.toml\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed
+Glob to include files. Repeat the flag to add multiple globs (`\-I \*(Aq*.rs\*(Aq \-I \*(Aq*.toml\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. A leading `./` is optional: `dir/**` and `./dir/**` are equivalent
 .TP
 \fB\-X\fR, \fB\-\-exclude\fR \fI<EXCLUDE>\fR
-Glob to exclude files. Repeat the flag to add multiple globs (`\-X \*(Aq*.tmp\*(Aq \-X \*(Aq*.bak\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. CLI values are *merged with* (unioned, not a replacement for) any `bca.toml` `exclude` list and any `\-\-exclude\-from` patterns, so a CLI `\-\-exclude` never silently un\-excludes a directory the project config deliberately skipped. Pass `\-\-no\-config` to ignore the manifest entirely
+Glob to exclude files. Repeat the flag to add multiple globs (`\-X \*(Aq*.tmp\*(Aq \-X \*(Aq*.bak\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. A leading `./` is optional: `dir/**` and `./dir/**` are equivalent. CLI values are *merged with* (unioned, not a replacement for) any `bca.toml` `exclude` list and any `\-\-exclude\-from` patterns, so a CLI `\-\-exclude` never silently un\-excludes a directory the project config deliberately skipped. Pass `\-\-no\-config` to ignore the manifest entirely
 .TP
 \fB\-l\fR, \fB\-\-language\fR \fI<LANGUAGE>\fR
 Force a language instead of inferring from extension. Accepts a canonical language name (`rust`, `python`, `cpp`, …) or a file extension (`rs`, `py`, …). An unrecognized value is a hard error

--- a/man/bca-exemptions.1
+++ b/man/bca-exemptions.1
@@ -56,10 +56,10 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 Input files or directories to analyze. Unioned with any positional `[PATHS]`. Defaults to the current directory (`.`) when omitted and no manifest `paths` is set; an explicitly\-given path that does not exist is an error (exit 1)
 .TP
 \fB\-I\fR, \fB\-\-include\fR \fI<INCLUDE>\fR
-Glob to include files. Repeat the flag to add multiple globs (`\-I \*(Aq*.rs\*(Aq \-I \*(Aq*.toml\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed
+Glob to include files. Repeat the flag to add multiple globs (`\-I \*(Aq*.rs\*(Aq \-I \*(Aq*.toml\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. A leading `./` is optional: `dir/**` and `./dir/**` are equivalent
 .TP
 \fB\-X\fR, \fB\-\-exclude\fR \fI<EXCLUDE>\fR
-Glob to exclude files. Repeat the flag to add multiple globs (`\-X \*(Aq*.tmp\*(Aq \-X \*(Aq*.bak\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. CLI values are *merged with* (unioned, not a replacement for) any `bca.toml` `exclude` list and any `\-\-exclude\-from` patterns, so a CLI `\-\-exclude` never silently un\-excludes a directory the project config deliberately skipped. Pass `\-\-no\-config` to ignore the manifest entirely
+Glob to exclude files. Repeat the flag to add multiple globs (`\-X \*(Aq*.tmp\*(Aq \-X \*(Aq*.bak\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. A leading `./` is optional: `dir/**` and `./dir/**` are equivalent. CLI values are *merged with* (unioned, not a replacement for) any `bca.toml` `exclude` list and any `\-\-exclude\-from` patterns, so a CLI `\-\-exclude` never silently un\-excludes a directory the project config deliberately skipped. Pass `\-\-no\-config` to ignore the manifest entirely
 .TP
 \fB\-l\fR, \fB\-\-language\fR \fI<LANGUAGE>\fR
 Force a language instead of inferring from extension. Accepts a canonical language name (`rust`, `python`, `cpp`, …) or a file extension (`rs`, `py`, …). An unrecognized value is a hard error

--- a/man/bca-find.1
+++ b/man/bca-find.1
@@ -26,10 +26,10 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 Input files or directories to analyze. Unioned with any positional `[PATHS]`. Defaults to the current directory (`.`) when omitted and no manifest `paths` is set; an explicitly\-given path that does not exist is an error (exit 1)
 .TP
 \fB\-I\fR, \fB\-\-include\fR \fI<INCLUDE>\fR
-Glob to include files. Repeat the flag to add multiple globs (`\-I \*(Aq*.rs\*(Aq \-I \*(Aq*.toml\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed
+Glob to include files. Repeat the flag to add multiple globs (`\-I \*(Aq*.rs\*(Aq \-I \*(Aq*.toml\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. A leading `./` is optional: `dir/**` and `./dir/**` are equivalent
 .TP
 \fB\-X\fR, \fB\-\-exclude\fR \fI<EXCLUDE>\fR
-Glob to exclude files. Repeat the flag to add multiple globs (`\-X \*(Aq*.tmp\*(Aq \-X \*(Aq*.bak\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. CLI values are *merged with* (unioned, not a replacement for) any `bca.toml` `exclude` list and any `\-\-exclude\-from` patterns, so a CLI `\-\-exclude` never silently un\-excludes a directory the project config deliberately skipped. Pass `\-\-no\-config` to ignore the manifest entirely
+Glob to exclude files. Repeat the flag to add multiple globs (`\-X \*(Aq*.tmp\*(Aq \-X \*(Aq*.bak\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. A leading `./` is optional: `dir/**` and `./dir/**` are equivalent. CLI values are *merged with* (unioned, not a replacement for) any `bca.toml` `exclude` list and any `\-\-exclude\-from` patterns, so a CLI `\-\-exclude` never silently un\-excludes a directory the project config deliberately skipped. Pass `\-\-no\-config` to ignore the manifest entirely
 .TP
 \fB\-l\fR, \fB\-\-language\fR \fI<LANGUAGE>\fR
 Force a language instead of inferring from extension. Accepts a canonical language name (`rust`, `python`, `cpp`, …) or a file extension (`rs`, `py`, …). An unrecognized value is a hard error

--- a/man/bca-functions.1
+++ b/man/bca-functions.1
@@ -17,10 +17,10 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 Input files or directories to analyze. Unioned with any positional `[PATHS]`. Defaults to the current directory (`.`) when omitted and no manifest `paths` is set; an explicitly\-given path that does not exist is an error (exit 1)
 .TP
 \fB\-I\fR, \fB\-\-include\fR \fI<INCLUDE>\fR
-Glob to include files. Repeat the flag to add multiple globs (`\-I \*(Aq*.rs\*(Aq \-I \*(Aq*.toml\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed
+Glob to include files. Repeat the flag to add multiple globs (`\-I \*(Aq*.rs\*(Aq \-I \*(Aq*.toml\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. A leading `./` is optional: `dir/**` and `./dir/**` are equivalent
 .TP
 \fB\-X\fR, \fB\-\-exclude\fR \fI<EXCLUDE>\fR
-Glob to exclude files. Repeat the flag to add multiple globs (`\-X \*(Aq*.tmp\*(Aq \-X \*(Aq*.bak\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. CLI values are *merged with* (unioned, not a replacement for) any `bca.toml` `exclude` list and any `\-\-exclude\-from` patterns, so a CLI `\-\-exclude` never silently un\-excludes a directory the project config deliberately skipped. Pass `\-\-no\-config` to ignore the manifest entirely
+Glob to exclude files. Repeat the flag to add multiple globs (`\-X \*(Aq*.tmp\*(Aq \-X \*(Aq*.bak\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. A leading `./` is optional: `dir/**` and `./dir/**` are equivalent. CLI values are *merged with* (unioned, not a replacement for) any `bca.toml` `exclude` list and any `\-\-exclude\-from` patterns, so a CLI `\-\-exclude` never silently un\-excludes a directory the project config deliberately skipped. Pass `\-\-no\-config` to ignore the manifest entirely
 .TP
 \fB\-l\fR, \fB\-\-language\fR \fI<LANGUAGE>\fR
 Force a language instead of inferring from extension. Accepts a canonical language name (`rust`, `python`, `cpp`, …) or a file extension (`rs`, `py`, …). An unrecognized value is a hard error

--- a/man/bca-init.1
+++ b/man/bca-init.1
@@ -26,10 +26,10 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 Input files or directories to analyze. Unioned with any positional `[PATHS]`. Defaults to the current directory (`.`) when omitted and no manifest `paths` is set; an explicitly\-given path that does not exist is an error (exit 1)
 .TP
 \fB\-I\fR, \fB\-\-include\fR \fI<INCLUDE>\fR
-Glob to include files. Repeat the flag to add multiple globs (`\-I \*(Aq*.rs\*(Aq \-I \*(Aq*.toml\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed
+Glob to include files. Repeat the flag to add multiple globs (`\-I \*(Aq*.rs\*(Aq \-I \*(Aq*.toml\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. A leading `./` is optional: `dir/**` and `./dir/**` are equivalent
 .TP
 \fB\-X\fR, \fB\-\-exclude\fR \fI<EXCLUDE>\fR
-Glob to exclude files. Repeat the flag to add multiple globs (`\-X \*(Aq*.tmp\*(Aq \-X \*(Aq*.bak\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. CLI values are *merged with* (unioned, not a replacement for) any `bca.toml` `exclude` list and any `\-\-exclude\-from` patterns, so a CLI `\-\-exclude` never silently un\-excludes a directory the project config deliberately skipped. Pass `\-\-no\-config` to ignore the manifest entirely
+Glob to exclude files. Repeat the flag to add multiple globs (`\-X \*(Aq*.tmp\*(Aq \-X \*(Aq*.bak\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. A leading `./` is optional: `dir/**` and `./dir/**` are equivalent. CLI values are *merged with* (unioned, not a replacement for) any `bca.toml` `exclude` list and any `\-\-exclude\-from` patterns, so a CLI `\-\-exclude` never silently un\-excludes a directory the project config deliberately skipped. Pass `\-\-no\-config` to ignore the manifest entirely
 .TP
 \fB\-l\fR, \fB\-\-language\fR \fI<LANGUAGE>\fR
 Force a language instead of inferring from extension. Accepts a canonical language name (`rust`, `python`, `cpp`, …) or a file extension (`rs`, `py`, …). An unrecognized value is a hard error

--- a/man/bca-metrics.1
+++ b/man/bca-metrics.1
@@ -56,10 +56,10 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 Input files or directories to analyze. Unioned with any positional `[PATHS]`. Defaults to the current directory (`.`) when omitted and no manifest `paths` is set; an explicitly\-given path that does not exist is an error (exit 1)
 .TP
 \fB\-I\fR, \fB\-\-include\fR \fI<INCLUDE>\fR
-Glob to include files. Repeat the flag to add multiple globs (`\-I \*(Aq*.rs\*(Aq \-I \*(Aq*.toml\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed
+Glob to include files. Repeat the flag to add multiple globs (`\-I \*(Aq*.rs\*(Aq \-I \*(Aq*.toml\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. A leading `./` is optional: `dir/**` and `./dir/**` are equivalent
 .TP
 \fB\-X\fR, \fB\-\-exclude\fR \fI<EXCLUDE>\fR
-Glob to exclude files. Repeat the flag to add multiple globs (`\-X \*(Aq*.tmp\*(Aq \-X \*(Aq*.bak\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. CLI values are *merged with* (unioned, not a replacement for) any `bca.toml` `exclude` list and any `\-\-exclude\-from` patterns, so a CLI `\-\-exclude` never silently un\-excludes a directory the project config deliberately skipped. Pass `\-\-no\-config` to ignore the manifest entirely
+Glob to exclude files. Repeat the flag to add multiple globs (`\-X \*(Aq*.tmp\*(Aq \-X \*(Aq*.bak\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. A leading `./` is optional: `dir/**` and `./dir/**` are equivalent. CLI values are *merged with* (unioned, not a replacement for) any `bca.toml` `exclude` list and any `\-\-exclude\-from` patterns, so a CLI `\-\-exclude` never silently un\-excludes a directory the project config deliberately skipped. Pass `\-\-no\-config` to ignore the manifest entirely
 .TP
 \fB\-l\fR, \fB\-\-language\fR \fI<LANGUAGE>\fR
 Force a language instead of inferring from extension. Accepts a canonical language name (`rust`, `python`, `cpp`, …) or a file extension (`rs`, `py`, …). An unrecognized value is a hard error

--- a/man/bca-ops.1
+++ b/man/bca-ops.1
@@ -47,10 +47,10 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 Input files or directories to analyze. Unioned with any positional `[PATHS]`. Defaults to the current directory (`.`) when omitted and no manifest `paths` is set; an explicitly\-given path that does not exist is an error (exit 1)
 .TP
 \fB\-I\fR, \fB\-\-include\fR \fI<INCLUDE>\fR
-Glob to include files. Repeat the flag to add multiple globs (`\-I \*(Aq*.rs\*(Aq \-I \*(Aq*.toml\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed
+Glob to include files. Repeat the flag to add multiple globs (`\-I \*(Aq*.rs\*(Aq \-I \*(Aq*.toml\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. A leading `./` is optional: `dir/**` and `./dir/**` are equivalent
 .TP
 \fB\-X\fR, \fB\-\-exclude\fR \fI<EXCLUDE>\fR
-Glob to exclude files. Repeat the flag to add multiple globs (`\-X \*(Aq*.tmp\*(Aq \-X \*(Aq*.bak\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. CLI values are *merged with* (unioned, not a replacement for) any `bca.toml` `exclude` list and any `\-\-exclude\-from` patterns, so a CLI `\-\-exclude` never silently un\-excludes a directory the project config deliberately skipped. Pass `\-\-no\-config` to ignore the manifest entirely
+Glob to exclude files. Repeat the flag to add multiple globs (`\-X \*(Aq*.tmp\*(Aq \-X \*(Aq*.bak\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. A leading `./` is optional: `dir/**` and `./dir/**` are equivalent. CLI values are *merged with* (unioned, not a replacement for) any `bca.toml` `exclude` list and any `\-\-exclude\-from` patterns, so a CLI `\-\-exclude` never silently un\-excludes a directory the project config deliberately skipped. Pass `\-\-no\-config` to ignore the manifest entirely
 .TP
 \fB\-l\fR, \fB\-\-language\fR \fI<LANGUAGE>\fR
 Force a language instead of inferring from extension. Accepts a canonical language name (`rust`, `python`, `cpp`, …) or a file extension (`rs`, `py`, …). An unrecognized value is a hard error

--- a/man/bca-preproc.1
+++ b/man/bca-preproc.1
@@ -20,10 +20,10 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 Input files or directories to analyze. Unioned with any positional `[PATHS]`. Defaults to the current directory (`.`) when omitted and no manifest `paths` is set; an explicitly\-given path that does not exist is an error (exit 1)
 .TP
 \fB\-I\fR, \fB\-\-include\fR \fI<INCLUDE>\fR
-Glob to include files. Repeat the flag to add multiple globs (`\-I \*(Aq*.rs\*(Aq \-I \*(Aq*.toml\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed
+Glob to include files. Repeat the flag to add multiple globs (`\-I \*(Aq*.rs\*(Aq \-I \*(Aq*.toml\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. A leading `./` is optional: `dir/**` and `./dir/**` are equivalent
 .TP
 \fB\-X\fR, \fB\-\-exclude\fR \fI<EXCLUDE>\fR
-Glob to exclude files. Repeat the flag to add multiple globs (`\-X \*(Aq*.tmp\*(Aq \-X \*(Aq*.bak\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. CLI values are *merged with* (unioned, not a replacement for) any `bca.toml` `exclude` list and any `\-\-exclude\-from` patterns, so a CLI `\-\-exclude` never silently un\-excludes a directory the project config deliberately skipped. Pass `\-\-no\-config` to ignore the manifest entirely
+Glob to exclude files. Repeat the flag to add multiple globs (`\-X \*(Aq*.tmp\*(Aq \-X \*(Aq*.bak\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. A leading `./` is optional: `dir/**` and `./dir/**` are equivalent. CLI values are *merged with* (unioned, not a replacement for) any `bca.toml` `exclude` list and any `\-\-exclude\-from` patterns, so a CLI `\-\-exclude` never silently un\-excludes a directory the project config deliberately skipped. Pass `\-\-no\-config` to ignore the manifest entirely
 .TP
 \fB\-l\fR, \fB\-\-language\fR \fI<LANGUAGE>\fR
 Force a language instead of inferring from extension. Accepts a canonical language name (`rust`, `python`, `cpp`, …) or a file extension (`rs`, `py`, …). An unrecognized value is a hard error

--- a/man/bca-report.1
+++ b/man/bca-report.1
@@ -55,10 +55,10 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 Input files or directories to analyze. Unioned with any positional `[PATHS]`. Defaults to the current directory (`.`) when omitted and no manifest `paths` is set; an explicitly\-given path that does not exist is an error (exit 1)
 .TP
 \fB\-I\fR, \fB\-\-include\fR \fI<INCLUDE>\fR
-Glob to include files. Repeat the flag to add multiple globs (`\-I \*(Aq*.rs\*(Aq \-I \*(Aq*.toml\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed
+Glob to include files. Repeat the flag to add multiple globs (`\-I \*(Aq*.rs\*(Aq \-I \*(Aq*.toml\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. A leading `./` is optional: `dir/**` and `./dir/**` are equivalent
 .TP
 \fB\-X\fR, \fB\-\-exclude\fR \fI<EXCLUDE>\fR
-Glob to exclude files. Repeat the flag to add multiple globs (`\-X \*(Aq*.tmp\*(Aq \-X \*(Aq*.bak\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. CLI values are *merged with* (unioned, not a replacement for) any `bca.toml` `exclude` list and any `\-\-exclude\-from` patterns, so a CLI `\-\-exclude` never silently un\-excludes a directory the project config deliberately skipped. Pass `\-\-no\-config` to ignore the manifest entirely
+Glob to exclude files. Repeat the flag to add multiple globs (`\-X \*(Aq*.tmp\*(Aq \-X \*(Aq*.bak\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. A leading `./` is optional: `dir/**` and `./dir/**` are equivalent. CLI values are *merged with* (unioned, not a replacement for) any `bca.toml` `exclude` list and any `\-\-exclude\-from` patterns, so a CLI `\-\-exclude` never silently un\-excludes a directory the project config deliberately skipped. Pass `\-\-no\-config` to ignore the manifest entirely
 .TP
 \fB\-l\fR, \fB\-\-language\fR \fI<LANGUAGE>\fR
 Force a language instead of inferring from extension. Accepts a canonical language name (`rust`, `python`, `cpp`, …) or a file extension (`rs`, `py`, …). An unrecognized value is a hard error

--- a/man/bca-strip-comments.1
+++ b/man/bca-strip-comments.1
@@ -23,10 +23,10 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 Input files or directories to analyze. Unioned with any positional `[PATHS]`. Defaults to the current directory (`.`) when omitted and no manifest `paths` is set; an explicitly\-given path that does not exist is an error (exit 1)
 .TP
 \fB\-I\fR, \fB\-\-include\fR \fI<INCLUDE>\fR
-Glob to include files. Repeat the flag to add multiple globs (`\-I \*(Aq*.rs\*(Aq \-I \*(Aq*.toml\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed
+Glob to include files. Repeat the flag to add multiple globs (`\-I \*(Aq*.rs\*(Aq \-I \*(Aq*.toml\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. A leading `./` is optional: `dir/**` and `./dir/**` are equivalent
 .TP
 \fB\-X\fR, \fB\-\-exclude\fR \fI<EXCLUDE>\fR
-Glob to exclude files. Repeat the flag to add multiple globs (`\-X \*(Aq*.tmp\*(Aq \-X \*(Aq*.bak\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. CLI values are *merged with* (unioned, not a replacement for) any `bca.toml` `exclude` list and any `\-\-exclude\-from` patterns, so a CLI `\-\-exclude` never silently un\-excludes a directory the project config deliberately skipped. Pass `\-\-no\-config` to ignore the manifest entirely
+Glob to exclude files. Repeat the flag to add multiple globs (`\-X \*(Aq*.tmp\*(Aq \-X \*(Aq*.bak\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. A leading `./` is optional: `dir/**` and `./dir/**` are equivalent. CLI values are *merged with* (unioned, not a replacement for) any `bca.toml` `exclude` list and any `\-\-exclude\-from` patterns, so a CLI `\-\-exclude` never silently un\-excludes a directory the project config deliberately skipped. Pass `\-\-no\-config` to ignore the manifest entirely
 .TP
 \fB\-l\fR, \fB\-\-language\fR \fI<LANGUAGE>\fR
 Force a language instead of inferring from extension. Accepts a canonical language name (`rust`, `python`, `cpp`, …) or a file extension (`rs`, `py`, …). An unrecognized value is a hard error

--- a/man/bca-vcs.1
+++ b/man/bca-vcs.1
@@ -112,10 +112,10 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 Input files or directories to analyze. Unioned with any positional `[PATHS]`. Defaults to the current directory (`.`) when omitted and no manifest `paths` is set; an explicitly\-given path that does not exist is an error (exit 1)
 .TP
 \fB\-I\fR, \fB\-\-include\fR \fI<INCLUDE>\fR
-Glob to include files. Repeat the flag to add multiple globs (`\-I \*(Aq*.rs\*(Aq \-I \*(Aq*.toml\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed
+Glob to include files. Repeat the flag to add multiple globs (`\-I \*(Aq*.rs\*(Aq \-I \*(Aq*.toml\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. A leading `./` is optional: `dir/**` and `./dir/**` are equivalent
 .TP
 \fB\-X\fR, \fB\-\-exclude\fR \fI<EXCLUDE>\fR
-Glob to exclude files. Repeat the flag to add multiple globs (`\-X \*(Aq*.tmp\*(Aq \-X \*(Aq*.bak\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. CLI values are *merged with* (unioned, not a replacement for) any `bca.toml` `exclude` list and any `\-\-exclude\-from` patterns, so a CLI `\-\-exclude` never silently un\-excludes a directory the project config deliberately skipped. Pass `\-\-no\-config` to ignore the manifest entirely
+Glob to exclude files. Repeat the flag to add multiple globs (`\-X \*(Aq*.tmp\*(Aq \-X \*(Aq*.bak\*(Aq`); each occurrence takes exactly one value, so a positional argument that follows is never swallowed. A leading `./` is optional: `dir/**` and `./dir/**` are equivalent. CLI values are *merged with* (unioned, not a replacement for) any `bca.toml` `exclude` list and any `\-\-exclude\-from` patterns, so a CLI `\-\-exclude` never silently un\-excludes a directory the project config deliberately skipped. Pass `\-\-no\-config` to ignore the manifest entirely
 .TP
 \fB\-l\fR, \fB\-\-language\fR \fI<LANGUAGE>\fR
 Force a language instead of inferring from extension. Accepts a canonical language name (`rust`, `python`, `cpp`, …) or a file extension (`rs`, `py`, …). An unrecognized value is a hard error


### PR DESCRIPTION
## Summary

Fixes the #726 glob inconsistency — `--exclude 'cve-corpus/**'` silently
matched nothing while `--exclude './cve-corpus/**'` worked — and the
related filter-semantics gaps a post-fix review surfaced.

### Core fix (`1a2c5f29`)

The walker matches files against a `./`-anchored walk-root path, but
patterns were compiled verbatim, so only `./`-anchored patterns ever
matched; bare-relative ones (`dir/**`) failed silently across
`--include`, `--exclude`, `--exclude-from`, `.bcaignore`, and
`[check.exclude]`. A single leading `./` is now stripped symmetrically
from both the pattern side (`mk_globset`) and the match-path side
(`WalkFilters::passes`, the `[check.exclude]` filter), making the two
spellings exactly equivalent. `**/`-prefixed, `*`, and absolute
patterns are unchanged.

Fixing the matcher un-masked a latent design question: explicit file
seeds were run through the same exclude deny-set, so the repo's own
`.bcaignore` started dropping files named directly via `--paths`.
Decision (best-UX): **an explicitly named file bypasses the exclude
deny-set** — the ripgrep/fd/git convention — while `--include` still
narrows it.

### Review follow-up (`d081cef7`)

- **Python bindings parity**: `analyze_paths` had the mirror-image bug
  (`./dir/**` matched nothing there). Patterns are now `./`-stripped
  identically, and file seeds bypass `exclude` (include narrows by
  basename).
- **CLI include anchoring**: `--include 'src/**'` now accepts
  `--paths "$PWD/src/f.rs"` like `--paths src/f.rs` via a CWD-relative
  match form (`file_seed_match_path`); the emitted `name` keeps the
  as-spelled form (#488 parity).
- **Edge hardening**: `.//x` no longer flips into an absolute glob; a
  bare `./` pattern is skipped instead of compiling an empty glob.

### Testing

Every behavior change is pinned by a test verified via test-via-revert
(`.claude/rules/testing.md`): CLI unit (`walk_seed_tests.rs`) +
integration (`exclude_path_form.rs`, `check_exclude.rs`), py Rust unit
tests, and pytest cases. Full gate run: fmt, clippy (both flavours),
`cargo test --workspace --all-features`, maturin + 281 pytest,
stubtest, mypy/pyright, doc build, man drift, snapshot anchors, both
self-scan tiers (baseline refreshed for `walk_seed.rs` file-level
sums).

No public library API change; CHANGELOG, clap help, man pages,
`_native.pyi`, and the book (CLI + Python chapters) document the new
semantics. Also adds lesson #73 (`5bfba9e6`) capturing the
load-bearing-silent-filter dynamic.

Fixes #726
