### PR TITLE
fix(web): reject cache knobs on /vcs/trend instead of ignoring them

### DIFF
--- a/.bca-baseline.toml
+++ b/.bca-baseline.toml
@@ -58,7 +58,7 @@ path = "big-code-analysis-cli/src/vcs_command.rs"
 qualified = "<file>"
 start_line = 1
 metric = "loc.sloc"
-value = 793.0
+value = 820.0
 
 [[entry]]
 path = "big-code-analysis-cli/src/vcs_jit.rs"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2401,6 +2401,16 @@ for historical reference.
 
 ### Fixed
 
+- Web (`POST /vcs/trend`): the trend endpoint no longer advertises the
+  `no_cache` / `cache_dir` cache controls it could never honor. Trend does
+  not use the persistent change-history cache (each sampled point re-anchors
+  at a distinct historical tip with its own `as_of`, which the cache
+  fingerprints separately and never evicts), so the two fields are removed
+  from the trend payload and now answer `400` (`unknown_field`) instead of
+  being silently accepted and ignored. The CLI mirrors this: `--no-cache` /
+  `--clear-cache` / `--cache-dir` combined with `bca vcs trend` or
+  `bca vcs commit` (which also do not cache) is now a usage error rather
+  than a silent no-op (#961).
 - Python `to_sarif`: findings are now emitted for the four
   subtree-aggregate metrics (`cyclomatic`, `cyclomatic.modified`,
   `cognitive`, `abc`) at *interior* spaces — a function owning nested

--- a/big-code-analysis-book/src/commands/rest.md
+++ b/big-code-analysis-book/src/commands/rest.md
@@ -597,7 +597,9 @@ representation.
 > directories and writes JSON cache files under it
 > (`<cache_dir>/<repo>/<head_sha>.json`), so a caller controlling
 > `cache_dir` can direct the server to write cache files at any path the
-> server process can write to. The endpoint's filesystem reach is
+> server process can write to. (`cache_dir` is accepted only by `/vcs`;
+> `/vcs/trend` and `/vcs/jit` do not cache.) The endpoint's filesystem
+> reach is
 > therefore an arbitrary read of any readable git repository *and* an
 > arbitrary write of cache files under any writable path. **Do not expose
 > `/vcs`, `/vcs/trend`, or `/vcs/jit` to untrusted clients without an
@@ -722,7 +724,10 @@ series, not a ranked snapshot, so it is a distinct route from `/vcs`.
 POST http://127.0.0.1:8080/v1/vcs/trend
 ```
 
-**Payload:** every `/vcs` field above, plus:
+**Payload:** every `/vcs` field above **except the cache controls**
+(`no_cache` / `cache_dir`) — trend does not use the persistent cache, so
+sending either field is a `400` (issue #961) rather than a silent no-op —
+plus:
 
 - `points`: number of evenly-spaced sample points (`>= 2`). Defaults to
   `12` (the `bca vcs trend --points` default) when omitted.

--- a/big-code-analysis-book/src/commands/vcs.md
+++ b/big-code-analysis-book/src/commands/vcs.md
@@ -259,6 +259,13 @@ The REST (`POST /vcs`) and Python ([`vcs.rank`](../python/vcs.md))
 surfaces expose the same behaviour through optional `no_cache` /
 `cache_dir` parameters.
 
+The cache is specific to the file ranking. The `trend` and `commit`
+subcommands — and the `/vcs/trend` and `/vcs/jit` endpoints — do not use
+it, so the cache flags do not apply there: passing `--no-cache` /
+`--cache-dir` alongside a subcommand is a usage error, and the trend
+endpoint rejects a `no_cache` / `cache_dir` field rather than silently
+ignoring it (issue #961).
+
 ## In `bca metrics`
 
 Pass `bca metrics --vcs` to attach a `vcs` block (plus a `hotspot_score`

--- a/big-code-analysis-cli/src/lib_tests.rs
+++ b/big-code-analysis-cli/src/lib_tests.rs
@@ -308,6 +308,31 @@ fn vcs_flags_bind_to_their_fields() {
     assert!(args.emit_author_details);
 }
 
+// #961: cache controls apply only to the bare `bca vcs` ranking. Combining
+// them with `commit` / `trend` (which never touch the cache) is rejected
+// rather than silently ignored — the CLI counterpart of the `/vcs/trend`
+// endpoint dropping its advertised cache knobs. `bca vcs trend --no-cache`
+// is already a clap error (the flags are non-`global`), so the gap is the
+// parent position, which these cases exercise.
+#[test]
+fn vcs_cache_flags_rejected_with_subcommand() {
+    use crate::vcs_command::reject_cache_flags_with_subcommand as guard;
+    for argv in [
+        vec!["vcs", "--no-cache", "trend"],
+        vec!["vcs", "--clear-cache", "trend"],
+        vec!["vcs", "--cache-dir", "/tmp/x", "trend"],
+        vec!["vcs", "--no-cache", "commit"],
+    ] {
+        assert!(
+            guard(&parse_vcs(&argv)).is_err(),
+            "{argv:?} must be rejected — the subcommand ignores the cache flag"
+        );
+    }
+    // The bare ranking still accepts the cache flags.
+    assert!(guard(&parse_vcs(&["vcs", "--no-cache"])).is_ok());
+    assert!(guard(&parse_vcs(&["vcs", "--cache-dir", "/tmp/x"])).is_ok());
+}
+
 // `bca vcs` carries its own format set (issue #573): the per-file
 // `MetricsFormat` values plus the rendered `markdown` / `html` pages.
 // Unlike `metrics`/`ops`, `--output` names a single file (a whole-repo

--- a/big-code-analysis-cli/src/vcs_command.rs
+++ b/big-code-analysis-cli/src/vcs_command.rs
@@ -68,6 +68,14 @@ pub(crate) fn run(mut globals: GlobalOpts, args: VcsArgs) {
     }
     let root = resolve_root(&globals);
 
+    // Cache controls apply only to the bare `bca vcs` file ranking. Reject
+    // them up front when combined with a subcommand so the CLI does not
+    // silently ignore a knob the caller set, exactly as the web `/vcs/trend`
+    // endpoint used to (issue #961).
+    if let Err(message) = reject_cache_flags_with_subcommand(&args) {
+        die(format_args!("{message}"));
+    }
+
     // `bca vcs commit <commit>` and `bca vcs trend` are distinct paths;
     // the bare `bca vcs` ranking flow is the `None` case below.
     match args.command.as_ref() {
@@ -108,6 +116,25 @@ pub(crate) fn run(mut globals: GlobalOpts, args: VcsArgs) {
     };
 
     emit(&report, &args).unwrap_or_else(|e| die(format_args!("writing vcs output: {e}")));
+}
+
+/// Reject the cache controls when they accompany a `vcs` subcommand.
+///
+/// `--no-cache` / `--clear-cache` / `--cache-dir` live on the parent
+/// [`VcsArgs`] but only the bare `bca vcs` ranking consults them; `commit`
+/// and `trend` never touch the persistent cache, so accepting the flags in
+/// the parent position (`bca vcs --no-cache trend`) would silently drop
+/// them — the misleading behaviour the web `/vcs/trend` endpoint had
+/// (issue #961). The bare ranking (no subcommand) is unaffected.
+pub(crate) fn reject_cache_flags_with_subcommand(args: &VcsArgs) -> Result<(), &'static str> {
+    if args.command.is_some() && (args.no_cache || args.clear_cache || args.cache_dir.is_some()) {
+        return Err(
+            "--no-cache / --clear-cache / --cache-dir apply only to the bare \
+                    `bca vcs` file ranking, not to `bca vcs commit` or `bca vcs trend` \
+                    (which do not use the cache)",
+        );
+    }
+    Ok(())
 }
 
 /// Build a ranked change-history [`Report`] with **default** windows for

--- a/big-code-analysis-web/src/web/server_tests.rs
+++ b/big-code-analysis-web/src/web/server_tests.rs
@@ -3149,6 +3149,47 @@ async fn test_web_vcs_trend_points_defaults_to_twelve() {
     );
 }
 
+/// #961: `/vcs/trend` does not use the persistent cache, so the shared
+/// `/vcs` cache knobs are not part of its payload. Sending `cache_dir` (or
+/// `no_cache`) must 400 naming the offender — not silently accept a value
+/// that could never affect execution, as the endpoint used to.
+#[actix_rt::test]
+async fn test_web_vcs_trend_rejects_cache_knobs() {
+    let repo = build_trend_repo();
+    let app = test::init_service(
+        App::new()
+            .app_data(test_config())
+            .configure(configure_routes),
+    )
+    .await;
+    for (field, value) in [("cache_dir", json!("/tmp/bca")), ("no_cache", json!(true))] {
+        let payload = json!({
+            "id": "trend-cache",
+            "repo_path": repo.path().to_str().unwrap(),
+            "points": 3,
+            "span": "300d",
+            field: value,
+        });
+        let req = test::TestRequest::post()
+            .uri("/v1/vcs/trend")
+            .insert_header(ContentType::json())
+            .set_json(&payload)
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "a `{field}` knob trend cannot honor must 400, not be silently ignored (#961)"
+        );
+        let parsed: Value = serde_json::from_slice(&test::read_body(resp).await).unwrap();
+        assert_eq!(parsed["error_kind"], json!("unknown_field"));
+        assert!(
+            parsed["error"].as_str().is_some_and(|e| e.contains(field)),
+            "the 400 must name the rejected `{field}`, got: {parsed}"
+        );
+    }
+}
+
 // --- POST /vcs/jit (issues #331 / #580) ----------------------------------
 
 #[actix_rt::test]

--- a/big-code-analysis-web/src/web/vcs.rs
+++ b/big-code-analysis-web/src/web/vcs.rs
@@ -27,8 +27,9 @@
 //! (`<cache_dir>/<repo>/<head_sha>.json`). A caller that controls
 //! `cache_dir` can therefore direct the server to create directories
 //! and write cache files at any path the server process can write to —
-//! a strictly larger filesystem reach than the `repo_path` read. Both
-//! `/vcs` and `/vcs/trend` accept `cache_dir`.
+//! a strictly larger filesystem reach than the `repo_path` read. Only
+//! `/vcs` accepts `cache_dir`; `/vcs/trend` does not use the persistent
+//! cache and rejects both cache knobs (issue #961).
 //!
 //! Together these make the endpoint's filesystem reach an arbitrary
 //! read of any readable git repository **and** an arbitrary write of
@@ -572,8 +573,15 @@ pub fn compute_vcs_jit(payload: WebVcsJitPayload) -> Result<WebVcsJitResponse, v
 /// cannot tell which struct owns a given key), so the only way to reject an
 /// unknown key on this endpoint is a single flat struct. The JSON shape is
 /// unchanged — every field still sits at the top level. The inlined block
-/// mirrors [`WebVcsPayload`] field-for-field; keep the two in lockstep when
-/// either gains a knob.
+/// mirrors [`WebVcsPayload`] field-for-field **except the cache knobs**
+/// (`no_cache` / `cache_dir`): trend does not use the persistent cache, so
+/// those fields are deliberately omitted and a client that sends them gets
+/// a `400` under `deny_unknown_fields` rather than the silent no-op the
+/// endpoint used to accept (issue #961). Each sampled point re-anchors at a
+/// distinct historical tip with its own `as_of`, which the cache
+/// fingerprints separately and never evicts — honoring the knobs would only
+/// grow the cache with per-point entries that never hit. Keep the two
+/// structs in lockstep when either gains any *other* knob.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct WebVcsTrendPayload {
@@ -621,11 +629,8 @@ pub struct WebVcsTrendPayload {
     pub include_deleted: Option<bool>,
     /// Bus-factor coverage (abandonment) threshold in `(0, 1)` (issue #332).
     pub bus_factor_threshold: Option<f64>,
-    /// Disable the persistent change-history cache for this request.
-    pub no_cache: Option<bool>,
-    /// Override the server-side cache directory. Caller-supplied write
-    /// path — see the module-level `# Security` note.
-    pub cache_dir: Option<String>,
+    // NOTE: `no_cache` / `cache_dir` are intentionally absent here — trend
+    // does not use the persistent cache (issue #961). See the struct doc.
     // --- trend-only knobs ---
     /// Number of evenly-spaced sample points (>= 2; default 12 — #636).
     #[serde(default = "default_trend_points")]
@@ -661,8 +666,13 @@ impl WebVcsTrendPayload {
             author_hash_key: self.author_hash_key,
             include_deleted: self.include_deleted,
             bus_factor_threshold: self.bus_factor_threshold,
-            no_cache: self.no_cache,
-            cache_dir: self.cache_dir,
+            // Trend never builds a `CacheConfig`, and these fields are not
+            // even present on the trend payload (issue #961): the base only
+            // exists to reuse `options_from`, which ignores them. Pin them
+            // off so a future reader cannot mistake the base for a caching
+            // path.
+            no_cache: None,
+            cache_dir: None,
         };
         let knobs = TrendKnobs {
             points: self.points,
@@ -867,6 +877,26 @@ mod tests {
             err.to_string().contains("top_dletas"),
             "the error must name the offending key, got: {err}"
         );
+    }
+
+    // #961 drift guard: the trend endpoint does not use the persistent
+    // cache, so the shared `/vcs` cache knobs are absent from its payload —
+    // a client that sends them gets a `400` under `deny_unknown_fields`
+    // (the serde error names the offender) rather than the silent no-op the
+    // endpoint used to accept. Re-adding either field by copy-paste from
+    // `WebVcsPayload` without wiring it into a real `CacheConfig` would flip
+    // this back to silent acceptance and fail here.
+    #[test]
+    fn trend_payload_rejects_cache_knobs() {
+        for (field, value) in [("no_cache", "true"), ("cache_dir", "\"/tmp/x\"")] {
+            let body = format!(r#"{{"id":"t","repo_path":"/x","{field}":{value}}}"#);
+            let err = serde_json::from_str::<WebVcsTrendPayload>(&body)
+                .expect_err("trend must reject a cache knob it cannot honor");
+            assert!(
+                err.to_string().contains(field),
+                "the error must name the rejected `{field}`, got: {err}"
+            );
+        }
     }
 
     // #647: the presence list, the named-field list, and the conflict


### PR DESCRIPTION
## Summary

`POST /vcs/trend` deserialized `no_cache` / `cache_dir` but called the
uncached `build_trend` and never built a `CacheConfig`, so the fields could
never affect execution — the endpoint advertised cache controls it silently
ignored (#961).

## Decision: reject/remove (not honor)

Trend cannot meaningfully cache. Each sampled point re-anchors at a
**distinct historical tip** with its own `as_of`, which the cache
fingerprints separately (`src/vcs/cache.rs::fingerprint`), and there is **no
cache eviction**. With the default unpinned `as_of` the sampling grid shifts
every run, so honoring the knobs would write `points` brand-new, never-hit
entries per invocation and grow the cache without bound — a footgun for
near-zero benefit. The Python `vcs.trend()` binding already forces the cache
disabled and exposes no cache parameters, so reject/remove is the consistent
design.

## Changes

- **Web**: removed `no_cache` / `cache_dir` from `WebVcsTrendPayload`. With
  `#[serde(deny_unknown_fields)]` the endpoint now answers `400`
  (`error_kind: unknown_field`, naming the offender) instead of silently
  ignoring them; `into_base` pins both to `None`. Module/struct docs fixed.
- **CLI**: `--no-cache` / `--clear-cache` / `--cache-dir` apply only to the
  bare `bca vcs` ranking. New guard `reject_cache_flags_with_subcommand`
  makes `bca vcs --no-cache trend` (and `… commit`) a usage error instead of
  a silent no-op. (`bca vcs trend --no-cache` was already a clap error — the
  flags are non-`global`.)
- **Docs**: `rest.md`, `vcs.md`, and the module/struct docs now state trend
  (and `commit` / `jit`) do not cache; `CHANGELOG.md` entry added.
- No library change needed: `build_trend` already takes no `CacheConfig`.
  `/vcs/jit` was already clean.

## Tests

- `trend_payload_rejects_cache_knobs` (web unit) — serde-level rejection.
- `test_web_vcs_trend_rejects_cache_knobs` (web integration) — HTTP 400 +
  `unknown_field` + offender naming.
- `vcs_cache_flags_rejected_with_subcommand` (CLI) — guard rejects with a
  subcommand, accepts the bare ranking.

All three were mutation-verified (re-adding the fields / neutering the guard
makes each fail). `make pre-commit` is green; the `.bca-baseline.toml`
`loc.sloc` bump for `vcs_command.rs` (793→820, from the new guard) is
included in the same commit.

Fixes #961
