### PR TITLE
docs(python): fix score_diff CLI reference

### DIFF
--- a/big-code-analysis-py/python/big_code_analysis/vcs.py
+++ b/big-code-analysis-py/python/big_code_analysis/vcs.py
@@ -6,7 +6,7 @@ functions of 1.x were namespaced here as ``rank`` / ``trend`` / ``commit``
 / ``score_diff`` plus a shared :class:`Options` object — the entry-point
 names mirror the ``bca vcs`` CLI subcommands (``bca vcs`` → ``vcs.rank``,
 ``vcs trend`` → ``vcs.trend``, ``vcs commit`` → ``vcs.commit``,
-``vcs jit --diff`` → ``vcs.score_diff``).
+``vcs commit --diff`` → ``vcs.score_diff``).
 
 Usage::
 

--- a/big-code-analysis-py/python/big_code_analysis/vcs.pyi
+++ b/big-code-analysis-py/python/big_code_analysis/vcs.pyi
@@ -169,7 +169,7 @@ def commit(
 def score_diff(diff: str, /) -> JitDiffReportDict:
     """Score an arbitrary unified diff for partial just-in-time risk.
 
-    The programmatic analogue of ``bca vcs jit --diff`` (issue #580). A
+    The programmatic analogue of ``bca vcs commit --diff`` (issue #580). A
     bare diff carries no author / parent / history, so the returned dict
     has ``source == "diff"``, a ``partial_risk_score`` **not comparable**
     to a commit ``risk_score``, and no history / experience / purpose


### PR DESCRIPTION
## Summary
- update the Python VCS facade docstrings to reference `bca vcs commit --diff`
- remove the deprecated `bca vcs jit --diff` spelling from the public Python docs

Fixes #864

## Validation
- `rg -n 'vcs (jit|commit) --diff|score_diff|command\(name = "commit"|alias = "jit"|DEPRECATED_SUBCOMMAND_ALIASES' big-code-analysis-py/python/big_code_analysis/vcs.py big-code-analysis-py/python/big_code_analysis/vcs.pyi big-code-analysis-cli/src/lib.rs big-code-analysis-cli/src/deprecations.rs`
- `python3 -m py_compile big-code-analysis-py/python/big_code_analysis/vcs.py`
- `git diff --check`
- `cargo test --ignore-rust-version -p big-code-analysis-cli deprecations --lib` (8 passed)
- `cargo run --ignore-rust-version -q -p big-code-analysis-cli -- vcs commit --help`
- `cargo run --ignore-rust-version -q -p big-code-analysis-cli -- vcs jit --help`

I did not run the full `make pre-commit` gate because this is a two-line docstring-only change and the local toolchain is Rust 1.92 while the repo declares MSRV 1.94. The focused Rust CLI/deprecation checks above passed with `--ignore-rust-version`.