### PR TITLE
fix(abc,tests): name-based C-family ABC matching + correct C test grammar (#730, #732)

### DIFF
--- a/src/macros/kind_sets.rs
+++ b/src/macros/kind_sets.rs
@@ -190,26 +190,25 @@ macro_rules! go_bool_terminal_kinds {
 }
 
 macro_rules! cpp_bool_terminal_kinds {
-    // `QualifiedIdentifier` has four numeric kind_ids (573..576) per
-    // tree-sitter-cpp's production-rule path. Halstead's getter
-    // already matches all four; the ABC walker needs them too so
-    // `if (ns::flag) {}` reaches the terminal-bool count.
-    //
-    // `CastExpression` (`(bool)v`) evaluates to a boolean in
+    // Matches on node-kind NAMES, not one grammar's enum discriminants,
+    // so it is correct for every C-family grammar: the shared ABC helpers
+    // run over both upstream `Cpp` and the Mozilla `Mozcpp` fork (#720),
+    // which assign *different* kind_ids to the same kinds (#732, mirroring
+    // the npa fix in #731). `qualified_identifier` has four numeric ids
+    // (573..576) in tree-sitter-cpp's production-rule path, but all four
+    // render to the one base name, so a single arm covers them — the
+    // ABC walker needs them so `if (ns::flag) {}` reaches the terminal
+    // count. `cast_expression` (`(bool)v`) evaluates to a boolean in
     // idiomatic C++ — mirrors the C# fix in #372 (lesson 19).
     () => {
-        $crate::Cpp::Identifier
-            | $crate::Cpp::True
-            | $crate::Cpp::False
-            | $crate::Cpp::CallExpression
-            | $crate::Cpp::CallExpression2
-            | $crate::Cpp::FieldExpression
-            | $crate::Cpp::SubscriptExpression
-            | $crate::Cpp::CastExpression
-            | $crate::Cpp::QualifiedIdentifier
-            | $crate::Cpp::QualifiedIdentifier2
-            | $crate::Cpp::QualifiedIdentifier3
-            | $crate::Cpp::QualifiedIdentifier4
+        "identifier"
+            | "true"
+            | "false"
+            | "call_expression"
+            | "field_expression"
+            | "subscript_expression"
+            | "cast_expression"
+            | "qualified_identifier"
     };
 }
 

--- a/src/metrics/abc.rs
+++ b/src/metrics/abc.rs
@@ -2235,42 +2235,37 @@ impl Abc for GoCode {
 
 // C++ ABC unary-conditional walker (Fitzpatrick Rule 9 in Figure 3;
 // see `rust_inspect_container` for the cross-language rationale).
-// `BinaryExpression` / `ParenthesizedExpression` / `UnaryExpression`
-// each have two token-id aliases in the C++ grammar (the second arises
-// under structured-binding / requires-clause production rules); the
-// walker matches both spellings.
+// Matches on node-kind NAMES so the helper is correct for every C-family
+// grammar: it is shared by the `CppCode` and `MozcppCode` ABC impls (#720),
+// and the Mozilla fork assigns different kind_ids to the same kinds (#732,
+// mirroring the npa fix in #731). Aliased kinds — `binary_expression`,
+// `parenthesized_expression`, `unary_expression` each have a second token-id
+// in the C++ grammar (under structured-binding / requires-clause production
+// rules) — all render to one base name, so a single string arm covers each
+// family: equivalent to the former `Cpp`-enum match for Cpp, and
+// grammar-agnostic for Mozcpp.
 fn cpp_inspect_container(container_node: &Node, conditions: &mut f64) {
-    use Cpp::*;
-
     let mut node = *container_node;
-    let mut node_kind = node.kind_id().into();
+    let mut node_kind = node.kind();
     let Some(parent) = node.parent() else { return };
-    let parent_kind = parent.kind_id().into();
+    let parent_kind = parent.kind();
     let mut has_boolean_content = matches!(
         parent_kind,
-        BinaryExpression
-            | BinaryExpression2
-            | IfStatement
-            | WhileStatement
-            | DoStatement
-            | ForStatement
-    ) || (matches!(parent_kind, ConditionalExpression)
+        "binary_expression" | "if_statement" | "while_statement" | "do_statement" | "for_statement"
+    ) || (parent_kind == "conditional_expression"
         && node
             .previous_sibling()
-            .is_none_or(|prev| !matches!(prev.kind_id().into(), QMARK | COLON)));
+            .is_none_or(|prev| !matches!(prev.kind(), "?" | ":")));
 
     loop {
-        // `ConditionClause` is the C++-grammar wrapper around an
+        // `condition_clause` is the C++-grammar wrapper around an
         // `if (...)` / `while (...)` head — same `(`, content, `)`
         // shape as `parenthesized_expression`, so it unwraps the
         // same way at child(1). `do { ... } while (...)`'s trailing
         // condition is a plain `parenthesized_expression`.
-        let is_parens = matches!(
-            node_kind,
-            ParenthesizedExpression | ParenthesizedExpression2 | ConditionClause
-        );
-        let is_not = matches!(node_kind, UnaryExpression | UnaryExpression2)
-            && node.child(0).is_some_and(|c| c.kind_id() == BANG as u16);
+        let is_parens = matches!(node_kind, "parenthesized_expression" | "condition_clause");
+        let is_not =
+            node_kind == "unary_expression" && node.child(0).is_some_and(|c| c.kind() == "!");
 
         if !is_parens && !is_not {
             break;
@@ -2281,7 +2276,7 @@ fn cpp_inspect_container(container_node: &Node, conditions: &mut f64) {
 
         let Some(child) = node.child(1) else { break };
         node = child;
-        node_kind = node.kind_id().into();
+        node_kind = node.kind();
 
         if matches!(node_kind, cpp_bool_terminal_kinds!()) {
             if has_boolean_content {
@@ -2305,19 +2300,15 @@ fn cpp_inspect_child(node: &Node, idx: usize, conditions: &mut f64) {
 }
 
 fn cpp_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
-    use Cpp::*;
-
-    let list_kind = list_node.kind_id().into();
+    let list_kind = list_node.kind();
     let mut cursor = list_node.cursor();
 
     if cursor.goto_first_child() {
         loop {
             let node = cursor.node();
-            let node_kind = node.kind_id().into();
+            let node_kind = node.kind();
 
-            if matches!(node_kind, cpp_bool_terminal_kinds!())
-                && matches!(list_kind, BinaryExpression | BinaryExpression2)
-            {
+            if matches!(node_kind, cpp_bool_terminal_kinds!()) && list_kind == "binary_expression" {
                 *conditions += 1.;
             } else if node.is_named() {
                 cpp_inspect_container(&node, conditions);

--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -2022,7 +2022,7 @@ mod tests {
 
     #[test]
     fn c_no_cognitive() {
-        check_metrics::<CppParser>("int a = 42;", "foo.c", |metric| {
+        check_metrics::<CParser>("int a = 42;", "foo.c", |metric| {
             insta::assert_json_snapshot!(
                 metric.cognitive,
                 @r#"
@@ -2671,7 +2671,7 @@ mod tests {
 
     #[test]
     fn c_simple_function() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "void f() {
                  if (a && b) { // +2 (+1 &&)
                      printf(\"test\");
@@ -2893,7 +2893,7 @@ mod tests {
 
     #[test]
     fn c_sequence_same_booleans() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "void f() {
                  if (a && b && 1 == 1) { // +2 (+1 sequence of &&)
                      printf(\"test\");
@@ -3125,8 +3125,8 @@ mod tests {
     fn c_not_booleans() {
         // `!` does not break boolean sequences (issue #392): the inner
         // `&&` is folded into the outer `&&`'s span because pre-order
-        // visits the outer BinaryExpression first.
-        check_metrics::<CppParser>(
+        // visits the outer `binary_expression` first.
+        check_metrics::<CParser>(
             "void f() {
                  if (a && !(b && c)) { // +2 (+1 if, +1 outer &&; inner && continues)
                      printf(\"test\");
@@ -3272,7 +3272,7 @@ mod tests {
 
     #[test]
     fn c_sequence_different_booleans() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "void f() {
                  if (a && b || 1 == 1) { // +3 (+1 &&, +1 ||)
                      printf(\"test\");
@@ -3432,7 +3432,7 @@ mod tests {
 
     #[test]
     fn c_1_level_nesting() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "void f() {
                  if (1 == 1) { // +1
                      if (1 == 1) { // +2 (nesting = 1)
@@ -4073,7 +4073,7 @@ mod tests {
 
     #[test]
     fn c_goto() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "void f() {
              OUT: for (int i = 1; i <= max; ++i) { // +1
                       for (int j = 2; j < i; ++j) { // +2 (nesting = 1)
@@ -4102,7 +4102,7 @@ mod tests {
 
     #[test]
     fn c_switch() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "void f() {
                  switch (1) { // +1
                      case 1:
@@ -4138,11 +4138,11 @@ mod tests {
 
     #[test]
     fn c_ternary() {
-        // Sonar's rule scores the C++ ternary `?:` as +1 (and +nesting), matching
-        // the JS/Java/Python/Rust families. `CppCode::compute` now matches on
-        // `ConditionalExpression`, so the operator participates in nesting like
-        // any other conditional construct.
-        check_metrics::<CppParser>(
+        // Sonar's rule scores the ternary `?:` as +1 (and +nesting), matching
+        // the JS/Java/Python/Rust families. The cognitive walker matches the
+        // `conditional_expression` node, so the operator participates in nesting
+        // like any other conditional construct.
+        check_metrics::<CParser>(
             "int f(int a) {
                  if (a) { // +1
                      return a > 0 ? 1 : -1; // +2 (1 + nesting 1)
@@ -4171,7 +4171,7 @@ mod tests {
     }
 
     #[test]
-    fn c_try_catch_single() {
+    fn cpp_try_catch_single() {
         check_metrics::<CppParser>(
             "void f() {
                  try {
@@ -4201,7 +4201,7 @@ mod tests {
     }
 
     #[test]
-    fn c_try_multiple_catches() {
+    fn cpp_try_multiple_catches() {
         check_metrics::<CppParser>(
             "void f() {
                  try {
@@ -4235,7 +4235,7 @@ mod tests {
     }
 
     #[test]
-    fn c_try_catch_in_loop() {
+    fn cpp_try_catch_in_loop() {
         check_metrics::<CppParser>(
             "void f() {
                  for (int i = 0; i < 10; ++i) { // +1
@@ -4267,7 +4267,7 @@ mod tests {
     }
 
     #[test]
-    fn c_range_based_for() {
+    fn cpp_range_based_for() {
         check_metrics::<CppParser>(
             "int sum(const std::vector<int>& v) {
                  int s = 0;
@@ -4299,7 +4299,7 @@ mod tests {
     }
 
     #[test]
-    fn c_nested_range_based_for() {
+    fn cpp_nested_range_based_for() {
         check_metrics::<CppParser>(
             "void f(const std::vector<std::vector<int>>& vv) {
                  for (const auto& row : vv) { // +1
@@ -4331,7 +4331,7 @@ mod tests {
 
     #[test]
     fn c_nested_for() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "void f(int n, int m) {
                  for (int i = 0; i < n; ++i) { // +1
                      for (int j = 0; j < m; ++j) { // +2 (nesting = 1)
@@ -4363,7 +4363,7 @@ mod tests {
 
     #[test]
     fn c_nested_while() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "void f(int n) {
                  while (n > 0) { // +1
                      while (n % 2 == 0) { // +2 (nesting = 1)
@@ -4399,7 +4399,7 @@ mod tests {
         // recursion is not tracked for C/C++ because the call graph is only
         // resolvable at run time. The body of `fact` therefore costs only
         // the explicit `if`.
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "int fact(int n) {
                  if (n <= 1) { // +1
                      return 1;
@@ -4428,7 +4428,7 @@ mod tests {
 
     #[test]
     fn c_goto_sibling_jump() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "void f(int n) {
                  if (n < 0) { // +1
                      goto err; // +1
@@ -4462,7 +4462,7 @@ mod tests {
     }
 
     #[test]
-    fn c_lambda_inside_function() {
+    fn cpp_lambda_inside_function() {
         // Per `increase_nesting`, entering a lambda bumps the effective nesting
         // by one — so an `if` directly inside a top-level lambda is +2 charged
         // to the enclosing function (Cpp lambdas are not split into a separate
@@ -4504,7 +4504,7 @@ mod tests {
         // A `case` without `break` (fall-through) does not add cognitive cost
         // beyond the enclosing `switch` itself: only `switch` is in the match
         // arm. Same accounting as `c_switch` above — switch +1 only.
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "void f(int n) {
                  switch (n) { // +1
                      case 1:
@@ -4540,7 +4540,7 @@ mod tests {
 
     #[test]
     fn c_switch_in_loop() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "void f(int n) {
                  for (int i = 0; i < n; ++i) { // +1
                      switch (i % 3) { // +2 (nesting = 1)
@@ -4582,7 +4582,7 @@ mod tests {
         // tracked for C/C++ — macros are treated as opaque tokens. This is the
         // defensive case: a control-flow-bearing macro contributes nothing on
         // its own; only the explicit `if` in the function body is counted.
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "#define CHECK(x) do { if (!(x)) return; } while (0)
              void f(int a, int b) {
                  CHECK(a);              // expansion is opaque: 0
@@ -7641,7 +7641,7 @@ end",
     fn c_sibling_bool_sequences() {
         // (a&&b)||(c&&d) — the right-hand && is a sibling, not nested.
         // Expected: &&(+1) + ||(+1) + &&(+1) = 3.
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "int f(int a, int b, int c, int d) {
                  return (a && b) || (c && d);  // +1(&&) +1(||) +1(&&) = 3
              }",
@@ -7658,7 +7658,7 @@ end",
     fn c_nested_bool_same_op() {
         // a||(b&&c&&d) — the inner && operators are nested, forming one sequence.
         // Expected: ||(+1) + &&(+1) = 2.
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "int f(int a, int b, int c, int d) {
                  return a || (b && c && d);  // +1(||) +1(&&) = 2
              }",

--- a/src/metrics/cyclomatic.rs
+++ b/src/metrics/cyclomatic.rs
@@ -1823,7 +1823,7 @@ mod tests {
 
     #[test]
     fn c_switch() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "void f() { // +2 (+1 unit space)
                  switch (1) {
                      case 1: // +1
@@ -1867,7 +1867,7 @@ mod tests {
     /// Modified CCN: 3 case arms in one switch collapse to 1 decision.
     #[test]
     fn c_switch_modified() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "void f() {
                  switch (x) {
                      case 1: break;
@@ -1903,7 +1903,7 @@ mod tests {
 
     #[test]
     fn c_real_function() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "int sumOfPrimes(int max) { // +2 (+1 unit space)
                  int total = 0;
                  OUT: for (int i = 1; i <= max; ++i) { // +1
@@ -1942,7 +1942,7 @@ mod tests {
 
     #[test]
     fn c_unit_before() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "
             int a=42;
             if(a==42) //+2(+1 unit space)
@@ -1994,7 +1994,7 @@ mod tests {
     /// while the function sumOfPrimes has a complexity of 4.
     #[test]
     fn c_unit_after() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "
             int sumOfPrimes(int max) { // +1
                  int total = 0;
@@ -5823,7 +5823,7 @@ f() {
     /// unit decisions.  No condition expressions, so `&&` / `||` do not fire.
     #[test]
     fn c_nested_loops() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "void f() {
                  for (int i = 0; i < 10; ++i) {     // +1
                      for (int j = 0; j < 10; ++j) { // +1
@@ -5985,7 +5985,7 @@ f() {
     /// Two nested ternaries in one expression therefore add 2 to each.
     #[test]
     fn c_ternary_chain() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "int f(int a, int b, int c) {
                  return a > 0 ? a : (b > 0 ? b : c); // +2 ternaries (?: each)
              }",
@@ -6021,7 +6021,7 @@ f() {
     /// operator token in the chain is a separate decision (Lizard parity).
     #[test]
     fn c_short_circuit_chain() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "int f(int a, int b, int c, int d) {
                  if (a && b || c && d) {            // 3 logical ops + 1 if = 4
                      return 1;
@@ -6061,7 +6061,7 @@ f() {
     /// arms into one switch container.
     #[test]
     fn c_switch_fallthrough() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "int f(int x) {
                  int r = 0;
                  switch (x) {
@@ -6113,7 +6113,7 @@ f() {
     /// macro fires here first.
     #[test]
     fn c_goto_not_counted() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "int f(int n) {
                  int i = 0;
              retry:

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -614,7 +614,7 @@ mod tests {
     /// snapshot-anchor policy.
     #[test]
     fn c_pointer_arithmetic_operators() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "int g(int* p, int* q) {
                  return *(p + 1) + *q;
              }",
@@ -638,7 +638,7 @@ mod tests {
     /// must NOT collapse, even though both render as ampersands.
     #[test]
     fn c_bitwise_and_logical_operators() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "int f(int a, int b) {
                  int x = (a & b) | (a ^ b);
                  int y = ~a;
@@ -670,7 +670,7 @@ mod tests {
     /// token classified as a primitive_type operator.
     #[test]
     fn c_increment_decrement_and_sizeof() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "void f(int* p) {
                  int n = sizeof(int);
                  ++p;

--- a/src/metrics/loc.rs
+++ b/src/metrics/loc.rs
@@ -2014,7 +2014,7 @@ mod tests {
 
     #[test]
     fn c_blank() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "
 
             int a = 42;
@@ -2647,7 +2647,7 @@ mod tests {
 
     #[test]
     fn c_cloc() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "/*Block comment
             Block Comment*/
             //Line Comment
@@ -2815,7 +2815,7 @@ mod tests {
 
     #[test]
     fn c_lloc() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "for (;;)
                 break;",
             "foo.c",

--- a/src/metrics/nargs.rs
+++ b/src/metrics/nargs.rs
@@ -682,7 +682,7 @@ mod tests {
 
     #[test]
     fn c_single_function() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "int f(int a, int b) {
                  if (a) {
                      return a;
@@ -1026,7 +1026,7 @@ mod tests {
 
     #[test]
     fn c_functions() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "int f(int a, int b) {
                  if (a) {
                      return a;
@@ -1300,7 +1300,7 @@ mod tests {
     /// `is_non_arg` filter (which excludes only `(`, `)`, and `,`).
     #[test]
     fn c_variadic_function() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "int printf(const char* fmt, ...) {
                  return 0;
              }",

--- a/src/metrics/nexits.rs
+++ b/src/metrics/nexits.rs
@@ -576,7 +576,7 @@ mod tests {
 
     #[test]
     fn c_no_exit() {
-        check_metrics::<CppParser>("int a = 42;", "foo.c", |metric| {
+        check_metrics::<CParser>("int a = 42;", "foo.c", |metric| {
             // 0 functions
             insta::assert_json_snapshot!(
                 metric.nexits,
@@ -596,7 +596,7 @@ mod tests {
     /// `Cpp::ReturnStatement` adds +1 — there is no early-out collapse.
     #[test]
     fn c_multiple_returns_in_branches() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "int f(int x) {
                  if (x < 0) {
                      return -1;
@@ -698,7 +698,7 @@ mod tests {
     /// trailing return — every reachable `return` is an exit.
     #[test]
     fn c_early_return_in_loop() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "int find(int* a, int n, int target) {
                  for (int i = 0; i < n; ++i) {
                      if (a[i] == target) {
@@ -731,7 +731,7 @@ mod tests {
     /// The implicit fall-through return is intentionally not modelled.
     #[test]
     fn c_void_no_explicit_return() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "void greet(const char* who) {
                  printf(\"hi %s\\n\", who);
              }",

--- a/src/metrics/nom.rs
+++ b/src/metrics/nom.rs
@@ -375,7 +375,7 @@ mod tests {
 
     #[test]
     fn c_nom() {
-        check_metrics::<CppParser>(
+        check_metrics::<CParser>(
             "int foo();
 
              int foo() {

--- a/src/spaces.rs
+++ b/src/spaces.rs
@@ -1556,12 +1556,12 @@ mod tests {
     }
 
     #[test]
-    fn c_scope_resolution_operator() {
+    fn cpp_scope_resolution_operator() {
         check_func_space::<CppParser, _>(
             "void Foo::bar(){
                 return;
             }",
-            "foo.c",
+            "foo.cpp",
             |func_space| {
                 insta::assert_json_snapshot!(
                     func_space.spaces[0].name,

--- a/tests/mozcpp_grammar_metrics.rs
+++ b/tests/mozcpp_grammar_metrics.rs
@@ -139,12 +139,13 @@ mod mozcpp_metrics {
 
     /// ABC condition counting must also match across the two grammars.
     /// This guards the `cpp_inspect_container` / `cpp_count_unary_conditions`
-    /// helpers, which (unlike the name-based `npa` helpers) still key off
-    /// the `Cpp` enum discriminants; they happen to agree with Mozcpp
-    /// today only because the relevant `kind_id`s coincide. A future
-    /// grammar bump that shifts those ids would silently break Mozcpp ABC
-    /// — this test fails if that happens. (Latent fragility tracked in
-    /// #732.)
+    /// helpers, which match on node-kind *names* (#732, mirroring the
+    /// `npa` fix in #731) rather than the `Cpp` enum discriminants — the
+    /// Mozilla fork assigns different `kind_id`s to the same kinds, so a
+    /// name-agnostic match is the only grammar-correct option. This test
+    /// pins the equivalence so a future regression to id-based matching
+    /// (or a divergent grammar) is caught instead of silently corrupting
+    /// Mozcpp ABC.
     #[test]
     fn mozcpp_matches_cpp_on_conditions() {
         let src = "int f(int a, int b, int c) {

--- a/tests/mozcpp_grammar_metrics.rs
+++ b/tests/mozcpp_grammar_metrics.rs
@@ -142,17 +142,27 @@ mod mozcpp_metrics {
     /// helpers, which match on node-kind *names* (#732, mirroring the
     /// `npa` fix in #731) rather than the `Cpp` enum discriminants — the
     /// Mozilla fork assigns different `kind_id`s to the same kinds, so a
-    /// name-agnostic match is the only grammar-correct option. This test
-    /// pins the equivalence so a future regression to id-based matching
-    /// (or a divergent grammar) is caught instead of silently corrupting
-    /// Mozcpp ABC.
+    /// name-agnostic match is the only grammar-correct option.
+    ///
+    /// The fixture's boolean operands are deliberately not bare
+    /// identifiers: `identifier` has `kind_id` 1 in *both* grammars, so a
+    /// fixture of `a`/`b`/`c` would pass even under the buggy id-based
+    /// code and protect nothing. The terminals exercised here all have
+    /// `kind_id`s that **diverge** between `Cpp` and the fork —
+    /// `field_expression` (361 vs 450), `subscript_expression`
+    /// (349 vs 438), `qualified_identifier` (484 vs 573), `call_expression`
+    /// (251 vs 340), `cast_expression` (343 vs 432) — so id-based matching
+    /// silently miscounts them for Mozcpp. Reverting either helper to
+    /// `kind_id().into()` against `Cpp` makes this test fail.
     #[test]
     fn mozcpp_matches_cpp_on_conditions() {
-        let src = "int f(int a, int b, int c) {
-                 if (a > 0 && b > 0) { return 1; }
-                 while (c < 10 || a == b) { c += 1; }
-                 int x = (a < b) ? a : b;
-                 return x;
+        // Operands span every divergent-id boolean terminal: `o->ready`
+        // (field_expression), `arr[i]` (subscript_expression), `ns::enabled`
+        // (qualified_identifier), `run()` (call_expression), `(bool)i`
+        // (cast_expression).
+        let src = "bool check(Obj* o, int* arr, int i) {
+                 if (o->ready && arr[i]) { return ns::enabled || run(); }
+                 return (bool)i ? o->ready : false;
              }";
         let moz = mozcpp_space(src);
         let cpp = analyze(
@@ -170,11 +180,12 @@ mod mozcpp_metrics {
             cpp.metrics.abc.assignments_sum(),
             "abc assignments parity"
         );
-        // Non-degenerate: the fixture really has several conditions.
-        assert!(
-            cpp.metrics.abc.conditions_sum() >= 4,
-            "fixture exercises conditions: {}",
-            cpp.metrics.abc.conditions_sum()
+        // Non-degenerate, and pins the divergent-id terminals are all
+        // counted: o->ready, arr[i], ns::enabled, run(), (bool)i = 5.
+        assert_eq!(
+            cpp.metrics.abc.conditions_sum(),
+            5,
+            "fixture exercises all five divergent-id boolean terminals"
         );
     }
 }


### PR DESCRIPTION
Fixes the two open follow-ups from the upstream C/C++ grammar epic (#718).

## #732 — ABC condition helpers keyed off the `Cpp` enum (bug)

The shared C-family ABC condition helpers (`cpp_inspect_container`,
`cpp_count_unary_conditions`, and the `cpp_bool_terminal_kinds!` macro)
matched node kinds via `kind_id().into()` against the `Cpp` enum, but are
also used by the `MozcppCode` ABC impl. A raw kind_id only maps to the
correct `Cpp` variant for `Cpp` nodes — the Mozilla fork assigns different
ids to the same kinds, so a future grammar bump shifting any condition id
would silently corrupt Mozcpp ABC with no parse error.

Rewritten to match on `node.kind()` **names**, which is grammar-agnostic —
mirroring the `npa` fix in #731.

- **Zero `Cpp` drift**: every node-kind name maps to exactly the set of
  `Cpp` variants the old code matched (verified against the `=> "..."`
  table in `language_cpp.rs`); no other variant renders to those names.
- Guarded by the (non-vacuous) `mozcpp_matches_cpp_on_conditions` parity
  test.

## #730 — `c_*` tests drove `CppParser`, not the dedicated C grammar (tests)

~48 metric tests named `c_*` predated the dedicated `LANG::C` / `CParser`
(#721) and drove `CppParser` on C-like snippets — misleading names, and
the `CCode` metric impls had almost no coverage of their own.

- Renamed the C++-only-content tests `c_* -> cpp_*` (try/catch, range-based
  `for`, lambda, and `spaces.rs`'s `::` scope-resolution case — the latter
  found outside `src/metrics/`); they stay on `CppParser`.
- Converted the ~41 pure-C tests from `CppParser` to `CParser` in place;
  they now exercise the real `tree-sitter-c` parse trees and the `CCode`
  metric arms.

End state matches the existing `mozjs_*`/`javascript_*` convention:
`c_*` => CParser, `cpp_*` => CppParser.

### Verification

- No snapshot drift — C is the strict subset grammar, so every converted
  inline snapshot is bit-identical to its former `CppParser` value.
- Confirmed `tree-sitter-c` parses every converted snippet with **no ERROR
  nodes**, so the tests genuinely exercise the C grammar rather than
  coincidentally-equal error-recovery output.

Quality suite (simplify-rust / rust-optimize / audit-tests / review /
code-review) and `make pre-commit` all green.

Fixes #730
Fixes #732
