### PR TITLE
docs(book): recipe for feeding bca metrics to an agentic coding tool

### DIFF
--- a/.claude/hooks/bca-check.sh
+++ b/.claude/hooks/bca-check.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Dogfood of the "Feeding metrics to an agent" recipe
+# (big-code-analysis-book/src/recipes/agent-feedback.md).
+#
+# PostToolUse hook: after Claude edits a file, run `bca check` on just
+# that file and, only when the per-function thresholds in the repo-root
+# bca.toml are exceeded, feed the offender list + guidance back to the
+# model. Stays silent (exit 0) on a clean file, an unsupported file
+# type, a tool error, or a missing analyzer — it must never block an
+# edit.
+set -euo pipefail
+
+root="${CLAUDE_PROJECT_DIR:-$PWD}"
+
+# Resolve the analyzer: explicit override first, then this checkout's
+# release build (so we dogfood THIS repo's bca, not whatever is on
+# PATH), then a bca on PATH. No analyzer ⇒ silent no-op.
+if [ -n "${BCA:-}" ]; then
+	bca="$BCA"
+elif [ -x "$root/target/release/bca" ]; then
+	bca="$root/target/release/bca"
+elif command -v bca >/dev/null 2>&1; then
+	bca="bca"
+else
+	exit 0
+fi
+
+# PostToolUse delivers the tool call as JSON on stdin; the edited file's
+# path is .tool_input.file_path for Edit/Write/MultiEdit.
+file_path="$(jq -r '.tool_input.file_path // empty')"
+[ -n "$file_path" ] || exit 0 # nothing to check.
+[ -f "$file_path" ] || exit 0 # file gone (e.g. a delete).
+case "$file_path" in          # only gate files inside this repo.
+	"$root"/*) ;;
+	*) exit 0 ;;
+esac
+
+# bca check exits 0 clean, 2 on offenders, 1 on tool error. Branch on 2
+# so an unsupported file type or config error stays silent rather than
+# being mislabelled as "complexity".
+status=0
+report="$("$bca" check "$file_path" --no-summary --no-remediation 2>&1)" || status=$?
+case "$status" in
+	0) exit 0 ;;
+	2) ;;
+	*) exit 0 ;;
+esac
+
+# Exit 2 makes Claude read stderr as context about the edit.
+guidance="$root/.claude/hooks/bca-guidance.txt"
+cat >&2 <<EOF
+bca flagged complexity in the file you just edited:
+
+$report
+
+$([ -f "$guidance" ] && cat "$guidance")
+EOF
+exit 2

--- a/.claude/hooks/bca-guidance.txt
+++ b/.claude/hooks/bca-guidance.txt
@@ -1,0 +1,28 @@
+Responding to bca metric feedback. A threshold violation (cognitive,
+cyclomatic, ABC, ...) means this function is hard for a human to follow.
+The number is a proxy for that, not the goal. Make the code genuinely
+simpler -- not the number smaller.
+
+- Do not game the metric. Do not extract a helper that exists only to
+  move complexity off one function, split a cohesive function at an
+  arbitrary line, collapse readable branches into a dense expression, or
+  inline/obfuscate logic to dodge the count. These lower the
+  per-function score while making the code worse -- and a spurious
+  helper often raises file-level nom/nargs, so you have not even helped
+  the file.
+- Refactor only when it truly clarifies. A good split has a name that
+  means something and a boundary a reader would have drawn anyway. If
+  you cannot name the extracted piece without inventing a foo_part2, the
+  split is gaming -- stop.
+- When the complexity is essential, suppress with a reason. Some
+  functions are irreducibly complex and clearest left whole -- a
+  dispatch match, a hand-rolled parser table, an exhaustive state
+  machine. For these, add a suppression marker with a one-line
+  rationale: // bca: suppress(<metrics>) inside the function (canonical
+  names; it is nexits, never exit -- an unknown metric voids the whole
+  marker). A clear function with an honest suppression beats a
+  "compliant" tangle.
+
+This repo also gates at the task boundary: run `make self-scan` (and
+`make pre-commit`) before declaring work done. The per-edit hook is an
+early-warning convenience, not the gate.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,6 +313,44 @@ A behaviour-changing fix without the matching submodule bump leaves
 the next fresh clone with either an unfetchable submodule SHA or
 stranded `.snap.new` drift that blocks CI on every subsequent change.
 
+## Responding to bca metric feedback
+
+This repo dogfoods its own analyzer: a `bca check` threshold violation
+may surface mid-edit (via the optional Claude Code `PostToolUse` hook in
+`.claude/hooks/bca-check.sh`) or at the task boundary (`make self-scan`,
+`make pre-commit`). A violation (cognitive, cyclomatic, ABC, …) means
+*this function is hard for a human to follow* — the number is a proxy
+for that, not the goal. Make the code genuinely simpler, not the number
+smaller.
+
+- **Do not game the metric.** Do not extract a helper that exists only
+  to move complexity off one function, split a cohesive function at an
+  arbitrary line, collapse readable branches into a dense expression, or
+  inline/obfuscate logic to dodge the count. These lower the
+  per-function score while making the code worse — and a spurious helper
+  often *raises* file-level `nom`/`nargs`, so the file is no better off.
+- **Refactor only when it truly clarifies.** A good split has a name
+  that means something and a boundary a reader would have drawn anyway.
+  If you cannot name the extracted piece without inventing a `foo_part2`,
+  the split is gaming — stop.
+- **When the complexity is essential, suppress with a reason.** Some
+  functions are irreducibly complex *and clearest left whole* — a
+  dispatch `match`, a hand-rolled parser table, an exhaustive state
+  machine. For these, add an in-source marker with a one-line rationale
+  rather than contorting the code:
+  `// bca: suppress(<metrics>)` inside the function (per-file:
+  `// bca: suppress-file(<metrics>)`). Use canonical metric names — it
+  is `nexits`, **never** `exit`; an unknown identifier warns *and voids
+  the entire marker*. `tokens` is not suppressible. See
+  [Suppression markers](big-code-analysis-book/src/commands/suppression.md)
+  and the full recipe at
+  [`recipes/agent-feedback.md`](big-code-analysis-book/src/recipes/agent-feedback.md).
+
+The per-edit hook is an early-warning convenience; the task-boundary
+gate (`make self-scan` / `make pre-commit`) is the real check before
+declaring work done. Thresholds are proxies, not correctness gates —
+weigh them, do not drive them to zero at any cost.
+
 ## Tree-sitter grammars
 
 External grammar crates are version-pinned (`=0.23.x`, etc.) in the root

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ for historical reference.
 
 ### Added
 
+- New book recipe, *Feeding metrics to an agentic coding tool*
+  (`recipes/agent-feedback.md`): wires the existing `bca check` surface
+  into an agent's after-edit feedback loop with copy-pasteable sections
+  for Claude Code (`PostToolUse` hook with stderr/`additionalContext`
+  injection) and opencode (a `tool.execute.after` plugin that throws to
+  signal). Ships a verbatim anti-gaming guidance block, the exact
+  in-source suppression syntax (canonical `nexits`, never `exit`), and
+  the task-boundary-vs-per-edit and Goodhart caveats. Documentation
+  only — no binary changes; contrasts itself with the proposed
+  `bca lsp` (#384) (#733).
+
 - `LANG::C` (slug `c`) and the `c` Cargo feature: a dedicated C
   language backed by upstream `tree-sitter-c` `=0.24.2`, owning the
   `.c` extension and the `c` emacs mode (both moved off `LANG::Cpp`).
@@ -2329,6 +2340,14 @@ for historical reference.
   HTML report Total SLOC roll-ups, comment ratio, and Average-MI inputs
   (which read `loc.sloc` directly) are corrected as a consequence.
   The default (`exclude_tests` off) path is byte-for-byte unchanged.
+- Documentation: the [Suppression markers](commands/suppression.md)
+  metric-identifier list no longer advertises the retired `exit`
+  spelling. `exit` was retired in favour of the canonical `nexits` in
+  #555, but the book still listed `exit` and claimed
+  `bca: suppress(exit)` silenced a `nexits` violation — following it
+  produced an unknown-identifier warning that voided the whole marker.
+  The list now reads `nexits` and calls out that `exit` is rejected
+  (#733).
 - Bare-relative glob patterns now match the same files as their `./`-prefixed
   equivalents: `--exclude 'dir/**'` is identical to `--exclude './dir/**'`
   (#726). The walker matches discovered files against a `./`-anchored

--- a/big-code-analysis-book/src/SUMMARY.md
+++ b/big-code-analysis-book/src/SUMMARY.md
@@ -17,6 +17,7 @@
   - [CI integration](recipes/ci.md)
   - [Baselines](recipes/baselines.md)
   - [Local threshold gates](recipes/local-gates.md)
+  - [Feeding metrics to an agent](recipes/agent-feedback.md)
   - [AST queries](recipes/ast-queries.md)
   - [Exporting metric data](recipes/exporting-data.md)
   - [Driving the REST API](recipes/rest-api.md)

--- a/big-code-analysis-book/src/commands/suppression.md
+++ b/big-code-analysis-book/src/commands/suppression.md
@@ -113,15 +113,16 @@ of the generated-code auto-skip mechanism (see
 The identifiers accepted inside `bca: suppress(...)` and
 `bca: suppress-file(...)` are:
 
-`abc`, `cognitive`, `cyclomatic`, `exit`, `halstead`, `loc`, `mi`,
-`nargs`, `nom`, `npa`, `npm`, `wmc`.
+`abc`, `cognitive`, `cyclomatic`, `halstead`, `loc`, `mi`, `nargs`,
+`nexits`, `nom`, `npa`, `npm`, `wmc`.
 
-They mostly match the JSON field names emitted on `CodeMetrics`, with
-two deliberate differences:
+These match the threshold names and the JSON field names emitted on
+`CodeMetrics`, with one deliberate exclusion:
 
-- `exit` is the suppression spelling for the threshold name `nexits`
-  (the JSON field is also `nexits`) — `bca: suppress(exit)` silences a
-  `nexits` threshold violation.
+- `nexits` is the canonical spelling — `bca: suppress(nexits)` silences
+  a `nexits` threshold violation. The legacy `exit` alias was retired
+  in #555 and is no longer accepted; spelling it `exit` is an unknown
+  identifier, which warns *and voids the entire marker* (see below).
 - `tokens` is a threshold-checkable metric (and a `CodeMetrics` JSON
   field) but is deliberately absent from the suppression list: a
   marker cannot turn it off. Treat `tokens` as a hard resource cap,

--- a/big-code-analysis-book/src/recipes/README.md
+++ b/big-code-analysis-book/src/recipes/README.md
@@ -16,6 +16,10 @@ The recipes are grouped by goal:
   gate on a developer machine with a two-tier (hard + headroom)
   Makefile / `just` / `pre-commit` pattern, so regressions never
   reach the pull request.
+- [Feeding metrics to an agent](agent-feedback.md) — wire `bca check`
+  into an agentic coding tool's after-edit feedback loop (Claude Code
+  `PostToolUse` hook, opencode plugin), with the anti-gaming guidance
+  that keeps the loop honest.
 - [AST queries](ast-queries.md) — search for syntactic constructs,
   count node types, dump trees, and detect parse errors.
 - [Exporting metric data](exporting-data.md) — emit structured output

--- a/big-code-analysis-book/src/recipes/agent-feedback.md
+++ b/big-code-analysis-book/src/recipes/agent-feedback.md
@@ -1,0 +1,339 @@
+# Feeding metrics to an agentic coding tool
+
+An agentic coding tool — Claude Code, opencode, and the like — is a
+fast-growing consumer of maintainability feedback, and it wants that
+feedback in a different shape than a human in an editor does. A human
+keystrokes, so the editor loop reaches for a language server: parse on
+`didChange`, render complexity in the margin, update on every
+character. An agent does not keystroke. It writes a whole edit through
+a tool call and yields the turn. The right feedback for that consumer
+is **batch, after-edit, structured** — exactly what
+[`bca check`](../commands/check.md) already emits.
+
+So this recipe ships no new binary surface. `bca check` already gives
+an agent everything it needs:
+
+- A machine-parseable offender list (per-violation lines on stderr, or
+  `--report-format sarif | code-climate | clang-warning | msvc-warning
+  | checkstyle` for a structured document).
+- A tiered exit code — `2` when offenders are present, `0` clean, `1`
+  on tool error — so a hook can branch on "did this edit make the code
+  too complex?" without parsing anything.
+- Baseline filtering, in-source suppression markers, and
+  `[check.exclude]` globs, so the signal an agent sees is the same
+  ratcheted signal a human sees.
+
+What was missing is the wiring. This page is that wiring: a
+copy-pasteable feedback loop per tool, plus the agent-facing guidance
+that keeps the loop from backfiring.
+
+## After-edit, not keystroke-time
+
+This recipe is the deliberate counterpart to the proposed
+[`bca lsp` server (#384)](https://github.com/dekobon/big-code-analysis/issues/384).
+The two serve different consumers and do not depend on each other:
+
+| | `bca lsp` (#384) | This recipe |
+| --- | --- | --- |
+| Consumer | Human in an editor | Agent in a tool loop |
+| Trigger | Keystroke (`didChange`) | Tool call completes (an edit lands) |
+| Reparse | Incremental | Whole-file, once per edit |
+| Surface | Margin diagnostics | Text fed back into the model |
+| Status | Proposed | Works today with `bca check` |
+
+Reach for the LSP when a person is typing; reach for this when an
+agent is editing. Wiring an agent through the LSP's incremental
+`didChange` path would pay for machinery the agent never uses.
+
+The command every per-tool section below invokes is the same one you
+would run by hand:
+
+```bash
+# Exit 2 ⇒ this file has at least one offender. Thresholds come from
+# the repo-root bca.toml (discovered automatically); override ad hoc
+# with one or more --threshold flags.
+bca check path/to/edited_file.rs --threshold cognitive=25
+```
+
+With a `bca.toml` at the repo root (see
+[Local threshold gates](local-gates.md#zero-config-the-bcatoml-manifest))
+the `--threshold` flags are unnecessary — a bare
+`bca check <file>` reads the committed limits, baseline, and excludes,
+so the agent loop gates on exactly what CI gates on.
+
+## Claude Code
+
+**Mechanism:** a
+[`PostToolUse` hook](https://code.claude.com/docs/en/hooks) in
+`.claude/settings.json`, with the `matcher` scoped to the
+file-editing tools.
+
+**Feedback channel:** this is the strongest fit of any agentic tool.
+A `PostToolUse` hook fires the instant an edit lands, and it can inject
+text straight back into the model — either by **exiting `2` with the
+message on stderr** (Claude reads stderr as context about what
+happened) or by emitting JSON with
+`hookSpecificOutput.additionalContext`. Feedback arrives at the exact
+edit boundary and costs zero tokens until there is something to say.
+
+Wire the hook in `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/bca-check.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The wrapper script reads the edited file's path from the hook's stdin
+JSON, runs `bca check` on just that file, and — only when the gate
+trips — prints the offender list followed by the agent-guidance block
+on stderr and exits `2`:
+
+```bash
+#!/usr/bin/env bash
+# .claude/hooks/bca-check.sh — gate a single edited file after the edit.
+set -euo pipefail
+
+# PostToolUse delivers the tool call as JSON on stdin; the edited
+# file's path is .tool_input.file_path for Edit/Write/MultiEdit.
+file_path="$(jq -r '.tool_input.file_path // empty')"
+[ -n "$file_path" ] || exit 0          # nothing to check; stay silent.
+[ -f "$file_path" ] || exit 0          # file gone (e.g. a delete).
+
+# Thresholds, baseline, and excludes come from the repo-root bca.toml.
+# --no-summary / --no-remediation keep the feedback to the offender
+# lines themselves; the guidance below tells the agent what to do.
+status=0
+report="$(bca check "$file_path" --no-summary --no-remediation 2>&1)" || status=$?
+
+# bca check exits 0 clean, 2 on offenders, 1 on tool error. Branch on 2
+# specifically so a config/IO error is not mislabelled as "complexity".
+case "$status" in
+  0) exit 0 ;;                         # clean ⇒ say nothing.
+  2) ;;                                # offenders ⇒ report them below.
+  *) printf 'bca check could not run (exit %s):\n%s\n' "$status" "$report" >&2
+     exit 0 ;;
+esac
+
+# Exit 2 makes Claude read stderr as context about the edit.
+cat >&2 <<EOF
+bca flagged complexity in the file you just edited:
+
+$report
+
+$(cat "${CLAUDE_PROJECT_DIR}/.claude/hooks/bca-guidance.txt")
+EOF
+exit 2
+```
+
+Store the [agent-guidance block](#agent-guidance-ship-this-verbatim)
+in `.claude/hooks/bca-guidance.txt` so the hook feedback and your
+`CLAUDE.md` cite identical wording. (`jq` is the only dependency; it
+ships with most agent images and is a one-line install otherwise.)
+
+If you would rather inject advisory context without the `exit 2`
+signal, emit JSON on stdout instead of writing to stderr:
+
+```bash
+jq -n --arg ctx "$offenders" '{
+  hookSpecificOutput: {
+    hookEventName: "PostToolUse",
+    additionalContext: $ctx
+  }
+}'
+exit 0
+```
+
+Use `additionalContext` when you want the offender list in Claude's
+view as a note; use `exit 2` when you want it framed as a problem to
+address before moving on. Both leave the edit in place — `PostToolUse`
+runs *after* the tool, so neither can undo it.
+
+## opencode
+
+**Mechanism:** a [plugin](https://opencode.ai/docs/plugins/) — a
+JavaScript or TypeScript module exporting an async function that
+returns a hooks object — using the **`tool.execute.after`** hook,
+which fires after a tool runs (including the `write` and `edit`
+file-modification tools).
+
+**Feedback channel:** the after-hook surfaces a problem to the agent by
+**throwing**. opencode's public plugins page documents the throw-to-signal
+pattern but not an advisory return value for the after-hook, so this
+recipe defaults to throwing — a thrown `Error` carries its message back
+to the agent as the tool's failure.
+
+**Mind the argument shape — it differs from the `before` hook.** The
+published `@opencode-ai/plugin` types give `tool.execute.after` the
+signature `(input, output)` where the tool name is `input.tool` and the
+**tool arguments are on `input.args`** (the file path is
+`input.args.filePath`). This is the trap: the docs' only worked example
+is for `tool.execute.before`, where args live on `output.args` (mutable,
+pre-execution). Copy that into an *after* hook and `output.args` is
+`undefined`, the guard below always trips, and the plugin silently never
+runs — a no-op that looks installed. Read `input.args.filePath` in the
+after hook.
+
+Drop this file in `.opencode/plugins/` (project-level; auto-loaded —
+no `opencode.json` entry needed, that key is for npm-published
+plugins). The plugin below is plain JavaScript; for a TypeScript plugin,
+`import type { Plugin } from "@opencode-ai/plugin"` and annotate the
+export, and declare any extra deps in `.opencode/package.json` (opencode
+installs it with Bun):
+
+```javascript
+// .opencode/plugins/bca-check.js
+const GUIDANCE = `
+Responding to bca metric feedback: make the code genuinely simpler,
+not the number smaller. Do not extract a meaningless helper or split a
+cohesive function to dodge the count — a spurious helper often raises
+file-level nom/nargs and helps nothing. If the complexity is essential
+and the function is clearest left whole, add a suppression marker with
+a one-line reason instead of contorting the code.
+`.trim()
+
+export const BcaCheck = async ({ $ }) => {
+  return {
+    // Note: the after-hook's args are on `input.args`, NOT `output.args`
+    // (output carries the tool's result: title/output/metadata).
+    "tool.execute.after": async (input, _output) => {
+      // React only to the file-writing tools. (Patch-style edit tools
+      // carry no single filePath and are intentionally not covered.)
+      if (input.tool !== "write" && input.tool !== "edit") return
+      const filePath = input.args?.filePath
+      if (!filePath) return
+
+      // `bca check` exits 0 clean, 2 on offenders, 1 on tool error.
+      // Bun's $ throws on non-zero by default; capture instead so we
+      // can branch on the exact code.
+      const res = await $`bca check ${filePath} --no-summary --no-remediation`
+        .quiet()
+        .nothrow()
+      if (res.exitCode !== 2) return // 0 clean, 1 tool error: not a complexity issue.
+
+      // Surface the offenders to the agent by throwing.
+      const offenders = res.stderr.toString().trim() || res.stdout.toString().trim()
+      throw new Error(`bca flagged complexity in ${filePath}:\n\n${offenders}\n\n${GUIDANCE}`)
+    },
+  }
+}
+```
+
+Keep the `GUIDANCE` string in sync with the verbatim block below (or
+read it from a shared file). Because the channel is a thrown error,
+opencode reports it as a failed post-edit step — which is the intended
+"address this before continuing" framing.
+
+## Agent guidance (ship this verbatim)
+
+The feedback channel is only half the recipe. A bare "cognitive 26 >
+25" reliably triggers the gaming move — the agent extracts a
+semantically empty helper to shave the per-function number, *lowering*
+per-function complexity while *raising* file-level `nom`/`nargs` and
+leaving the code worse. The mitigation is telling the agent what a
+violation means and what to do about it. Paste this block into your
+agent rules file (`CLAUDE.md`, opencode `AGENTS.md`) **and** into the
+hook feedback text, so the instruction is present both as standing
+policy and at the moment of the violation:
+
+```markdown
+**Responding to `bca` metric feedback.** A threshold violation
+(cognitive, cyclomatic, ABC, …) means *this function is hard for a
+human to follow*. The number is a proxy for that, not the goal. Your
+job is to make the code genuinely simpler — not to make the number go
+down.
+
+- **Do not game the metric.** Do not extract a helper that exists only
+  to move complexity off one function, split a cohesive function at an
+  arbitrary line, collapse readable branches into a dense expression,
+  or inline/obfuscate logic to dodge the count. These lower the
+  per-function score while making the code worse — and a spurious
+  helper often *raises* file-level `nom`/`nargs`, so you have not even
+  helped the file.
+- **Refactor only when it truly clarifies.** A good split has a name
+  that means something and a boundary a reader would have drawn anyway.
+  If you cannot name the extracted piece without inventing a
+  `foo_part2`, the split is gaming — stop.
+- **When the complexity is essential, suppress with a reason.** Some
+  functions are irreducibly complex *and clearest left whole* — a
+  dispatch `match`, a hand-rolled parser table, an exhaustive state
+  machine. For these, do not contort the code: add a suppression marker
+  with a one-line rationale and move on. A clear function with an
+  honest `// bca: suppress(...)` is better than a "compliant" tangle.
+```
+
+## Honest suppression (exact syntax)
+
+The guidance above tells the agent that suppression is a legitimate
+move. For that to work the agent has to spell the marker correctly —
+and the marker syntax is a frequent source of silent no-ops. Teach it
+precisely (full reference:
+[Suppression markers](../commands/suppression.md)):
+
+- **Per function** — place the marker in a comment inside the function
+  body, naming the metric(s):
+  `// bca: suppress(cyclomatic, abc)`. A bare `// bca: suppress`
+  (no list) silences *every* metric for that function.
+- **Whole file** — `// bca: suppress-file(halstead, nargs, nexits)`
+  anywhere in the file; the bare `// bca: suppress-file` form silences
+  every metric file-wide.
+- **Use canonical metric names.** The accepted identifiers are `abc`,
+  `cognitive`, `cyclomatic`, `halstead`, `loc`, `mi`, `nargs`,
+  `nexits`, `nom`, `npa`, `npm`, `wmc`. It is **`nexits`, not `exit`**
+  (the legacy `exit` alias was retired) — and an unknown identifier
+  both warns *and voids the entire marker*, silently un-suppressing
+  everything it listed. `tokens` is deliberately *not* suppressible;
+  treat it as a hard resource cap.
+- **Always pair a suppression with a rationale comment** so a reviewer
+  — human or agent — can later tell an honest exemption from a dodge.
+  `bca exemptions` lists every marker in the tree for exactly this
+  audit.
+
+## Gate at the task boundary, not per edit
+
+The per-edit hooks above are an early-warning convenience, not the
+gate. The gate is the same check a human runs before declaring a task
+done: the two-tier
+[`make self-scan` / pre-commit pattern](local-gates.md) (hard tier
+mirroring CI, soft tier as a 95%-of-limit headroom band). Point the
+agent at that as its "before I'm finished" step.
+
+Going finer-grained than the task boundary is low- or negative-value
+for an agent. A complexity threshold is a proxy, not a correctness
+gate (see the caveats below), so re-running it after *every* micro-edit
+mid-refactor just produces transient violations that resolve
+themselves a few edits later — noise the agent then wastes a turn
+"fixing". Let the agent finish a coherent change, then gate once.
+
+## Caveats
+
+Two caveats the recipe depends on; ignore them and the loop does more
+harm than good.
+
+- **Goodhart's law / metric-gaming.** "Make this number smaller" is not
+  the same instruction as "make this code simpler", and an LLM told the
+  former will satisfy it the cheapest way it can — usually by shuffling
+  complexity across a function boundary rather than removing it. The
+  [agent-guidance block](#agent-guidance-ship-this-verbatim) and the
+  [honest-suppression section](#honest-suppression-exact-syntax) are
+  the mitigation; they are load-bearing, not optional polish. Ship them
+  with the hook or expect the gaming move.
+- **Thresholds are proxies, not correctness gates.** A failing
+  compile or a red test is unambiguous — a tight agent loop on those
+  converges. A complexity threshold is softer: crossing it means
+  "a human should look at whether this is still readable", which is a
+  judgement call, not a defect. Set expectations accordingly — wire
+  complexity feedback as advice the agent weighs, not a pass/fail it
+  must drive to zero at any cost.


### PR DESCRIPTION
## Summary

Closes #733. Adds a book recipe showing how to feed `bca` metrics into
an **agentic coding tool's** after-edit feedback loop — the agent
counterpart to the human-in-editor `bca lsp` proposal (#384) — and
dogfoods it on this repo. Documentation + Claude Code tooling; **no
binary changes**.

## What's here

- **`big-code-analysis-book/src/recipes/agent-feedback.md`** (registered
  in `SUMMARY.md` / `recipes/README.md`). Shared after-edit-vs-keystroke
  framing and a `#384` contrast, then copy-pasteable, verified sections
  for **Claude Code** (`PostToolUse` hook injecting stderr /
  `additionalContext`) and **opencode** (a `tool.execute.after` plugin
  that throws to signal). Ships the verbatim anti-gaming guidance block,
  the exact in-source suppression syntax, the task-boundary-vs-per-edit
  rationale, and the Goodhart / proxy-not-correctness caveats.
- **Stale-doc fix in `commands/suppression.md`**: it still listed the
  retired `exit` metric identifier and claimed `bca: suppress(exit)`
  silenced a `nexits` violation. `exit` was retired for canonical
  `nexits` in #555; the old spelling now warns *and voids the whole
  marker*. The recipe links this page, so the reference had to be right.
- **Dogfood (`.claude/hooks/`)**: a tested `bca-check.sh` PostToolUse
  wrapper + `bca-guidance.txt`, the working reference behind the Claude
  Code section. Activation lives in `.claude/settings.json` (gitignored,
  per-developer — matching the existing serena hooks), so these are
  opt-in.
- **`AGENTS.md`**: a "Responding to bca metric feedback" standing-policy
  section, the rules-file counterpart to the hook's at-violation text.

## Scope note

Cursor was dropped from the recipe at the maintainer's request. (Aside:
while verifying sources I found Cursor now ships a `postToolUse` hook
with `additional_context` — a per-edit channel the issue's premise
predates; noted on the issue if it's added later.)

## Verification

- Every technical claim checked against source (`check_format.rs`,
  `lib.rs`, `suppression.rs`, `metric_set.rs`) and live tool docs.
- Both hook snippets branch on exit code **2** so a `bca` tool error
  (exit 1) is not mislabelled as complexity; exercised against the real
  binary and a stub.
- `make pre-commit` green (fmt, clippy ×2, workspace tests, udeps,
  manpages, both self-scan tiers, python tests + stubtest, all lint
  families); `mdbook build` clean; rumdl clean.
