### PR TITLE
refactor(metrics): reduce complexity hotspots from self-scan

### DIFF
--- a/.bca-baseline.toml
+++ b/.bca-baseline.toml
@@ -40,20 +40,6 @@ metric = "nom"
 value = 30.0
 
 [[entry]]
-path = "big-code-analysis-cli/src/lib.rs"
-qualified = "expand_seed_paths"
-start_line = 2758
-metric = "cognitive"
-value = 24.0
-
-[[entry]]
-path = "big-code-analysis-cli/src/markdown_report.rs"
-qualified = "language_display_name"
-start_line = 260
-metric = "cyclomatic"
-value = 26.0
-
-[[entry]]
 path = "big-code-analysis-cli/src/markdown_report/hotspot.rs"
 qualified = "<file>"
 start_line = 1
@@ -101,20 +87,6 @@ qualified = "_native"
 start_line = 829
 metric = "abc"
 value = 67.0
-
-[[entry]]
-path = "big-code-analysis-py/src/sarif.rs"
-qualified = "collect_offenders"
-start_line = 485
-metric = "cognitive"
-value = 31.0
-
-[[entry]]
-path = "big-code-analysis-py/src/sarif.rs"
-qualified = "collect_offenders"
-start_line = 485
-metric = "cyclomatic"
-value = 15.0
 
 [[entry]]
 path = "big-code-analysis-py/src/types_codegen.rs"
@@ -166,36 +138,8 @@ metric = "nexits"
 value = 5.0
 
 [[entry]]
-path = "src/preproc.rs"
-qualified = "preprocess_with_parser"
-start_line = 432
-metric = "cognitive"
-value = 33.0
-
-[[entry]]
-path = "src/preproc.rs"
-qualified = "preprocess_with_parser"
-start_line = 432
-metric = "cyclomatic"
-value = 15.0
-
-[[entry]]
-path = "src/preproc.rs"
-qualified = "record_indirect_includes"
-start_line = 320
-metric = "cognitive"
-value = 25.0
-
-[[entry]]
 path = "src/vcs/error.rs"
 qualified = "Error::fmt"
 start_line = 124
 metric = "cyclomatic"
 value = 17.0
-
-[[entry]]
-path = "src/vcs/git/diff_parse.rs"
-qualified = "parse_unified_diff"
-start_line = 74
-metric = "cyclomatic"
-value = 16.0

--- a/big-code-analysis-cli/src/commands.rs
+++ b/big-code-analysis-cli/src/commands.rs
@@ -1751,29 +1751,32 @@ fn resolve_structured_output(
     StructuredOutput::Stdout
 }
 
