### PR TITLE
feat(vcs): opt-in keyed author-detail hashing (#956)

### DIFF
--- a/.bca-baseline.toml
+++ b/.bca-baseline.toml
@@ -54,6 +54,13 @@ metric = "nexits"
 value = 5.0
 
 [[entry]]
+path = "big-code-analysis-cli/src/vcs_command.rs"
+qualified = "<file>"
+start_line = 1
+metric = "loc.sloc"
+value = 793.0
+
+[[entry]]
 path = "big-code-analysis-cli/src/vcs_jit.rs"
 qualified = "<file>"
 start_line = 1
@@ -72,12 +79,12 @@ path = "big-code-analysis-py/src/lib.rs"
 qualified = "<file>"
 start_line = 1
 metric = "loc.sloc"
-value = 904.0
+value = 908.0
 
 [[entry]]
 path = "big-code-analysis-py/src/lib.rs"
 qualified = "_native"
-start_line = 829
+start_line = 833
 metric = "abc"
 value = 67.0
 
@@ -138,8 +145,15 @@ metric = "nexits"
 value = 5.0
 
 [[entry]]
+path = "src/vcs/bus_factor.rs"
+qualified = "<file>"
+start_line = 1
+metric = "nom"
+value = 29.0
+
+[[entry]]
 path = "src/vcs/error.rs"
 qualified = "Error::fmt"
-start_line = 124
+start_line = 129
 metric = "cyclomatic"
-value = 17.0
+value = 18.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,21 @@ for historical reference.
 - `AuthorId::has_identity()` reports whether a VCS author carries any
   usable name or email key (#817).
 
+- Opt-in keyed author-identity hashing for `--emit-author-details`
+  (#956). A secret key — `--author-hash-key <KEY>` (or the
+  `BCA_AUTHOR_HASH_KEY` environment variable, preferred so the secret
+  stays off the process list), the REST `author_hash_key` field, and the
+  Python `vcs.Options(author_hash_key=…)` — hardens the emitted author
+  digests into an `HMAC-SHA256(key, SHA-256(email))`, defeating the
+  email-enumeration and precomputed-table attacks a bare SHA-256
+  pseudonym is vulnerable to (the Gravatar weakness; see #811). The key
+  hardens only the *emitted* digests (it requires `--emit-author-details`)
+  and is applied at finalization, so default output is unchanged and the
+  persistent-cache replay invariant (#334) holds: the cache stores the
+  unkeyed inner digest and a cached walk re-finalizes under any key
+  without a re-walk. New library surface: `vcs::AuthorHashKey`, the
+  additive `Options::author_hash_key` field, and `AuthorId::emit_hashed`.
+
 - `LANG::Objc` (slug `objc`) and the `objc` Cargo feature: dedicated
   Objective-C support backed by upstream `tree-sitter-objc` `=3.0.2`,
   owning the `.m` extension and the `objc` / `objective-c` emacs modes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,6 +421,7 @@ dependencies = [
  "dekobon-tree-sitter-groovy",
  "gix",
  "globset",
+ "hmac",
  "insta",
  "jsonschema",
  "num-derive",
@@ -1030,6 +1031,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -2358,6 +2360,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "http"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,6 +180,10 @@ serde_json = { workspace = true, features = ["float_roundtrip"] }
 # crates (Cargo.lock). Used by the GitLab Code Climate writer to
 # compute stable per-violation fingerprints.
 sha2 = "=0.10.9"
+# HMAC-SHA256 for the opt-in keyed author-identity hashing
+# (`--author-hash-key`, #956). Shares the RustCrypto `digest` 0.10 trait
+# family with `sha2`, so it adds no new transitive trait version.
+hmac = "=0.12.1"
 termcolor = "^1.2"
 
 tree-sitter.workspace = true

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -344,6 +344,18 @@ additive and non-breaking for external constructors. This was landed early
 (part of the `2.0` `#[non_exhaustive]` sweep, #505) because the VCS surface
 is still unreleased, so sealing it now breaks no existing downstream user.
 
+Opt-in keyed author-identity hashing (#956) is an additive hardening of
+`--emit-author-details`: `big_code_analysis::vcs::AuthorHashKey`, the
+additive `Options::author_hash_key` field (admissible precisely because
+`Options` is `#[non_exhaustive]`), and `AuthorId::emit_hashed`. It is
+surfaced by `bca vcs --author-hash-key` (and the `BCA_AUTHOR_HASH_KEY`
+environment variable), the `POST /vcs` `author_hash_key` field, and the
+`vcs.Options(author_hash_key=…)` parameter. The default (no key) emits the
+same bare SHA-256 digest as before, so output is unchanged; the key is a
+finalization-time transform that leaves the cache-replay invariant intact
+(the on-disk cache stores the unkeyed inner digest, so a cached walk
+re-finalizes under any key without a re-walk).
+
 The following are explicitly **not** part of the shape contract:
 
 - Anything marked `#[doc(hidden)]` (see `src/traits.rs` for current

--- a/big-code-analysis-book/src/commands/rest.md
+++ b/big-code-analysis-book/src/commands/rest.md
@@ -660,6 +660,9 @@ are:
 - `as_of`: reference "now" (RFC 3339 / `@unix` / git date) for
   snapshots.
 - `emit_author_details`: emit SHA-256-hashed author identities.
+- `author_hash_key`: secret key that hardens `emit_author_details` into a
+  keyed HMAC-SHA256 (requires `emit_author_details`; an empty key or one
+  without the flag is a `400`).
 - `include_deleted`: include files deleted at the target ref.
 - `bus_factor_threshold`: bus-factor coverage threshold in `(0, 1)`
   (default `0.5`).

--- a/big-code-analysis-book/src/commands/vcs.md
+++ b/big-code-analysis-book/src/commands/vcs.md
@@ -206,6 +206,7 @@ cross-project robustness.
 | `--as-of <WHEN>` | wall clock | Reference "now" (RFC 3339 / `@unix` / git date) for reproducible snapshots |
 | `--risk-formula {weighted\|percentile}` | `weighted` | Composite formula |
 | `--emit-author-details` | off | Emit SHA-256-hashed canonical author IDs |
+| `--author-hash-key <KEY>` | unset | Harden the emitted author digests into a keyed HMAC (see [Author-detail privacy](#author-detail-privacy)); requires `--emit-author-details` |
 | `--include-deleted` | off | Also rank files deleted at the target ref |
 | `--no-cache` | off | Skip the persistent history cache (always walk fresh) |
 | `--clear-cache` | off | Wipe this repo's cached history before running |
@@ -231,8 +232,9 @@ every run, so a cached result is never stale. An entry is ignored — and
 the history recomputed — whenever the schema, the score-formula version,
 or the *walk-affecting* options differ; in particular **changing a window
 forces a fresh walk**. (Finalization-only knobs such as `--risk-formula`,
-`--emit-author-details`, and `--include-deleted` are applied on replay, so
-they reuse the same cached walk.)
+`--emit-author-details`, `--author-hash-key`, and `--include-deleted` are
+applied on replay, so they reuse the same cached walk — a cached walk even
+re-finalizes under a *different* author-hash key without re-walking.)
 
 By default the cache lives under
 `$XDG_CACHE_HOME/big-code-analysis/vcs` (`%LOCALAPPDATA%` on Windows,
@@ -600,10 +602,45 @@ recover which digest belongs to whom by hashing each candidate or with a
 precomputed email→hash table. This is the same weakness that broke
 Gravatar's email hashing.
 
-Treat published `key_author_ids` as pseudonymization that avoids emitting
-plaintext emails, **not** as a guarantee that authors cannot be
-re-identified by a determined attacker. If you need that guarantee, do not
-publish the digests.
+Treat published `key_author_ids` (and the per-file `author_ids`) as
+pseudonymization that avoids emitting plaintext emails, **not** as a
+guarantee that authors cannot be re-identified by a determined attacker. If
+you need that guarantee, do not publish the digests.
+
+#### Hardened mode: `--author-hash-key`
+
+For stronger resistance, pass a secret key with `--author-hash-key <KEY>`
+(requires `--emit-author-details`). The emitted digests then become an
+`HMAC-SHA256(key, SHA-256(email))` instead of a bare hash: an attacker
+without the key can no longer hash a candidate email to recognise its
+digest, nor use a precomputed email→hash table — both attacks need the
+secret key. Pick a high-entropy key and keep it secret; anyone who learns
+it can re-run the enumeration.
+
+The key is **stable**: the same key yields the same digests across every
+report and across a persistent-cache replay, so cross-report correlation
+and the cache still work. Different keys produce unrelated digests, so two
+teams sharing histories cannot cross-link authors unless they share the
+key.
+
+Prefer the `BCA_AUTHOR_HASH_KEY` environment variable over the flag — a key
+on the command line is visible to other local users via the process list
+(`ps`) and is saved in shell history. The flag takes precedence when both
+are set:
+
+```bash
+export BCA_AUTHOR_HASH_KEY="$(cat ~/.config/bca/author-key)"
+bca vcs --emit-author-details
+```
+
+What the key does **not** cover: the on-disk history cache (issue #334)
+deliberately stores the *unkeyed* inner SHA-256 digest, because the key is
+applied at finalization so a cached walk can be re-finalized under any key
+without re-walking. The cache is local-only and never published, but if
+your threat model includes an attacker reading your local cache directory,
+disable the cache (`--no-cache`) or clear it (`--clear-cache`). The same
+key option is available on the REST endpoint (`author_hash_key`) and in
+Python (`vcs.Options(author_hash_key=…)`).
 
 ## Dogfooding in this repo
 

--- a/big-code-analysis-book/src/python/vcs.md
+++ b/big-code-analysis-book/src/python/vcs.md
@@ -193,7 +193,10 @@ The history-walk toggles mirror the CLI flags: `full_history`,
 (default `True`), and `bot_pattern` to override the bot-author regular
 expression. `bus_factor_threshold` sets the coverage fraction for the
 bus-factor flag (default `0.5`), and `emit_author_details` includes
-SHA-256-hashed canonical author identities.
+SHA-256-hashed canonical author identities. `author_hash_key` (requires
+`emit_author_details`) hardens those digests into a keyed HMAC-SHA256, the
+same opt-in described under
+[Author-detail privacy](../commands/vcs.md#author-detail-privacy).
 
 ## Caching
 

--- a/big-code-analysis-cli/src/lib.rs
+++ b/big-code-analysis-cli/src/lib.rs
@@ -890,6 +890,29 @@ struct VcsArgs {
     /// Emit SHA-256-hashed canonical author identities.
     #[clap(long)]
     emit_author_details: bool,
+    /// Secret key that hardens `--emit-author-details` into a keyed
+    /// HMAC-SHA256: an attacker can no longer recover the emitted digests
+    /// by hashing a candidate set of emails or with a precomputed
+    /// email→hash table. Without it the digests are a bare SHA-256
+    /// pseudonym. Requires `--emit-author-details`; the same key yields the
+    /// same digests across runs and a cache replay.
+    ///
+    /// Prefer the `BCA_AUTHOR_HASH_KEY` environment variable: a key on the
+    /// command line is visible to other users via the process list (`ps`)
+    /// and lands in shell history. The flag takes precedence when both are
+    /// set.
+    //
+    // Hardening tracked in issue #956 (follow-up to #811); the rationale
+    // lives here in a `//` maintainer comment so clap never renders the
+    // issue number into `--help` (the help-text issue-reference gate).
+    //
+    // SECURITY: this holds the raw secret. `VcsArgs` derives `Debug`, so
+    // never whole-struct debug-log it (`{args:?}`) — that would leak the
+    // key. It is moved into the redacting `AuthorHashKey` newtype as early
+    // as `vcs_command::resolve_author_hash_key`. (On the CLI the key is also
+    // argv-visible, which is why the env-var form is recommended.)
+    #[clap(long, value_name = "KEY")]
+    author_hash_key: Option<String>,
     /// Emit stats for files deleted at the target ref.
     #[clap(long)]
     include_deleted: bool,

--- a/big-code-analysis-cli/src/vcs_command.rs
+++ b/big-code-analysis-cli/src/vcs_command.rs
@@ -25,8 +25,8 @@ use serde::Serialize;
 use big_code_analysis::FuncSpace;
 use big_code_analysis::defang_formula;
 use big_code_analysis::vcs::{
-    self, CacheConfig, Options, build_history_index_cached, hotspot, parse_timestamp, parse_window,
-    score, stats,
+    self, AuthorHashKey, CacheConfig, Options, build_history_index_cached, hotspot,
+    parse_timestamp, parse_window, score, stats,
 };
 use big_code_analysis::wire;
 
@@ -246,6 +246,7 @@ pub(crate) fn build_options(args: &VcsArgs) -> Options {
     options.as_of = as_of;
     options.risk_formula = args.risk_formula.into();
     options.emit_author_details = args.emit_author_details;
+    options.author_hash_key = resolve_author_hash_key(args);
     options.include_deleted = args.include_deleted;
     // `build_options` (the shared builder) leaves `compute_bus_factor` at its
     // `Default` (`false`); the ranking callers `run` / `default_aggregate_index`
@@ -255,6 +256,41 @@ pub(crate) fn build_options(args: &VcsArgs) -> Options {
             .unwrap_or_else(|e| die(format_args!("--bus-factor-threshold: {e}")));
     options.file_types = file_types;
     options
+}
+
+/// Environment variable holding the author-hash key, preferred over the
+/// `--author-hash-key` flag so the secret stays off the process list and
+/// out of shell history (issue #956).
+const AUTHOR_HASH_KEY_ENV: &str = "BCA_AUTHOR_HASH_KEY";
+
+/// Resolve the optional author-hash key (issue #956): the
+/// `--author-hash-key` flag takes precedence, else the
+/// [`AUTHOR_HASH_KEY_ENV`] environment variable.
+///
+/// The key only hardens *emitted* digests, so it is read only when
+/// `--emit-author-details` is set; an ambient environment variable never
+/// fails an unrelated run. An explicit flag without
+/// `--emit-author-details` is a usage error rather than a silent no-op,
+/// and an empty key is rejected by [`AuthorHashKey::new`].
+fn resolve_author_hash_key(args: &VcsArgs) -> Option<AuthorHashKey> {
+    if args.author_hash_key.is_some() && !args.emit_author_details {
+        die(format_args!(
+            "--author-hash-key requires --emit-author-details (the key only \
+             hardens the emitted author digests)"
+        ));
+    }
+    if !args.emit_author_details {
+        return None;
+    }
+    let raw = args.author_hash_key.clone().or_else(|| {
+        std::env::var(AUTHOR_HASH_KEY_ENV)
+            .ok()
+            .filter(|value| !value.is_empty())
+    })?;
+    Some(
+        AuthorHashKey::new(raw.into_bytes())
+            .unwrap_or_else(|e| die(format_args!("--author-hash-key: {e}"))),
+    )
 }
 
 /// Select the tracked files the global filters admit, sort them by risk

--- a/big-code-analysis-cli/tests/vcs.rs
+++ b/big-code-analysis-cli/tests/vcs.rs
@@ -451,6 +451,69 @@ fn vcs_emit_author_details_controls_author_ids() {
 }
 
 #[test]
+fn vcs_author_hash_key_hardens_the_emitted_ids() {
+    let repo = repo_two_commits();
+    // First file's `author_ids` array for the given extra args / env.
+    let ids = |extra: &[&str], env: Option<(&str, &str)>| -> Vec<String> {
+        let mut args = vec!["vcs", "--paths", ".", "--format", "json"];
+        args.extend_from_slice(extra);
+        let mut cmd = cli();
+        cmd.current_dir(repo.path()).args(args);
+        if let Some((key, value)) = env {
+            cmd.env(key, value);
+        }
+        let assert = cmd.assert().success();
+        let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8");
+        let doc: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+        doc["files"][0]["vcs"]["author_ids"]
+            .as_array()
+            .expect("author_ids array")
+            .iter()
+            .map(|v| v.as_str().expect("hex string").to_owned())
+            .collect()
+    };
+
+    let plain = ids(&["--emit-author-details"], None);
+    let keyed = ids(
+        &["--emit-author-details", "--author-hash-key", "team-secret"],
+        None,
+    );
+    // The key hardens every id (HMAC) while keeping the SHA-256 hex width.
+    assert_eq!(keyed.len(), plain.len());
+    assert_ne!(keyed, plain);
+    assert!(keyed.iter().all(|h| h.len() == 64));
+    // Deterministic for a fixed key (stable cross-report pseudonyms).
+    assert_eq!(
+        keyed,
+        ids(
+            &["--emit-author-details", "--author-hash-key", "team-secret"],
+            None
+        )
+    );
+    // The `BCA_AUTHOR_HASH_KEY` env var is equivalent to the flag.
+    assert_eq!(
+        keyed,
+        ids(
+            &["--emit-author-details"],
+            Some(("BCA_AUTHOR_HASH_KEY", "team-secret"))
+        )
+    );
+}
+
+#[test]
+fn vcs_author_hash_key_requires_emit_author_details() {
+    let repo = repo_two_commits();
+    // The key only hardens *emitted* digests; supplying it without
+    // `--emit-author-details` is a loud usage error, not a silent no-op.
+    cli()
+        .current_dir(repo.path())
+        .args(["vcs", "--paths", ".", "--author-hash-key", "team-secret"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("requires --emit-author-details"));
+}
+
+#[test]
 fn vcs_include_deleted_surfaces_removed_file() {
     let now = now();
     let repo = tempfile::tempdir().expect("tempdir");

--- a/big-code-analysis-py/python/big_code_analysis/vcs.pyi
+++ b/big-code-analysis-py/python/big_code_analysis/vcs.pyi
@@ -52,6 +52,10 @@ class Options:
         or a string (RFC 3339 / ``@unix`` / git date).
     emit_author_details
         Include SHA-256-hashed canonical author identities.
+    author_hash_key
+        Secret key that hardens ``emit_author_details`` into a keyed
+        HMAC-SHA256 (issue #956). ``None`` (default) emits the bare
+        SHA-256 pseudonym. Requires ``emit_author_details``.
     include_deleted
         Rank files deleted at the reference too.
     bus_factor_threshold
@@ -80,6 +84,7 @@ class Options:
         bot_pattern: str | None = None,
         as_of: datetime | str | None = None,
         emit_author_details: bool = False,
+        author_hash_key: str | None = None,
         include_deleted: bool = False,
         bus_factor_threshold: float | None = None,
     ) -> Options: ...

--- a/big-code-analysis-py/src/lib.rs
+++ b/big-code-analysis-py/src/lib.rs
@@ -582,6 +582,7 @@ struct PyVcsOptions {
     bot_pattern: Option<String>,
     as_of: Option<String>,
     emit_author_details: bool,
+    author_hash_key: Option<String>,
     include_deleted: bool,
     bus_factor_threshold: Option<f64>,
 }
@@ -589,7 +590,7 @@ struct PyVcsOptions {
 #[pymethods]
 impl PyVcsOptions {
     #[new]
-    #[pyo3(signature = (*, long_window = None, recent_window = None, reference = None, risk_formula = None, file_types = None, full_history = false, include_merges = false, follow_renames = true, exclude_bots = true, bot_pattern = None, as_of = None, emit_author_details = false, include_deleted = false, bus_factor_threshold = None))]
+    #[pyo3(signature = (*, long_window = None, recent_window = None, reference = None, risk_formula = None, file_types = None, full_history = false, include_merges = false, follow_renames = true, exclude_bots = true, bot_pattern = None, as_of = None, emit_author_details = false, author_hash_key = None, include_deleted = false, bus_factor_threshold = None))]
     #[allow(
         clippy::too_many_arguments,
         clippy::fn_params_excessive_bools,
@@ -611,6 +612,7 @@ impl PyVcsOptions {
         bot_pattern: Option<String>,
         as_of: Option<Bound<'_, PyAny>>,
         emit_author_details: bool,
+        author_hash_key: Option<String>,
         include_deleted: bool,
         bus_factor_threshold: Option<f64>,
     ) -> PyResult<Self> {
@@ -628,6 +630,7 @@ impl PyVcsOptions {
             bot_pattern,
             as_of,
             emit_author_details,
+            author_hash_key,
             include_deleted,
             bus_factor_threshold,
         })
@@ -657,6 +660,7 @@ impl PyVcsOptions {
             bot_pattern: self.bot_pattern.clone(),
             as_of: self.as_of.clone(),
             emit_author_details: self.emit_author_details,
+            author_hash_key: self.author_hash_key.clone(),
             include_deleted: self.include_deleted,
             bus_factor_threshold: self.bus_factor_threshold,
             no_cache,

--- a/big-code-analysis-py/src/vcs.rs
+++ b/big-code-analysis-py/src/vcs.rs
@@ -27,8 +27,8 @@ use pyo3::exceptions::PyValueError;
 use serde_json::Value;
 
 use big_code_analysis::vcs::{
-    self, CacheConfig, Options, build_history_index_cached, build_trend, hotspot, parse_timestamp,
-    parse_window, score_commit, score_diff, workdir_root,
+    self, AuthorHashKey, CacheConfig, Options, build_history_index_cached, build_trend, hotspot,
+    parse_timestamp, parse_window, score_commit, score_diff, workdir_root,
 };
 use big_code_analysis::wire::{self, VcsReport, VcsReportFile};
 
@@ -54,6 +54,14 @@ pub(crate) struct VcsParams {
     pub bot_pattern: Option<String>,
     pub as_of: Option<String>,
     pub emit_author_details: bool,
+    /// Secret key that hardens `emit_author_details` into a keyed
+    /// HMAC-SHA256 (issue #956). `None` emits the bare SHA-256 pseudonym.
+    /// Requires `emit_author_details`.
+    ///
+    /// SECURITY: holds the raw secret. If a `Debug` derive is ever added to
+    /// this struct, do not whole-struct debug-log it — it is moved into the
+    /// redacting `AuthorHashKey` newtype in `options_from`.
+    pub author_hash_key: Option<String>,
     pub include_deleted: bool,
     pub bus_factor_threshold: Option<f64>,
     /// Disable the persistent change-history cache for this call (issue
@@ -82,6 +90,17 @@ fn options_from(params: &VcsParams) -> Result<Options, PyErr> {
     options.follow_renames = params.follow_renames;
     options.exclude_bots = params.exclude_bots;
     options.emit_author_details = params.emit_author_details;
+    if let Some(key) = &params.author_hash_key {
+        // The key only hardens emitted digests, so reject it without
+        // `emit_author_details` rather than silently doing nothing.
+        if !params.emit_author_details {
+            return Err(vcs_error_to_py(vcs::Error::InvalidAuthorHashKey(
+                "author_hash_key requires emit_author_details".to_owned(),
+            )));
+        }
+        options.author_hash_key =
+            Some(AuthorHashKey::new(key.clone().into_bytes()).map_err(vcs_error_to_py)?);
+    }
     options.include_deleted = params.include_deleted;
     if let Some(spec) = &params.long_window {
         options.long_window_secs = parse_window(spec).map_err(vcs_error_to_py)?;

--- a/big-code-analysis-py/tests/test_vcs.py
+++ b/big-code-analysis-py/tests/test_vcs.py
@@ -565,6 +565,37 @@ def test_vcs_exception_hierarchy() -> None:
         assert issubclass(cls, ValueError), cls
 
 
+def test_vcs_metrics_author_hash_key_hardens_ids(tmp_path: Path) -> None:
+    """Issue #956: ``author_hash_key`` hardens the emitted ``author_ids``
+    into a keyed HMAC, deterministically, without leaking the plaintext."""
+    repo = _build_repo(tmp_path)
+
+    def author_ids(**kw: Any) -> list[str]:
+        report = bca_vcs.rank(repo, options=bca_vcs.Options(emit_author_details=True, **kw))
+        ids = report["files"][0]["vcs"]["author_ids"]
+        assert isinstance(ids, list)
+        return ids
+
+    plain = author_ids()
+    keyed = author_ids(author_hash_key="team-secret")
+    assert len(keyed) == len(plain)
+    assert keyed != plain
+    assert all(len(h) == 64 for h in keyed)
+    assert "ada@example.com" not in keyed
+    # Stable across runs for a fixed key.
+    assert keyed == author_ids(author_hash_key="team-secret")
+    # A different key yields different digests.
+    assert keyed != author_ids(author_hash_key="other-secret")
+
+
+def test_vcs_metrics_author_hash_key_requires_emit(tmp_path: Path) -> None:
+    """A key without ``emit_author_details`` is a client error, not a
+    silent no-op (#956)."""
+    repo = _build_repo(tmp_path)
+    with pytest.raises(bca.VcsError, match="emit_author_details"):
+        bca_vcs.rank(repo, options=bca_vcs.Options(author_hash_key="team-secret"))
+
+
 # --- Python-native kwarg widenings (issue #619) -----------------------------
 #
 # Each widened kwarg is asserted to produce output IDENTICAL to its

--- a/big-code-analysis-web/src/web/vcs.rs
+++ b/big-code-analysis-web/src/web/vcs.rs
@@ -41,8 +41,9 @@ use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
 use big_code_analysis::vcs::{
-    self, CacheConfig, JitDiffReport, JitReport, Options, build_history_index_cached, build_trend,
-    parse_timestamp, parse_window, score_commit, score_diff,
+    self, AuthorHashKey, CacheConfig, JitDiffReport, JitReport, Options,
+    build_history_index_cached, build_trend, parse_timestamp, parse_window, score_commit,
+    score_diff,
 };
 use big_code_analysis::wire;
 
@@ -120,6 +121,15 @@ pub struct WebVcsPayload {
     pub as_of: Option<String>,
     /// Emit SHA-256-hashed author identities.
     pub emit_author_details: Option<bool>,
+    /// Secret key that hardens `emit_author_details` into a keyed
+    /// HMAC-SHA256 (issue #956). Requires `emit_author_details`; an empty
+    /// key or one without it is a `400`.
+    ///
+    /// SECURITY: holds the raw secret, and this struct derives `Debug`, so
+    /// never whole-struct debug-log a payload (`{payload:?}`) — that would
+    /// leak the key into server logs. It is moved into the redacting
+    /// `AuthorHashKey` newtype in `options_from`.
+    pub author_hash_key: Option<String>,
     /// Include files deleted at the target ref.
     pub include_deleted: Option<bool>,
     /// Bus-factor coverage (abandonment) threshold in `(0, 1)` (issue
@@ -201,6 +211,16 @@ fn options_from(payload: &WebVcsPayload) -> Result<Options, vcs::Error> {
     options.emit_author_details = payload
         .emit_author_details
         .unwrap_or(options.emit_author_details);
+    if let Some(key) = &payload.author_hash_key {
+        // The key only hardens emitted digests, so it is meaningless —
+        // and a likely client mistake — without `emit_author_details`.
+        if !options.emit_author_details {
+            return Err(vcs::Error::InvalidAuthorHashKey(
+                "author_hash_key requires emit_author_details".to_owned(),
+            ));
+        }
+        options.author_hash_key = Some(AuthorHashKey::new(key.clone().into_bytes())?);
+    }
     options.include_deleted = payload.include_deleted.unwrap_or(options.include_deleted);
     // The endpoint always surfaces the aggregate; validate the threshold
     // up front so a bad value is a clean 4xx, not a clamped surprise.
@@ -592,6 +612,11 @@ pub struct WebVcsTrendPayload {
     pub as_of: Option<String>,
     /// Emit SHA-256-hashed author identities.
     pub emit_author_details: Option<bool>,
+    /// Secret key that hardens `emit_author_details` into a keyed
+    /// HMAC-SHA256 (issue #956). Requires `emit_author_details`. SECURITY:
+    /// raw secret in a `Debug`-deriving struct — never whole-struct
+    /// debug-log a payload; see [`WebVcsPayload::author_hash_key`].
+    pub author_hash_key: Option<String>,
     /// Include files deleted at the target ref.
     pub include_deleted: Option<bool>,
     /// Bus-factor coverage (abandonment) threshold in `(0, 1)` (issue #332).
@@ -633,6 +658,7 @@ impl WebVcsTrendPayload {
             bot_pattern: self.bot_pattern,
             as_of: self.as_of,
             emit_author_details: self.emit_author_details,
+            author_hash_key: self.author_hash_key,
             include_deleted: self.include_deleted,
             bus_factor_threshold: self.bus_factor_threshold,
             no_cache: self.no_cache,
@@ -757,6 +783,44 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         repo_path_must_exist(dir.path().to_str().expect("utf-8 path"))
             .expect("an existing path must pass the existence guard");
+    }
+
+    // #956: an `author_hash_key` without `emit_author_details` is a client
+    // mistake (the key would do nothing), surfaced as a `400`; an empty key
+    // is likewise rejected; and a key with the flag builds keyed options.
+    #[test]
+    fn author_hash_key_requires_emit_and_rejects_empty() {
+        let without_emit: WebVcsPayload =
+            serde_json::from_str(r#"{"id":"x","repo_path":"/x","author_hash_key":"k"}"#)
+                .expect("payload deserializes");
+        let err = options_from(&without_emit).expect_err("key without emit must be rejected");
+        assert!(
+            matches!(err, vcs::Error::InvalidAuthorHashKey(_)),
+            "key without emit must map to InvalidAuthorHashKey, got: {err:?}"
+        );
+        assert!(err.is_client_input(), "must map to a 400, not a 500");
+
+        let empty_key: WebVcsPayload = serde_json::from_str(
+            r#"{"id":"x","repo_path":"/x","emit_author_details":true,"author_hash_key":""}"#,
+        )
+        .expect("payload deserializes");
+        assert!(
+            matches!(
+                options_from(&empty_key),
+                Err(vcs::Error::InvalidAuthorHashKey(_))
+            ),
+            "an empty key must be rejected"
+        );
+
+        let valid: WebVcsPayload = serde_json::from_str(
+            r#"{"id":"x","repo_path":"/x","emit_author_details":true,"author_hash_key":"k"}"#,
+        )
+        .expect("payload deserializes");
+        let options = options_from(&valid).expect("a key with the flag builds options");
+        assert!(
+            options.author_hash_key.is_some(),
+            "the key must reach the backend options"
+        );
     }
 
     // #636: the web defaults must equal the CLI's bounded defaults so the

--- a/docs/development/lessons_learned.md
+++ b/docs/development/lessons_learned.md
@@ -4060,3 +4060,48 @@ every place is a regression class — give it one home), here applied across
 CLI surfaces rather than language modules.
 
 ---
+
+## 79. Key the derived digest, not the pre-image, when a cache already stores the derived form
+
+When you add a keyed or salted transform to an identity that a
+content-addressed cache persists in *derived* (already-hashed) form, key the
+**derived** digest, not the original pre-image. A cache that kept only the
+post-transform value has discarded the pre-image, so a cache replay can only
+reproduce the new keyed output if the key folds over the value the cache
+actually retained. Keying the pre-image instead forces an ugly fork —
+invalidate or re-key the whole cache per key, or persist the plaintext
+pre-image on disk — whereas keying the stored digest makes the key a pure
+finalization-time transform that the cache neither sees nor pays for.
+
+**Opt-in keyed author hashing had to harden published output without
+breaking the issue-#334 cache-replay invariant** (#956, `4493598a`).
+`--emit-author-details` emits a SHA-256 of the canonical email, and the
+persistent VCS cache stores only that digest — never the plaintext email (a
+`from_digest` identity *is* the digest). The obvious construction,
+`HMAC(key, email)`, cannot be reproduced from a cached walk: the email is
+gone, so replay would emit a different value and violate #334's
+bit-identical-replay contract. The shipped construction keys the *inner*
+digest — `HMAC-SHA256(key, hex(SHA-256(email)))`, the HMAC taken over the
+hex-encoded inner digest — applied at finalization over the exact value the
+cache retained. The author-hash key therefore stays out
+of the cache fingerprint (like `--emit-author-details` itself), a cached walk
+re-finalizes under any key with no re-walk, and
+`keyed_emit_survives_a_cache_round_trip` pins that a fresh identity and one
+rebuilt via `from_digest` emit the same keyed value. Security is unchanged:
+the secret key still defeats brute-force and precomputed-table attacks
+because the attacker must hold the key to compute the outer HMAC for any
+candidate — the public inner digest does not weaken it.
+
+**Lesson:** Before adding a key, salt, or any per-run transform to an
+identity a cache materializes, ask *what does the cache actually store?* If it
+stores the derived digest, layer the new transform **outside** that digest so
+replay reconstructs the output from cached state, and keep the transform out
+of the cache's invalidation fingerprint — it is a finalization concern, not a
+walk concern. Keying the pre-image silently couples the cache key to the
+secret and either re-walks on every key change or spills the pre-image to
+disk. Related to lesson #56 (a similarity hash must exclude the dimension it
+claims to be insensitive to): here the inner digest must *exclude* the key so
+the cache stays key-agnostic, while the outer digest *includes* it so the
+emitted value is hardened.
+
+---

--- a/man/bca-vcs.1
+++ b/man/bca-vcs.1
@@ -4,7 +4,7 @@
 .SH NAME
 bca\-vcs \- Rank files by change\-history (VCS) risk: churn, commit and author counts, ownership dilution, and bug\- / security\-fix history over a git working tree. Errors clearly outside a repo
 .SH SYNOPSIS
-\fBbca\-vcs\fR [\fB\-p\fR|\fB\-\-paths\fR] [\fB\-I\fR|\fB\-\-include\fR] [\fB\-X\fR|\fB\-\-exclude\fR] [\fB\-l\fR|\fB\-\-language\fR] [\fB\-\-no\-skip\-generated\fR] [\fB\-\-paths\-from\fR] [\fB\-\-exclude\-from\fR] [\fB\-\-no\-ignore\fR] [\fB\-\-no\-config\fR] [\fB\-j\fR|\fB\-\-jobs\fR] [\fB\-\-exclude\-tests\fR] [\fB\-\-cyclomatic\-count\-try\fR] [\fB\-O\fR|\fB\-\-format\fR] [\fB\-o\fR|\fB\-\-output\fR] [\fB\-\-pretty\fR] [\fB\-\-long\-window\fR] [\fB\-\-recent\-window\fR] [\fB\-\-top\fR] [\fB\-\-file\-types\fR] [\fB\-\-ref\fR] [\fB\-\-full\-history\fR] [\fB\-\-include\-merges\fR] [\fB\-\-no\-follow\-renames\fR] [\fB\-\-no\-exclude\-bots\fR] [\fB\-\-bot\-pattern\fR] [\fB\-\-as\-of\fR] [\fB\-\-risk\-formula\fR] [\fB\-\-emit\-author\-details\fR] [\fB\-\-include\-deleted\fR] [\fB\-\-bus\-factor\-threshold\fR] [\fB\-\-no\-cache\fR] [\fB\-\-clear\-cache\fR] [\fB\-\-cache\-dir\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fIsubcommands\fR]
+\fBbca\-vcs\fR [\fB\-p\fR|\fB\-\-paths\fR] [\fB\-I\fR|\fB\-\-include\fR] [\fB\-X\fR|\fB\-\-exclude\fR] [\fB\-l\fR|\fB\-\-language\fR] [\fB\-\-no\-skip\-generated\fR] [\fB\-\-paths\-from\fR] [\fB\-\-exclude\-from\fR] [\fB\-\-no\-ignore\fR] [\fB\-\-no\-config\fR] [\fB\-j\fR|\fB\-\-jobs\fR] [\fB\-\-exclude\-tests\fR] [\fB\-\-cyclomatic\-count\-try\fR] [\fB\-O\fR|\fB\-\-format\fR] [\fB\-o\fR|\fB\-\-output\fR] [\fB\-\-pretty\fR] [\fB\-\-long\-window\fR] [\fB\-\-recent\-window\fR] [\fB\-\-top\fR] [\fB\-\-file\-types\fR] [\fB\-\-ref\fR] [\fB\-\-full\-history\fR] [\fB\-\-include\-merges\fR] [\fB\-\-no\-follow\-renames\fR] [\fB\-\-no\-exclude\-bots\fR] [\fB\-\-bot\-pattern\fR] [\fB\-\-as\-of\fR] [\fB\-\-risk\-formula\fR] [\fB\-\-emit\-author\-details\fR] [\fB\-\-author\-hash\-key\fR] [\fB\-\-include\-deleted\fR] [\fB\-\-bus\-factor\-threshold\fR] [\fB\-\-no\-cache\fR] [\fB\-\-clear\-cache\fR] [\fB\-\-cache\-dir\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fIsubcommands\fR]
 .SH DESCRIPTION
 Rank files by change\-history (VCS) risk: churn, commit and author counts, ownership dilution, and bug\- / security\-fix history over a git working tree. Errors clearly outside a repo
 .SH OPTIONS
@@ -88,6 +88,11 @@ percentile: Per\-signal percentile rank within the analyzed set, averaged
 .TP
 \fB\-\-emit\-author\-details\fR
 Emit SHA\-256\-hashed canonical author identities
+.TP
+\fB\-\-author\-hash\-key\fR \fI<KEY>\fR
+Secret key that hardens `\-\-emit\-author\-details` into a keyed HMAC\-SHA256: an attacker can no longer recover the emitted digests by hashing a candidate set of emails or with a precomputed email→hash table. Without it the digests are a bare SHA\-256 pseudonym. Requires `\-\-emit\-author\-details`; the same key yields the same digests across runs and a cache replay.
+
+Prefer the `BCA_AUTHOR_HASH_KEY` environment variable: a key on the command line is visible to other users via the process list (`ps`) and lands in shell history. The flag takes precedence when both are set.
 .TP
 \fB\-\-include\-deleted\fR
 Emit stats for files deleted at the target ref

--- a/src/vcs/bus_factor.rs
+++ b/src/vcs/bus_factor.rs
@@ -80,7 +80,7 @@ use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
-use super::identity::AuthorId;
+use super::identity::{AuthorHashKey, AuthorId};
 
 /// Output-shape / algorithm version for the bus-factor aggregate. Bump on
 /// any change to the formula, thresholds, grouping, or serialized fields.
@@ -190,12 +190,17 @@ pub struct VcsAggregate {
 ///
 /// `coverage_threshold` is clamped into the open interval `(0, 1)`
 /// defensively (front ends validate it); `emit_author_details` opts the
-/// hashed key-developer lists into the output.
+/// hashed key-developer lists into the output. `author_hash_key`, when
+/// present, hardens those emitted ids into a keyed HMAC (issue #956)
+/// without affecting the bus-factor count or the tie-break order, both of
+/// which stay keyed on the unkeyed digest so they remain key-independent
+/// and cache-replay-stable.
 #[must_use]
 pub fn compute(
     authorship: &[FileAuthorship],
     coverage_threshold: f64,
     emit_author_details: bool,
+    author_hash_key: Option<&AuthorHashKey>,
 ) -> BusFactor {
     let coverage = clamp_threshold(coverage_threshold);
 
@@ -215,7 +220,7 @@ pub fn compute(
     let resolved: Vec<Vec<&AuthorId>> = files.iter().map(|f| authors_of_file(f)).collect();
 
     let repo_files: Vec<&[&AuthorId]> = resolved.iter().map(Vec::as_slice).collect();
-    let repo = group_bus_factor(&repo_files, coverage, emit_author_details);
+    let repo = group_bus_factor(&repo_files, coverage, emit_author_details, author_hash_key);
 
     let mut groups: HashMap<PathBuf, Vec<usize>> = HashMap::new();
     for (idx, file) in files.iter().enumerate() {
@@ -232,7 +237,7 @@ pub fn compute(
             let directory = path_to_forward_slash(&dir)?;
             let files: Vec<&[&AuthorId]> =
                 indices.iter().map(|&i| resolved[i].as_slice()).collect();
-            let group = group_bus_factor(&files, coverage, emit_author_details);
+            let group = group_bus_factor(&files, coverage, emit_author_details, author_hash_key);
             Some(DirectoryBusFactor { directory, group })
         })
         .collect();
@@ -271,7 +276,12 @@ struct GroupAuthor {
 /// Developers are greedily removed (most-authored-files first, ties broken
 /// by hashed id) until more than `coverage` of the files are orphaned; the
 /// count removed is the bus factor.
-fn group_bus_factor(files: &[&[&AuthorId]], coverage: f64, emit: bool) -> GroupBusFactor {
+fn group_bus_factor(
+    files: &[&[&AuthorId]],
+    coverage: f64,
+    emit: bool,
+    key: Option<&AuthorHashKey>,
+) -> GroupBusFactor {
     let total_files = files.len();
     if total_files == 0 {
         return GroupBusFactor::default();
@@ -298,7 +308,7 @@ fn group_bus_factor(files: &[&[&AuthorId]], coverage: f64, emit: bool) -> GroupB
         }
     }
 
-    let bus_factor = greedy_truck_factor(&authors, &mut remaining_authors, coverage, emit);
+    let bus_factor = greedy_truck_factor(&authors, &mut remaining_authors, coverage, emit, key);
     GroupBusFactor {
         bus_factor: bus_factor.removed,
         files: u32::try_from(total_files).unwrap_or(u32::MAX),
@@ -374,6 +384,7 @@ fn greedy_truck_factor(
     remaining_authors: &mut [u32],
     coverage: f64,
     emit: bool,
+    key: Option<&AuthorHashKey>,
 ) -> TruckFactor {
     let total_files = remaining_authors.len();
     #[allow(clippy::cast_precision_loss)] // file counts never approach 2^53
@@ -391,7 +402,11 @@ fn greedy_truck_factor(
         removed_set[pick] = true;
         removed = removed.saturating_add(1);
         if let Some(ids) = key_authors.as_mut() {
-            ids.push(authors[pick].hashed.clone());
+            // Emit the unkeyed digest, or its keyed HMAC when a key is set.
+            // Tie-breaking above still uses the unkeyed `hashed`, so the
+            // removal order — and the bus-factor count — is key-independent.
+            let digest = &authors[pick].hashed;
+            ids.push(key.map_or_else(|| digest.clone(), |k| k.apply(digest)));
         }
         for &file_idx in &authors[pick].authored_files {
             if let Some(count) = remaining_authors.get_mut(file_idx)

--- a/src/vcs/bus_factor_tests.rs
+++ b/src/vcs/bus_factor_tests.rs
@@ -36,7 +36,7 @@ fn schema_version_is_pinned() {
 
 #[test]
 fn empty_input_yields_zero_everywhere() {
-    let bf = compute(&[], DEFAULT_COVERAGE_THRESHOLD, false);
+    let bf = compute(&[], DEFAULT_COVERAGE_THRESHOLD, false, None);
     assert_eq!(bf.repo, GroupBusFactor::default());
     assert!(bf.by_directory.is_empty());
 }
@@ -51,7 +51,7 @@ fn single_author_repo_has_bus_factor_one() {
         file("b.rs", &[("alice", 5, false)]),
         file("c.rs", &[("alice", 3, false)]),
     ];
-    let bf = compute(&files, DEFAULT_COVERAGE_THRESHOLD, false);
+    let bf = compute(&files, DEFAULT_COVERAGE_THRESHOLD, false, None);
     assert_eq!(bf.repo.bus_factor, 1);
     assert_eq!(bf.repo.files, 3);
     assert_eq!(bf.repo.authors, 1);
@@ -66,7 +66,7 @@ fn two_single_author_files_need_both_owners_removed() {
         file("a.rs", &[("alice", 5, true)]),
         file("b.rs", &[("bob", 5, true)]),
     ];
-    let bf = compute(&files, DEFAULT_COVERAGE_THRESHOLD, false);
+    let bf = compute(&files, DEFAULT_COVERAGE_THRESHOLD, false, None);
     assert_eq!(bf.repo.bus_factor, 2);
     assert_eq!(bf.repo.authors, 2);
 }
@@ -81,7 +81,7 @@ fn shared_authorship_raises_the_factor() {
         file("c.rs", &[("alice", 5, true), ("bob", 5, false)]),
         file("d.rs", &[("alice", 5, false), ("bob", 5, true)]),
     ];
-    let bf = compute(&files, DEFAULT_COVERAGE_THRESHOLD, false);
+    let bf = compute(&files, DEFAULT_COVERAGE_THRESHOLD, false, None);
     assert_eq!(bf.repo.bus_factor, 2);
 }
 
@@ -94,7 +94,7 @@ fn dominant_author_excludes_minor_contributor() {
         file("a.rs", &[("alice", 40, true), ("bob", 1, false)]),
         file("b.rs", &[("alice", 40, true), ("bob", 1, false)]),
     ];
-    let bf = compute(&files, DEFAULT_COVERAGE_THRESHOLD, false);
+    let bf = compute(&files, DEFAULT_COVERAGE_THRESHOLD, false, None);
     assert_eq!(bf.repo.bus_factor, 1);
     // Bob never clears the authorship threshold for any file.
     assert_eq!(bf.repo.authors, 1);
@@ -109,8 +109,8 @@ fn coverage_threshold_changes_the_factor() {
         file("b.rs", &[("bob", 5, true)]),
         file("c.rs", &[("carol", 5, true)]),
     ];
-    assert_eq!(compute(&files, 0.5, false).repo.bus_factor, 2);
-    assert_eq!(compute(&files, 0.9, false).repo.bus_factor, 3);
+    assert_eq!(compute(&files, 0.5, false, None).repo.bus_factor, 2);
+    assert_eq!(compute(&files, 0.9, false, None).repo.bus_factor, 3);
 }
 
 #[test]
@@ -123,7 +123,7 @@ fn directory_grouping_is_independent_of_the_repo() {
         file("dir2/c.rs", &[("bob", 5, true)]),
         file("dir2/d.rs", &[("bob", 5, false)]),
     ];
-    let bf = compute(&files, DEFAULT_COVERAGE_THRESHOLD, false);
+    let bf = compute(&files, DEFAULT_COVERAGE_THRESHOLD, false, None);
     assert_eq!(bf.repo.bus_factor, 2);
 
     let dirs: Vec<(&str, u32)> = bf
@@ -145,7 +145,7 @@ fn directory_grouping_breaks_out_depth_two() {
         file("src/metrics/abc.rs", &[("bob", 5, true)]),
         file("README.md", &[("carol", 5, true)]),
     ];
-    let bf = compute(&files, DEFAULT_COVERAGE_THRESHOLD, false);
+    let bf = compute(&files, DEFAULT_COVERAGE_THRESHOLD, false, None);
     let dirs: Vec<&str> = bf
         .by_directory
         .iter()
@@ -166,8 +166,8 @@ fn result_is_independent_of_input_order() {
     let mut reversed = files.to_vec();
     reversed.reverse();
     assert_eq!(
-        compute(&files, DEFAULT_COVERAGE_THRESHOLD, true),
-        compute(&reversed, DEFAULT_COVERAGE_THRESHOLD, true),
+        compute(&files, DEFAULT_COVERAGE_THRESHOLD, true, None),
+        compute(&reversed, DEFAULT_COVERAGE_THRESHOLD, true, None),
     );
 }
 
@@ -175,18 +175,51 @@ fn result_is_independent_of_input_order() {
 fn key_author_ids_emitted_only_on_opt_in() {
     let files = [file("a.rs", &[("alice", 5, true)])];
     assert!(
-        compute(&files, DEFAULT_COVERAGE_THRESHOLD, false)
+        compute(&files, DEFAULT_COVERAGE_THRESHOLD, false, None)
             .repo
             .key_author_ids
             .is_none()
     );
-    let opted = compute(&files, DEFAULT_COVERAGE_THRESHOLD, true);
+    let opted = compute(&files, DEFAULT_COVERAGE_THRESHOLD, true, None);
     let ids = opted.repo.key_author_ids.expect("opt-in emits ids");
     // One removed key author, surfaced as a SHA-256 hex digest, never the
     // plaintext email.
     assert_eq!(ids.len(), 1);
     assert_eq!(ids[0], author("alice").hashed());
     assert!(!ids[0].contains('@'));
+}
+
+#[test]
+fn author_hash_key_hardens_ids_without_changing_the_factor() {
+    // Issue #956: a key must harden the emitted `key_author_ids` into an
+    // HMAC while leaving the bus-factor *count* and the removal-order
+    // tie-break (which key off the unkeyed digest) untouched — so the
+    // numeric result stays key-independent and cache-replay-stable.
+    let files = [
+        file("a.rs", &[("alice", 5, true)]),
+        file("b.rs", &[("bob", 5, true)]),
+    ];
+    let key = AuthorHashKey::new(b"team-secret".to_vec()).expect("non-empty");
+
+    let unkeyed = compute(&files, DEFAULT_COVERAGE_THRESHOLD, true, None);
+    let keyed = compute(&files, DEFAULT_COVERAGE_THRESHOLD, true, Some(&key));
+
+    // The aggregate count is identical with and without the key.
+    assert_eq!(keyed.repo.bus_factor, unkeyed.repo.bus_factor);
+    assert_eq!(keyed.repo.authors, unkeyed.repo.authors);
+
+    let unkeyed_ids = unkeyed.repo.key_author_ids.expect("opt-in emits ids");
+    let keyed_ids = keyed.repo.key_author_ids.expect("opt-in emits ids");
+    // Same number of key developers, in the same order (order is
+    // key-independent), but every id is hardened to its HMAC.
+    assert_eq!(keyed_ids.len(), unkeyed_ids.len());
+    assert_ne!(keyed_ids, unkeyed_ids);
+    // Each emitted id matches the keyed emission of that author identity.
+    let expected: Vec<String> = unkeyed_ids
+        .iter()
+        .map(|digest| AuthorId::from_digest(digest.clone()).emit_hashed(Some(&key)))
+        .collect();
+    assert_eq!(keyed_ids, expected);
 }
 
 #[test]
@@ -270,12 +303,14 @@ fn authors_of_file_is_independent_of_contribution_order() {
         compute(
             std::slice::from_ref(&forward),
             DEFAULT_COVERAGE_THRESHOLD,
-            true
+            true,
+            None,
         ),
         compute(
             std::slice::from_ref(&backward),
             DEFAULT_COVERAGE_THRESHOLD,
-            true
+            true,
+            None,
         ),
     );
 }
@@ -292,11 +327,17 @@ fn compute_ignores_empty_contribution_files() {
         contributions: Vec::new(),
     };
 
-    let with_empty = compute(&[real.clone(), empty], DEFAULT_COVERAGE_THRESHOLD, false);
+    let with_empty = compute(
+        &[real.clone(), empty],
+        DEFAULT_COVERAGE_THRESHOLD,
+        false,
+        None,
+    );
     let without = compute(
         std::slice::from_ref(&real),
         DEFAULT_COVERAGE_THRESHOLD,
         false,
+        None,
     );
 
     // The empty file contributes no authorship signal, so it must not

--- a/src/vcs/cache.rs
+++ b/src/vcs/cache.rs
@@ -28,15 +28,24 @@
 //!
 //! # Author privacy
 //!
-//! Authors are stored only as their SHA-256 [`hashed`](super::identity::AuthorId::hashed)
-//! digests, never plaintext: the cache must not write raw author emails to
-//! disk. Replay reconstructs identities with
+//! Authors are stored only as their **unkeyed** SHA-256
+//! [`hashed`](super::identity::AuthorId::hashed) digests, never plaintext:
+//! the cache must not write raw author emails to disk. Replay reconstructs
+//! identities with
 //! [`AuthorId::from_digest`](super::identity::AuthorId::from_digest),
 //! which preserves author counts, ownership, and the emitted hashes
 //! bit-for-bit (distinct emails yield distinct digests). The digest is a
 //! stable pseudonym, **not** anonymization — it is recoverable against a
 //! candidate email set; see [`hashed`](super::identity::AuthorId::hashed)
 //! for the threat model.
+//!
+//! The opt-in `--author-hash-key` hardening (issue #956) keys the *emitted*
+//! digest only, applied at finalization (like `--emit-author-details`), so
+//! it never changes what the cache stores: the cache holds the unkeyed
+//! inner digest and replaying it under any key reproduces a fresh walk's
+//! keyed output. The on-disk digest is therefore deliberately unkeyed; it
+//! is local-only and never published. See
+//! [`AuthorId::emit_hashed`](super::identity::AuthorId::emit_hashed).
 //!
 //! # Invalidation
 //!
@@ -223,8 +232,10 @@ impl HistoryCache {
 /// and the `--as-of` reference time.
 ///
 /// Finalization-only knobs (`--risk-formula`, `--emit-author-details`,
-/// `--include-deleted`, the bus-factor options) are deliberately excluded:
-/// they are applied at replay, so changing one reuses the same event log.
+/// `--author-hash-key` (#956), `--include-deleted`, the bus-factor options)
+/// are deliberately excluded: they are applied at replay, so changing one
+/// reuses the same event log — including re-finalizing a cached walk under
+/// a different author-hash key without a re-walk.
 /// The file-type scope (`--file-types`, #576) is excluded for the same
 /// reason — the cached event log spans every touched file regardless of
 /// scope, and the scope is re-applied to the freshly-enumerated seed and

--- a/src/vcs/error.rs
+++ b/src/vcs/error.rs
@@ -60,6 +60,10 @@ pub enum Error {
     /// The bus-factor coverage threshold is outside the open interval
     /// `(0, 1)` (issue #332).
     InvalidBusFactorThreshold(String),
+    /// The opt-in author-hash key is unusable — empty, or supplied
+    /// without `--emit-author-details` (which it has no effect without)
+    /// (issue #956).
+    InvalidAuthorHashKey(String),
     /// The historical-trend parameters are out of range — the point
     /// count is below the two-point minimum or above
     /// [`MAX_TREND_POINTS`](crate::vcs::trend::MAX_TREND_POINTS) (issue
@@ -108,6 +112,7 @@ impl Error {
             | Self::InvalidFormula(_)
             | Self::InvalidFileTypeScope(_)
             | Self::InvalidBusFactorThreshold(_)
+            | Self::InvalidAuthorHashKey(_)
             | Self::InvalidTrend(_)
             | Self::InvalidDiff(_) => true,
             Self::OpenRepository(_)
@@ -147,6 +152,9 @@ impl std::fmt::Display for Error {
             Self::InvalidFileTypeScope(reason) => write!(f, "invalid file-type scope: {reason}"),
             Self::InvalidBusFactorThreshold(reason) => {
                 write!(f, "invalid bus-factor threshold: {reason}")
+            }
+            Self::InvalidAuthorHashKey(reason) => {
+                write!(f, "invalid author-hash key: {reason}")
             }
             Self::InvalidTrend(reason) => write!(f, "invalid trend parameters: {reason}"),
             Self::Blame(reason) => write!(f, "failed to blame file: {reason}"),

--- a/src/vcs/identity.rs
+++ b/src/vcs/identity.rs
@@ -21,7 +21,13 @@
 //! mapping by hashing each candidate or via a precomputed email→hash
 //! table — the same weakness that broke Gravatar's email hashing. See
 //! [`AuthorId::hashed`] for the threat model.
+//!
+//! Users who need stronger resistance can opt into keyed hashing with a
+//! secret [`AuthorHashKey`] (`--author-hash-key`, issue #956): the emitted
+//! digest becomes an HMAC the attacker cannot reproduce without the key.
+//! See [`AuthorId::emit_hashed`].
 
+use hmac::{Hmac, Mac};
 use sha2::{Digest, Sha256};
 
 use regex::Regex;
@@ -138,16 +144,105 @@ impl AuthorId {
         }
         let mut hasher = Sha256::new();
         hasher.update(self.key.as_bytes());
-        let digest = hasher.finalize();
-        let mut hex = String::with_capacity(digest.len() * 2);
-        for byte in digest {
-            use std::fmt::Write as _;
-            // Writing to a String is infallible; the formatter never
-            // errors, so the result is discarded deliberately.
-            let _ = write!(hex, "{byte:02x}");
-        }
-        hex
+        to_hex(&hasher.finalize())
     }
+
+    /// The author digest emitted for `--emit-author-details`, optionally
+    /// hardened with a caller-supplied [`AuthorHashKey`].
+    ///
+    /// Without a key this is exactly [`hashed`](Self::hashed) — the bare
+    /// SHA-256 — so default output is unchanged. With a key it is
+    /// `HMAC-SHA256(key, hashed_hex)`: an attacker holding a candidate set
+    /// of emails can no longer recover the mapping by hashing each
+    /// candidate, nor with a precomputed email→hash table (the Gravatar
+    /// weakness [`hashed`](Self::hashed) documents), because computing the
+    /// digest for any candidate now requires the secret key they do not
+    /// hold.
+    ///
+    /// Keying the *inner* digest rather than the raw email is what
+    /// preserves the issue-#334 cache-replay invariant: the persistent
+    /// cache stores the unkeyed inner SHA-256 (a
+    /// [`from_digest`](Self::from_digest) identity *is* that digest), so
+    /// replaying a cached walk under any key reproduces the same emitted
+    /// value as a fresh walk, and the same cached walk can be re-finalized
+    /// under a different key without re-walking. The trade-off is that the
+    /// on-disk cache still holds the *unkeyed* digest; it is local-only and
+    /// never published, matching the cache's existing threat model.
+    #[must_use]
+    pub fn emit_hashed(&self, key: Option<&AuthorHashKey>) -> String {
+        let base = self.hashed();
+        match key {
+            None => base,
+            Some(key) => key.apply(&base),
+        }
+    }
+}
+
+/// A secret key for the opt-in keyed author-identity hashing
+/// (`--author-hash-key`, issue #956).
+///
+/// A newtype for two reasons: it keeps the key material out of any
+/// derived `Debug` (the impl below redacts it, so the secret never lands
+/// in [`Options`](super::options::Options)' debug output or a log), and it
+/// gives the non-empty validation one enforced home — an
+/// [`AuthorHashKey`] cannot hold a zero-length key.
+#[derive(Clone)]
+pub struct AuthorHashKey {
+    key: Vec<u8>,
+}
+
+impl AuthorHashKey {
+    /// Build a key from raw bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidAuthorHashKey`] when `key` is empty — an
+    /// empty key provides no protection and is always a user mistake
+    /// (e.g. an unset environment variable expanding to `""`).
+    pub fn new(key: Vec<u8>) -> Result<Self, Error> {
+        if key.is_empty() {
+            return Err(Error::InvalidAuthorHashKey("the key is empty".to_owned()));
+        }
+        Ok(Self { key })
+    }
+
+    /// Harden an already-computed unkeyed hex digest into its keyed
+    /// `HMAC-SHA256(key, digest_hex)` form. Shared by
+    /// [`AuthorId::emit_hashed`] and the bus-factor key-author list, which
+    /// holds the unkeyed digest for deterministic tie-breaking and only
+    /// hardens it on the way out.
+    #[must_use]
+    pub(crate) fn apply(&self, digest_hex: &str) -> String {
+        // `new_from_slice` accepts a key of any length (HMAC pads or hashes
+        // it per RFC 2104), so it is infallible here; the `expect`
+        // documents that provably-unreachable invariant (AGENTS.md permits
+        // it for such cases).
+        let mut mac =
+            Hmac::<Sha256>::new_from_slice(&self.key).expect("HMAC accepts a key of any length");
+        mac.update(digest_hex.as_bytes());
+        to_hex(&mac.finalize().into_bytes())
+    }
+}
+
+impl std::fmt::Debug for AuthorHashKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never render the secret material — report only that a key is set,
+        // so it cannot leak through `Options`' derived `Debug`.
+        f.debug_struct("AuthorHashKey").finish_non_exhaustive()
+    }
+}
+
+/// Lowercase-hex encode bytes. Shared by [`AuthorId::hashed`] and the
+/// keyed [`AuthorHashKey::apply`] so both render digests identically.
+fn to_hex(bytes: &[u8]) -> String {
+    let mut hex = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        use std::fmt::Write as _;
+        // Writing to a String is infallible; the formatter never errors,
+        // so the result is discarded deliberately.
+        let _ = write!(hex, "{byte:02x}");
+    }
+    hex
 }
 
 /// Matches author identities against a bot-exclusion pattern.

--- a/src/vcs/identity_tests.rs
+++ b/src/vcs/identity_tests.rs
@@ -90,6 +90,84 @@ fn from_digest_hashes_to_itself_and_preserves_identity() {
 }
 
 #[test]
+fn empty_author_hash_key_is_rejected() {
+    // An empty key provides no protection and is always a user mistake
+    // (e.g. an unset environment variable expanding to ""); reject it loudly.
+    assert!(matches!(
+        AuthorHashKey::new(Vec::new()),
+        Err(Error::InvalidAuthorHashKey(_))
+    ));
+    // A non-empty key is accepted.
+    assert!(AuthorHashKey::new(b"secret".to_vec()).is_ok());
+}
+
+#[test]
+fn author_hash_key_debug_redacts_the_secret() {
+    // The key must never leak through `Options`' derived `Debug`; its own
+    // `Debug` reports only that a key is set, never the bytes.
+    let key = AuthorHashKey::new(b"super-secret-key".to_vec()).expect("non-empty");
+    let rendered = format!("{key:?}");
+    // Pin the *exact* redacted form. A `#[derive(Debug)]` would instead
+    // render `AuthorHashKey { key: [115, 117, ...] }` — note it leaks the
+    // bytes as decimals, not as the ASCII string, so a plain
+    // `!contains("super-secret-key")` check would pass against the leaky
+    // derive. Exact equality is what actually catches that regression.
+    assert_eq!(rendered, "AuthorHashKey { .. }");
+    assert!(!rendered.contains("super-secret-key"));
+}
+
+#[test]
+fn emit_hashed_without_key_is_the_bare_digest() {
+    // Default output (no key) is exactly `hashed()` — #956 must not change
+    // the unkeyed emission, for SemVer and cache compatibility.
+    let id = AuthorId::new(b"Ada", b"ada@example.com");
+    assert_eq!(id.emit_hashed(None), id.hashed());
+}
+
+#[test]
+fn emit_hashed_with_key_hardens_and_is_deterministic() {
+    let email = "ada@example.com";
+    let id = AuthorId::new(b"Ada", email.as_bytes());
+    let key = AuthorHashKey::new(b"team-secret".to_vec()).expect("non-empty");
+
+    let keyed = id.emit_hashed(Some(&key));
+    // Still a 64-char SHA-256-width hex digest, never the plaintext email.
+    assert_eq!(keyed.len(), 64);
+    assert!(keyed.chars().all(|c| c.is_ascii_hexdigit()));
+    assert!(!keyed.contains(email));
+    // The key changes the emission: an attacker without the key sees a
+    // value unrelated to the bare SHA-256 they could precompute.
+    assert_ne!(keyed, id.hashed());
+    // Stable across runs/reports for a fixed key (the property #334 and
+    // cross-report pseudonyms rely on).
+    assert_eq!(keyed, id.emit_hashed(Some(&key)));
+    // A different key yields a different digest for the same author.
+    let other_key = AuthorHashKey::new(b"different-secret".to_vec()).expect("non-empty");
+    assert_ne!(keyed, id.emit_hashed(Some(&other_key)));
+    // Distinct authors stay distinct under the same key.
+    let bob = AuthorId::new(b"Bob", b"bob@example.com");
+    assert_ne!(keyed, bob.emit_hashed(Some(&key)));
+}
+
+#[test]
+fn keyed_emit_survives_a_cache_round_trip() {
+    // The crux of the #334 reconciliation: the cache stores the *unkeyed*
+    // inner digest, and the key is applied at finalization. So a fresh
+    // identity and one reconstructed from its cached digest must emit the
+    // SAME keyed value — otherwise replaying a cached walk under a key
+    // would diverge from a fresh walk.
+    let key = AuthorHashKey::new(b"team-secret".to_vec()).expect("non-empty");
+    let fresh = AuthorId::new(b"Ada", b"ada@example.com");
+    let restored = AuthorId::from_digest(fresh.hashed());
+    assert_eq!(
+        fresh.emit_hashed(Some(&key)),
+        restored.emit_hashed(Some(&key))
+    );
+    // And the unkeyed round-trip is unchanged too.
+    assert_eq!(fresh.emit_hashed(None), restored.emit_hashed(None));
+}
+
+#[test]
 fn default_bot_pattern_matches_known_bots() {
     let filter = BotFilter::new(DEFAULT_BOT_PATTERN).expect("default pattern compiles");
     assert!(filter.is_bot(

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -53,6 +53,7 @@ pub use bus_factor::{
 };
 pub use cache::{CACHE_SCHEMA_VERSION, CacheConfig};
 pub use error::Error;
+pub use identity::AuthorHashKey;
 pub use jit::{
     JIT_SCHEMA_VERSION, JIT_SCORE_VERSION, JitCommit, JitContributions, JitDiffContributions,
     JitDiffReport, JitDiffusion, JitExperience, JitFeatures, JitHistory, JitPurpose, JitReport,

--- a/src/vcs/options.rs
+++ b/src/vcs/options.rs
@@ -15,6 +15,7 @@
 use std::path::Path;
 
 use super::error::Error;
+use super::identity::AuthorHashKey;
 
 /// Seconds in a day.
 pub(crate) const SECONDS_PER_DAY: i64 = 86_400;
@@ -228,6 +229,14 @@ pub struct Options {
     /// Emit SHA-256-hashed canonical author identities (default: off —
     /// author identities never leave the process otherwise).
     pub emit_author_details: bool,
+    /// Optional secret key that hardens `emit_author_details` into a keyed
+    /// HMAC (issue #956). `None` (the default) emits the bare SHA-256
+    /// pseudonym. Has no effect unless `emit_author_details` is set. The
+    /// key is a finalization-time concern (like `emit_author_details`
+    /// itself), so it never enters the persistent-cache fingerprint: the
+    /// same cached walk re-finalizes under any key without a re-walk (see
+    /// [`AuthorId::emit_hashed`](super::identity::AuthorId::emit_hashed)).
+    pub author_hash_key: Option<AuthorHashKey>,
     /// Emit stats for files deleted at the target ref (default: off).
     pub include_deleted: bool,
     /// Compute the directory- / repo-level bus-factor aggregate from the
@@ -267,6 +276,7 @@ impl Default for Options {
             as_of: None,
             risk_formula: RiskFormula::Weighted,
             emit_author_details: false,
+            author_hash_key: None,
             include_deleted: false,
             compute_bus_factor: false,
             bus_factor_threshold: DEFAULT_BUS_FACTOR_THRESHOLD,

--- a/src/vcs/replay.rs
+++ b/src/vcs/replay.rs
@@ -247,6 +247,7 @@ pub(crate) fn bus_factor_aggregate(
         &authorship,
         options.bus_factor_threshold,
         options.emit_author_details,
+        options.author_hash_key.as_ref(),
     ))
 }
 

--- a/src/vcs/stats.rs
+++ b/src/vcs/stats.rs
@@ -301,10 +301,11 @@ impl Accumulator {
         });
 
         let author_ids = options.emit_author_details.then(|| {
+            let key = options.author_hash_key.as_ref();
             let mut ids: Vec<String> = self
                 .author_edits_long
                 .keys()
-                .map(AuthorId::hashed)
+                .map(|author| author.emit_hashed(key))
                 .collect();
             ids.sort_unstable();
             ids


### PR DESCRIPTION
## Summary

Opt-in **keyed author-identity hashing** for `--emit-author-details`
(closes #956, follow-up to #811). When a secret key is supplied, the
emitted author digests become `HMAC-SHA256(key, hex(SHA-256(email)))`
instead of a bare SHA-256, defeating the email-enumeration and
precomputed-table attacks the plain pseudonym is vulnerable to (the
Gravatar weakness). **Default output is byte-for-byte unchanged.**

## Why HMAC over the inner digest (reconciling with #334)

The naive `HMAC(key, email)` would break the #334 cache-replay invariant:
the persistent VCS cache stores only the SHA-256 digest, never the
plaintext email, so a cached walk could not reproduce a key applied to the
email. Keying the **inner digest** makes the key a pure finalization-time
transform over the value the cache already holds:

- The cache keeps storing the **unkeyed** inner digest (a `from_digest`
  identity *is* that digest).
- The key stays **out of the cache fingerprint** (like
  `--emit-author-details` itself), so a cached walk re-finalizes under any
  key with **no re-walk**, and replay reproduces a fresh walk's keyed
  output bit-for-bit.

Trade-off (documented): the on-disk cache holds the unkeyed digest. It is
local-only and never published; a user whose threat model includes a
local-cache reader can use `--no-cache` / `--clear-cache`.

## Surfaces (all opt-in; default unchanged)

- **CLI**: `--author-hash-key <KEY>` and the `BCA_AUTHOR_HASH_KEY`
  environment variable (preferred — keeps the secret off the process list
  and out of shell history). Requires `--emit-author-details`.
- **REST**: `author_hash_key` field on `POST /vcs` (+ trend). Key without
  `emit_author_details`, or an empty key, is a `400`.
- **Python**: `vcs.Options(author_hash_key=…)`. Requires
  `emit_author_details`, else `VcsError`.
- **Library**: new `vcs::AuthorHashKey` (redacting `Debug`), the additive
  `Options::author_hash_key` field (`#[non_exhaustive]`, non-breaking), and
  `AuthorId::emit_hashed`. Bus-factor `key_author_ids` are hardened while
  the bus-factor **count** and tie-break order stay keyed on the unkeyed
  digest, so they remain key-independent and cache-replay-stable.

## Tests

- **Unit**: empty-key rejection; `Debug` redaction (exact-form assertion —
  a leaky `#[derive(Debug)]` renders bytes as decimals and would fail);
  unkeyed `emit_hashed(None) == hashed()`; keyed determinism /
  key-sensitivity / distinct-author separation; cache round-trip stability
  (`keyed_emit_survives_a_cache_round_trip`); bus-factor key-independence.
- **Integration**: CLI (hardening, env-var parity, requires-emit error),
  web (400 paths), Python (hardening + requires-emit).

## Docs

`STABILITY.md`, `CHANGELOG.md`, the mdBook (`commands/vcs.md` Author-detail
privacy section + option/cache tables, `commands/rest.md`,
`python/vcs.md`), the regenerated `man/bca-vcs.1`, and lesson #79
(`docs/development/lessons_learned.md`).

## Validation

`make pre-commit` green: fmt, clippy ×2, workspace tests, doc, udeps,
self-scan ×2, man-page drift, and the full Python
ruff/mypy/pyright/pytest/stubtest chain.

Fixes #956