+/// Resolve the `--metrics` selection (#691) into the library `Metric`
+/// families to compute, or `None` (compute all metrics) when the flag is
+/// absent. Every requested name is validated against the catalog via the
+/// shared #662 did-you-mean validator first, so an unrecognized name is a
+/// hard error (exit 1) rather than a silently dropped selection.
+fn resolve_selected_metrics(names: &[String]) -> Option<Vec<big_code_analysis::Metric>> {
+    if names.is_empty() {
+        return None;
+    }
+    crate::metric_alias::validate_diff_metrics(names).unwrap_or_else(|e| die(e));
+    let mut selected: Vec<big_code_analysis::Metric> = names
+        .iter()
+        .filter_map(|name| crate::metric_alias::metric_for_name(name))
+        .collect();
+    selected.sort_unstable();
+    selected.dedup();
+    Some(selected)
+}
+
 fn run_command_metrics(
     globals: GlobalOpts,
     args: MetricsArgs,
     preproc: Option<Arc<PreprocResults>>,
 ) {
     let mut structured = args.structured;
-    // `--metrics` (issue #691): validate every requested name against the
-    // catalog (reusing the #662 did-you-mean validator), then map each to
-    // its library `Metric` family. An unknown name errors (exit 1). An
-    // empty list (flag absent) leaves the selection `None` → all metrics.
-    let selected_metrics = if args.metrics.is_empty() {
-        None
-    } else {
-        crate::metric_alias::validate_diff_metrics(&args.metrics).unwrap_or_else(|e| die(e));
-        let mut selected: Vec<big_code_analysis::Metric> = args
-            .metrics
-            .iter()
-            .filter_map(|name| crate::metric_alias::metric_for_name(name))
-            .collect();
-        selected.sort_unstable();
-        selected.dedup();
-        Some(selected)
-    };
+    let selected_metrics = resolve_selected_metrics(&args.metrics);
     // `--format text` (issue #604) is a surface alias for the historical
     // no-`--format` default — the human-readable tree. Collapse it to
     // `None` here so every downstream guard and the dispatch see the
@@ -2080,24 +2083,18 @@ fn run_command_report(
         None => AdvisoryThresholds::DEFAULT,
     };
 
-    let report = match (format, vcs.as_ref()) {
-        (ReportFormat::Markdown, None) => {
-            generate_report_with_vcs(&summaries, top, policy, &advisory, None, Some(&prov))
+    // `generate_*_with_vcs` already accept the change-history section as an
+    // `Option`, so dispatch only on the output format and pass the optional
+    // report straight through rather than enumerating the four format×vcs
+    // combinations.
+    let vcs = vcs.as_ref();
+    let report = match format {
+        ReportFormat::Markdown => {
+            generate_report_with_vcs(&summaries, top, policy, &advisory, vcs, Some(&prov))
         }
-        (ReportFormat::Markdown, Some(vcs)) => {
-            generate_report_with_vcs(&summaries, top, policy, &advisory, Some(vcs), Some(&prov))
+        ReportFormat::Html => {
+            generate_html_report_with_vcs(&summaries, top, policy, &advisory, vcs, Some(&prov))
         }
-        (ReportFormat::Html, None) => {
-            generate_html_report_with_vcs(&summaries, top, policy, &advisory, None, Some(&prov))
-        }
-        (ReportFormat::Html, Some(vcs)) => generate_html_report_with_vcs(
-            &summaries,
-            top,
-            policy,
-            &advisory,
-            Some(vcs),
-            Some(&prov),
-        ),
     };
     write_output_or_stdout(args.output.as_deref(), "write report to", report.as_bytes());
 }

--- a/big-code-analysis-cli/src/lib.rs
+++ b/big-code-analysis-cli/src/lib.rs
@@ -2761,7 +2761,6 @@ fn expand_seed_paths(
     no_ignore: bool,
     filters: &WalkFilters<'_>,
 ) -> ResolvedFiles {
-    use ignore::WalkBuilder;
     if let Some(src) = paths_from {
         paths.extend(read_paths_from(&src).unwrap_or_else(|e| die(e)));
     }
@@ -2828,46 +2827,7 @@ fn expand_seed_paths(
             }
             continue;
         }
-        let mut wb = WalkBuilder::new(&seed);
-        wb.hidden(true)
-            .follow_links(false)
-            .require_git(false)
-            .git_ignore(!no_ignore)
-            .git_exclude(!no_ignore)
-            .git_global(!no_ignore)
-            .ignore(!no_ignore)
-            .parents(!no_ignore);
-        for entry in wb.build() {
-            // A per-entry walk error (an unreadable subdirectory, a
-            // broken symlink, a racing unlink) skips-with-warning rather
-            // than aborting the entire run (#704): a single EACCES
-            // directory deep in a large tree previously took down every
-            // file the walk had yet to reach. This mirrors the per-file
-            // tolerance the worker pool already applies to unparseable
-            // files.
-            let entry = match entry {
-                Ok(entry) => entry,
-                Err(e) => {
-                    eprintln!(
-                        "bca: warning: skipping walk entry in {}: {e}",
-                        seed.display()
-                    );
-                    continue;
-                }
-            };
-            if entry.file_type().is_some_and(|t| t.is_file()) {
-                let path = entry.into_path();
-                // Anchor the glob match to the walk root rather than the
-                // emitted (possibly absolute) path, so `./`-anchored
-                // excludes match regardless of how the seed resolved —
-                // including a manifest root above the CWD (#489).
-                if filters.passes(&walk_seed::match_path_for(&seed, &path))
-                    && seen.insert(path.clone())
-                {
-                    out.push(path);
-                }
-            }
-        }
+        walk_directory_seed(&seed, no_ignore, filters, &mut out, &mut seen);
     }
     // A walk that resolved zero files is almost always a mistake — an
     // over-narrow `--include`, an `--exclude` that swept everything, or
@@ -2881,6 +2841,59 @@ fn expand_seed_paths(
     ResolvedFiles {
         files: out,
         explicit_files,
+    }
+}
+
+/// Walk the directory `seed`, pushing every supported file that passes the
+/// include/exclude `filters` into `out` exactly once (deduped through `seen`).
+/// Factored out of [`expand_seed_paths`] so its per-seed loop reads as
+/// "handle a file seed, else expand a directory seed" rather than inlining the
+/// whole `ignore::WalkBuilder` setup and per-entry handling.
+///
+/// A per-entry walk error (an unreadable subdirectory, a broken symlink, a
+/// racing unlink) skips that entry with a warning rather than aborting the
+/// run (#704): a single EACCES directory deep in a large tree previously took
+/// down every file the walk had yet to reach. This mirrors the per-file
+/// tolerance the worker pool already applies to unparseable files.
+fn walk_directory_seed(
+    seed: &Path,
+    no_ignore: bool,
+    filters: &WalkFilters<'_>,
+    out: &mut Vec<PathBuf>,
+    seen: &mut std::collections::HashSet<PathBuf>,
+) {
+    use ignore::WalkBuilder;
+    let mut wb = WalkBuilder::new(seed);
+    wb.hidden(true)
+        .follow_links(false)
+        .require_git(false)
+        .git_ignore(!no_ignore)
+        .git_exclude(!no_ignore)
+        .git_global(!no_ignore)
+        .ignore(!no_ignore)
+        .parents(!no_ignore);
+    for entry in wb.build() {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(e) => {
+                eprintln!(
+                    "bca: warning: skipping walk entry in {}: {e}",
+                    seed.display()
+                );
+                continue;
+            }
+        };
+        if entry.file_type().is_some_and(|t| t.is_file()) {
+            let path = entry.into_path();
+            // Anchor the glob match to the walk root rather than the emitted
+            // (possibly absolute) path, so `./`-anchored excludes match
+            // regardless of how the seed resolved — including a manifest root
+            // above the CWD (#489).
+            if filters.passes(&walk_seed::match_path_for(seed, &path)) && seen.insert(path.clone())
+            {
+                out.push(path);
+            }
+        }
     }
 }
 

--- a/big-code-analysis-cli/src/markdown_report.rs
+++ b/big-code-analysis-cli/src/markdown_report.rs
@@ -261,6 +261,12 @@ pub(super) fn language_display_name(slug: &str) -> Cow<'_, str> {
     let Ok(lang) = slug.parse::<LANG>() else {
         return Cow::Owned(title_case(slug));
     };
+    // bca: suppress(cyclomatic)
+    // Exhaustive, wildcard-free `match LANG` display table (one arm per
+    // language variant), kept whole on purpose: the doc comment above relies
+    // on it being a compile error to add a language without choosing a name.
+    // Its branch count is the size of the language set, not logic a reader
+    // needs to follow; splitting it would only scatter the table.
     let display = match lang {
         LANG::Bash => "Bash",
         LANG::C => "C",

--- a/big-code-analysis-py/src/sarif.rs
+++ b/big-code-analysis-py/src/sarif.rs
@@ -60,7 +60,7 @@
 //! `thresholds` produces a well-formed SARIF run with `results: []`
 //! and `rules: []`, matching the CLI's empty case.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use pyo3::Bound;
 use pyo3::PyResult;
@@ -482,6 +482,73 @@ fn qualified_symbol(fields: &SpaceFields, parent_prefix: &str) -> String {
     }
 }
 
+/// Evaluate one space's `metrics` against every threshold, pushing an
+/// [`OffenderRecord`] for each breach. Factored out of [`collect_offenders`]
+/// so the tree walk reads as "evaluate this space, then descend" rather than
+/// inlining the per-threshold comparison.
+fn record_threshold_breaches(
+    metrics: &Bound<'_, PyAny>,
+    fields: &SpaceFields,
+    qualified: &str,
+    path: &Path,
+    thresholds: &[Threshold],
+    out: &mut Vec<OffenderRecord>,
+) {
+    for threshold in thresholds {
+        if fields.is_unit && threshold.skip_at_unit {
+            continue;
+        }
+        let Some(value) = extract_metric(metrics, threshold.path) else {
+            continue;
+        };
+        // `mi.*` is lower-is-worse: a value below the limit is the violation.
+        // Every other metric flags above the limit. The exact-limit value is
+        // acceptable either way (#698).
+        let breaches = if threshold.lower_is_worse {
+            value < threshold.limit
+        } else {
+            value > threshold.limit
+        };
+        if !breaches {
+            continue;
+        }
+        out.push(OffenderRecord {
+            path: path.to_path_buf(),
+            function: Some(qualified.to_string()),
+            start_line: fields.start_line,
+            end_line: fields.end_line,
+            start_col: None,
+            metric: threshold.name.to_string(),
+            value,
+            limit: threshold.limit,
+            severity: Severity::default(),
+        });
+    }
+}
+
+/// Push each child space of `space` onto the walk `stack`, tagged with
+/// `child_prefix` as the parent qualified prefix. Non-dict children are
+/// skipped (mirroring the original inline tolerance). Factored out of
+/// [`collect_offenders`].
+fn push_child_spaces<'py>(
+    space: &Bound<'py, PyDict>,
+    child_prefix: &str,
+    stack: &mut Vec<(Bound<'py, PyDict>, String)>,
+) -> PyResult<()> {
+    let py = space.py();
+    if let Some(spaces) = space.get_item(intern!(py, "spaces"))?
+        && let Ok(seq) = spaces.try_iter()
+    {
+        for child in seq {
+            let child = child?;
+            if let Ok(child_dict) = child.cast_into::<PyDict>() {
+                stack.push((child_dict, child_prefix.to_string()));
+            }
+        }
+    }
+    Ok(())
+}
+
 fn collect_offenders(
     result: &Bound<'_, PyDict>,
     thresholds: &[Threshold],
@@ -510,36 +577,7 @@ fn collect_offenders(
         let fields = extract_space_fields(&space)?;
         let qualified = qualified_symbol(&fields, &parent_prefix);
 
-        for threshold in thresholds {
-            if fields.is_unit && threshold.skip_at_unit {
-                continue;
-            }
-            let Some(value) = extract_metric(&metrics, threshold.path) else {
-                continue;
-            };
-            // `mi.*` is lower-is-worse: a value below the limit is the
-            // violation. Every other metric flags above the limit. The
-            // exact-limit value is acceptable either way (#698).
-            let breaches = if threshold.lower_is_worse {
-                value < threshold.limit
-            } else {
-                value > threshold.limit
-            };
-            if !breaches {
-                continue;
-            }
-            out.push(OffenderRecord {
-                path: path.clone(),
-                function: Some(qualified.clone()),
-                start_line: fields.start_line,
-                end_line: fields.end_line,
-                start_col: None,
-                metric: threshold.name.to_string(),
-                value,
-                limit: threshold.limit,
-                severity: Severity::default(),
-            });
-        }
+        record_threshold_breaches(&metrics, &fields, &qualified, &path, thresholds, out);
 
         // Children inherit this space's qualified symbol as their prefix,
         // except the file root, which stays empty so a top-level function
@@ -549,17 +587,7 @@ fn collect_offenders(
         } else {
             qualified
         };
-
-        if let Some(spaces) = space.get_item(intern!(py, "spaces"))?
-            && let Ok(seq) = spaces.try_iter()
-        {
-            for child in seq {
-                let child = child?;
-                if let Ok(child_dict) = child.cast_into::<PyDict>() {
-                    stack.push((child_dict, child_prefix.clone()));
-                }
-            }
-        }
+        push_child_spaces(&space, &child_prefix, &mut stack)?;
     }
     Ok(())
 }

--- a/src/preproc.rs
+++ b/src/preproc.rs
@@ -28,6 +28,7 @@ use crate::c_langs_macros::is_specials;
 
 use crate::langs::*;
 use crate::languages::language_preproc::*;
+use crate::node::{Cursor, Node};
 use crate::tools::*;
 use crate::traits::*;
 
@@ -325,35 +326,42 @@ fn record_indirect_includes<S: ::std::hash::BuildHasher>(
     diagnostics: &mut Vec<PreprocDiagnostic>,
 ) {
     for (path, start) in nodes {
-        let mut dfs = Dfs::new(g, *start);
-        if let Some(pf) = files.get_mut(path) {
-            let x_inc = &mut pf.indirect_includes;
-            while let Some(node) = dfs.next(g) {
-                let w = g
-                    .node_weight(node)
-                    .expect("invariant: DFS-visited node must have weight in graph");
-                if w == &PathBuf::from("") {
-                    if let Some(paths) = scc_map.get(&node) {
-                        for p in paths {
-                            x_inc.insert(p.clone());
-                        }
-                    } else {
-                        unreachable!(
-                            "every empty-path node is an SCC replacement and must have a scc_map entry"
-                        );
-                    }
-                } else {
-                    let Some(s) = w.to_str() else {
-                        diagnostics.push(PreprocDiagnostic::NonUtf8IndirectInclude {
-                            path: w.display().to_string(),
-                        });
-                        continue;
-                    };
-                    x_inc.insert(s.to_string());
-                }
-            }
-        } else {
+        let Some(pf) = files.get_mut(path) else {
             diagnostics.push(PreprocDiagnostic::NotPreprocessed { file: path.clone() });
+            continue;
+        };
+        accumulate_reachable_includes(g, *start, scc_map, &mut pf.indirect_includes, diagnostics);
+    }
+}
+
+/// Walk the include graph from `start`, inserting the transitive closure of
+/// reachable include paths into `x_inc`. An SCC replacement node (empty path)
+/// contributes every member path it stands in for; a non-UTF-8 path is
+/// reported and skipped. Factored out of [`record_indirect_includes`] so the
+/// per-file accumulation reads as one step rather than three nested loops.
+fn accumulate_reachable_includes(
+    g: &IncludeGraph,
+    start: NodeIndex,
+    scc_map: &HashMap<NodeIndex, HashSet<String>>,
+    x_inc: &mut HashSet<String>,
+    diagnostics: &mut Vec<PreprocDiagnostic>,
+) {
+    let mut dfs = Dfs::new(g, start);
+    while let Some(node) = dfs.next(g) {
+        let w = g
+            .node_weight(node)
+            .expect("invariant: DFS-visited node must have weight in graph");
+        if w == &PathBuf::from("") {
+            let paths = scc_map.get(&node).expect(
+                "every empty-path node is an SCC replacement and must have a scc_map entry",
+            );
+            x_inc.extend(paths.iter().cloned());
+        } else if let Some(s) = w.to_str() {
+            x_inc.insert(s.to_string());
+        } else {
+            diagnostics.push(PreprocDiagnostic::NonUtf8IndirectInclude {
+                path: w.display().to_string(),
+            });
         }
     }
 }
@@ -436,7 +444,6 @@ pub(crate) fn preprocess_with_parser(
 ) {
     let node = parser.root();
     let mut cursor = node.cursor();
-    let mut stack = Vec::new();
     let code = parser.code();
     let mut file_result = PreprocFile::default();
 
@@ -448,62 +455,84 @@ pub(crate) fn preprocess_with_parser(
     // re-introduces it (issue #705).
     let mut macro_events: Vec<(usize, MacroEvent)> = Vec::new();
 
-    stack.push(node);
-
+    let mut stack = vec![node];
     while let Some(node) = stack.pop() {
-        cursor.reset(&node);
-        if cursor.goto_first_child() {
-            loop {
-                stack.push(cursor.node());
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-
-        let id = Preproc::from(node.kind_id());
-        match id {
-            Preproc::Define | Preproc::Undef => {
-                cursor.reset(&node);
-                cursor.goto_first_child();
-                let identifier = cursor.node();
-
-                if identifier.kind_id() == Preproc::Identifier {
-                    let Some(macro_text) = identifier.utf8_text(code) else {
-                        continue;
-                    };
-                    if !is_specials(macro_text) {
-                        // `#undef` un-defines: a macro is in the final set
-                        // only if its last directive was a `#define`.
-                        let event = if id == Preproc::Undef {
-                            MacroEvent::Undef(macro_text.to_string())
-                        } else {
-                            MacroEvent::Define(macro_text.to_string())
-                        };
-                        macro_events.push((identifier.start_byte(), event));
-                    }
-                }
-            }
-            Preproc::PreprocInclude => {
-                cursor.reset(&node);
-                cursor.goto_first_child();
-                let file = cursor.node();
-
-                if file.kind_id() == Preproc::StringLiteral
-                    && let Some(include) =
-                        strip_include_quotes(code, file.start_byte(), file.end_byte())
-                {
-                    file_result.direct_includes.insert(include.to_string());
-                }
-            }
-            _ => {}
-        }
+        push_children(&mut cursor, &node, &mut stack);
+        classify_preproc_node(&node, code, &mut file_result, &mut macro_events);
     }
 
-    // Replay the `#define`/`#undef` directives in source order. A stable
-    // sort on the byte offset preserves the (already unique) directive
-    // order; ties cannot occur because each identifier starts at a
-    // distinct byte.
+    apply_macro_events(macro_events, &mut file_result);
+
+    results.files.insert(path.to_path_buf(), file_result);
+}
+
+/// Push `node`'s children onto `stack` for the stack-based DFS in
+/// [`preprocess_with_parser`]. Children are pushed in source order so they
+/// pop in reverse; directive order is recovered from byte offsets in
+/// [`apply_macro_events`], so visit order does not affect the result.
+fn push_children<'a>(cursor: &mut Cursor<'a>, node: &Node<'a>, stack: &mut Vec<Node<'a>>) {
+    cursor.reset(node);
+    if cursor.goto_first_child() {
+        loop {
+            stack.push(cursor.node());
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+}
+
+/// Classify one node from the [`preprocess_with_parser`] walk: a
+/// `#define`/`#undef` is captured as a [`MacroEvent`] tagged with its byte
+/// offset (replayed in source order later), and a quoted `#include` is
+/// recorded directly into `file_result`. All other nodes are ignored.
+fn classify_preproc_node<'a>(
+    node: &Node<'a>,
+    code: &'a [u8],
+    file_result: &mut PreprocFile,
+    macro_events: &mut Vec<(usize, MacroEvent)>,
+) {
+    let id = Preproc::from(node.kind_id());
+    match id {
+        Preproc::Define | Preproc::Undef => {
+            let mut cursor = node.cursor();
+            cursor.goto_first_child();
+            let identifier = cursor.node();
+            if identifier.kind_id() == Preproc::Identifier
+                && let Some(macro_text) = identifier.utf8_text(code)
+                && !is_specials(macro_text)
+            {
+                // `#undef` un-defines: a macro is in the final set only if
+                // its last directive was a `#define`.
+                let event = if id == Preproc::Undef {
+                    MacroEvent::Undef(macro_text.to_string())
+                } else {
+                    MacroEvent::Define(macro_text.to_string())
+                };
+                macro_events.push((identifier.start_byte(), event));
+            }
+        }
+        Preproc::PreprocInclude => {
+            let mut cursor = node.cursor();
+            cursor.goto_first_child();
+            let file = cursor.node();
+            if file.kind_id() == Preproc::StringLiteral
+                && let Some(include) =
+                    strip_include_quotes(code, file.start_byte(), file.end_byte())
+            {
+                file_result.direct_includes.insert(include.to_string());
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Replay collected `#define`/`#undef` directives in source order so the
+/// final macro set reflects the last directive seen for each name (issue
+/// #705). A stable sort on the byte offset preserves the (already unique)
+/// directive order; ties cannot occur because each identifier starts at a
+/// distinct byte.
+fn apply_macro_events(mut macro_events: Vec<(usize, MacroEvent)>, file_result: &mut PreprocFile) {
     macro_events.sort_by_key(|(offset, _)| *offset);
     for (_, event) in macro_events {
         match event {
@@ -515,8 +544,6 @@ pub(crate) fn preprocess_with_parser(
             }
         }
     }
-
-    results.files.insert(path.to_path_buf(), file_result);
 }
 
 /// A single `#define`/`#undef` directive captured during the AST walk,

--- a/src/preproc.rs
+++ b/src/preproc.rs
@@ -664,15 +664,21 @@ mod tests {
         assert!(!macros.contains("NEVER_DEFINED"));
     }
 
-    /// A `#define` that follows a `#undef` re-introduces the macro: the
-    /// final source-order directive wins, so FOO ends up defined. Set-diff
-    /// approaches get this wrong; source-order replay is required.
+    /// Regression for #705's source-order replay: a `#define` that follows a
+    /// `#undef` in source order re-introduces the macro. The AST walk visits
+    /// siblings in *reverse* source order, so the raw encounter order is
+    /// `define` then `undef` (which would drop FOO); only the byte-offset
+    /// re-sort in `apply_macro_events` recovers the correct `undef` → `define`
+    /// order. The fixture is deliberately asymmetric (undef first, define
+    /// last) so a missing or reversed sort flips the result — a `define`
+    /// … `undef` … `define` sequence ends on a `define` either way and would
+    /// not exercise the ordering at all.
     #[test]
-    fn preprocess_redefine_after_undef_keeps_macro() {
-        let macros = macros_of("#define FOO 1\n#undef FOO\n#define FOO 2\n");
+    fn preprocess_define_after_undef_reintroduces_in_source_order() {
+        let macros = macros_of("#undef FOO\n#define FOO 1\n");
         assert!(
             macros.contains("FOO"),
-            "the trailing #define must win; got {macros:?}"
+            "the trailing source-order #define must win; got {macros:?}"
         );
     }
 
@@ -682,6 +688,24 @@ mod tests {
         let macros = macros_of("#define FOO 1\n#define BAR 2\n#undef FOO\n");
         assert!(!macros.contains("FOO"));
         assert!(macros.contains("BAR"));
+    }
+
+    /// `classify_preproc_node` drops `#define`s of compiler/type "special"
+    /// tokens (the `is_specials` filter — `size_t`, `NULL`, keywords, …) so
+    /// they never pollute the recorded macro set, while an ordinary macro on
+    /// an adjacent line is still recorded. Pins the `is_specials` guard that
+    /// the #736 refactor moved out of the inline walk and into the helper.
+    #[test]
+    fn preprocess_define_of_special_token_is_skipped() {
+        let macros = macros_of("#define size_t unsigned\n#define APP_FLAG 1\n");
+        assert!(
+            !macros.contains("size_t"),
+            "special token `size_t` must be filtered out; got {macros:?}"
+        );
+        assert!(
+            macros.contains("APP_FLAG"),
+            "an ordinary adjacent macro must still be recorded; got {macros:?}"
+        );
     }
 
     /// Regression for #705 (ambiguous include fan-out): when an `#include`

--- a/src/preproc.rs
+++ b/src/preproc.rs
@@ -458,7 +458,13 @@ pub(crate) fn preprocess_with_parser(
     let mut stack = vec![node];
     while let Some(node) = stack.pop() {
         push_children(&mut cursor, &node, &mut stack);
-        classify_preproc_node(&node, code, &mut file_result, &mut macro_events);
+        classify_preproc_node(
+            &mut cursor,
+            &node,
+            code,
+            &mut file_result,
+            &mut macro_events,
+        );
     }
 
     apply_macro_events(macro_events, &mut file_result);
@@ -486,7 +492,12 @@ fn push_children<'a>(cursor: &mut Cursor<'a>, node: &Node<'a>, stack: &mut Vec<N
 /// `#define`/`#undef` is captured as a [`MacroEvent`] tagged with its byte
 /// offset (replayed in source order later), and a quoted `#include` is
 /// recorded directly into `file_result`. All other nodes are ignored.
+///
+/// Takes the walk's shared `cursor` by `&mut` and `reset`s it to reach the
+/// directive's first child, rather than allocating a fresh cursor per node —
+/// the caller is done with `cursor` by the time this runs.
 fn classify_preproc_node<'a>(
+    cursor: &mut Cursor<'a>,
     node: &Node<'a>,
     code: &'a [u8],
     file_result: &mut PreprocFile,
@@ -495,7 +506,7 @@ fn classify_preproc_node<'a>(
     let id = Preproc::from(node.kind_id());
     match id {
         Preproc::Define | Preproc::Undef => {
-            let mut cursor = node.cursor();
+            cursor.reset(node);
             cursor.goto_first_child();
             let identifier = cursor.node();
             if identifier.kind_id() == Preproc::Identifier
@@ -513,7 +524,7 @@ fn classify_preproc_node<'a>(
             }
         }
         Preproc::PreprocInclude => {
-            let mut cursor = node.cursor();
+            cursor.reset(node);
             cursor.goto_first_child();
             let file = cursor.node();
             if file.kind_id() == Preproc::StringLiteral

--- a/src/vcs/git/diff_parse.rs
+++ b/src/vcs/git/diff_parse.rs
@@ -115,39 +115,7 @@ fn parse_unified_diff(diff: &str) -> Result<Vec<Touched>, Error> {
             continue;
         };
 
-        if line.starts_with("@@") {
-            // Check the hunk header before the `+`/`-` content branches so a
-            // `@@@`/`@@` line is never mistaken for a body line.
-            parse_hunk_header(line)?;
-            file.saw_hunk = true;
-            file.hunks = file.hunks.saturating_add(1);
-        } else if !file.saw_hunk && line.starts_with("+++ ") {
-            // The `+++ b/<path>` new-side header only ever appears *before*
-            // the first `@@` of a file. Once a hunk is open, a `+++ …` line
-            // is a real added body line whose content starts with `++ `
-            // (e.g. a `++` operator), so it falls through to the `+` branch.
-            if let Some(path) = line.strip_prefix("+++ ") {
-                file.set_new_path(path);
-            }
-        } else if !file.saw_hunk && line.starts_with("--- ") {
-            // Pre-hunk old-side path: not needed (diffusion keys on the new
-            // side), and must not be counted as a deleted body line. After a
-            // hunk opens, a `--- …` line is a real deleted body line (e.g. a
-            // SQL/Lua/Haskell `--` comment) and falls through to the `-`
-            // branch — gating on `!saw_hunk` is what stops that deletion from
-            // being silently dropped.
-        } else if line.starts_with('+') {
-            file.require_open_hunk()?;
-            file.added = file.added.saturating_add(1);
-        } else if line.starts_with('-') {
-            file.require_open_hunk()?;
-            file.deleted = file.deleted.saturating_add(1);
-        }
-        // Everything else is ignored: context lines (' '), `index`,
-        // `old/new mode`, `rename from/to`, a `Binary files … differ`
-        // marker (the file still flushes as a zero-churn touched entry, like
-        // the commit path skips binary blobs), and `\ No newline at end of
-        // file`.
+        file.classify_body_line(line)?;
     }
     flush_diff_file(&mut files, current.take());
     if files.is_empty() && saw_orphan_marker {
@@ -204,6 +172,47 @@ impl DiffFile {
                 "a +/- line appears before any @@ hunk header".to_owned(),
             ))
         }
+    }
+
+    /// Classify one `line` that falls *inside* this open file stanza,
+    /// updating the hunk count and added/deleted body-line counters. The
+    /// caller ([`parse_unified_diff`]) handles stanza framing (the
+    /// `diff --git` header and the no-stanza-open preamble); this method owns
+    /// only the per-line body grammar so the two concerns read separately.
+    fn classify_body_line(&mut self, line: &str) -> Result<(), Error> {
+        if line.starts_with("@@") {
+            // Check the hunk header before the `+`/`-` content branches so a
+            // `@@@`/`@@` line is never mistaken for a body line.
+            parse_hunk_header(line)?;
+            self.saw_hunk = true;
+            self.hunks = self.hunks.saturating_add(1);
+        } else if !self.saw_hunk && line.starts_with("+++ ") {
+            // The `+++ b/<path>` new-side header only ever appears *before*
+            // the first `@@` of a file. Once a hunk is open, a `+++ …` line
+            // is a real added body line whose content starts with `++ `
+            // (e.g. a `++` operator), so it falls through to the `+` branch.
+            if let Some(path) = line.strip_prefix("+++ ") {
+                self.set_new_path(path);
+            }
+        } else if !self.saw_hunk && line.starts_with("--- ") {
+            // Pre-hunk old-side path: not needed (diffusion keys on the new
+            // side), and must not be counted as a deleted body line. After a
+            // hunk opens, a `--- …` line is a real deleted body line (e.g. a
+            // SQL/Lua/Haskell `--` comment) and falls through to the `-`
+            // branch — gating on `!saw_hunk` is what stops that deletion from
+            // being silently dropped.
+        } else if line.starts_with('+') {
+            self.require_open_hunk()?;
+            self.added = self.added.saturating_add(1);
+        } else if line.starts_with('-') {
+            self.require_open_hunk()?;
+            self.deleted = self.deleted.saturating_add(1);
+        }
+        // Everything else is ignored: context lines (' '), `index`,
+        // `old/new mode`, `rename from/to`, a `Binary files … differ` marker
+        // (the file still flushes as a zero-churn touched entry, like the
+        // commit path skips binary blobs), and `\ No newline at end of file`.
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary

Behavior-preserving refactors of the per-function complexity hotspots
surfaced by the project's own `bca` self-scan (see #736 for the audit and
plan). Each oversized function is split into named, single-purpose helpers
at a boundary a reader would draw — the metric drops because the code is
genuinely simpler, not because a `foo_part2` helper moved the count.

Implements **Tier 1 + Tier 2** of #736. Tier 3 (`web/negotiate.rs`, the
large-but-cohesive report builders) is intentionally deferred — it was the
"leave unless a natural boundary emerges" tier.

## Changes & measured impact

All numbers measured with the repo's own `bca` (honoring `bca.toml`).

| Target | Metric | Before → After | How |
| --- | --- | --- | --- |
| `preproc.rs::preprocess_with_parser` | cognitive | **33 → ~10** | split into `push_children` / `classify_preproc_node` / `apply_macro_events` |
| `preproc.rs::record_indirect_includes` | cognitive | **25 → ~10** | extracted `accumulate_reachable_includes` |
| `cli/lib.rs::expand_seed_paths` | cognitive | **24 → 11** | extracted `walk_directory_seed` (file-seed vs dir-walk split) |
| `cli/commands.rs::run_command_report` | ABC | **46 → 41** | collapsed redundant 4-arm `(format, vcs)` match → 2 arms |
| `cli/commands.rs::run_command_metrics` | ABC | **45 → 37** | extracted `resolve_selected_metrics` |
| `py/sarif.rs::collect_offenders` | cognitive / cyclomatic | **31 → ~8 / 15 → 11** | split into `record_threshold_breaches` / `push_child_spaces` |
| `vcs/git/diff_parse.rs::parse_unified_diff` | cognitive / cyclomatic | **20 → 9 / 16 → 9** | extracted `DiffFile::classify_body_line` |
| `cli/markdown_report.rs::language_display_name` | cyclomatic 26 | suppressed | `// bca: suppress(cyclomatic)` — exhaustive wildcard-free `match LANG` display table, kept whole on purpose |

`collapse_scc` (cognitive 17) was left whole: already under the 25
threshold, and a split there would only inflate file-level `nom`/`nargs`.

No public API changes — every modified function keeps its signature; only
private helpers were added.

## Verification

- `make pre-commit` green: fmt, clippy ×2, workspace tests
  `--all-features` (2687 lib + 281 py), doc, udeps, all lint families,
  manpages, self-scan hard + soft tiers, stubtest.
- `.bca-baseline.toml` refreshed (soft tier) — **removal-only** diff
  dropping the 8 now-passing entries; no new offenders.
- Ran `simplify-rust`, `rust-optimize`, `audit-tests` (test-via-revert
  confirmed existing tests guard the macro-ordering path), and a
  high-effort `code-review` — no actionable findings.

Refs #736
