### PR TITLE
fix(check): scope thresholds to the space kind each metric measures (#969 Findings 1 & 3)

### DIFF
--- a/.bca-baseline.toml
+++ b/.bca-baseline.toml
@@ -12,65 +12,436 @@ tier = "soft"
 headroom = 0.95
 
 [[entry]]
-path = "big-code-analysis-cli/src/baseline_diff.rs"
-qualified = "<file>"
-start_line = 1
-metric = "nom"
-value = 29.0
-
-[[entry]]
-path = "big-code-analysis-cli/src/deprecations.rs"
-qualified = "<file>"
-start_line = 1
-metric = "halstead.effort"
-value = 110647.96133609534
-
-[[entry]]
-path = "big-code-analysis-cli/src/deprecations.rs"
-qualified = "<file>"
-start_line = 1
-metric = "nargs"
-value = 13.0
-
-[[entry]]
-path = "big-code-analysis-cli/src/manifest.rs"
+path = "big-code-analysis-cli/src/baseline.rs"
 qualified = "<file>"
 start_line = 1
 metric = "loc.sloc"
-value = 767.0
+value = 1080.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/baseline.rs"
+qualified = "Baseline::from_str"
+start_line = 380
+metric = "halstead.effort"
+value = 56942.06556051136
+
+[[entry]]
+path = "big-code-analysis-cli/src/baseline.rs"
+qualified = "Baseline::match_in_group"
+start_line = 581
+metric = "nargs"
+value = 7.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/baseline_diff.rs"
+qualified = "BaselineDiff::column_widths"
+start_line = 298
+metric = "nargs"
+value = 8.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/baseline_diff.rs"
+qualified = "BaselineDiff::compute"
+start_line = 109
+metric = "halstead.effort"
+value = 116932.193453204
+
+[[entry]]
+path = "big-code-analysis-cli/src/baseline_diff.rs"
+qualified = "BaselineDiff::compute"
+start_line = 109
+metric = "nargs"
+value = 8.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/check_format.rs"
+qualified = "AggregatedFormat::dump"
+start_line = 89
+metric = "nargs"
+value = 7.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/check_format.rs"
+qualified = "write_github_annotations"
+start_line = 173
+metric = "halstead.effort"
+value = 47834.17129195417
+
+[[entry]]
+path = "big-code-analysis-cli/src/commands.rs"
+qualified = "<file>"
+start_line = 1
+metric = "loc.sloc"
+value = 2918.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/commands.rs"
+qualified = "EffectiveConfig::from_resolved"
+start_line = 338
+metric = "nargs"
+value = 14.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/commands.rs"
+qualified = "compute_since_diff"
+start_line = 2620
+metric = "nargs"
+value = 8.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/commands.rs"
+qualified = "compute_since_diff"
+start_line = 2620
+metric = "nexits"
+value = 5.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/commands.rs"
+qualified = "emit_check_results"
+start_line = 945
+metric = "nargs"
+value = 8.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/commands.rs"
+qualified = "filter_by_baseline"
+start_line = 756
+metric = "nargs"
+value = 8.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/commands.rs"
+qualified = "print_effective_config"
+start_line = 224
+metric = "nargs"
+value = 9.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/commands.rs"
+qualified = "run"
+start_line = 1458
+metric = "halstead.effort"
+value = 136001.1105471366
+
+[[entry]]
+path = "big-code-analysis-cli/src/commands.rs"
+qualified = "run_check"
+start_line = 55
+metric = "halstead.effort"
+value = 66597.90133805902
+
+[[entry]]
+path = "big-code-analysis-cli/src/commands.rs"
+qualified = "run_command_init"
+start_line = 2446
+metric = "nargs"
+value = 7.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/commands.rs"
+qualified = "run_command_metrics"
+start_line = 1776
+metric = "halstead.effort"
+value = 66645.11013574834
+
+[[entry]]
+path = "big-code-analysis-cli/src/commands.rs"
+qualified = "run_command_report"
+start_line = 2008
+metric = "halstead.effort"
+value = 62475.13739950393
+
+[[entry]]
+path = "big-code-analysis-cli/src/commands.rs"
+qualified = "scaffold_baseline"
+start_line = 2378
+metric = "nargs"
+value = 7.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/commands.rs"
+qualified = "write_aggregate"
+start_line = 1899
+metric = "nargs"
+value = 7.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/diff.rs"
+qualified = "materialize_tree"
+start_line = 477
+metric = "halstead.effort"
+value = 60390.01093335322
+
+[[entry]]
+path = "big-code-analysis-cli/src/diff.rs"
+qualified = "materialize_tree"
+start_line = 477
+metric = "nargs"
+value = 10.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/diff.rs"
+qualified = "materialize_tree"
+start_line = 477
+metric = "nexits"
+value = 9.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/diff.rs"
+qualified = "parse_ls_tree_record"
+start_line = 568
+metric = "nexits"
+value = 6.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/dispatch.rs"
+qualified = "dispatch_exemptions"
+start_line = 536
+metric = "nexits"
+value = 5.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/dispatch.rs"
+qualified = "dispatch_metrics"
+start_line = 191
+metric = "nargs"
+value = 7.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/dispatch.rs"
+qualified = "dispatch_ops"
+start_line = 252
+metric = "nargs"
+value = 8.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/html_report.rs"
+qualified = "<file>"
+start_line = 1
+metric = "loc.sloc"
+value = 1418.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/html_report.rs"
+qualified = "write_language_section"
+start_line = 1345
+metric = "halstead.effort"
+value = 55025.638284623434
+
+[[entry]]
+path = "big-code-analysis-cli/src/html_report.rs"
+qualified = "write_language_section"
+start_line = 1345
+metric = "nargs"
+value = 7.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/html_report.rs"
+qualified = "write_table_classed"
+start_line = 516
+metric = "nargs"
+value = 7.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/html_report.rs"
+qualified = "write_table_classed_with_tooltips"
+start_line = 556
+metric = "nargs"
+value = 9.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/html_report.rs"
+qualified = "write_table_core"
+start_line = 574
+metric = "halstead.effort"
+value = 91596.1159616176
+
+[[entry]]
+path = "big-code-analysis-cli/src/html_report.rs"
+qualified = "write_table_core"
+start_line = 574
+metric = "nargs"
+value = 7.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/html_report.rs"
+qualified = "write_table_with_tooltips"
+start_line = 543
+metric = "nargs"
+value = 8.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/lib.rs"
+qualified = "<file>"
+start_line = 1
+metric = "loc.sloc"
+value = 3324.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/lib.rs"
+qualified = "legacy_hint"
+start_line = 3221
+metric = "halstead.effort"
+value = 59351.805921378844
+
+[[entry]]
+path = "big-code-analysis-cli/src/markdown_report.rs"
+qualified = "<file>"
+start_line = 1
+metric = "loc.sloc"
+value = 853.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/markdown_report.rs"
+qualified = "write_language_section"
+start_line = 962
+metric = "halstead.effort"
+value = 52993.355167839094
 
 [[entry]]
 path = "big-code-analysis-cli/src/markdown_report/hotspot.rs"
 qualified = "<file>"
 start_line = 1
 metric = "loc.sloc"
-value = 993.0
+value = 987.0
 
 [[entry]]
-path = "big-code-analysis-cli/src/metric_alias.rs"
+path = "big-code-analysis-cli/src/markdown_report/sections.rs"
+qualified = "emit_section_md"
+start_line = 68
+metric = "nargs"
+value = 8.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/metric_diff.rs"
+qualified = "MetricDiff::from_sets"
+start_line = 177
+metric = "nargs"
+value = 8.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/threshold_suggestion.rs"
+qualified = "closest_names"
+start_line = 77
+metric = "halstead.effort"
+value = 55785.628204736706
+
+[[entry]]
+path = "big-code-analysis-cli/src/threshold_suggestion.rs"
+qualified = "closest_names"
+start_line = 77
+metric = "nargs"
+value = 9.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/threshold_suggestion.rs"
+qualified = "edit_distance_with_cutoff"
+start_line = 28
+metric = "halstead.effort"
+value = 66737.04848699087
+
+[[entry]]
+path = "big-code-analysis-cli/src/thresholds.rs"
 qualified = "<file>"
 start_line = 1
-metric = "nexits"
-value = 5.0
+metric = "loc.sloc"
+value = 1015.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/thresholds.rs"
+qualified = "ThresholdSet::evaluate_with_policy"
+start_line = 892
+metric = "halstead.effort"
+value = 73855.97988892866
 
 [[entry]]
 path = "big-code-analysis-cli/src/vcs_command.rs"
 qualified = "<file>"
 start_line = 1
 metric = "loc.sloc"
-value = 820.0
+value = 815.0
 
 [[entry]]
-path = "big-code-analysis-cli/src/vcs_jit.rs"
-qualified = "<file>"
-start_line = 1
+path = "big-code-analysis-cli/src/vcs_command.rs"
+qualified = "build_options"
+start_line = 231
+metric = "nargs"
+value = 8.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/vcs_command.rs"
+qualified = "emit"
+start_line = 444
 metric = "nexits"
-value = 6.0
+value = 5.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/vcs_command.rs"
+qualified = "rank"
+start_line = 321
+metric = "nargs"
+value = 7.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/vcs_command.rs"
+qualified = "write_csv"
+start_line = 556
+metric = "halstead.effort"
+value = 50108.004893127785
+
+[[entry]]
+path = "big-code-analysis-cli/src/vcs_command.rs"
+qualified = "write_table"
+start_line = 494
+metric = "nexits"
+value = 5.0
 
 [[entry]]
 path = "big-code-analysis-cli/src/vcs_jit.rs"
 qualified = "emit"
-start_line = 119
+start_line = 113
+metric = "nexits"
+value = 5.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/vcs_report.rs"
+qualified = "write_html_body"
+start_line = 620
+metric = "nargs"
+value = 8.0
+
+[[entry]]
+path = "big-code-analysis-py/src/batch.rs"
+qualified = "PyAnalysisError::__repr__"
+start_line = 166
+metric = "nexits"
+value = 8.0
+
+[[entry]]
+path = "big-code-analysis-py/src/batch.rs"
+qualified = "analyze_batch"
+start_line = 369
+metric = "nargs"
+value = 8.0
+
+[[entry]]
+path = "big-code-analysis-py/src/batch.rs"
+qualified = "analyze_batch"
+start_line = 369
+metric = "nexits"
+value = 6.0
+
+[[entry]]
+path = "big-code-analysis-py/src/batch.rs"
+qualified = "analyze_paths"
+start_line = 622
+metric = "nargs"
+value = 12.0
+
+[[entry]]
+path = "big-code-analysis-py/src/batch.rs"
+qualified = "analyze_paths"
+start_line = 622
 metric = "nexits"
 value = 5.0
 
@@ -79,74 +450,886 @@ path = "big-code-analysis-py/src/lib.rs"
 qualified = "<file>"
 start_line = 1
 metric = "loc.sloc"
-value = 918.0
+value = 913.0
+
+[[entry]]
+path = "big-code-analysis-py/src/lib.rs"
+qualified = "PyVcsOptions::py_new"
+start_line = 599
+metric = "nargs"
+value = 15.0
+
+[[entry]]
+path = "big-code-analysis-py/src/lib.rs"
+qualified = "_native"
+start_line = 830
+metric = "nexits"
+value = 35.0
+
+[[entry]]
+path = "big-code-analysis-py/src/lib.rs"
+qualified = "analyze"
+start_line = 284
+metric = "nargs"
+value = 8.0
+
+[[entry]]
+path = "big-code-analysis-py/src/lib.rs"
+qualified = "extract_as_of"
+start_line = 532
+metric = "nexits"
+value = 5.0
+
+[[entry]]
+path = "big-code-analysis-py/src/lib.rs"
+qualified = "register_vcs_submodule"
+start_line = 893
+metric = "nexits"
+value = 14.0
+
+[[entry]]
+path = "big-code-analysis-py/src/lib.rs"
+qualified = "vcs_trend"
+start_line = 746
+metric = "nargs"
+value = 7.0
+
+[[entry]]
+path = "big-code-analysis-py/src/node.rs"
+qualified = "PyNode"
+start_line = 135
+metric = "nom"
+value = 51.0
+
+[[entry]]
+path = "big-code-analysis-py/src/node.rs"
+qualified = "PyNode"
+start_line = 135
+metric = "wmc"
+value = 58.0
+
+[[entry]]
+path = "big-code-analysis-py/src/node.rs"
+qualified = "PyNode::span"
+start_line = 227
+metric = "nexits"
+value = 6.0
+
+[[entry]]
+path = "big-code-analysis-py/src/sarif.rs"
+qualified = "collect_offenders"
+start_line = 523
+metric = "nexits"
+value = 6.0
+
+[[entry]]
+path = "big-code-analysis-py/src/sarif.rs"
+qualified = "extract_line_number"
+start_line = 350
+metric = "nexits"
+value = 5.0
+
+[[entry]]
+path = "big-code-analysis-py/src/sarif.rs"
+qualified = "resolve_thresholds"
+start_line = 267
+metric = "nexits"
+value = 6.0
 
 [[entry]]
 path = "big-code-analysis-py/src/types_codegen.rs"
 qualified = "<file>"
 start_line = 1
-metric = "nargs"
+metric = "loc.sloc"
+value = 875.0
+
+[[entry]]
+path = "big-code-analysis-py/src/vcs.rs"
+qualified = "options_from"
+start_line = 80
+metric = "halstead.effort"
+value = 47661.70050580648
+
+[[entry]]
+path = "big-code-analysis-py/src/vcs.rs"
+qualified = "options_from"
+start_line = 80
+metric = "nexits"
 value = 8.0
 
 [[entry]]
-path = "big-code-analysis-py/src/walk.rs"
+path = "big-code-analysis-web/src/web/server.rs"
 qualified = "<file>"
 start_line = 1
-metric = "nexits"
-value = 5.0
+metric = "loc.sloc"
+value = 1677.0
 
 [[entry]]
-path = "big-code-analysis-web/src/web/negotiate.rs"
-qualified = "<file>"
-start_line = 1
+path = "big-code-analysis-web/src/web/server.rs"
+qualified = "register_endpoints"
+start_line = 1325
+metric = "abc"
+value = 91.0
+
+[[entry]]
+path = "big-code-analysis-web/src/web/server.rs"
+qualified = "run_parse"
+start_line = 157
 metric = "halstead.effort"
-value = 135040.16842105263
+value = 82478.1543040951
 
 [[entry]]
-path = "big-code-analysis-web/src/web/negotiate.rs"
-qualified = "<file>"
-start_line = 1
-metric = "nargs"
-value = 12.0
-
-[[entry]]
-path = "src/alterator.rs"
-qualified = "<file>"
-start_line = 1
-metric = "wmc"
-value = 66.0
-
-[[entry]]
-path = "src/count.rs"
-qualified = "<file>"
-start_line = 1
+path = "big-code-analysis-web/src/web/server.rs"
+qualified = "run_with_timeout"
+start_line = 1612
 metric = "nargs"
 value = 7.0
 
 [[entry]]
-path = "src/metrics/nargs.rs"
-qualified = "<file>"
-start_line = 1
-metric = "wmc"
-value = 70.0
-
-[[entry]]
-path = "src/preproc.rs"
-qualified = "<file>"
-start_line = 1
+path = "big-code-analysis-web/src/web/vcs.rs"
+qualified = "compute_vcs_jit"
+start_line = 539
 metric = "nexits"
 value = 5.0
 
 [[entry]]
-path = "src/vcs/bus_factor.rs"
-qualified = "<file>"
-start_line = 1
-metric = "nom"
-value = 29.0
+path = "big-code-analysis-web/src/web/vcs.rs"
+qualified = "options_from"
+start_line = 180
+metric = "halstead.effort"
+value = 51846.28098938873
 
 [[entry]]
-path = "src/vcs/error.rs"
-qualified = "Error::fmt"
-start_line = 129
+path = "big-code-analysis-web/src/web/vcs.rs"
+qualified = "options_from"
+start_line = 180
+metric = "nexits"
+value = 8.0
+
+[[entry]]
+path = "src/ast.rs"
+qualified = "build"
+start_line = 206
+metric = "halstead.effort"
+value = 72581.41181251501
+
+[[entry]]
+path = "src/c_macro.rs"
+qualified = "replace"
+start_line = 275
+metric = "halstead.effort"
+value = 82510.45138724327
+
+[[entry]]
+path = "src/c_macro.rs"
+qualified = "step_normal"
+start_line = 106
+metric = "halstead.effort"
+value = 67149.37366558494
+
+[[entry]]
+path = "src/c_macro.rs"
+qualified = "step_normal"
+start_line = 106
+metric = "nexits"
+value = 6.0
+
+[[entry]]
+path = "src/checker.rs"
+qualified = "<file>"
+start_line = 1
+metric = "loc.sloc"
+value = 2038.0
+
+[[entry]]
+path = "src/concurrent_files.rs"
+qualified = "ConcurrentRunner<Config>::run"
+start_line = 360
+metric = "halstead.effort"
+value = 60410.49600898003
+
+[[entry]]
+path = "src/concurrent_files.rs"
+qualified = "ConcurrentRunner<Config>::run"
+start_line = 360
+metric = "nexits"
+value = 6.0
+
+[[entry]]
+path = "src/getter.rs"
+qualified = "<file>"
+start_line = 1
+metric = "loc.sloc"
+value = 2673.0
+
+[[entry]]
+path = "src/getter.rs"
+qualified = "BashCode::get_op_type"
+start_line = 1714
+metric = "halstead.effort"
+value = 54681.01625588078
+
+[[entry]]
+path = "src/getter.rs"
+qualified = "ElixirCode::get_op_type"
+start_line = 2360
+metric = "halstead.effort"
+value = 48241.44928566978
+
+[[entry]]
+path = "src/getter.rs"
+qualified = "PerlCode::get_op_type"
+start_line = 1536
+metric = "halstead.effort"
+value = 65994.57830587434
+
+[[entry]]
+path = "src/getter.rs"
+qualified = "PhpCode::get_op_type"
+start_line = 2100
+metric = "halstead.effort"
+value = 48279.902911067526
+
+[[entry]]
+path = "src/getter.rs"
+qualified = "RubyCode::get_op_type"
+start_line = 2458
+metric = "halstead.effort"
+value = 72634.96827369716
+
+[[entry]]
+path = "src/metrics/abc.rs"
+qualified = "<file>"
+start_line = 1
+metric = "loc.sloc"
+value = 4419.0
+
+[[entry]]
+path = "src/metrics/abc.rs"
+qualified = "CCode::compute"
+start_line = 2478
 metric = "cyclomatic"
-value = 18.0
+value = 15.0
+
+[[entry]]
+path = "src/metrics/abc.rs"
+qualified = "CppCode::compute"
+start_line = 2356
+metric = "cyclomatic"
+value = 15.0
+
+[[entry]]
+path = "src/metrics/abc.rs"
+qualified = "GoCode::compute"
+start_line = 2163
+metric = "cyclomatic"
+value = 15.0
+
+[[entry]]
+path = "src/metrics/abc.rs"
+qualified = "KotlinCode::compute"
+start_line = 1148
+metric = "cyclomatic"
+value = 16.0
+
+[[entry]]
+path = "src/metrics/abc.rs"
+qualified = "MozcppCode::compute"
+start_line = 2659
+metric = "cyclomatic"
+value = 15.0
+
+[[entry]]
+path = "src/metrics/abc.rs"
+qualified = "ObjcCode::compute"
+start_line = 2594
+metric = "cyclomatic"
+value = 16.0
+
+[[entry]]
+path = "src/metrics/abc.rs"
+qualified = "PerlCode::compute"
+start_line = 3832
+metric = "halstead.effort"
+value = 67862.8313802447
+
+[[entry]]
+path = "src/metrics/abc.rs"
+qualified = "RustCode::compute"
+start_line = 1962
+metric = "cyclomatic"
+value = 16.0
+
+[[entry]]
+path = "src/metrics/abc.rs"
+qualified = "perl_inspect_container"
+start_line = 3687
+metric = "halstead.effort"
+value = 53345.08959628053
+
+[[entry]]
+path = "src/metrics/cognitive.rs"
+qualified = "<file>"
+start_line = 1
+metric = "loc.sloc"
+value = 2043.0
+
+[[entry]]
+path = "src/metrics/cognitive.rs"
+qualified = "RubyCode::compute"
+start_line = 1922
+metric = "halstead.effort"
+value = 53101.26216241871
+
+[[entry]]
+path = "src/metrics/cognitive.rs"
+qualified = "tcl_switch_decision_arms"
+start_line = 1695
+metric = "nargs"
+value = 7.0
+
+[[entry]]
+path = "src/metrics/cognitive.rs"
+qualified = "tcl_switch_decision_arms"
+start_line = 1695
+metric = "nexits"
+value = 6.0
+
+[[entry]]
+path = "src/metrics/cyclomatic.rs"
+qualified = "<file>"
+start_line = 1
+metric = "loc.sloc"
+value = 1226.0
+
+[[entry]]
+path = "src/metrics/loc.rs"
+qualified = "<file>"
+start_line = 1
+metric = "loc.sloc"
+value = 2066.0
+
+[[entry]]
+path = "src/metrics/loc.rs"
+qualified = "CCode::compute"
+start_line = 1143
+metric = "nargs"
+value = 7.0
+
+[[entry]]
+path = "src/metrics/loc.rs"
+qualified = "CppCode::compute"
+start_line = 1089
+metric = "nargs"
+value = 7.0
+
+[[entry]]
+path = "src/metrics/loc.rs"
+qualified = "GroovyCode::compute"
+start_line = 1376
+metric = "nargs"
+value = 7.0
+
+[[entry]]
+path = "src/metrics/loc.rs"
+qualified = "MozcppCode::compute"
+start_line = 1277
+metric = "nargs"
+value = 7.0
+
+[[entry]]
+path = "src/metrics/loc.rs"
+qualified = "ObjcCode::compute"
+start_line = 1198
+metric = "nargs"
+value = 7.0
+
+[[entry]]
+path = "src/metrics/loc.rs"
+qualified = "PerlCode::compute"
+start_line = 1549
+metric = "halstead.effort"
+value = 47758.10174656215
+
+[[entry]]
+path = "src/metrics/npa.rs"
+qualified = "<file>"
+start_line = 1
+metric = "loc.sloc"
+value = 2156.0
+
+[[entry]]
+path = "src/metrics/npa.rs"
+qualified = "PhpCode::compute"
+start_line = 638
+metric = "halstead.effort"
+value = 49615.191188139346
+
+[[entry]]
+path = "src/metrics/npa.rs"
+qualified = "PhpCode::compute"
+start_line = 638
+metric = "nargs"
+value = 9.0
+
+[[entry]]
+path = "src/metrics/npa.rs"
+qualified = "python_self_attr_name_bytes"
+start_line = 1691
+metric = "nexits"
+value = 6.0
+
+[[entry]]
+path = "src/metrics/npm.rs"
+qualified = "<file>"
+start_line = 1
+metric = "loc.sloc"
+value = 1189.0
+
+[[entry]]
+path = "src/metrics/npm.rs"
+qualified = "GoCode::compute"
+start_line = 580
+metric = "halstead.effort"
+value = 64139.86021318563
+
+[[entry]]
+path = "src/metrics/npm.rs"
+qualified = "GoCode::compute"
+start_line = 580
+metric = "nargs"
+value = 9.0
+
+[[entry]]
+path = "src/metrics/npm.rs"
+qualified = "PhpCode::compute"
+start_line = 415
+metric = "nargs"
+value = 7.0
+
+[[entry]]
+path = "src/node.rs"
+qualified = "Node<'a>"
+start_line = 75
+metric = "nom"
+value = 31.0
+
+[[entry]]
+path = "src/ops.rs"
+qualified = "ops_inner"
+start_line = 204
+metric = "halstead.effort"
+value = 56640.89870124066
+
+[[entry]]
+path = "src/output/checkstyle.rs"
+qualified = "write_checkstyle"
+start_line = 45
+metric = "nexits"
+value = 7.0
+
+[[entry]]
+path = "src/output/code_climate.rs"
+qualified = "write_code_climate"
+start_line = 73
+metric = "halstead.effort"
+value = 60471.77938561803
+
+[[entry]]
+path = "src/output/dump_metrics.rs"
+qualified = "dump_metrics"
+start_line = 138
+metric = "nexits"
+value = 6.0
+
+[[entry]]
+path = "src/output/dump_metrics.rs"
+qualified = "dump_space"
+start_line = 95
+metric = "nexits"
+value = 9.0
+
+[[entry]]
+path = "src/output/dump_metrics.rs"
+qualified = "dump_value"
+start_line = 217
+metric = "nexits"
+value = 5.0
+
+[[entry]]
+path = "src/output/dump_ops.rs"
+qualified = "dump_ops_values"
+start_line = 121
+metric = "nexits"
+value = 12.0
+
+[[entry]]
+path = "src/output/dump_ops.rs"
+qualified = "dump_space"
+start_line = 66
+metric = "nexits"
+value = 9.0
+
+[[entry]]
+path = "src/output/funcspace_row.rs"
+qualified = "metric_values"
+start_line = 34
+metric = "abc"
+value = 111.87939935484101
+
+[[entry]]
+path = "src/output/funcspace_row.rs"
+qualified = "metric_values"
+start_line = 34
+metric = "halstead.effort"
+value = 80351.11907066956
+
+[[entry]]
+path = "src/output/sarif.rs"
+qualified = "write_sarif_with_suppressed"
+start_line = 168
+metric = "nargs"
+value = 7.0
+
+[[entry]]
+path = "src/parser.rs"
+qualified = "Parser<T>::filters"
+start_line = 175
+metric = "halstead.effort"
+value = 50360.26160456827
+
+[[entry]]
+path = "src/spaces.rs"
+qualified = "<file>"
+start_line = 1
+metric = "loc.sloc"
+value = 2081.0
+
+[[entry]]
+path = "src/spaces.rs"
+qualified = "Ast::from_path"
+start_line = 764
+metric = "nexits"
+value = 5.0
+
+[[entry]]
+path = "src/spaces.rs"
+qualified = "CodeMetrics::fmt"
+start_line = 193
+metric = "nexits"
+value = 8.0
+
+[[entry]]
+path = "src/spaces.rs"
+qualified = "compute_per_node"
+start_line = 1033
+metric = "halstead.effort"
+value = 66012.71705067596
+
+[[entry]]
+path = "src/spaces.rs"
+qualified = "compute_per_node"
+start_line = 1033
+metric = "nargs"
+value = 7.0
+
+[[entry]]
+path = "src/spaces.rs"
+qualified = "metrics_inner"
+start_line = 1177
+metric = "halstead.effort"
+value = 109810.50849120741
+
+[[entry]]
+path = "src/suppression.rs"
+qualified = "parse_native"
+start_line = 380
+metric = "nexits"
+value = 8.0
+
+[[entry]]
+path = "src/tools.rs"
+qualified = "<file>"
+start_line = 1
+metric = "loc.sloc"
+value = 761.0
+
+[[entry]]
+path = "src/tools.rs"
+qualified = "read_file_with_eol"
+start_line = 140
+metric = "nexits"
+value = 6.0
+
+[[entry]]
+path = "src/vcs/bus_factor.rs"
+qualified = "authors_of_file"
+start_line = 322
+metric = "nargs"
+value = 9.0
+
+[[entry]]
+path = "src/vcs/bus_factor.rs"
+qualified = "compute"
+start_line = 192
+metric = "halstead.effort"
+value = 47694.803479864124
+
+[[entry]]
+path = "src/vcs/bus_factor.rs"
+qualified = "compute"
+start_line = 192
+metric = "nargs"
+value = 10.0
+
+[[entry]]
+path = "src/vcs/git/blame.rs"
+qualified = "PerFunctionBlame::open"
+start_line = 262
+metric = "nexits"
+value = 6.0
+
+[[entry]]
+path = "src/vcs/git/blame.rs"
+qualified = "PerFunctionBlame::resolve_commit"
+start_line = 438
+metric = "nexits"
+value = 6.0
+
+[[entry]]
+path = "src/vcs/git/cached.rs"
+qualified = "build_cached"
+start_line = 40
+metric = "halstead.effort"
+value = 76740.04063247392
+
+[[entry]]
+path = "src/vcs/git/cached.rs"
+qualified = "build_cached"
+start_line = 40
+metric = "nexits"
+value = 11.0
+
+[[entry]]
+path = "src/vcs/git/cached.rs"
+qualified = "incremental_events"
+start_line = 161
+metric = "nargs"
+value = 12.0
+
+[[entry]]
+path = "src/vcs/git/cached.rs"
+qualified = "load_candidates"
+start_line = 216
+metric = "nargs"
+value = 7.0
+
+[[entry]]
+path = "src/vcs/git/diff_parse.rs"
+qualified = "unquote_git_path"
+start_line = 401
+metric = "halstead.effort"
+value = 71494.28221151498
+
+[[entry]]
+path = "src/vcs/git/history.rs"
+qualified = "collect_events"
+start_line = 49
+metric = "halstead.effort"
+value = 48928.29416311421
+
+[[entry]]
+path = "src/vcs/git/history.rs"
+qualified = "collect_events"
+start_line = 49
+metric = "nexits"
+value = 8.0
+
+[[entry]]
+path = "src/vcs/git/history.rs"
+qualified = "diff_collect"
+start_line = 200
+metric = "nexits"
+value = 8.0
+
+[[entry]]
+path = "src/vcs/git/history.rs"
+qualified = "diff_collect::<anon@L217>"
+start_line = 217
+metric = "nexits"
+value = 6.0
+
+[[entry]]
+path = "src/vcs/git/history.rs"
+qualified = "process_commit"
+start_line = 128
+metric = "nargs"
+value = 8.0
+
+[[entry]]
+path = "src/vcs/git/history.rs"
+qualified = "process_commit"
+start_line = 128
+metric = "nexits"
+value = 9.0
+
+[[entry]]
+path = "src/vcs/git/jit.rs"
+qualified = "collect_touched"
+start_line = 205
+metric = "nexits"
+value = 10.0
+
+[[entry]]
+path = "src/vcs/git/jit.rs"
+qualified = "collect_touched::<anon@L224>"
+start_line = 224
+metric = "nexits"
+value = 7.0
+
+[[entry]]
+path = "src/vcs/git/jit.rs"
+qualified = "compute_features"
+start_line = 161
+metric = "nargs"
+value = 7.0
+
+[[entry]]
+path = "src/vcs/git/jit.rs"
+qualified = "compute_features"
+start_line = 161
+metric = "nexits"
+value = 5.0
+
+[[entry]]
+path = "src/vcs/git/jit.rs"
+qualified = "experience_features"
+start_line = 475
+metric = "nargs"
+value = 7.0
+
+[[entry]]
+path = "src/vcs/git/jit.rs"
+qualified = "experience_features"
+start_line = 475
+metric = "nexits"
+value = 6.0
+
+[[entry]]
+path = "src/vcs/git/jit.rs"
+qualified = "history_features"
+start_line = 388
+metric = "halstead.effort"
+value = 52560.02538757721
+
+[[entry]]
+path = "src/vcs/git/jit.rs"
+qualified = "score_commit"
+start_line = 67
+metric = "nexits"
+value = 6.0
+
+[[entry]]
+path = "src/vcs/git/mod.rs"
+qualified = "build"
+start_line = 51
+metric = "nexits"
+value = 6.0
+
+[[entry]]
+path = "src/vcs/git/mod.rs"
+qualified = "resolve_anchor"
+start_line = 96
+metric = "nexits"
+value = 5.0
+
+[[entry]]
+path = "src/vcs/git/repo.rs"
+qualified = "enumerate_target_files"
+start_line = 127
+metric = "nexits"
+value = 7.0
+
+[[entry]]
+path = "src/vcs/git/trend.rs"
+qualified = "build_trend"
+start_line = 42
+metric = "nexits"
+value = 5.0
+
+[[entry]]
+path = "src/vcs/options.rs"
+qualified = "parse_iso8601"
+start_line = 393
+metric = "nexits"
+value = 7.0
+
+[[entry]]
+path = "src/vcs/options.rs"
+qualified = "parse_window"
+start_line = 345
+metric = "nexits"
+value = 5.0
+
+[[entry]]
+path = "src/vcs/replay.rs"
+qualified = "fold_commit"
+start_line = 89
+metric = "nargs"
+value = 7.0
+
+[[entry]]
+path = "src/vcs/score.rs"
+qualified = "apply_percentile"
+start_line = 200
+metric = "halstead.effort"
+value = 68450.87280037583
+
+[[entry]]
+path = "src/vcs/score.rs"
+qualified = "apply_percentile"
+start_line = 200
+metric = "nargs"
+value = 13.0
+
+[[entry]]
+path = "src/vcs/stats.rs"
+qualified = "Accumulator::finalize"
+start_line = 238
+metric = "halstead.effort"
+value = 79569.58843331039
+
+[[entry]]
+path = "src/vcs/stats.rs"
+qualified = "Accumulator::finalize"
+start_line = 238
+metric = "nargs"
+value = 7.0
+
+[[entry]]
+path = "src/vcs/stats.rs"
+qualified = "Accumulator::record"
+start_line = 154
+metric = "halstead.effort"
+value = 56240.27018612609
+
+[[entry]]
+path = "src/wire.rs"
+qualified = "<file>"
+start_line = 1
+metric = "loc.sloc"
+value = 1360.0
+
+[[entry]]
+path = "src/wire.rs"
+qualified = "CodeMetrics::from"
+start_line = 1204
+metric = "halstead.effort"
+value = 49790.15156224738
+
+[[entry]]
+path = "src/wire.rs"
+qualified = "VcsTrend::from_trend"
+start_line = 915
+metric = "nargs"
+value = 8.0

--- a/.bca-baseline.toml
+++ b/.bca-baseline.toml
@@ -345,14 +345,14 @@ path = "big-code-analysis-cli/src/thresholds.rs"
 qualified = "<file>"
 start_line = 1
 metric = "loc.sloc"
-value = 1015.0
+value = 941.0
 
 [[entry]]
 path = "big-code-analysis-cli/src/thresholds.rs"
 qualified = "ThresholdSet::evaluate_with_policy"
-start_line = 892
+start_line = 823
 metric = "halstead.effort"
-value = 73855.97988892866
+value = 56531.05676283881
 
 [[entry]]
 path = "big-code-analysis-cli/src/vcs_command.rs"
@@ -518,21 +518,21 @@ value = 6.0
 [[entry]]
 path = "big-code-analysis-py/src/sarif.rs"
 qualified = "collect_offenders"
-start_line = 523
+start_line = 558
 metric = "nexits"
 value = 6.0
 
 [[entry]]
 path = "big-code-analysis-py/src/sarif.rs"
 qualified = "extract_line_number"
-start_line = 350
+start_line = 366
 metric = "nexits"
 value = 5.0
 
 [[entry]]
 path = "big-code-analysis-py/src/sarif.rs"
 qualified = "resolve_thresholds"
-start_line = 267
+start_line = 277
 metric = "nexits"
 value = 6.0
 
@@ -1003,40 +1003,40 @@ path = "src/spaces.rs"
 qualified = "<file>"
 start_line = 1
 metric = "loc.sloc"
-value = 2081.0
+value = 2113.0
 
 [[entry]]
 path = "src/spaces.rs"
 qualified = "Ast::from_path"
-start_line = 764
+start_line = 793
 metric = "nexits"
 value = 5.0
 
 [[entry]]
 path = "src/spaces.rs"
 qualified = "CodeMetrics::fmt"
-start_line = 193
+start_line = 222
 metric = "nexits"
 value = 8.0
 
 [[entry]]
 path = "src/spaces.rs"
 qualified = "compute_per_node"
-start_line = 1033
+start_line = 1062
 metric = "halstead.effort"
 value = 66012.71705067596
 
 [[entry]]
 path = "src/spaces.rs"
 qualified = "compute_per_node"
-start_line = 1033
+start_line = 1062
 metric = "nargs"
 value = 7.0
 
 [[entry]]
 path = "src/spaces.rs"
 qualified = "metrics_inner"
-start_line = 1177
+start_line = 1206
 metric = "halstead.effort"
 value = 109810.50849120741
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ for historical reference.
 
 ### Added
 
+- Public `metric_catalog::MetricScope` enum (`File` / `Function` /
+  `Container`) with `MetricScope::admits(SpaceKind)`, a
+  `metric_catalog::scope(id)` lookup, a `scope` field on the
+  `#[non_exhaustive]` `MetricInfo`, and `SpaceKind::from_serialized` —
+  the single source of truth for which space kind each threshold metric
+  gates (#969), shared by the CLI gate and the Python `to_sarif` binding
+  so they cannot drift.
 - Lazy `Node` traversal handle for Python (`big_code_analysis.Node`) over
   the tree retained by `Ast`, so a caller walks the AST py-tree-sitter-style
   — `kind`, byte offsets, points, `children`, `child_by_field_name`,
@@ -2477,7 +2484,12 @@ for historical reference.
   default; there is no new manifest or CLI syntax. Not a SemVer break —
   the CLI grammar is unchanged and the file/container aggregate firing
   was never a documented per-function limit; if you relied on it as a
-  crude whole-file budget, set an explicit `loc.*` threshold instead.
+  crude whole-file budget, set an explicit `loc.*` threshold instead. The
+  scope is owned by the shared `metric_catalog` (the new public
+  `MetricScope` enum, alongside the existing lower-is-worse direction), so
+  the Python `to_sarif` binding applies the identical gate and emits the
+  same offenders as `bca check` — e.g. `wmc` now emits per class, not at
+  the file unit, in both.
 - Web (`POST /vcs/trend`): the trend endpoint no longer advertises the
   `no_cache` / `cache_dir` cache controls it could never honor. Trend does
   not use the persistent change-history cache (each sampled point re-anchors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2460,6 +2460,24 @@ for historical reference.
 
 ### Fixed
 
+- `bca check`: threshold limits now apply only to the space kind each
+  metric actually measures, so a metric's whole-file or whole-`impl`
+  aggregate no longer fires as if it were a per-function limit (#969).
+  The subtree-summed and per-function metrics (`cognitive`, `cyclomatic`,
+  `cyclomatic.modified`, `halstead.*`, `mi.*`, `abc`, `nargs`, `nexits`,
+  `tokens`) gate individual functions; the object-oriented size metrics
+  (`nom`, `wmc`, `npm`, `npa`) gate container spaces (class / struct /
+  trait / impl / namespace / interface); and the `loc.*` size family
+  gates the file root. Previously every limit was checked against every
+  space, so a clean file or a multi-method `impl` tripped a per-function
+  limit purely from the summed total — which forced ~120 whole-file
+  `bca: suppress-file` markers across this repo that in turn blinded the
+  gate to genuine per-function regressions. This restores per-function
+  coverage without suppression. The scope is an intrinsic, per-metric
+  default; there is no new manifest or CLI syntax. Not a SemVer break —
+  the CLI grammar is unchanged and the file/container aggregate firing
+  was never a documented per-function limit; if you relied on it as a
+  crude whole-file budget, set an explicit `loc.*` threshold instead.
 - Web (`POST /vcs/trend`): the trend endpoint no longer advertises the
   `no_cache` / `cache_dir` cache controls it could never honor. Trend does
   not use the persistent change-history cache (each sampled point re-anchors

--- a/bca.toml
+++ b/bca.toml
@@ -54,9 +54,16 @@ baseline = ".bca-baseline.toml"
 #         mi.original, mi.sei, mi.visual_studio,
 #         abc, wmc, npm, npa
 #   * Quote keys containing a dot (TOML requires it).
-#   * Values are per-function limits. A function whose metric exceeds the
-#     limit becomes an offender; the baseline file decides whether it
-#     fails CI.
+#   * Each limit is checked against the space kind the metric actually
+#     measures (#969): the complexity and per-function metrics
+#     (cognitive, cyclomatic, halstead.*, mi.*, abc, nargs, nexits,
+#     tokens) gate individual functions; the OO size metrics (nom, wmc,
+#     npm, npa) gate container spaces (impl / struct / trait / ...); and
+#     loc.* gates the whole-file root. A metric's file-wide or impl-wide
+#     aggregate is therefore never mistaken for a per-function limit, so
+#     whole-file `suppress-file` markers are no longer needed to mute it.
+#     A space whose metric exceeds the limit becomes an offender; the
+#     baseline file decides whether it fails CI.
 #   * Adding a metric is a tightening — regenerate `.bca-baseline.toml`
 #     in the same change so day-one CI does not flip red on offenders
 #     that were previously invisible to the gate.
@@ -82,10 +89,11 @@ cyclomatic = 15
 # report files), plus a few mid-size modules in the ~760-890 band
 # (alterator.rs, ops.rs, baseline.rs, ...). The soft tier scales this
 # limit to 760 (BCA_HEADROOM 0.95), so files between 760 and 800 are
-# baselined for the soft gate even though they clear the hard one. The
-# same limit also gates per-function SLOC, but that is redundant here:
-# cognitive / cyclomatic / nom / abc catch an oversized function long
-# before it nears 800 lines.
+# baselined for the soft gate even though they clear the hard one.
+# loc.sloc is File-scoped (#969): it gates the whole-file root only, not
+# each function — a per-function SLOC gate would be redundant here, since
+# cognitive / cyclomatic / abc catch an oversized function long before it
+# nears 800 lines.
 "loc.sloc" = 800
 nom = 30
 nargs = 7

--- a/big-code-analysis-book/book.toml
+++ b/big-code-analysis-book/book.toml
@@ -1,7 +1,10 @@
 [book]
 title = "big-code-analysis Documentation"
 description = "This book documents big-code-analysis"
-authors = ["Calixte Denizet <cdenizet@mozilla.com>", "Elijah Zupancic <elijah@zupancic.name>"]
+authors = [
+  "Calixte Denizet <cdenizet@mozilla.com>",
+  "Elijah Zupancic <elijah@zupancic.name>",
+]
 language = "en"
 
 [output.html]

--- a/big-code-analysis-book/src/commands/check.md
+++ b/big-code-analysis-book/src/commands/check.md
@@ -109,6 +109,29 @@ form:
 An unknown threshold name is a tool error (exit `1`), not silently
 ignored.
 
+### Threshold scope
+
+A threshold is checked only against the space kind its metric actually
+measures, so a metric's whole-file or whole-`impl` aggregate is never
+mistaken for a per-function limit. Each metric has a fixed scope; there
+is nothing to configure.
+
+| Scope | Gated spaces | Metrics |
+|-------|--------------|---------|
+| File | the whole-file root only | `loc.sloc`, `loc.ploc`, `loc.lloc`, `loc.cloc`, `loc.blank` |
+| Function | individual functions, methods, and closures | `cognitive`, `cyclomatic`, `cyclomatic.modified`, `halstead.*`, `mi.*`, `abc`, `nargs`, `nexits`, `tokens` |
+| Container | classes, structs, traits, impls, namespaces, interfaces | `nom`, `wmc`, `npm`, `npa` |
+
+The Function-scoped metrics include the subtree sums (`nargs`, `nexits`,
+`tokens`, `halstead.*`): these still roll a function's own nested closures
+into its figure, but they are no longer summed across an entire file or
+`impl`. The Container-scoped metrics describe a type's method set (methods
+per class, weighted methods, public members), so they gate the container
+rather than every leaf function. This means a clean file whose functions
+are individually fine no longer trips an additive limit purely from the
+file-wide total — the false positive that `bca: suppress-file` markers
+used to mask.
+
 The bare `bca diff --metric` spelling of a `loc` sub-metric is accepted
 as an alias for its dotted form (`sloc` is equivalent to `loc.sloc`, and
 so on for `ploc`/`lloc`/`cloc`/`blank`), so a name copied from a `diff`

--- a/big-code-analysis-book/src/commands/suppression.md
+++ b/big-code-analysis-book/src/commands/suppression.md
@@ -78,6 +78,17 @@ function validate(input) { /* ... */ }
 // other metric is still enforced file-wide.
 ```
 
+> **Prefer a narrower tool first.** Since [threshold scope](./check.md#threshold-scope)
+> (#969), a metric's file-wide or `impl`-wide *aggregate* no longer fires
+> as a per-function limit, so the most common reason `suppress-file` was
+> reached for — muting a file-level `halstead` / `nargs` / `nexits` /
+> `nom` total — is gone. Reach for `suppress-file` only when you genuinely
+> want to silence a metric for *every* function in the file. To excuse one
+> irreducibly-complex function, use a function-scoped `bca: suppress(...)`
+> inside it; to grandfather existing offenders without blinding the gate
+> to future regressions, prefer a [baseline](./check.md) entry, which keeps
+> firing once a function gets *worse* than its recorded value.
+
 ## Lizard compatibility markers
 
 Two Lizard-style markers are recognized verbatim so existing

--- a/big-code-analysis-cli/src/baseline.rs
+++ b/big-code-analysis-cli/src/baseline.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, loc, nargs, nexits, nom)
-// Baseline TOML parse/serialize + entry-matching; the offenders are
-// parse-table volume, many-fn, and impl-aggregate artifacts, not
-// per-function logic complexity (cognitive/cyclomatic stay enforced).
-
 //! Baseline file for `bca check`: external record of currently-known
 //! threshold offenders that the check is allowed to ignore until the
 //! team gets around to fixing them. Companion to (not substitute for)

--- a/big-code-analysis-cli/src/baseline_diff.rs
+++ b/big-code-analysis-cli/src/baseline_diff.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, nargs)
-// Mechanical baseline-vs-baseline diff + column-width formatting; the
-// offenders are many-fn / impl-aggregate artifacts, not per-function logic
-// complexity (cognitive/cyclomatic stay enforced).
-
 //! Structured diff between two baseline files for `bca diff-baseline`
 //! (issue #382). Replaces the in-the-reviewer's-head TOML diff parsing
 //! that `recipes/baselines.md` used to walk through: it pairs entries

--- a/big-code-analysis-cli/src/check_flags.rs
+++ b/big-code-analysis-cli/src/check_flags.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead)
-// Cohesive bag of small flag value-types + their parsers; the
-// file-level halstead.effort is a many-small-items aggregation
-// artifact (Halstead is non-linear over a shared vocabulary), not
-// per-function logic complexity — every function here clears the gate.
-
 //! Value types for `bca check`'s threshold-tier and CI-presentation
 //! flags (issues #385/#666/#683/#688). Split out of `lib.rs` so the
 //! parsing / resolution logic for `--tier`, `--exit-codes`,

--- a/big-code-analysis-cli/src/check_format.rs
+++ b/big-code-analysis-cli/src/check_format.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, loc, nargs, nexits, nom)
-// Check-result output writers (CI annotation / aggregated formats); the
-// offenders are mechanical-writer and many-fn aggregation artifacts, not
-// per-function logic complexity (cognitive/cyclomatic stay enforced).
-
 //! Aggregated violation-document output formats for `bca check`.
 //!
 //! `bca check` walks the source tree, collects [`Violation`] records,

--- a/big-code-analysis-cli/src/commands.rs
+++ b/big-code-analysis-cli/src/commands.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead, loc, nargs, nexits, nom)
-// CLI command orchestration: top-level subcommand dispatch plus many
-// config-passing / scaffolding fns. The offenders are many-fn / arg-passing /
-// aggregation artifacts. (`run`'s cyclomatic — flat subcommand dispatch — is
-// suppressed per-function below; cognitive stays enforced.)
-
 //! Top-level command dispatch for the `bca` CLI.
 //!
 //! Owns the public `run()` entry point (called by `bca`'s `main` and
@@ -64,6 +58,11 @@ fn run_check(
     manifest: Option<&Manifest>,
     preproc: Option<Arc<PreprocResults>>,
 ) {
+    // bca: suppress(abc)
+    // Linear check-pipeline orchestration: each stage (threshold resolve,
+    // walk, baseline filter, classify, emit) is already its own helper; the
+    // ABC count is the call/assignment density of wiring them together, not
+    // branching logic.
     // Merge the check-only manifest keys (baseline / headroom) under the
     // CLI flags, and take the `[thresholds]` table (hard + soft layers)
     // as the base for the resolver. `--config` merges on top of it;
@@ -2370,6 +2369,80 @@ version = {}
     )
 }
 
+/// Write the initial `.bca-baseline.toml` for `bca init`: an empty
+/// template when `no_baseline`, otherwise a populated one produced by the
+/// same `bca check --write-baseline` path so it is byte-identical to a
+/// manual bootstrap. Split out of `run_command_init` so scaffolding the
+/// config files and producing the baseline read as the two distinct steps
+/// they are (#969).
+fn scaffold_baseline(
+    globals: GlobalOpts,
+    target: &Path,
+    manifest_path: &Path,
+    baseline_path: &Path,
+    no_baseline: bool,
+    preproc: Option<Arc<PreprocResults>>,
+) {
+    if no_baseline {
+        write_atomic(baseline_path, init_empty_baseline_template().as_bytes())
+            .unwrap_or_else(|e| die_io("write", baseline_path, e));
+        eprintln!(
+            "bca init: wrote empty {} (populate via `bca check --write-baseline {}`)",
+            baseline_path.display(),
+            baseline_path.display(),
+        );
+        return;
+    }
+
+    // Reuse the same code path `bca check --write-baseline` uses so the
+    // produced baseline is byte-identical to one a manual bootstrap would
+    // write. The thresholds we just wrote are loaded from the scaffolded
+    // `bca.toml` to keep this consistent with what the user will use
+    // day-to-day.
+    let check_args = CheckArgs {
+        positional: crate::PositionalPaths::default(),
+        selection: crate::WalkSelectionArgs::default(),
+        tuning: crate::WalkTuningArgs::default(),
+        preproc: crate::PreprocConsumeArgs::default(),
+        thresholds: Vec::new(),
+        config: Some(manifest_path.to_path_buf()),
+        no_fail: false,
+        no_suppress: false,
+        report_suppressed: false,
+        output_format: None,
+        output: None,
+        baseline: None,
+        write_baseline: Some(Some(baseline_path.to_path_buf())),
+        no_summary: true,
+        since: None,
+        changed_only: false,
+        github_annotations: crate::CiDetect::Auto,
+        summary_file: None,
+        no_remediation: true,
+        print_effective_config: None,
+        headroom: None,
+        tier: TierSpec::Hard,
+        exit_codes: None,
+        strict_exit_codes: false,
+        baseline_line_tolerance: None,
+        baseline_fuzzy_match: None,
+        check_exclude: Vec::new(),
+        check_exclude_from: None,
+    };
+    // `run_check` early-exits after `write_check_baseline` runs, so it
+    // returns normally on success here.
+    let mut walk_globals = globals;
+    if walk_globals.paths.is_empty() {
+        walk_globals.paths.push(target.to_path_buf());
+    }
+    // `init` writes its baseline from the manifest it just scaffolded, so
+    // it deliberately bypasses manifest discovery (passing `None`) — the
+    // freshly-written `bca.toml` is the source of truth here, supplied
+    // directly via `--config`.
+    run_check(walk_globals, check_args, None, preproc);
+    eprintln!("bca init: wrote {}", baseline_path.display());
+}
+
 fn run_command_init(globals: GlobalOpts, args: InitArgs, preproc: Option<Arc<PreprocResults>>) {
     let target = args.dir.clone().unwrap_or_else(|| PathBuf::from("."));
     if !target.exists() {
@@ -2415,63 +2488,16 @@ fn run_command_init(globals: GlobalOpts, args: InitArgs, preproc: Option<Arc<Pre
         .unwrap_or_else(|e| die_io("write", &bcaignore_path, e));
     eprintln!("bca init: wrote {}", bcaignore_path.display());
 
-    if args.no_baseline {
-        write_atomic(&baseline_path, init_empty_baseline_template().as_bytes())
-            .unwrap_or_else(|e| die_io("write", &baseline_path, e));
-        eprintln!(
-            "bca init: wrote empty {} (populate via `bca check --write-baseline {}`)",
-            baseline_path.display(),
-            baseline_path.display(),
-        );
-    } else {
-        // Reuse the same code path `bca check --write-baseline` uses
-        // so the produced baseline is byte-identical to one a manual
-        // bootstrap would write. The thresholds we just wrote are
-        // loaded from the scaffolded `bca.toml` to keep this consistent
-        // with what the user will use day-to-day.
-        let check_args = CheckArgs {
-            positional: crate::PositionalPaths::default(),
-            selection: crate::WalkSelectionArgs::default(),
-            tuning: crate::WalkTuningArgs::default(),
-            preproc: crate::PreprocConsumeArgs::default(),
-            thresholds: Vec::new(),
-            config: Some(manifest_path.clone()),
-            no_fail: false,
-            no_suppress: false,
-            report_suppressed: false,
-            output_format: None,
-            output: None,
-            baseline: None,
-            write_baseline: Some(Some(baseline_path.clone())),
-            no_summary: true,
-            since: None,
-            changed_only: false,
-            github_annotations: crate::CiDetect::Auto,
-            summary_file: None,
-            no_remediation: true,
-            print_effective_config: None,
-            headroom: None,
-            tier: TierSpec::Hard,
-            exit_codes: None,
-            strict_exit_codes: false,
-            baseline_line_tolerance: None,
-            baseline_fuzzy_match: None,
-            check_exclude: Vec::new(),
-            check_exclude_from: None,
-        };
-        // `run_check` early-exits after `write_check_baseline` runs,
-        // so it returns normally on success here.
-        let mut walk_globals = globals;
-        if walk_globals.paths.is_empty() {
-            walk_globals.paths.push(target.clone());
-        }
-        // `init` writes its baseline from the manifest it just
-        // scaffolded, so it deliberately bypasses manifest discovery
-        // (passing `None`) — the freshly-written `bca.toml` is the
-        // source of truth here, supplied directly via `--config`.
-        run_check(walk_globals, check_args, None, preproc);
-        eprintln!("bca init: wrote {}", baseline_path.display());
-    }
+    // The config files exist; now produce the initial baseline (empty or
+    // populated from the freshly-scaffolded manifest).
+    scaffold_baseline(
+        globals,
+        &target,
+        &manifest_path,
+        &baseline_path,
+        args.no_baseline,
+        preproc,
+    );
 
     eprintln!(
         "bca init: done. Next steps:\n  \

--- a/big-code-analysis-cli/src/diff.rs
+++ b/big-code-analysis-cli/src/diff.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits, nom)
-// `bca diff` tree materialization + diffing; the offenders are many-fn /
-// early-return aggregation artifacts, not per-function logic complexity.
-// `nom` counts the many small, well-named helpers in this module — a
-// file-level extraction artifact, not a per-function complexity signal.
-
 //! Diff-aware filtering for `bca check`.
 //!
 //! Resolves the git ref to diff `HEAD` against (from the `--since`

--- a/big-code-analysis-cli/src/dispatch.rs
+++ b/big-code-analysis-cli/src/dispatch.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits)
-// Per-subcommand dispatch fns; the offenders are many-fn / early-return
-// aggregation artifacts, not per-function logic complexity
-// (cognitive/cyclomatic stay enforced).
-
 //! Per-file dispatch for the `bca` walker.
 //!
 //! `act_on_file` is the entry point: it runs the shared pre-dispatch
@@ -202,6 +197,11 @@ fn dispatch_metrics(
     format: Option<&MetricsFormat>,
     pretty: bool,
 ) -> std::io::Result<()> {
+    // bca: suppress(cognitive)
+    // Output-mode dispatch: each nesting level is a real emit decision
+    // (format present? --vcs? per-function blame? aggregate vs per-file?
+    // Generic vs Csv?). Flattening would relocate the nesting, not remove
+    // it. Kept in lockstep with the sibling `dispatch_ops`.
     if let Some(fmt) = format {
         if let Ok(mut space) = analyze_file(language, source, &path, pr, cfg.metrics_options()) {
             // `bca metrics --vcs`: attach the file's change-history block

--- a/big-code-analysis-cli/src/exemptions.rs
+++ b/big-code-analysis-cli/src/exemptions.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, nargs)
-// `bca exemptions` report assembly; the offenders are many-fn /
-// impl-aggregate artifacts, not per-function logic complexity
-// (cognitive/cyclomatic stay enforced).
-
 //! `bca exemptions` — a unified audit of everything the `bca check`
 //! gate skips (issue #386).
 //!

--- a/big-code-analysis-cli/src/format_util.rs
+++ b/big-code-analysis-cli/src/format_util.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead)
-// Numeric-display helpers plus a large unit-test module exercising every
-// formatting branch; the file-level halstead.effort is string-formatting /
-// many-tiny-fn aggregation volume (the same artifact the sibling report
-// renderers suppress), not per-function logic complexity.
-
 //! Shared formatting helpers for metric scalars across the CLI.
 //!
 //! Metric values are stored as `f64` even when conceptually integer

--- a/big-code-analysis-cli/src/formats.rs
+++ b/big-code-analysis-cli/src/formats.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits, nom)
-// Output-format selection / writer plumbing; the offenders are many-fn
-// aggregation artifacts, not per-function logic complexity
-// (cognitive/cyclomatic stay enforced).
-
 #![allow(clippy::needless_pass_by_value)]
 
 use std::fs::{File, create_dir_all};

--- a/big-code-analysis-cli/src/html_report.rs
+++ b/big-code-analysis-cli/src/html_report.rs
@@ -1,10 +1,3 @@
-// bca: suppress-file(halstead, loc, nargs, nexits, nom)
-// HTML report templating; thin per-language orchestrators delegating to small
-// write_* helpers. File-level halstead/loc and summed nargs/nom/nexits are
-// string-formatting-volume / many-fn aggregation artifacts — the many tiny
-// early-returning write helpers (and the in-file test module) inflate the
-// file-level nexits sum the same way they inflate the others.
-
 // Metric counts (token, function, branch, argument, etc.) are stored as
 // `usize` and crossed with `f64` averages, ratios, and Halstead scores
 // across the cyclomatic / MI / Halstead computations. The `usize as f64`

--- a/big-code-analysis-cli/src/lib.rs
+++ b/big-code-analysis-cli/src/lib.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, loc, nargs, nexits, nom)
-// CLI library glue (seed-path expansion, legacy-flag hints, walk wiring); the
-// offenders are static-table volume and many-fn aggregation artifacts, not
-// per-function logic complexity (cognitive/cyclomatic stay enforced).
-
 //! Library surface for the `bca` CLI.
 //!
 //! Exists so the workspace `xtask` crate can render man pages from the

--- a/big-code-analysis-cli/src/manifest.rs
+++ b/big-code-analysis-cli/src/manifest.rs
@@ -1,10 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits, nom)
-// bca.toml manifest load/merge; the offenders are many-fn / impl-aggregate
-// artifacts. `nom` counts the module's many small accessors / typed-table
-// helpers (one per manifest key family) — a flat config-merge surface, not a
-// hard-to-follow function. (`merge_check`'s cyclomatic — flat field-by-field
-// config merge — is suppressed per-function below; cognitive stays enforced.)
-
 //! `bca.toml` manifest discovery and merge (issue #374).
 //!
 //! Consolidates the flags every local-gate recipe used to thread

--- a/big-code-analysis-cli/src/markdown_report.rs
+++ b/big-code-analysis-cli/src/markdown_report.rs
@@ -1,10 +1,3 @@
-// bca: suppress-file(halstead, loc, nargs, nom, nexits)
-// Markdown report templating; thin per-language orchestrators delegating to
-// small write_* helpers. File-level halstead/loc and summed nargs/nom/nexits
-// are string-formatting-volume / many-fn aggregation artifacts (the large
-// in-file test module — rich fixture + cross-format checks — adds to the
-// summed nexits count the same way it adds to the others).
-
 // Metric counts (token, function, branch, argument, etc.) are stored as
 // `usize` and crossed with `f64` averages, ratios, and Halstead scores
 // across the cyclomatic / MI / Halstead computations. The `usize as f64`

--- a/big-code-analysis-cli/src/markdown_report/advisory.rs
+++ b/big-code-analysis-cli/src/markdown_report/advisory.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead)
-// The manifest-key string literals and the BTreeMap-driven test fixtures
-// inflate the file-level Halstead effort (string-formatting / table-lookup
-// volume), the same artifact the sibling report renderers suppress — not
-// per-function logic complexity (cognitive/cyclomatic stay enforced).
-
 //! Resolved advisory cutoffs for the report's Actionable Summary, the CC
 //! note, and the Many-Parameters table (issue #630).
 //!

--- a/big-code-analysis-cli/src/markdown_report/hotspot.rs
+++ b/big-code-analysis-cli/src/markdown_report/hotspot.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead, nargs, nom)
-// The `SPECS` table is declarative data: ~70 capture-free cell-projector
-// closures inflate the file-level nom/nargs/halstead sums (each closure is a
-// one-arg "function"), the same string-formatting / many-fn aggregation
-// artifact the sibling report renderers suppress — not per-function logic.
-
 //! Format-neutral source of truth for the per-language hotspot sections
 //! shared by the Markdown (`super`) and HTML (`crate::html_report`)
 //! report renderers.

--- a/big-code-analysis-cli/src/markdown_report/sections.rs
+++ b/big-code-analysis-cli/src/markdown_report/sections.rs
@@ -1,7 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits, nom)
-// Markdown report section builders; the offenders are string-formatting-volume
-// and many-fn aggregation artifacts, not per-function logic complexity.
-
 //! Per-section writers for [`super::write_language_section`].
 //!
 //! Each writer appends one Markdown section (heading + optional table)

--- a/big-code-analysis-cli/src/metric_alias.rs
+++ b/big-code-analysis-cli/src/metric_alias.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead, nargs)
-// Catalog-driven name mapping: the offenders are the doc-heavy module's
-// string-literal volume and the summed-arg count across the two small
-// normalize helpers, not per-function logic complexity (cognitive /
-// cyclomatic stay enforced).
-
 //! Shared metric-name aliasing between `bca check --threshold` and
 //! `bca diff --metric` (issue #514).
 //!

--- a/big-code-analysis-cli/src/metric_catalog.rs
+++ b/big-code-analysis-cli/src/metric_catalog.rs
@@ -1,7 +1,3 @@
-// bca: suppress-file(halstead, nargs)
-// `bca list-metrics` rendering over the derived catalog; file-level halstead
-// and summed nargs are table-size aggregation artifacts.
-
 //! `bca list-metrics` rendering.
 //!
 //! The catalog itself is no longer maintained here: rows are derived

--- a/big-code-analysis-cli/src/metric_diff.rs
+++ b/big-code-analysis-cli/src/metric_diff.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits, nom)
-// Mechanical per-metric struct diff (`from_sets` builds it field by field);
-// the offenders are many-fn / impl-aggregate artifacts, not per-function
-// logic complexity (cognitive/cyclomatic stay enforced).
-
 //! Per-metric structured diff between two `bca metrics -O json` runs
 //! (issue #487). Replaces the legacy grammar-bump glue chain — the
 //! external `json-minimal-tests` binary plus `split-minimal-tests.py` —
@@ -136,6 +131,28 @@ pub(crate) struct MetricDiff {
 /// top-level `metrics` object for that file.
 pub(crate) type MetricSet = BTreeMap<String, Value>;
 
+/// Sorted (added, removed) file-key sets between two metric sets: keys
+/// present only in `new` are additions, keys present only in `old` are
+/// removals. Split out of `from_sets` so the file-presence diff reads as
+/// one step, separate from the scalar-bucketing loop (#969).
+fn file_set_deltas(old: &MetricSet, new: &MetricSet) -> (Vec<String>, Vec<String>) {
+    let mut added = Vec::new();
+    let mut removed = Vec::new();
+    for key in new.keys() {
+        if !old.contains_key(key) {
+            added.push(key.clone());
+        }
+    }
+    for key in old.keys() {
+        if !new.contains_key(key) {
+            removed.push(key.clone());
+        }
+    }
+    added.sort();
+    removed.sort();
+    (added, removed)
+}
+
 impl MetricDiff {
     /// Load both sides, then compute the bucketed diff. `min_change` is
     /// the inclusive absolute-delta threshold (`0.0` reports any
@@ -175,18 +192,7 @@ impl MetricDiff {
             .collect();
         let metric_filter = metric_filter.as_slice();
 
-        for key in new.keys() {
-            if !old.contains_key(key) {
-                diff.added_files.push(key.clone());
-            }
-        }
-        for key in old.keys() {
-            if !new.contains_key(key) {
-                diff.removed_files.push(key.clone());
-            }
-        }
-        diff.added_files.sort();
-        diff.removed_files.sort();
+        (diff.added_files, diff.removed_files) = file_set_deltas(old, new);
 
         // Files present on both sides: walk the metric tree and bucket
         // each scalar leaf whose value moved past the threshold.

--- a/big-code-analysis-cli/src/provenance.rs
+++ b/big-code-analysis-cli/src/provenance.rs
@@ -1,10 +1,3 @@
-// bca: suppress-file(halstead, nargs)
-// Provenance-footer assembly plus a unit-test module: the file-level
-// halstead.effort is string-formatting volume and the file-level nargs sum is
-// the many small render/format helpers and the `Provenance` constructors in
-// the tests — the same many-fn aggregation artifact the sibling report
-// renderers suppress, not per-function logic complexity.
-
 //! Shared provenance footer for the AST report (issue #680).
 //!
 //! Both the Markdown and HTML AST reports close with one provenance line so

--- a/big-code-analysis-cli/src/threshold_suggestion.rs
+++ b/big-code-analysis-cli/src/threshold_suggestion.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits)
-// Edit-distance "did you mean?" suggester; halstead is arithmetic volume and
-// the rest are many-fn aggregation artifacts. No cognitive/cyclomatic offender
-// here — those stay enforced.
-
 //! "Did you mean?" suggester for the unknown-`--threshold` /
 //! `[thresholds]`-key error.
 //!

--- a/big-code-analysis-cli/src/thresholds.rs
+++ b/big-code-analysis-cli/src/thresholds.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, loc, nargs, nexits, nom)
-// Threshold-table parse/eval + Violation/ThresholdSet types; the offenders are
-// parse-table volume, many-fn, and impl-aggregate artifacts, not per-function
-// logic complexity (cognitive/cyclomatic stay enforced).
-
 //! Threshold engine for `bca check`.
 //!
 //! Maps stable metric names (the same set surfaced by `bca list-metrics`,
@@ -31,6 +26,59 @@ use serde::Deserialize;
 use crate::baseline::Coverage;
 use crate::format_util::MetricScalar;
 
+/// Which space kinds a metric's threshold is meaningful on (issue #969).
+///
+/// `bca check` walks every [`FuncSpace`] — the file-level
+/// [`SpaceKind::Unit`] root, every container (class/impl/trait/...), and
+/// every individual function. Metrics fall into three natural units of
+/// measure, and gating a metric on the wrong kind manufactures false
+/// positives: the subtree accessors (`nargs.total()`, `nexits_sum()`, the
+/// rolled-up Halstead figures, ...) read a *sum* at any space that owns
+/// children, so a per-function limit (`nargs = 7`) trips on every
+/// non-trivial file *and* every multi-method `impl` — no matter how clean
+/// each individual function is. Scope lets each metric declare where its
+/// limit applies, so those aggregates stop firing without blanket
+/// whole-file suppression.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ThresholdScope {
+    /// Gate only the file-level [`SpaceKind::Unit`] root (whole-file
+    /// size). The `loc.*` family lives here: the limits are calibrated on
+    /// the file-level distribution and a per-function line count is
+    /// redundant with the complexity metrics.
+    File,
+    /// Gate only individual function spaces ([`SpaceKind::Function`] —
+    /// free functions, methods, and closures). The per-function metrics
+    /// live here: the complexity figures (cognitive, cyclomatic, abc,
+    /// mi.*) and the subtree sums that describe one function and its
+    /// nested closures (halstead.*, nargs, nexits, tokens). Their value on
+    /// a container or the file root is an aggregate across many functions,
+    /// not a per-function limit, so those kinds are skipped.
+    Function,
+    /// Gate only container spaces that own methods (class / struct / trait
+    /// / impl / namespace / interface), never the file root or a leaf
+    /// function. The object-oriented size metrics live here: `nom` (methods
+    /// per container), `wmc` (weighted methods), `npm` / `npa` (public
+    /// methods / attributes). These are meaningless on a leaf function and
+    /// a file-wide artifact on the `Unit` root.
+    Container,
+}
+
+/// True for the container kinds gated by [`ThresholdScope::Container`]:
+/// spaces that own methods. Deliberately excludes [`SpaceKind::Unit`] (the
+/// file root, gated by [`ThresholdScope::File`]), [`SpaceKind::Function`]
+/// (gated by [`ThresholdScope::Function`]), and [`SpaceKind::Unknown`].
+fn is_container_kind(kind: SpaceKind) -> bool {
+    matches!(
+        kind,
+        SpaceKind::Class
+            | SpaceKind::Struct
+            | SpaceKind::Trait
+            | SpaceKind::Impl
+            | SpaceKind::Namespace
+            | SpaceKind::Interface
+    )
+}
+
 /// Static registry entry: stable threshold name -> scalar extractor.
 #[derive(Debug)]
 struct MetricExtractor {
@@ -40,6 +88,8 @@ struct MetricExtractor {
     /// loc.*, nargs, ...) round-trip exactly through `f64` for the ranges
     /// that occur in practice.
     extract: fn(&CodeMetrics) -> f64,
+    /// Which space kinds this metric's threshold gates (issue #969).
+    scope: ThresholdScope,
 }
 
 /// Source of truth for accepted threshold names. Order matters only for
@@ -62,102 +112,135 @@ struct MetricExtractor {
 /// of measurement; it is intentional, not an oversight. When adding a new
 /// extractor, pick the accessor that matches the metric's reported figure
 /// and note which side of this split it falls on.
+///
+/// Each metric's `scope` (issue #969) places its limit on the kind it
+/// actually measures: `loc.*` is [`ThresholdScope::File`] (whole-file
+/// size); the per-function complexity figures (cognitive, cyclomatic,
+/// abc, mi.*) and the per-function subtree sums (halstead.*, nargs,
+/// nexits, tokens) are [`ThresholdScope::Function`]; and the
+/// object-oriented size metrics (nom, wmc, npm, npa) are
+/// [`ThresholdScope::Container`]. This keeps a metric's file-wide or
+/// `impl`-wide aggregate from firing as if it were a per-function limit.
 const EXTRACTORS: &[MetricExtractor] = &[
     MetricExtractor {
         name: "cognitive",
         extract: |m| m.cognitive.cognitive() as f64,
+        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "cyclomatic",
         extract: |m| m.cyclomatic.cyclomatic() as f64,
+        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "cyclomatic.modified",
         extract: |m| m.cyclomatic.cyclomatic_modified() as f64,
+        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "halstead.volume",
         extract: |m| m.halstead.volume(),
+        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "halstead.difficulty",
         extract: |m| m.halstead.difficulty(),
+        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "halstead.effort",
         extract: |m| m.halstead.effort(),
+        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "halstead.time",
         extract: |m| m.halstead.time(),
+        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "halstead.bugs",
         extract: |m| m.halstead.bugs(),
+        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "loc.sloc",
         extract: |m| m.loc.sloc() as f64,
+        scope: ThresholdScope::File,
     },
     MetricExtractor {
         name: "loc.ploc",
         extract: |m| m.loc.ploc() as f64,
+        scope: ThresholdScope::File,
     },
     MetricExtractor {
         name: "loc.lloc",
         extract: |m| m.loc.lloc() as f64,
+        scope: ThresholdScope::File,
     },
     MetricExtractor {
         name: "loc.cloc",
         extract: |m| m.loc.cloc() as f64,
+        scope: ThresholdScope::File,
     },
     MetricExtractor {
         name: "loc.blank",
         extract: |m| m.loc.blank() as f64,
+        scope: ThresholdScope::File,
     },
     MetricExtractor {
         name: "nom",
         extract: |m| m.nom.total() as f64,
+        scope: ThresholdScope::Container,
     },
     MetricExtractor {
         name: "tokens",
         extract: |m| m.tokens.tokens_sum() as f64,
+        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "nexits",
         extract: |m| m.nexits.nexits_sum() as f64,
+        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "nargs",
         extract: |m| m.nargs.total() as f64,
+        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "mi.original",
         extract: |m| m.mi.original(),
+        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "mi.sei",
         extract: |m| m.mi.sei(),
+        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "mi.visual_studio",
         extract: |m| m.mi.visual_studio(),
+        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "abc",
         extract: |m| m.abc.magnitude(),
+        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "wmc",
         extract: |m| m.wmc.total_wmc() as f64,
+        scope: ThresholdScope::Container,
     },
     MetricExtractor {
         name: "npm",
         extract: |m| m.npm.total_npm() as f64,
+        scope: ThresholdScope::Container,
     },
     MetricExtractor {
         name: "npa",
         extract: |m| m.npa.total_npa() as f64,
+        scope: ThresholdScope::Container,
     },
 ];
 
@@ -689,6 +772,10 @@ struct ResolvedThreshold {
     /// limit is the violation, and the breach ratio inverts to
     /// `limit / value`.
     lower_is_worse: bool,
+    /// Which space kinds this threshold gates (issue #969), copied from
+    /// the extractor so the evaluation loop reads it without a registry
+    /// lookup.
+    scope: ThresholdScope,
 }
 
 /// Whether the metric named `name` is lower-is-worse (the `mi.*`
@@ -748,6 +835,7 @@ impl ThresholdSet {
                 extractor,
                 limit: *limit,
                 lower_is_worse: metric_is_lower_is_worse(extractor.name),
+                scope: extractor.scope,
             });
         }
         Ok(Self { entries })
@@ -839,7 +927,23 @@ impl ThresholdSet {
                     extractor,
                     limit,
                     lower_is_worse,
+                    scope,
                 } = entry;
+                // Per-metric scope gate (#969): a metric's subtree
+                // accessor read at the file root or a container is a sum
+                // across many functions, not a per-function value, so skip
+                // the (space, threshold) pair whose scope excludes this
+                // space kind. Runs before the breach/suppression logic, so
+                // an out-of-scope pair never produces a `Violation` and
+                // composes trivially with suppression and the baseline.
+                let in_scope = match scope {
+                    ThresholdScope::File => matches!(current.kind, SpaceKind::Unit),
+                    ThresholdScope::Function => matches!(current.kind, SpaceKind::Function),
+                    ThresholdScope::Container => is_container_kind(current.kind),
+                };
+                if !in_scope {
+                    continue;
+                }
                 let value = (extractor.extract)(&current.metrics);
                 // Direction-aware gate (#698): for the lower-is-worse
                 // `mi.*` family a value *below* the limit is the

--- a/big-code-analysis-cli/src/thresholds.rs
+++ b/big-code-analysis-cli/src/thresholds.rs
@@ -18,6 +18,7 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
+use big_code_analysis::metric_catalog::MetricScope;
 use big_code_analysis::{
     CodeMetrics, FuncSpace, SpaceKind, SuppressionPolicy, threshold_metric_for_name,
 };
@@ -26,57 +27,16 @@ use serde::Deserialize;
 use crate::baseline::Coverage;
 use crate::format_util::MetricScalar;
 
-/// Which space kinds a metric's threshold is meaningful on (issue #969).
-///
-/// `bca check` walks every [`FuncSpace`] — the file-level
-/// [`SpaceKind::Unit`] root, every container (class/impl/trait/...), and
-/// every individual function. Metrics fall into three natural units of
-/// measure, and gating a metric on the wrong kind manufactures false
-/// positives: the subtree accessors (`nargs.total()`, `nexits_sum()`, the
-/// rolled-up Halstead figures, ...) read a *sum* at any space that owns
-/// children, so a per-function limit (`nargs = 7`) trips on every
-/// non-trivial file *and* every multi-method `impl` — no matter how clean
-/// each individual function is. Scope lets each metric declare where its
-/// limit applies, so those aggregates stop firing without blanket
-/// whole-file suppression.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ThresholdScope {
-    /// Gate only the file-level [`SpaceKind::Unit`] root (whole-file
-    /// size). The `loc.*` family lives here: the limits are calibrated on
-    /// the file-level distribution and a per-function line count is
-    /// redundant with the complexity metrics.
-    File,
-    /// Gate only individual function spaces ([`SpaceKind::Function`] —
-    /// free functions, methods, and closures). The per-function metrics
-    /// live here: the complexity figures (cognitive, cyclomatic, abc,
-    /// mi.*) and the subtree sums that describe one function and its
-    /// nested closures (halstead.*, nargs, nexits, tokens). Their value on
-    /// a container or the file root is an aggregate across many functions,
-    /// not a per-function limit, so those kinds are skipped.
-    Function,
-    /// Gate only container spaces that own methods (class / struct / trait
-    /// / impl / namespace / interface), never the file root or a leaf
-    /// function. The object-oriented size metrics live here: `nom` (methods
-    /// per container), `wmc` (weighted methods), `npm` / `npa` (public
-    /// methods / attributes). These are meaningless on a leaf function and
-    /// a file-wide artifact on the `Unit` root.
-    Container,
-}
-
-/// True for the container kinds gated by [`ThresholdScope::Container`]:
-/// spaces that own methods. Deliberately excludes [`SpaceKind::Unit`] (the
-/// file root, gated by [`ThresholdScope::File`]), [`SpaceKind::Function`]
-/// (gated by [`ThresholdScope::Function`]), and [`SpaceKind::Unknown`].
-fn is_container_kind(kind: SpaceKind) -> bool {
-    matches!(
-        kind,
-        SpaceKind::Class
-            | SpaceKind::Struct
-            | SpaceKind::Trait
-            | SpaceKind::Impl
-            | SpaceKind::Namespace
-            | SpaceKind::Interface
-    )
+/// The space kind each metric's threshold gates (issue #969) — owned by
+/// the library catalog so the CLI gate and the Python `to_sarif` binding
+/// cannot drift on which kinds a metric measures, exactly as they share
+/// the lower-is-worse direction.
+fn metric_scope(name: &str) -> MetricScope {
+    // Every name reaching here has resolved to a catalog entry (pinned by
+    // `extractor_ids_match_library_catalog`), so the lookup is infallible;
+    // an unknown id defaults to the narrowest scope rather than ever
+    // gating a file/container aggregate.
+    big_code_analysis::metric_catalog::scope(name).unwrap_or(MetricScope::Function)
 }
 
 /// Static registry entry: stable threshold name -> scalar extractor.
@@ -88,8 +48,6 @@ struct MetricExtractor {
     /// loc.*, nargs, ...) round-trip exactly through `f64` for the ranges
     /// that occur in practice.
     extract: fn(&CodeMetrics) -> f64,
-    /// Which space kinds this metric's threshold gates (issue #969).
-    scope: ThresholdScope,
 }
 
 /// Source of truth for accepted threshold names. Order matters only for
@@ -113,134 +71,107 @@ struct MetricExtractor {
 /// extractor, pick the accessor that matches the metric's reported figure
 /// and note which side of this split it falls on.
 ///
-/// Each metric's `scope` (issue #969) places its limit on the kind it
-/// actually measures: `loc.*` is [`ThresholdScope::File`] (whole-file
-/// size); the per-function complexity figures (cognitive, cyclomatic,
-/// abc, mi.*) and the per-function subtree sums (halstead.*, nargs,
-/// nexits, tokens) are [`ThresholdScope::Function`]; and the
-/// object-oriented size metrics (nom, wmc, npm, npa) are
-/// [`ThresholdScope::Container`]. This keeps a metric's file-wide or
-/// `impl`-wide aggregate from firing as if it were a per-function limit.
+/// Each metric's threshold scope (issue #969) — the space kind it gates —
+/// lives in the library [`big_code_analysis::metric_catalog`] (read via
+/// [`metric_scope`]), the same single source of truth that owns the
+/// lower-is-worse direction, so the CLI gate and the Python `to_sarif`
+/// binding cannot disagree on which kinds a metric measures.
 const EXTRACTORS: &[MetricExtractor] = &[
     MetricExtractor {
         name: "cognitive",
         extract: |m| m.cognitive.cognitive() as f64,
-        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "cyclomatic",
         extract: |m| m.cyclomatic.cyclomatic() as f64,
-        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "cyclomatic.modified",
         extract: |m| m.cyclomatic.cyclomatic_modified() as f64,
-        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "halstead.volume",
         extract: |m| m.halstead.volume(),
-        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "halstead.difficulty",
         extract: |m| m.halstead.difficulty(),
-        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "halstead.effort",
         extract: |m| m.halstead.effort(),
-        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "halstead.time",
         extract: |m| m.halstead.time(),
-        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "halstead.bugs",
         extract: |m| m.halstead.bugs(),
-        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "loc.sloc",
         extract: |m| m.loc.sloc() as f64,
-        scope: ThresholdScope::File,
     },
     MetricExtractor {
         name: "loc.ploc",
         extract: |m| m.loc.ploc() as f64,
-        scope: ThresholdScope::File,
     },
     MetricExtractor {
         name: "loc.lloc",
         extract: |m| m.loc.lloc() as f64,
-        scope: ThresholdScope::File,
     },
     MetricExtractor {
         name: "loc.cloc",
         extract: |m| m.loc.cloc() as f64,
-        scope: ThresholdScope::File,
     },
     MetricExtractor {
         name: "loc.blank",
         extract: |m| m.loc.blank() as f64,
-        scope: ThresholdScope::File,
     },
     MetricExtractor {
         name: "nom",
         extract: |m| m.nom.total() as f64,
-        scope: ThresholdScope::Container,
     },
     MetricExtractor {
         name: "tokens",
         extract: |m| m.tokens.tokens_sum() as f64,
-        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "nexits",
         extract: |m| m.nexits.nexits_sum() as f64,
-        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "nargs",
         extract: |m| m.nargs.total() as f64,
-        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "mi.original",
         extract: |m| m.mi.original(),
-        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "mi.sei",
         extract: |m| m.mi.sei(),
-        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "mi.visual_studio",
         extract: |m| m.mi.visual_studio(),
-        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "abc",
         extract: |m| m.abc.magnitude(),
-        scope: ThresholdScope::Function,
     },
     MetricExtractor {
         name: "wmc",
         extract: |m| m.wmc.total_wmc() as f64,
-        scope: ThresholdScope::Container,
     },
     MetricExtractor {
         name: "npm",
         extract: |m| m.npm.total_npm() as f64,
-        scope: ThresholdScope::Container,
     },
     MetricExtractor {
         name: "npa",
         extract: |m| m.npa.total_npa() as f64,
-        scope: ThresholdScope::Container,
     },
 ];
 
@@ -772,10 +703,10 @@ struct ResolvedThreshold {
     /// limit is the violation, and the breach ratio inverts to
     /// `limit / value`.
     lower_is_worse: bool,
-    /// Which space kinds this threshold gates (issue #969), copied from
-    /// the extractor so the evaluation loop reads it without a registry
-    /// lookup.
-    scope: ThresholdScope,
+    /// Which space kind this threshold gates (issue #969), resolved once
+    /// from the library catalog at build time so the evaluation loop reads
+    /// it without a per-space lookup.
+    scope: MetricScope,
 }
 
 /// Whether the metric named `name` is lower-is-worse (the `mi.*`
@@ -835,7 +766,7 @@ impl ThresholdSet {
                 extractor,
                 limit: *limit,
                 lower_is_worse: metric_is_lower_is_worse(extractor.name),
-                scope: extractor.scope,
+                scope: metric_scope(extractor.name),
             });
         }
         Ok(Self { entries })
@@ -936,12 +867,7 @@ impl ThresholdSet {
                 // space kind. Runs before the breach/suppression logic, so
                 // an out-of-scope pair never produces a `Violation` and
                 // composes trivially with suppression and the baseline.
-                let in_scope = match scope {
-                    ThresholdScope::File => matches!(current.kind, SpaceKind::Unit),
-                    ThresholdScope::Function => matches!(current.kind, SpaceKind::Function),
-                    ThresholdScope::Container => is_container_kind(current.kind),
-                };
-                if !in_scope {
+                if !scope.admits(current.kind) {
                     continue;
                 }
                 let value = (extractor.extract)(&current.metrics);

--- a/big-code-analysis-cli/src/thresholds_tests.rs
+++ b/big-code-analysis-cli/src/thresholds_tests.rs
@@ -526,6 +526,7 @@ fn tokens_threshold_never_suppressed() {
             extractor,
             limit: -0.5,
             lower_is_worse: false,
+            scope: extractor.scope,
         }],
     };
 
@@ -550,11 +551,13 @@ fn tokens_threshold_never_suppressed() {
 
 #[test]
 fn evaluate_stamps_qualified_symbols_through_container_chain() {
-    // Unit(file) -> Impl(MyStruct) -> Function(do_thing). With a
-    // cyclomatic limit of 0 every space's default complexity of 1 trips,
-    // so each emitted violation's function slot reveals its qualified
-    // symbol: the file collapses to `<file>`, the impl keeps its bare
-    // name, and the method is qualified by its container.
+    // Unit(file) -> Impl(MyStruct) -> Function(do_thing). cyclomatic is
+    // Function-scoped (#969), so with a cyclomatic limit of 0 only the
+    // `do_thing` leaf trips — and its violation's function slot reveals the
+    // full container-qualified symbol `MyStruct::do_thing`. The `Unit` root
+    // and the `MyStruct` impl are skipped by scope, so this asserts the
+    // qualified-symbol chain; the `<file>` collapse path is covered by
+    // `file_scoped_loc_fires_only_on_unit`.
     let mut unit = space("src/foo.rs", SpaceKind::Unit, SuppressionScope::default());
     let mut imp = space("MyStruct", SpaceKind::Impl, SuppressionScope::default());
     imp.spaces.push(space(
@@ -573,9 +576,11 @@ fn evaluate_stamps_qualified_symbols_through_container_chain() {
         &mut out,
     );
     let names: Vec<&str> = out.iter().map(|v| v.function.as_str()).collect();
-    assert!(names.contains(&"<file>"), "{names:?}");
-    assert!(names.contains(&"MyStruct"), "{names:?}");
-    assert!(names.contains(&"MyStruct::do_thing"), "{names:?}");
+    assert_eq!(
+        names,
+        ["MyStruct::do_thing"],
+        "only the leaf fires, stamped with its container chain: {names:?}"
+    );
 }
 
 #[test]
@@ -947,5 +952,217 @@ fn mi_ratio_inverts_so_lower_value_ranks_worse() {
         Violation::pick_worst(&[&mild, &severe])
             .is_some_and(|w| (w.value - 5.0).abs() < f64::EPSILON),
         "pick_worst must rank the lower MI as worse"
+    );
+}
+
+// --- Per-metric threshold scope (#969) ---------------------------------
+//
+// `bca check` walked every `FuncSpace`, so a subtree-sum metric read at
+// the file-level `Unit` root or a container (a sum across many functions)
+// tripped a per-function limit on any non-trivial file or `impl`. Scope
+// pins each metric to the kind it measures: `loc.*` to the `Unit` root,
+// the per-function metrics to `SpaceKind::Function` leaves, and the OO
+// size metrics (nom/wmc/npm/npa) to container spaces. These tests pin all
+// three directions.
+
+/// Parse a small multi-line Rust snippet into its full space tree: a
+/// `SpaceKind::Unit` root with a nested function child, both carrying real
+/// `loc.*` and `mi.*` values (neither has a public setter). Used by the
+/// scope tests that need a genuine file-aggregate-vs-per-function split.
+fn analyzed_tree() -> FuncSpace {
+    big_code_analysis::analyze(
+        big_code_analysis::Source::new(
+            big_code_analysis::LANG::Rust,
+            b"fn f(x: i32) -> i32 {\n    if x > 0 {\n        x + 1\n    } else {\n        x - 1\n    }\n}\n",
+        ),
+        big_code_analysis::MetricsOptions::default(),
+    )
+    .expect("snippet has a top-level FuncSpace")
+}
+
+/// Parse a Rust `struct` plus an `impl` of two methods. The `impl` space's
+/// `nom.total()` is 2 (its two methods), giving the Container-scope test a
+/// real container metric to gate (no public setter exists for `nom`).
+fn analyzed_impl_tree() -> FuncSpace {
+    big_code_analysis::analyze(
+        big_code_analysis::Source::new(
+            big_code_analysis::LANG::Rust,
+            b"struct S;\nimpl S {\n    fn a(&self) {}\n    fn b(&self) {}\n}\n",
+        ),
+        big_code_analysis::MetricsOptions::default(),
+    )
+    .expect("snippet has a top-level FuncSpace")
+}
+
+/// Attach `child` under a fresh `SpaceKind::Unit` root and return the root.
+/// The root keeps `CodeMetrics::default()` (cyclomatic `1.0`), so a
+/// `cyclomatic = 0` threshold fired on it under the pre-#969 file-aggregate
+/// behavior — letting the scope tests assert it no longer does.
+fn unit_with_child(child: FuncSpace) -> FuncSpace {
+    let mut root = space("<file>", SpaceKind::Unit, SuppressionScope::default());
+    root.spaces.push(child);
+    root
+}
+
+#[test]
+fn function_scoped_metric_skips_unit_root() {
+    // cyclomatic is Function-scoped: the file-level Unit root is never
+    // gated, even though its default cyclomatic of 1.0 exceeds a `0` limit.
+    // Pre-#969 this fired a spurious `<file>` violation.
+    let root = space("<file>", SpaceKind::Unit, SuppressionScope::default());
+    let mut out = Vec::new();
+    threshold_set("cyclomatic", 0.0).evaluate_with_policy(
+        Path::new("fixture.rs"),
+        &root,
+        SuppressionPolicy::Honor,
+        false,
+        &mut out,
+    );
+    assert!(
+        out.is_empty(),
+        "Unit root must not be gated for a Function-scoped metric, got {out:?}"
+    );
+}
+
+#[test]
+fn function_scoped_metric_fires_on_nested_function() {
+    let child = space("inner", SpaceKind::Function, SuppressionScope::default());
+    let root = unit_with_child(child);
+    let mut out = Vec::new();
+    threshold_set("cyclomatic", 0.0).evaluate_with_policy(
+        Path::new("fixture.rs"),
+        &root,
+        SuppressionPolicy::Honor,
+        false,
+        &mut out,
+    );
+    assert_eq!(
+        out.len(),
+        1,
+        "exactly the nested function fires, got {out:?}"
+    );
+    assert_eq!(out[0].function, "inner");
+    assert_eq!(out[0].metric, "cyclomatic");
+}
+
+#[test]
+fn function_scoped_metric_skips_container() {
+    // Function scope is `SpaceKind::Function` only: a container (impl /
+    // class) is never gated for a per-function metric, so an `impl`'s
+    // method-summed value cannot fire as if it were one function's.
+    let container = space("MyType", SpaceKind::Impl, SuppressionScope::default());
+    let root = unit_with_child(container);
+    let mut out = Vec::new();
+    threshold_set("cyclomatic", 0.0).evaluate_with_policy(
+        Path::new("fixture.rs"),
+        &root,
+        SuppressionPolicy::Honor,
+        false,
+        &mut out,
+    );
+    assert!(
+        out.is_empty(),
+        "container must not be gated for a Function-scoped metric, got {out:?}"
+    );
+}
+
+#[test]
+fn container_scoped_metric_fires_on_container_only() {
+    // nom is Container-scoped: it gates the `impl` (methods-per-container),
+    // not the file root (a file-wide method sum) and not the leaf methods.
+    let root = analyzed_impl_tree();
+    let mut out = Vec::new();
+    // Limit 1 so the impl's `nom` of 2 trips while the leaf methods
+    // (`nom` 0/1) and the Unit root are not flagged.
+    threshold_set("nom", 1.0).evaluate_with_policy(
+        Path::new("fixture.rs"),
+        &root,
+        SuppressionPolicy::Honor,
+        false,
+        &mut out,
+    );
+    assert_eq!(
+        out.len(),
+        1,
+        "only the impl container fires for nom, got {out:?}"
+    );
+    assert_ne!(out[0].function, "<file>", "the Unit root must not be gated");
+    assert_eq!(out[0].metric, "nom");
+}
+
+#[test]
+fn file_scoped_loc_fires_only_on_unit() {
+    // loc.sloc is File-scoped: it gates the whole-file Unit root, never the
+    // nested function — even though both spans exceed the limit.
+    let root = analyzed_tree();
+    let unit_sloc = root.metrics.loc.sloc();
+    assert!(
+        unit_sloc > 2,
+        "fixture Unit sloc must exceed the test limit, got {unit_sloc}"
+    );
+    let mut out = Vec::new();
+    threshold_set("loc.sloc", 2.0).evaluate_with_policy(
+        Path::new("fixture.rs"),
+        &root,
+        SuppressionPolicy::Honor,
+        false,
+        &mut out,
+    );
+    assert_eq!(
+        out.len(),
+        1,
+        "only the Unit root fires for loc.sloc, got {out:?}"
+    );
+    assert_eq!(out[0].function, "<file>");
+    assert_eq!(out[0].metric, "loc.sloc");
+}
+
+#[test]
+fn scope_guard_runs_before_suppression() {
+    // The scope guard is independent of suppression: even under `Ignore`
+    // (which honors no markers) the Function-scoped metric does not fire on
+    // the Unit root, while the nested function still does.
+    let child = space("inner", SpaceKind::Function, SuppressionScope::All);
+    let mut root = space("<file>", SpaceKind::Unit, SuppressionScope::All);
+    root.spaces.push(child);
+    let mut out = Vec::new();
+    threshold_set("cyclomatic", 0.0).evaluate_with_policy(
+        Path::new("fixture.rs"),
+        &root,
+        SuppressionPolicy::Ignore,
+        false,
+        &mut out,
+    );
+    assert_eq!(
+        out.len(),
+        1,
+        "Unit skipped by scope; function fires under Ignore: {out:?}"
+    );
+    assert_eq!(out[0].function, "inner");
+}
+
+#[test]
+fn mi_lower_is_worse_skips_unit_root() {
+    // `mi.*` is lower-is-worse AND Function-scoped: a limit above the Unit's
+    // MI would breach it if the file root were gated, but the scope guard
+    // runs before the direction-aware breach test, so the `<file>` aggregate
+    // never appears.
+    let root = analyzed_tree();
+    let unit_mi = root.metrics.mi.original();
+    assert!(
+        unit_mi.is_finite(),
+        "fixture Unit MI must be finite, got {unit_mi}"
+    );
+    let mut out = Vec::new();
+    threshold_set("mi.original", unit_mi + 50.0).evaluate_with_policy(
+        Path::new("fixture.rs"),
+        &root,
+        SuppressionPolicy::Honor,
+        false,
+        &mut out,
+    );
+    assert!(
+        !out.iter().any(|v| v.function == "<file>"),
+        "the file aggregate must not be flagged for a Function-scoped mi.*: {out:?}"
     );
 }

--- a/big-code-analysis-cli/src/thresholds_tests.rs
+++ b/big-code-analysis-cli/src/thresholds_tests.rs
@@ -526,7 +526,7 @@ fn tokens_threshold_never_suppressed() {
             extractor,
             limit: -0.5,
             lower_is_worse: false,
-            scope: extractor.scope,
+            scope: metric_scope(extractor.name),
         }],
     };
 

--- a/big-code-analysis-cli/src/vcs_command.rs
+++ b/big-code-analysis-cli/src/vcs_command.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits, nom)
-// File-level halstead/nargs/exit/nom are many-fn aggregation artifacts
-// (the options-builder + rank/emit/CSV plumbing), not per-function
-// logic complexity (cognitive/cyclomatic stay enforced).
-
 //! `bca vcs` — rank files by change-history (VCS) risk (issue #328).
 //!
 //! Unlike the AST commands, this runs **one** history walk over the

--- a/big-code-analysis-cli/src/vcs_jit.rs
+++ b/big-code-analysis-cli/src/vcs_jit.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead, nargs)
-// File-level halstead/nargs are many-fn aggregation artifacts (the
-// format-dispatch `emit` match + the small write helpers), not
-// per-function logic complexity (cognitive/cyclomatic stay enforced) —
-// mirrors the sibling `vcs_command.rs`.
-
 //! `bca vcs commit` — score a single commit (or an arbitrary diff) for
 //! just-in-time (commit-level) defect-induction risk (issues #331 / #580).
 //!

--- a/big-code-analysis-cli/src/vcs_report.rs
+++ b/big-code-analysis-cli/src/vcs_report.rs
@@ -1,11 +1,3 @@
-// bca: suppress-file(halstead, nargs, nom)
-// The `VCS_SPECS` table is declarative data: ~17 capture-free cell-projector
-// closures inflate the file-level nom/nargs/halstead sums (each closure is a
-// one-arg "function"), the same string-formatting / many-fn aggregation
-// artifact the sibling report renderers suppress (see
-// `markdown_report/hotspot.rs`) — not per-function logic complexity
-// (cognitive/cyclomatic stay enforced).
-
 //! Rendered change-history (VCS) report (issue #573).
 //!
 //! Produces the Markdown and HTML pages for `bca vcs --format

--- a/big-code-analysis-cli/src/vcs_trend.rs
+++ b/big-code-analysis-cli/src/vcs_trend.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead, nargs)
-// File-level halstead/nargs are many-fn aggregation artifacts (the
-// format-dispatch `emit` match + the small write helpers), not
-// per-function logic complexity (cognitive/cyclomatic stay enforced) —
-// mirrors the sibling `vcs_jit.rs`.
-
 //! `bca vcs trend` — sample the change-history metrics at several points
 //! in time and emit a per-file time series (issue #333).
 //!

--- a/big-code-analysis-cli/src/walk_seed.rs
+++ b/big-code-analysis-cli/src/walk_seed.rs
@@ -1,11 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits)
-// File-level halstead/nargs/nexits are aggregation artifacts: this
-// module is many small path-normalisation helpers (strip, anchor,
-// reanchor, match-form) whose early returns and parameters sum at the
-// file level without any one function being complex
-// (cognitive/cyclomatic stay enforced) — the same posture as
-// big-code-analysis-py/src/walk.rs.
-
 //! Walk-seed re-anchoring.
 //!
 //! Keeps the walker's emitted path form independent of how the user

--- a/big-code-analysis-py/python/big_code_analysis/_flatten.py
+++ b/big-code-analysis-py/python/big_code_analysis/_flatten.py
@@ -1,6 +1,3 @@
-# bca: suppress-file(halstead)
-# Flatten helper; file-level halstead is a many-fn aggregation artifact.
-
 """Flat-record iterator over the nested ``FuncSpace`` tree.
 
 The compiled ``_native`` extension returns analysis results as a

--- a/big-code-analysis-py/src/ast.rs
+++ b/big-code-analysis-py/src/ast.rs
@@ -1,11 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits, nom)
-// Thin PyO3 delegations over `big_code_analysis::Ast`: each method forwards
-// to one upstream accessor and serializes the result. The flagged scores are
-// many-method aggregation artifacts (nom counts the wrappers; nargs/nexits
-// sum over them; Halstead effort sums over the impl block), not per-method
-// complexity — the same shape the sibling `lib.rs` suppresses for the same
-// reason.
-
 //! The `Ast` parse-once handle exposed to Python (#727).
 //!
 //! Binds the Rust [`big_code_analysis::Ast`] seam so a Python caller can

--- a/big-code-analysis-py/src/batch.rs
+++ b/big-code-analysis-py/src/batch.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits, nom)
-// PyO3 batch analysis + error type; nexits is never-raise error-folding /
-// FFI-repr boilerplate and the rest are many-fn aggregation artifacts, not
-// per-function logic complexity (cognitive/cyclomatic stay enforced).
-
 //! Batch entry point and the structured `AnalysisFailure` Python class.
 //!
 //! Where [`crate::analysis`] raises a Python exception per failing

--- a/big-code-analysis-py/src/conversion.rs
+++ b/big-code-analysis-py/src/conversion.rs
@@ -1,7 +1,3 @@
-// bca: suppress-file(halstead, nargs)
-// PyO3 JSON -> Python object conversion plumbing; file-level halstead and
-// summed nargs are many-fn aggregation artifacts.
-
 //! JSON-string → Python object conversion.
 //!
 //! The Python bindings reuse the library's existing `Serialize`

--- a/big-code-analysis-py/src/language.rs
+++ b/big-code-analysis-py/src/language.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead, nargs, nom)
-// Language-name / enum mapping helpers; file-level halstead, summed
-// nargs, and method count (nom) are many-fn aggregation artifacts — the
-// module is a handful of tiny lookup helpers plus their regression
-// tests, none individually complex.
-
 //! Language detection helpers exposed to Python.
 //!
 //! These thin wrappers reuse the upstream `LANG` enum and its

--- a/big-code-analysis-py/src/lib.rs
+++ b/big-code-analysis-py/src/lib.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits, nom)
-// PyO3 module registration + thin analyze wrappers; `_native`'s nexits is one
-// `?` per `m.add(...)` registration line (boilerplate), and the rest are many-fn
-// aggregation artifacts, not per-function logic complexity.
-
 //! `PyO3` entry point for the `big_code_analysis._native` extension
 //! module.
 //!

--- a/big-code-analysis-py/src/node.rs
+++ b/big-code-analysis-py/src/node.rs
@@ -1,12 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits, nom, wmc)
-// Thin PyO3 accessors over a single `tree_sitter::Node`: each method
-// forwards to one upstream tree-sitter call (or a short local walk). The
-// flagged scores are many-method aggregation artifacts (nom counts the
-// accessors; wmc sums their per-method cyclomatic; nargs/nexits sum over
-// them; Halstead effort sums over the impl block), not per-method
-// complexity — the same shape `ast.rs` / `lib.rs` suppress for the same
-// reason.
-
 //! Lazy `Node` handle over the tree retained by [`PyAst`] (#728).
 //!
 //! A [`PyNode`] is a py-tree-sitter-style cursor into the parsed tree: it

--- a/big-code-analysis-py/src/sarif.rs
+++ b/big-code-analysis-py/src/sarif.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead, loc, nargs, nexits, nom)
-// SARIF rendering for the Python bindings; file-level halstead/loc and summed
-// nargs/exit/nom are mechanical-writer / many-fn aggregation artifacts.
-// cognitive is deliberately NOT suppressed — `collect_offenders`'s nested
-// tree-walk is genuine logic and stays baselined.
-
 //! SARIF 2.1.0 rendering for the Python bindings (phase 5/9, #269).
 //!
 //! `bca.to_sarif(result_or_iter, *, thresholds=None) -> str` walks the

--- a/big-code-analysis-py/src/sarif.rs
+++ b/big-code-analysis-py/src/sarif.rs
@@ -38,8 +38,12 @@
 //! # Interior-space emission
 //!
 //! The binding emits a finding wherever a space's **own** metric value
-//! breaches its limit — at every space level (unit, container, leaf)
-//! alike — matching the CLI's per-space accessors exactly.
+//! breaches its limit, at each space level the metric's
+//! [`MetricScope`](big_code_analysis::metric_catalog::MetricScope) admits
+//! — `loc.*` only at the file `unit`, the OO size metrics (`nom`, `wmc`,
+//! `npm`, `npa`) only at containers, every other metric only at leaf
+//! functions (#969) — matching the CLI's per-space accessors and scope
+//! gate exactly via the shared catalog.
 //!
 //! For most metrics the JSON's headline field at any space already IS
 //! that space's own value (e.g. `loc.sloc`, `wmc.total`, `mi.original`,
@@ -73,7 +77,8 @@ use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyAnyMethods, PyBool, PyDict, PyDictMethods, PyMapping, PyString};
 
-use big_code_analysis::{OffenderRecord, Severity, write_sarif};
+use big_code_analysis::metric_catalog::MetricScope;
+use big_code_analysis::{OffenderRecord, Severity, SpaceKind, write_sarif};
 
 use crate::batch::PyAnalysisError;
 
@@ -93,8 +98,9 @@ const FILE_SYMBOL: &str = "<file>";
 /// One metric entry in the threshold-name → JSON-path table.
 ///
 /// Every entry's `path` reaches that space's **own** per-space scalar —
-/// the value the CLI thresholds against — so a breach is emitted at
-/// every space level. For `cyclomatic`, `cyclomatic.modified`,
+/// the value the CLI thresholds against — so a breach is emitted at each
+/// space level the metric's scope admits (#969). For `cyclomatic`,
+/// `cyclomatic.modified`,
 /// `cognitive`, and `abc` that scalar is the `value` field the wire
 /// shape gained in #958 (the sibling `sum`/`magnitude` field is a
 /// subtree aggregate and is deliberately *not* used here); for every
@@ -248,6 +254,11 @@ struct Threshold {
     /// library metric catalog so it stays in lockstep with the CLI gate
     /// (#698).
     lower_is_worse: bool,
+    /// The space kind this metric gates (issue #969), sourced from the
+    /// same library catalog as the CLI gate so the binding skips the file
+    /// root / containers / leaf functions a metric does not measure
+    /// exactly as `bca check` does.
+    scope: MetricScope,
 }
 
 /// Builds the "unknown threshold metric" error for `name`, listing the
@@ -295,11 +306,17 @@ fn resolve_thresholds(thresholds: Option<&Bound<'_, PyDict>>) -> PyResult<Vec<Th
             .find(|m| m.name == name)
             .ok_or_else(|| unknown_threshold_metric_err(&name))?;
         let lower_is_worse = big_code_analysis::metric_catalog::lower_is_worse(entry.name);
+        // Resolved from the catalog (infallible for a known entry); an
+        // unknown id defaults to the narrowest scope rather than gating an
+        // aggregate, mirroring the CLI's `metric_scope`.
+        let scope =
+            big_code_analysis::metric_catalog::scope(entry.name).unwrap_or(MetricScope::Function);
         out.push(Threshold {
             name: entry.name,
             path: entry.path,
             limit,
             lower_is_worse,
+            scope,
         });
     }
     Ok(out)
@@ -373,9 +390,10 @@ fn extract_line_number(
 /// in [`extract_space_fields`] so the threshold loop stays a thin
 /// compare-and-push.
 struct SpaceFields {
-    /// Whether the space is the file-level `unit` space (drives the
-    /// `<file>` function-name rule and the empty child prefix).
-    is_unit: bool,
+    /// This space's kind, parsed from the serialized `kind` field. Drives
+    /// the `<file>` function-name rule and the empty child prefix (for the
+    /// `unit` root) and the per-metric threshold scope gate (#969).
+    kind: SpaceKind,
     /// This space's own `::`-segment in the qualified-symbol chain (the
     /// CLI's `space_segment`): the AST-derived name for a named space, or
     /// `<anon@L{start_line}>` for anonymous / unnamed spaces. The unit
@@ -400,7 +418,7 @@ struct SpaceFields {
 fn extract_space_fields(space: &Bound<'_, PyDict>) -> PyResult<SpaceFields> {
     let py = space.py();
 
-    let kind: Option<String> = space
+    let kind: SpaceKind = space
         .get_item(intern!(py, "kind"))?
         .and_then(|k| k.extract::<String>().ok())
         // Normalise case so an upstream rename or a hand-crafted dict
@@ -409,8 +427,11 @@ fn extract_space_fields(space: &Bound<'_, PyDict>) -> PyResult<SpaceFields> {
         // prefix). Upstream serialises with
         // `#[serde(rename_all = "lowercase")]` today; this is a
         // defensive lowercase guard against future drift.
-        .map(|s| s.to_ascii_lowercase());
-    let is_unit = kind.as_deref() == Some("unit");
+        .map(|s| s.to_ascii_lowercase())
+        // Map the serialized string to the library `SpaceKind` so the
+        // per-metric threshold scope gate (#969) sees the same kinds the
+        // CLI does; an unrecognized kind degrades to `Unknown`.
+        .map_or(SpaceKind::Unknown, |s| SpaceKind::from_serialized(&s));
 
     let space_name: Option<String> = space
         .get_item(intern!(py, "name"))?
@@ -433,11 +454,19 @@ fn extract_space_fields(space: &Bound<'_, PyDict>) -> PyResult<SpaceFields> {
     };
 
     Ok(SpaceFields {
-        is_unit,
+        kind,
         segment,
         start_line,
         end_line,
     })
+}
+
+impl SpaceFields {
+    /// Whether this is the file-level `unit` space — the `<file>`
+    /// function-name rule and the empty child prefix key off it.
+    fn is_unit(&self) -> bool {
+        matches!(self.kind, SpaceKind::Unit)
+    }
 }
 
 /// The qualified symbol of a space, given the `::`-joined symbol of its
@@ -446,7 +475,7 @@ fn extract_space_fields(space: &Bound<'_, PyDict>) -> PyResult<SpaceFields> {
 /// `<file>`; every other space appends its own [`SpaceFields::segment`]
 /// to the parent prefix.
 fn qualified_symbol(fields: &SpaceFields, parent_prefix: &str) -> String {
-    if fields.is_unit {
+    if fields.is_unit() {
         return FILE_SYMBOL.to_string();
     }
     if parent_prefix.is_empty() {
@@ -469,6 +498,13 @@ fn record_threshold_breaches(
     out: &mut Vec<OffenderRecord>,
 ) {
     for threshold in thresholds {
+        // Per-metric threshold scope (#969): skip a space whose kind this
+        // metric does not measure (e.g. `wmc` on the file root, `nargs` on
+        // a container), matching the CLI gate via the shared catalog so the
+        // two front-ends emit the same offenders.
+        if !threshold.scope.admits(fields.kind) {
+            continue;
+        }
         let Some(value) = extract_metric(metrics, threshold.path) else {
             continue;
         };
@@ -553,7 +589,7 @@ fn collect_offenders(
         // Children inherit this space's qualified symbol as their prefix,
         // except the file root, which stays empty so a top-level function
         // is `foo`, not `<file>::foo` (matching the CLI walk).
-        let child_prefix = if fields.is_unit {
+        let child_prefix = if fields.is_unit() {
             String::new()
         } else {
             qualified

--- a/big-code-analysis-py/src/types_codegen.rs
+++ b/big-code-analysis-py/src/types_codegen.rs
@@ -1,10 +1,3 @@
-// bca: suppress-file(halstead, loc, abc)
-// A flat catalogue of `DictSpec` / `Field` literals (one per metric and
-// container) plus the drift tests — the same volume / field-count shape
-// as `src/wire.rs`, which carries the same marker. File-level
-// halstead.effort / loc.sloc are volume artifacts, not per-function
-// logic complexity (cognitive/cyclomatic stay enforced).
-
 //! Deterministic generator for the checked-in `_types.py` module —
 //! `TypedDict` mirrors of the analysis-result wire shapes (issue #623).
 //!

--- a/big-code-analysis-py/src/vcs.rs
+++ b/big-code-analysis-py/src/vcs.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits, nom)
-// File-level halstead/nargs/exit are many-fn aggregation artifacts (the
-// option-builder + report/inject `?` error maps and the many-field
-// report assembly), not per-function logic complexity
-// (cognitive/cyclomatic stay enforced).
-
 //! Bridge for the change-history (VCS) metrics surface exposed to
 //! Python under the `big_code_analysis.vcs` facade (issue #612).
 //!

--- a/big-code-analysis-py/src/walk.rs
+++ b/big-code-analysis-py/src/walk.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead, nargs)
-// File-level halstead/nargs are aggregation artifacts: the glob-set
-// builders and the many `WalkBuilder` option-chain arguments across a
-// few small functions, not per-function logic complexity
-// (cognitive/cyclomatic stay enforced).
-
 //! Directory walker backing `analyze_paths` (issue #658).
 //!
 //! Reuses the gitignore-aware [`ignore`] crate (the same crate the `bca`

--- a/big-code-analysis-py/tests/test_sarif.py
+++ b/big-code-analysis-py/tests/test_sarif.py
@@ -296,14 +296,15 @@ def test_to_sarif_filters_analysis_errors_silently(tmp_path: Path) -> None:
         "fixture expected to produce at least one AnalysisFailure"
     )
     parsed = _parse(bca.to_sarif(results, thresholds={"cyclomatic": 0}))
-    # Both ok.py spaces have cyclomatic value = 1 > 0 → the file unit
-    # (`<file>`) and `f` each emit. Pins that AnalysisFailure entries are
-    # dropped while the successful dict is still walked at every space.
+    # cyclomatic is Function-scoped (#969), so only ok.py's function `f`
+    # (cyclomatic 1 > 0) emits — not the `<file>` unit. Pins that
+    # AnalysisFailure entries are dropped while the successful dict is
+    # still walked and its function gated.
     findings = parsed["runs"][0]["results"]
     fq_names = sorted(
         f["locations"][0]["logicalLocations"][0]["fullyQualifiedName"] for f in findings
     )
-    assert fq_names == ["<file>", "f"], (
+    assert fq_names == ["f"], (
         f"expected findings from ok.py only (errors skipped, dict kept), got {findings!r}"
     )
     for finding in findings:
@@ -352,8 +353,9 @@ def test_to_sarif_filters_none_entries_silently(tmp_path: Path) -> None:
     fq_names = sorted(
         f["locations"][0]["logicalLocations"][0]["fullyQualifiedName"] for f in findings
     )
-    # Both ok.py spaces (`<file>` and `f`) have cyclomatic value 1 > 0.
-    assert fq_names == ["<file>", "f"], (
+    # cyclomatic is Function-scoped (#969), so only ok.py's function `f`
+    # (cyclomatic 1 > 0) is gated — the `<file>` unit is not.
+    assert fq_names == ["f"], (
         f"expected findings from ok.py only (None skipped, dict kept), got {findings!r}"
     )
     for finding in findings:
@@ -510,18 +512,48 @@ def test_to_sarif_matches_cli_check_for_single_function(bca_binary: str, tmp_pat
         )
 
 
-def test_to_sarif_matches_cli_check_for_wmc_with_unit_emission(
+def _sarif_sort_key(r: dict[str, Any]) -> tuple[int, str]:
+    """Sort SARIF results by (startLine, fullyQualifiedName) so a walk-order
+    difference across the two sides doesn't masquerade as a real divergence —
+    semantic equality is what's under test."""
+    loc = r["locations"][0]
+    line = int(loc["physicalLocation"]["region"]["startLine"])
+    fq = loc.get("logicalLocations", [{}])[0].get("fullyQualifiedName", "")
+    return (line, fq)
+
+
+def _assert_sarif_results_match(
+    py_results: list[dict[str, Any]], cli_results: list[dict[str, Any]]
+) -> None:
+    """Assert two SARIF result lists are field-for-field equal after sorting."""
+    py_results.sort(key=_sarif_sort_key)
+    cli_results.sort(key=_sarif_sort_key)
+    for py_r, cli_r in zip(py_results, cli_results, strict=True):
+        assert py_r["ruleId"] == cli_r["ruleId"]
+        assert py_r["level"] == cli_r["level"]
+        assert py_r["message"]["text"] == cli_r["message"]["text"]
+        assert py_r["locations"][0]["logicalLocations"] == cli_r["locations"][0]["logicalLocations"]
+        assert (
+            py_r["locations"][0]["physicalLocation"]["region"]
+            == cli_r["locations"][0]["physicalLocation"]["region"]
+        )
+        assert (
+            py_r["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
+            == cli_r["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
+        )
+
+
+def test_to_sarif_matches_cli_check_for_wmc_container_scope(
     bca_binary: str, tmp_path: Path
 ) -> None:
-    """CLI parity for a metric that emits at the unit level.
+    """CLI parity for a Container-scoped metric (#969).
 
-    Complements ``test_to_sarif_matches_cli_check_for_single_function``
-    by exercising a metric (`wmc`) whose subtree total naturally breaches
-    at the file unit. A multi-class Python file produces one finding per
-    class plus one file-level finding; both sides must agree on count,
-    rule, level, message, physical region, logical location, and
-    artifact URI. Catches any regression in the unit-level `<file>`
-    placeholder or in walking the file unit at all.
+    `wmc` (weighted methods per class) gates container spaces, not the
+    file unit: its file-level total is an aggregate across every class,
+    not a per-class limit. A multi-class Python file therefore produces
+    exactly one finding per class and **no** `<file>` finding. Both sides
+    must agree — this catches a regression where one front-end forgets to
+    apply the per-metric scope gate and emits the file aggregate.
     """
     src = tmp_path / "classes.py"
     src.write_text(
@@ -541,34 +573,51 @@ def test_to_sarif_matches_cli_check_for_wmc_with_unit_emission(
     py_results = py_doc["runs"][0]["results"]
     cli_results = cli_doc["runs"][0]["results"]
 
-    # Sort by (startLine, fullyQualifiedName) so any difference in
-    # walk order across sides doesn't masquerade as a real divergence
-    # — semantic equality is what's under test.
-    def _sort_key(r: dict[str, Any]) -> tuple[int, str]:
-        loc = r["locations"][0]
-        line = int(loc["physicalLocation"]["region"]["startLine"])
-        fq = loc.get("logicalLocations", [{}])[0].get("fullyQualifiedName", "")
-        return (line, fq)
-
-    py_results.sort(key=_sort_key)
-    cli_results.sort(key=_sort_key)
-
-    assert len(py_results) == len(cli_results) == 3, (
-        f"expected 3 findings (file + 2 classes), got py={len(py_results)} cli={len(cli_results)}"
+    assert len(py_results) == len(cli_results) == 2, (
+        f"expected 2 findings (the 2 classes, no file unit), "
+        f"got py={len(py_results)} cli={len(cli_results)}"
     )
-    for py_r, cli_r in zip(py_results, cli_results, strict=True):
-        assert py_r["ruleId"] == cli_r["ruleId"] == "wmc"
-        assert py_r["level"] == cli_r["level"]
-        assert py_r["message"]["text"] == cli_r["message"]["text"]
-        assert py_r["locations"][0]["logicalLocations"] == cli_r["locations"][0]["logicalLocations"]
-        assert (
-            py_r["locations"][0]["physicalLocation"]["region"]
-            == cli_r["locations"][0]["physicalLocation"]["region"]
-        )
-        assert (
-            py_r["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
-            == cli_r["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
-        )
+    for results in (py_results, cli_results):
+        names = {r["locations"][0]["logicalLocations"][0]["fullyQualifiedName"] for r in results}
+        assert names == {"A", "B"}, f"wmc must gate the classes, not the file unit: {names}"
+        assert all(r["ruleId"] == "wmc" for r in results)
+    _assert_sarif_results_match(py_results, cli_results)
+
+
+def test_to_sarif_matches_cli_check_for_loc_unit_emission(bca_binary: str, tmp_path: Path) -> None:
+    """CLI parity for a File-scoped metric (#969).
+
+    `loc.sloc` gates the whole-file `unit` root only, never a class or
+    function. A multi-class file therefore produces exactly one finding,
+    the `<file>` unit. Complements the Container-scope case above and
+    guards the unit-level `<file>` placeholder and walking the file unit
+    at all.
+    """
+    src = tmp_path / "classes.py"
+    src.write_text(
+        "class A:\n"
+        "    def m1(self): pass\n"
+        "    def m2(self): pass\n"
+        "\n"
+        "class B:\n"
+        "    def n1(self): pass\n"
+    )
+
+    analyzed = bca.analyze(src)
+    assert analyzed is not None, "fixture must not be skipped"
+    py_doc = json.loads(bca.to_sarif(analyzed, thresholds={"loc.sloc": 0}))
+    cli_doc = _cli_check_sarif(bca_binary, src, threshold="loc.sloc=0")
+
+    py_results = py_doc["runs"][0]["results"]
+    cli_results = cli_doc["runs"][0]["results"]
+
+    assert len(py_results) == len(cli_results) == 1, (
+        f"expected 1 finding (the file unit only), got py={len(py_results)} cli={len(cli_results)}"
+    )
+    for results in (py_results, cli_results):
+        assert results[0]["locations"][0]["logicalLocations"][0]["fullyQualifiedName"] == "<file>"
+        assert results[0]["ruleId"] == "loc.sloc"
+    _assert_sarif_results_match(py_results, cli_results)
 
 
 def test_to_sarif_qualified_symbol_matches_cli_for_nested_method(
@@ -753,12 +802,23 @@ def test_to_sarif_treats_unit_kind_case_insensitively() -> None:
     but defending against a future upstream rename (or a hand-crafted
     dict using ``Unit``) is cheap: the kind comparison normalises to
     ASCII-lowercase. The capitalised ``Unit`` must still resolve to the
-    file-level ``<file>`` symbol on the offender it emits. The unit's own
-    ``cyclomatic.value`` breaches the limit, so it emits; the point under
-    test is the kind-name normalisation driving the ``<file>`` symbol.
+    file-level ``<file>`` symbol on the offender it emits. A File-scoped
+    ``loc.sloc`` breaches at the unit, so it emits; the point under test
+    is the kind-name normalisation driving both the scope match and the
+    ``<file>`` symbol.
     """
-    fake = _fake_function_dict(kind="Unit", cyclomatic_value=999)
-    parsed = _parse(bca.to_sarif(fake, thresholds={"cyclomatic": 1}))
+    # loc.sloc is File-scoped (#969), so it gates the unit root; the
+    # capitalised "Unit" must normalise to unit for both the scope match
+    # and the <file> symbol.
+    fake: dict[str, Any] = {
+        "name": "mod.py",
+        "kind": "Unit",  # capitalised on purpose
+        "start_line": 1,
+        "end_line": 5,
+        "spaces": [],
+        "metrics": {"loc": {"sloc": 999}},
+    }
+    parsed = _parse(bca.to_sarif(cast("FuncSpaceDict", fake), thresholds={"loc.sloc": 1}))
     findings = parsed["runs"][0]["results"]
     fq_names = [f["locations"][0]["logicalLocations"][0]["fullyQualifiedName"] for f in findings]
     assert fq_names == ["<file>"], (
@@ -781,13 +841,12 @@ def test_to_sarif_rejects_mappingproxytype_with_clear_error() -> None:
         bca.to_sarif(proxy, thresholds={"cyclomatic": 0})  # type: ignore[arg-type]
 
 
-def test_to_sarif_emits_unit_level_finding_for_non_sum_metrics() -> None:
-    """Unit-level findings are emitted whenever the file unit's own value
-    breaches the limit. Pinned with ``wmc`` because the multi-class
-    fixture cleanly distinguishes the file total from per-class values.
-    (Since #958 ``cyclomatic``/``cognitive``/``abc`` also emit at the unit
-    when their per-space ``value`` breaches — see
-    ``test_to_sarif_emits_interior_space_when_own_value_breaches``.)
+def test_to_sarif_emits_container_level_finding_for_oo_metrics() -> None:
+    """Container-scoped metrics (`nom`, `wmc`, `npm`, `npa`) emit one
+    finding per container (#969), never at the file unit — their file-level
+    total is an aggregate across every class, not a per-class limit. Pinned
+    with ``wmc`` because the multi-class fixture cleanly distinguishes the
+    per-class values from the file total.
     """
     code = (
         "class A:\n"
@@ -800,15 +859,13 @@ def test_to_sarif_emits_unit_level_finding_for_non_sum_metrics() -> None:
     result = bca.analyze_source(code, "python")
     parsed = _parse(bca.to_sarif(result, thresholds={"wmc": 0}))
     findings = parsed["runs"][0]["results"]
-    # Expect: 1 finding per class (A, B) + 1 file-level (unit) finding.
-    fully_qualified = [
+    # Expect exactly one finding per class (A, B) and no file-level finding.
+    fully_qualified = sorted(
         f["locations"][0]["logicalLocations"][0]["fullyQualifiedName"] for f in findings
-    ]
-    assert "<file>" in fully_qualified, (
-        f"unit finding missing; logicalLocations seen: {fully_qualified!r}"
     )
-    assert "A" in fully_qualified
-    assert "B" in fully_qualified
+    assert fully_qualified == ["A", "B"], (
+        f"wmc must gate the classes, not the file unit: {fully_qualified!r}"
+    )
 
 
 def _own_value_block(metric_name: str, own: float) -> dict[str, Any]:
@@ -897,17 +954,17 @@ def test_to_sarif_nameless_space_emits_anon_line_placeholder() -> None:
 
 
 def test_to_sarif_unit_space_emits_file_placeholder() -> None:
-    """A unit-level finding (for a non-skip metric) emits
+    """A unit-level finding (for a File-scoped metric, #969) emits
     ``logicalLocations: [{fullyQualifiedName: '<file>'}]`` rather than
     duplicating the path that already appears in
     ``artifactLocation.uri``. Matches the CLI's ``function_token``.
     """
     code = "class A:\n    def m(self): pass\n"
     result = bca.analyze_source(code, "python")
-    parsed = _parse(bca.to_sarif(result, thresholds={"wmc": 0}))
+    parsed = _parse(bca.to_sarif(result, thresholds={"loc.sloc": 0}))
     findings = parsed["runs"][0]["results"]
     fq_names = [f["locations"][0]["logicalLocations"][0]["fullyQualifiedName"] for f in findings]
-    assert "<file>" in fq_names, (
+    assert fq_names == ["<file>"], (
         f"unit-level finding must carry '<file>' placeholder, got {fq_names!r}"
     )
 
@@ -996,12 +1053,10 @@ def test_to_sarif_reports_deeply_nested_space_offender() -> None:
     span. Guards the nested-space traversal feeding ``collect_offenders``'
     qualified-prefix threading.
 
-    Also the interior-emission regression test for #958: each space's
-    own ``cyclomatic.value`` drives emission independently, so an interior
-    container (``C``) whose own value breaches is reported *alongside* the
-    leaf method — while the file unit, whose own value stays below the
-    limit, is not. Pre-#958 the binding read only the subtree ``sum`` and
-    skipped every interior space, so ``C`` was silently dropped.
+    cyclomatic is Function-scoped (#969), so only the leaf method ``m``
+    (a function space) is gated — the enclosing class ``C`` and the file
+    unit are not, regardless of their own ``cyclomatic.value``. The
+    qualified ``C::m`` name still exercises the nested-prefix threading.
     """
     unit: dict[str, Any] = {
         "name": "mod.rs",
@@ -1016,9 +1071,9 @@ def test_to_sarif_reports_deeply_nested_space_offender() -> None:
                 "kind": "class",
                 "start_line": 2,
                 "end_line": 29,
-                # The class body itself owns enough complexity to breach
-                # (own value 5 > limit 3); pre-#958 this interior space was
-                # skipped, so its genuine breach went unreported.
+                # The class body's own cyclomatic (5) would breach the
+                # limit, but cyclomatic is Function-scoped (#969), so a
+                # class space is never gated — only the nested method is.
                 "metrics": {"cyclomatic": {"sum": 12.0, "value": 5.0}},
                 "spaces": [
                     {
@@ -1038,10 +1093,11 @@ def test_to_sarif_reports_deeply_nested_space_offender() -> None:
     fq_names = sorted(
         f["locations"][0]["logicalLocations"][0]["fullyQualifiedName"] for f in findings
     )
-    # Both the interior class `C` (own value 5) and the leaf method `C::m`
-    # (own value 7) breach; the file unit (own value 1) does not.
-    assert fq_names == ["C", "C::m"], (
-        f"interior container and leaf method must both emit on own-value breach, got {fq_names!r}"
+    # Only the leaf method `C::m` (a function space) is gated; the
+    # enclosing class `C` and the file unit are not, as cyclomatic is
+    # Function-scoped (#969).
+    assert fq_names == ["C::m"], (
+        f"only the leaf method must emit for a Function-scoped metric, got {fq_names!r}"
     )
     method_finding = next(
         f

--- a/big-code-analysis-web/src/lib.rs
+++ b/big-code-analysis-web/src/lib.rs
@@ -1,7 +1,3 @@
-// bca: suppress-file(halstead)
-// Web crate glue; file-level halstead is a many-fn aggregation artifact, not
-// per-function logic complexity.
-
 //! REST API surface for `big-code-analysis`. Run via the `bca-web` binary.
 
 // The deeply nested `json!` literals in server.rs tests exceed the default

--- a/big-code-analysis-web/src/web/cors.rs
+++ b/big-code-analysis-web/src/web/cors.rs
@@ -1,11 +1,3 @@
-// bca: suppress-file(halstead, nargs)
-// CORS policy + middleware glue. The file-aggregate halstead.effort is
-// inflated by the module's extensive rationale doc comments and the
-// header-name token vocabulary, and the file-aggregate nargs is the sum of
-// the small per-function arg lists (the 3-param `apply_cors_headers` and
-// `cors_middleware`) — both are many-fn aggregation artifacts, not
-// per-function logic complexity, mirroring the sibling `server.rs` marker.
-
 //! Opt-in Cross-Origin Resource Sharing (CORS) support (#694).
 //!
 //! CORS is **off by default**: a `bca-web` instance never emits

--- a/big-code-analysis-web/src/web/metrics.rs
+++ b/big-code-analysis-web/src/web/metrics.rs
@@ -1,7 +1,3 @@
-// bca: suppress-file(halstead, nargs)
-// Metrics HTTP handler glue; file-level halstead and summed nargs are many-fn
-// aggregation artifacts, not per-function logic complexity.
-
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 

--- a/big-code-analysis-web/src/web/server.rs
+++ b/big-code-analysis-web/src/web/server.rs
@@ -1,10 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits, abc, nom, loc)
-// Actix server setup + handlers; the file-aggregate halstead/nargs/exit/nom/loc and
-// the route-registration closure's abc (one `.service()`/`.route()` per endpoint)
-// are declarative many-fn aggregation artifacts, not per-function logic
-// complexity. The per-endpoint handlers plus the content-type guard helpers
-// (#515) push the file's method count past the per-file nom cap.
-
 use std::borrow::Cow;
 use std::fmt;
 use std::path::PathBuf;

--- a/big-code-analysis-web/src/web/vcs.rs
+++ b/big-code-analysis-web/src/web/vcs.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits)
-// File-level halstead/nargs/exit are many-fn aggregation artifacts (the
-// option-builder + handler `?` error maps), not per-function logic
-// complexity (cognitive/cyclomatic stay enforced).
-
 //! `POST /vcs` — change-history (VCS) metrics over a server-side git
 //! working tree (issue #328).
 //!

--- a/check-enums-codegen-drift.sh
+++ b/check-enums-codegen-drift.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
-# bca: suppress-file(halstead)
-# Codegen-drift checker script; file-level halstead is script-length volume,
-# not per-function logic complexity.
-
 # check-enums-codegen-drift
 #
 # Runs the `enums/` codegen into a tempdir, formats the output,

--- a/src/alterator.rs
+++ b/src/alterator.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, loc, nargs, nom)
-// Per-language Alterator impls are flat node-kind dispatch; the offenders
-// are arm-count and many-fn aggregation artifacts, not per-function logic
-// complexity (cognitive/cyclomatic stay enforced).
-
 // Per-language metric and AST modules deliberately consume the macro-
 // generated tree-sitter token enums via `use crate::*` and `use Foo::*`
 // inside match expressions — explicit imports would list dozens of

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits)
-// Per-language AST-builder dispatch plus the `AstNode` serde derive; the
-// offenders are arm-count / many-fn aggregation artifacts, not per-function
-// logic complexity.
-
 // Per-language metric and AST modules deliberately consume the macro-
 // generated tree-sitter token enums via `use crate::*` and `use Foo::*`
 // inside match expressions — explicit imports would list dozens of

--- a/src/c_macro.rs
+++ b/src/c_macro.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits, nom)
-// C/C++ macro-handling helpers (predefined-macro and raw-string handling);
-// the offenders are many-fn aggregation artifacts, not per-function logic
-// complexity (cognitive/cyclomatic stay enforced).
-
 use std::collections::HashSet;
 
 use crate::c_langs_macros::is_predefined_macros;

--- a/src/cfg_predicate.rs
+++ b/src/cfg_predicate.rs
@@ -1,7 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits)
-// Rust `cfg(...)` mini-parser; the offenders are many-fn aggregation
-// artifacts, not per-function logic complexity (cognitive/cyclomatic enforced).
-
 //! Ad-hoc parser for Rust `cfg(...)` attribute predicates.
 //!
 //! Determines whether a Rust attribute body marks the annotated item as

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, loc, nargs, nexits, nom, wmc, abc)
-// Per-language Checker impls are flat node-kind `match` / `matches!`
-// predicates; the offenders are arm-count and many-fn aggregation
-// artifacts, not per-function logic complexity (cognitive stays enforced).
-
 // Per-language metric and AST modules deliberately consume the macro-
 // generated tree-sitter token enums via `use crate::*` and `use Foo::*`
 // inside match expressions — explicit imports would list dozens of

--- a/src/comment_rm.rs
+++ b/src/comment_rm.rs
@@ -1,12 +1,3 @@
-// bca: suppress-file(halstead)
-// Per-language comment-removal dispatch; file-level halstead is a many-fn
-// aggregation artifact, not per-function logic complexity.
-// bca: suppress-file(nargs)
-// File-level nargs is the sum across the small LineEnding helpers and the
-// walk core; each function's own arity is modest — the file total is an
-// aggregation artifact (issue #767 added the LineEnding helper), not a
-// wide-signature smell.
-
 // Per-language metric and AST modules deliberately consume the macro-
 // generated tree-sitter token enums via `use crate::*` and `use Foo::*`
 // inside match expressions — explicit imports would list dozens of

--- a/src/concurrent_files.rs
+++ b/src/concurrent_files.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits)
-// Parallel walker orchestration; the offenders are many-fn / early-return
-// aggregation artifacts (no cognitive/cyclomatic offender here — those stay
-// enforced), not per-function logic complexity.
-
 #![allow(clippy::needless_pass_by_value)]
 
 use std::fmt;

--- a/src/count.rs
+++ b/src/count.rs
@@ -1,7 +1,3 @@
-// bca: suppress-file(halstead)
-// Metric-count arithmetic over the whole metric set; file-level halstead is
-// a many-fn aggregation artifact, not per-function logic complexity.
-
 // Metric counts (token, function, branch, argument, etc.) are stored as
 // `usize` and crossed with `f64` averages, ratios, and Halstead scores
 // across the cyclomatic / MI / Halstead computations. The `usize as f64`

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,3 @@
-// bca: suppress-file(halstead)
-// This module is nothing but error-enum definitions and their idiomatic
-// `Display`/`Error`/`From` impls. The file-level Halstead effort is the sum
-// over many individually-trivial `match` arms (one short string per
-// variant); no single function here is hard to follow. Splitting the error
-// types across files to dodge the aggregate would scatter the error taxonomy
-// for no reader benefit.
-
 //! Error type returned from the library's top-level entry points.
 //!
 //! Prior to this module, every entry point returned `Option<…>` and

--- a/src/find.rs
+++ b/src/find.rs
@@ -1,7 +1,3 @@
-// bca: suppress-file(halstead)
-// Per-language node-find dispatch; file-level halstead is a many-fn
-// aggregation artifact, not per-function logic complexity.
-
 // Per-language metric and AST modules deliberately consume the macro-
 // generated tree-sitter token enums via `use crate::*` and `use Foo::*`
 // inside match expressions — explicit imports would list dozens of

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,7 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits)
-// Per-language function-span dispatch; the offenders are arm-count and
-// many-fn aggregation artifacts, not per-function logic complexity.
-
 // Per-language metric and AST modules deliberately consume the macro-
 // generated tree-sitter token enums via `use crate::*` and `use Foo::*`
 // inside match expressions — explicit imports would list dozens of

--- a/src/getter.rs
+++ b/src/getter.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, loc, nargs, nexits, nom, wmc)
-// Per-language Getter impls (`get_op_type`, `get_func_space_name`) are
-// flat `match node.kind()` dispatch tables; the offenders are arm-count
-// and many-fn aggregation artifacts, not per-function logic complexity.
-
 // Per-language metric and AST modules deliberately consume the macro-
 // generated tree-sitter token enums via `use crate::*` and `use Foo::*`
 // inside match expressions — explicit imports would list dozens of

--- a/src/langs.rs
+++ b/src/langs.rs
@@ -1,7 +1,3 @@
-// bca: suppress-file(halstead)
-// Per-language enum / table dispatch; file-level halstead is a many-fn
-// aggregation artifact, not per-function logic complexity.
-
 // Per-language metric and AST modules deliberately consume the macro-
 // generated tree-sitter token enums via `use crate::*` and `use Foo::*`
 // inside match expressions — explicit imports would list dozens of

--- a/src/macros/kind_sets.rs
+++ b/src/macros/kind_sets.rs
@@ -1,7 +1,3 @@
-// bca: suppress-file(halstead)
-// `macro_rules!` token-set bundles (one `|`-list per language); file-level
-// halstead is a macro-expansion aggregation artifact, not logic complexity.
-
 // Per-language `kind_id`-set and alias macros.
 //
 // Split out of `macros.rs` (now `macros/mod.rs`) so that file is no

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, loc)
-// `macro_rules!` definitions that generate the per-language structure;
-// file-level halstead/loc are macro-expansion aggregation artifacts, not
-// per-function logic complexity.
-
 // `get_language!` is invoked only from feature-gated arms in `mk_lang!`
 // (one arm per `LANG::*` variant whose per-language Cargo feature is
 // enabled). A build with `--no-default-features` and no language

--- a/src/metric_catalog.rs
+++ b/src/metric_catalog.rs
@@ -1,7 +1,3 @@
-// bca: suppress-file(halstead)
-// Single-source-of-truth metric catalog table; file-level halstead is a
-// table-size aggregation artifact, not per-function logic complexity.
-
 //! Single source of truth for the metric catalog.
 //!
 //! Before this module existed, the same set of offender metric ids was

--- a/src/metric_catalog.rs
+++ b/src/metric_catalog.rs
@@ -25,6 +25,61 @@
 
 #![allow(clippy::doc_markdown)]
 
+use crate::spaces::SpaceKind;
+
+/// The space kind a metric's threshold is meaningful on (issue #969).
+///
+/// A threshold gate (`bca check`, the Python `to_sarif` binding) walks
+/// every [`crate::FuncSpace`] — the file-level [`SpaceKind::Unit`] root,
+/// every container (class / impl / ...), and every individual function.
+/// For the subtree-summed accessors a metric's value at any space that
+/// owns children is a *sum across many functions*, so a per-function
+/// limit would fire on every non-trivial file and multi-method `impl`.
+/// Scope records the kind each metric actually measures so the front-ends
+/// gate it there and nowhere else — keeping the CLI gate and the binding
+/// in lockstep, the same way [`Direction`] keeps their breach direction
+/// aligned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MetricScope {
+    /// Gate only the whole-file [`SpaceKind::Unit`] root — the `loc.*`
+    /// size family, whose limit is a per-file ceiling.
+    File,
+    /// Gate only individual function spaces ([`SpaceKind::Function`] —
+    /// free functions, methods, closures). The per-function complexity
+    /// metrics (cognitive, cyclomatic, abc, mi.*) and the subtree sums
+    /// that describe one function and its nested closures (halstead.*,
+    /// nargs, nexits, tokens) live here.
+    Function,
+    /// Gate only container spaces that own methods (class / struct /
+    /// trait / impl / namespace / interface) — the object-oriented size
+    /// metrics `nom`, `wmc`, `npm`, `npa`.
+    Container,
+}
+
+impl MetricScope {
+    /// Whether a threshold with this scope is evaluated against `kind`.
+    ///
+    /// The single source of truth for the kind-filtering both the CLI
+    /// gate and the Python binding apply, so the two cannot drift on
+    /// which space kinds a metric gates.
+    #[must_use]
+    pub fn admits(self, kind: SpaceKind) -> bool {
+        match self {
+            Self::File => matches!(kind, SpaceKind::Unit),
+            Self::Function => matches!(kind, SpaceKind::Function),
+            Self::Container => matches!(
+                kind,
+                SpaceKind::Class
+                    | SpaceKind::Struct
+                    | SpaceKind::Trait
+                    | SpaceKind::Impl
+                    | SpaceKind::Namespace
+                    | SpaceKind::Interface
+            ),
+        }
+    }
+}
+
 /// Which direction of a metric's value is unhealthy.
 ///
 /// Most metrics grow worse as they grow larger; the Maintainability
@@ -91,6 +146,12 @@ pub struct MetricInfo {
     /// which only this registry now records once for both front-ends to
     /// share (#442).
     pub skip_at_unit: bool,
+    /// The space kind this metric's threshold gates (issue #969). Both
+    /// the CLI threshold engine and the Python `to_sarif` binding read
+    /// this to skip spaces a metric does not measure, so a metric's
+    /// file-wide or `impl`-wide aggregate never fires as a per-function
+    /// limit. See [`MetricScope`].
+    pub scope: MetricScope,
 }
 
 /// A `bca list-metrics` row: the bare name printed in `names` mode and
@@ -137,30 +198,30 @@ pub struct MetricFamily {
 /// scannable; rustfmt would otherwise wrap each struct over many lines.
 #[rustfmt::skip]
 pub const METRICS: &[MetricInfo] = &[
-    MetricInfo { id: "cognitive",           family: "cognitive",  long_description: "Cognitive Complexity exceeds the configured threshold.",          direction: Direction::HigherIsWorse, skip_at_unit: true  },
-    MetricInfo { id: "cyclomatic",          family: "cyclomatic", long_description: "Cyclomatic Complexity exceeds the configured threshold.",         direction: Direction::HigherIsWorse, skip_at_unit: true  },
-    MetricInfo { id: "cyclomatic.modified", family: "cyclomatic", long_description: "Modified Cyclomatic Complexity exceeds the configured threshold.", direction: Direction::HigherIsWorse, skip_at_unit: true  },
-    MetricInfo { id: "halstead.volume",     family: "halstead",   long_description: "Halstead volume exceeds the configured threshold.",               direction: Direction::HigherIsWorse, skip_at_unit: false },
-    MetricInfo { id: "halstead.difficulty", family: "halstead",   long_description: "Halstead difficulty exceeds the configured threshold.",           direction: Direction::HigherIsWorse, skip_at_unit: false },
-    MetricInfo { id: "halstead.effort",     family: "halstead",   long_description: "Halstead effort exceeds the configured threshold.",               direction: Direction::HigherIsWorse, skip_at_unit: false },
-    MetricInfo { id: "halstead.time",       family: "halstead",   long_description: "Halstead time-to-program exceeds the configured threshold.",      direction: Direction::HigherIsWorse, skip_at_unit: false },
-    MetricInfo { id: "halstead.bugs",       family: "halstead",   long_description: "Estimated Halstead bugs exceed the configured threshold.",         direction: Direction::HigherIsWorse, skip_at_unit: false },
-    MetricInfo { id: "loc.sloc",            family: "loc",        long_description: "Source lines of code exceed the configured threshold.",            direction: Direction::HigherIsWorse, skip_at_unit: false },
-    MetricInfo { id: "loc.ploc",            family: "loc",        long_description: "Physical lines of code exceed the configured threshold.",          direction: Direction::HigherIsWorse, skip_at_unit: false },
-    MetricInfo { id: "loc.lloc",            family: "loc",        long_description: "Logical lines of code exceed the configured threshold.",           direction: Direction::HigherIsWorse, skip_at_unit: false },
-    MetricInfo { id: "loc.cloc",            family: "loc",        long_description: "Comment lines of code exceed the configured threshold.",           direction: Direction::HigherIsWorse, skip_at_unit: false },
-    MetricInfo { id: "loc.blank",           family: "loc",        long_description: "Blank lines of code exceed the configured threshold.",             direction: Direction::HigherIsWorse, skip_at_unit: false },
-    MetricInfo { id: "nom",                 family: "nom",        long_description: "Number of methods/functions exceeds the configured threshold.",    direction: Direction::HigherIsWorse, skip_at_unit: false },
-    MetricInfo { id: "tokens",              family: "tokens",     long_description: "Number of tokens exceeds the configured threshold.",               direction: Direction::HigherIsWorse, skip_at_unit: false },
-    MetricInfo { id: "nexits",              family: "nexits",     long_description: "Number of exit points exceeds the configured threshold.",          direction: Direction::HigherIsWorse, skip_at_unit: false },
-    MetricInfo { id: "nargs",               family: "nargs",      long_description: "Number of function arguments exceeds the configured threshold.",   direction: Direction::HigherIsWorse, skip_at_unit: false },
-    MetricInfo { id: "mi.original",         family: "mi",         long_description: "Maintainability Index falls below the configured threshold.",      direction: Direction::LowerIsWorse,  skip_at_unit: false },
-    MetricInfo { id: "mi.sei",              family: "mi",         long_description: "Maintainability Index (SEI) falls below the configured threshold.", direction: Direction::LowerIsWorse,  skip_at_unit: false },
-    MetricInfo { id: "mi.visual_studio",    family: "mi",         long_description: "Maintainability Index (Visual Studio) falls below the configured threshold.", direction: Direction::LowerIsWorse,  skip_at_unit: false },
-    MetricInfo { id: "abc",                 family: "abc",        long_description: "ABC magnitude exceeds the configured threshold.",                  direction: Direction::HigherIsWorse, skip_at_unit: true  },
-    MetricInfo { id: "wmc",                 family: "wmc",        long_description: "Weighted Methods per Class exceeds the configured threshold.",     direction: Direction::HigherIsWorse, skip_at_unit: false },
-    MetricInfo { id: "npm",                 family: "npm",        long_description: "Number of public methods exceeds the configured threshold.",       direction: Direction::HigherIsWorse, skip_at_unit: false },
-    MetricInfo { id: "npa",                 family: "npa",        long_description: "Number of public attributes exceeds the configured threshold.",    direction: Direction::HigherIsWorse, skip_at_unit: false },
+    MetricInfo { id: "cognitive",           family: "cognitive",  long_description: "Cognitive Complexity exceeds the configured threshold.",          direction: Direction::HigherIsWorse, skip_at_unit: true,  scope: MetricScope::Function  },
+    MetricInfo { id: "cyclomatic",          family: "cyclomatic", long_description: "Cyclomatic Complexity exceeds the configured threshold.",         direction: Direction::HigherIsWorse, skip_at_unit: true,  scope: MetricScope::Function  },
+    MetricInfo { id: "cyclomatic.modified", family: "cyclomatic", long_description: "Modified Cyclomatic Complexity exceeds the configured threshold.", direction: Direction::HigherIsWorse, skip_at_unit: true,  scope: MetricScope::Function  },
+    MetricInfo { id: "halstead.volume",     family: "halstead",   long_description: "Halstead volume exceeds the configured threshold.",               direction: Direction::HigherIsWorse, skip_at_unit: false, scope: MetricScope::Function  },
+    MetricInfo { id: "halstead.difficulty", family: "halstead",   long_description: "Halstead difficulty exceeds the configured threshold.",           direction: Direction::HigherIsWorse, skip_at_unit: false, scope: MetricScope::Function  },
+    MetricInfo { id: "halstead.effort",     family: "halstead",   long_description: "Halstead effort exceeds the configured threshold.",               direction: Direction::HigherIsWorse, skip_at_unit: false, scope: MetricScope::Function  },
+    MetricInfo { id: "halstead.time",       family: "halstead",   long_description: "Halstead time-to-program exceeds the configured threshold.",      direction: Direction::HigherIsWorse, skip_at_unit: false, scope: MetricScope::Function  },
+    MetricInfo { id: "halstead.bugs",       family: "halstead",   long_description: "Estimated Halstead bugs exceed the configured threshold.",         direction: Direction::HigherIsWorse, skip_at_unit: false, scope: MetricScope::Function  },
+    MetricInfo { id: "loc.sloc",            family: "loc",        long_description: "Source lines of code exceed the configured threshold.",            direction: Direction::HigherIsWorse, skip_at_unit: false, scope: MetricScope::File      },
+    MetricInfo { id: "loc.ploc",            family: "loc",        long_description: "Physical lines of code exceed the configured threshold.",          direction: Direction::HigherIsWorse, skip_at_unit: false, scope: MetricScope::File      },
+    MetricInfo { id: "loc.lloc",            family: "loc",        long_description: "Logical lines of code exceed the configured threshold.",           direction: Direction::HigherIsWorse, skip_at_unit: false, scope: MetricScope::File      },
+    MetricInfo { id: "loc.cloc",            family: "loc",        long_description: "Comment lines of code exceed the configured threshold.",           direction: Direction::HigherIsWorse, skip_at_unit: false, scope: MetricScope::File      },
+    MetricInfo { id: "loc.blank",           family: "loc",        long_description: "Blank lines of code exceed the configured threshold.",             direction: Direction::HigherIsWorse, skip_at_unit: false, scope: MetricScope::File      },
+    MetricInfo { id: "nom",                 family: "nom",        long_description: "Number of methods/functions exceeds the configured threshold.",    direction: Direction::HigherIsWorse, skip_at_unit: false, scope: MetricScope::Container },
+    MetricInfo { id: "tokens",              family: "tokens",     long_description: "Number of tokens exceeds the configured threshold.",               direction: Direction::HigherIsWorse, skip_at_unit: false, scope: MetricScope::Function  },
+    MetricInfo { id: "nexits",              family: "nexits",     long_description: "Number of exit points exceeds the configured threshold.",          direction: Direction::HigherIsWorse, skip_at_unit: false, scope: MetricScope::Function  },
+    MetricInfo { id: "nargs",               family: "nargs",      long_description: "Number of function arguments exceeds the configured threshold.",   direction: Direction::HigherIsWorse, skip_at_unit: false, scope: MetricScope::Function  },
+    MetricInfo { id: "mi.original",         family: "mi",         long_description: "Maintainability Index falls below the configured threshold.",      direction: Direction::LowerIsWorse,  skip_at_unit: false, scope: MetricScope::Function  },
+    MetricInfo { id: "mi.sei",              family: "mi",         long_description: "Maintainability Index (SEI) falls below the configured threshold.", direction: Direction::LowerIsWorse,  skip_at_unit: false, scope: MetricScope::Function  },
+    MetricInfo { id: "mi.visual_studio",    family: "mi",         long_description: "Maintainability Index (Visual Studio) falls below the configured threshold.", direction: Direction::LowerIsWorse,  skip_at_unit: false, scope: MetricScope::Function  },
+    MetricInfo { id: "abc",                 family: "abc",        long_description: "ABC magnitude exceeds the configured threshold.",                  direction: Direction::HigherIsWorse, skip_at_unit: true,  scope: MetricScope::Function  },
+    MetricInfo { id: "wmc",                 family: "wmc",        long_description: "Weighted Methods per Class exceeds the configured threshold.",     direction: Direction::HigherIsWorse, skip_at_unit: false, scope: MetricScope::Container },
+    MetricInfo { id: "npm",                 family: "npm",        long_description: "Number of public methods exceeds the configured threshold.",       direction: Direction::HigherIsWorse, skip_at_unit: false, scope: MetricScope::Container },
+    MetricInfo { id: "npa",                 family: "npa",        long_description: "Number of public attributes exceeds the configured threshold.",    direction: Direction::HigherIsWorse, skip_at_unit: false, scope: MetricScope::Container },
 ];
 
 /// Canonical `bca list-metrics` view. Family summaries moved here
@@ -305,6 +366,15 @@ pub fn lower_is_worse(id: &str) -> bool {
     lookup(id).is_some_and(|m| matches!(m.direction, Direction::LowerIsWorse))
 }
 
+/// The [`MetricScope`] of metric `id` — the space kind its threshold
+/// gates (issue #969). `None` for an id the catalog does not know; both
+/// front-ends treat an unknown id as a usage error before reaching here,
+/// so the `None` arm is only a defensive fallback.
+#[must_use]
+pub fn scope(id: &str) -> Option<MetricScope> {
+    lookup(id).map(|m| m.scope)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -439,5 +509,99 @@ mod tests {
             "skip_at_unit set drifted from the JSON-aggregate-vs-CLI-accessor \
              property; review against the CLI EXTRACTORS accessors before editing",
         );
+    }
+
+    /// The per-metric [`MetricScope`] partition (#969): `loc.*` gates the
+    /// file root, the OO size metrics gate containers, everything else
+    /// gates leaf functions. Enumerated so a new metric must be placed
+    /// deliberately rather than defaulting silently — both the CLI gate
+    /// and the Python binding derive their kind-filtering from this.
+    #[test]
+    fn scope_partitions_metrics_by_measured_kind() {
+        let by_scope = |want: MetricScope| {
+            let mut ids: Vec<&str> = METRICS
+                .iter()
+                .filter(|m| m.scope == want)
+                .map(|m| m.id)
+                .collect();
+            ids.sort_unstable();
+            ids
+        };
+        assert_eq!(
+            by_scope(MetricScope::File),
+            ["loc.blank", "loc.cloc", "loc.lloc", "loc.ploc", "loc.sloc"],
+            "only the loc.* size family is File-scoped",
+        );
+        assert_eq!(
+            by_scope(MetricScope::Container),
+            ["nom", "npa", "npm", "wmc"],
+            "only the OO size metrics are Container-scoped",
+        );
+        // Everything else is per-function; spot-check the representatives
+        // and confirm the partition is total (no metric left unscoped).
+        for id in [
+            "cognitive",
+            "cyclomatic",
+            "halstead.effort",
+            "nargs",
+            "nexits",
+            "abc",
+            "mi.original",
+        ] {
+            assert_eq!(
+                scope(id),
+                Some(MetricScope::Function),
+                "{id} should be Function-scoped"
+            );
+        }
+        let counted = by_scope(MetricScope::File).len()
+            + by_scope(MetricScope::Function).len()
+            + by_scope(MetricScope::Container).len();
+        assert_eq!(
+            counted,
+            METRICS.len(),
+            "every metric must have exactly one scope"
+        );
+    }
+
+    /// [`MetricScope::admits`] gates exactly the intended kinds: File only
+    /// the `Unit` root, Function only `Function`, Container the
+    /// method-owning kinds — and nothing admits `Unknown`.
+    #[test]
+    fn scope_admits_only_its_kinds() {
+        assert!(MetricScope::File.admits(SpaceKind::Unit));
+        assert!(!MetricScope::File.admits(SpaceKind::Function));
+        assert!(!MetricScope::File.admits(SpaceKind::Class));
+
+        assert!(MetricScope::Function.admits(SpaceKind::Function));
+        assert!(!MetricScope::Function.admits(SpaceKind::Unit));
+        assert!(!MetricScope::Function.admits(SpaceKind::Impl));
+
+        for kind in [
+            SpaceKind::Class,
+            SpaceKind::Struct,
+            SpaceKind::Trait,
+            SpaceKind::Impl,
+            SpaceKind::Namespace,
+            SpaceKind::Interface,
+        ] {
+            assert!(
+                MetricScope::Container.admits(kind),
+                "{kind:?} is a container"
+            );
+        }
+        assert!(!MetricScope::Container.admits(SpaceKind::Unit));
+        assert!(!MetricScope::Container.admits(SpaceKind::Function));
+
+        for scope in [
+            MetricScope::File,
+            MetricScope::Function,
+            MetricScope::Container,
+        ] {
+            assert!(
+                !scope.admits(SpaceKind::Unknown),
+                "{scope:?} must not admit Unknown"
+            );
+        }
     }
 }

--- a/src/metric_set.rs
+++ b/src/metric_set.rs
@@ -1,7 +1,3 @@
-// bca: suppress-file(halstead, nargs)
-// `Metric` enum + `MetricSet` bitfield; the offenders are many-fn
-// aggregation artifacts, not per-function logic complexity.
-
 //! Per-metric selection: the [`Metric`] enum and the
 //! [`MetricSet`] bitfield it gates.
 //!

--- a/src/metrics/abc.rs
+++ b/src/metrics/abc.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(cyclomatic, halstead, loc, nargs, nexits, nom, wmc)
-// Per-language `compute` impls are flat `match node.kind()` dispatch and
-// the `Stats` serde impls are mechanical writers; these offenders are
-// arm-count / many-fn aggregation artifacts, not per-function logic
-// complexity (cognitive stays enforced).
-
 // Per-language metric and AST modules deliberately consume the macro-
 // generated tree-sitter token enums via `use crate::*` and `use Foo::*`
 // inside match expressions — explicit imports would list dozens of

--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead, loc, nargs, nexits, nom, wmc)
-// Per-language `compute` impls are flat `match node.kind()` dispatch and
-// the `Stats` serde impls are mechanical writers; these offenders are
-// arm-count / many-fn aggregation artifacts, not per-function logic
-// complexity (cognitive stays enforced).
-
 // Per-language metric and AST modules deliberately consume the macro-
 // generated tree-sitter token enums via `use crate::*` and `use Foo::*`
 // inside match expressions — explicit imports would list dozens of

--- a/src/metrics/cyclomatic.rs
+++ b/src/metrics/cyclomatic.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead, loc, nargs, nexits, nom, wmc)
-// Per-language `compute` impls are flat `match node.kind()` dispatch and
-// the `Stats` serde impls are mechanical writers; these offenders are
-// arm-count / many-fn aggregation artifacts, not per-function logic
-// complexity (cognitive stays enforced).
-
 // Per-language metric and AST modules deliberately consume the macro-
 // generated tree-sitter token enums via `use crate::*` and `use Foo::*`
 // inside match expressions — explicit imports would list dozens of

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead, loc, nargs, nexits, nom)
-// Per-language `compute` impls are flat `match node.kind()` dispatch and
-// the `Stats` serde impls are mechanical writers; these offenders are
-// arm-count / many-fn aggregation artifacts, not per-function logic
-// complexity (cognitive stays enforced).
-
 // Per-language metric and AST modules deliberately consume the macro-
 // generated tree-sitter token enums via `use crate::*` and `use Foo::*`
 // inside match expressions — explicit imports would list dozens of

--- a/src/metrics/loc.rs
+++ b/src/metrics/loc.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead, loc, nargs, nexits, nom, wmc, abc)
-// Per-language `compute` impls are flat `match node.kind()` dispatch and
-// the `Stats` serde impls are mechanical writers; these offenders are
-// arm-count / many-fn aggregation artifacts, not per-function logic
-// complexity (cognitive stays enforced).
-
 // Per-language metric and AST modules deliberately consume the macro-
 // generated tree-sitter token enums via `use crate::*` and `use Foo::*`
 // inside match expressions — explicit imports would list dozens of

--- a/src/metrics/mi.rs
+++ b/src/metrics/mi.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits)
-// Per-language `compute` impls are flat `match node.kind()` dispatch and
-// the `Stats` serde impls are mechanical writers; these offenders are
-// arm-count / many-fn aggregation artifacts, not per-function logic
-// complexity (cognitive stays enforced).
-
 // Per-language metric and AST modules deliberately consume the macro-
 // generated tree-sitter token enums via `use crate::*` and `use Foo::*`
 // inside match expressions — explicit imports would list dozens of

--- a/src/metrics/nargs.rs
+++ b/src/metrics/nargs.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead, loc, nargs, nexits, nom)
-// Per-language `compute` impls are flat `match node.kind()` dispatch and
-// the `Stats` serde impls are mechanical writers; these offenders are
-// arm-count / many-fn aggregation artifacts, not per-function logic
-// complexity (cognitive stays enforced).
-
 // Per-language metric and AST modules deliberately consume the macro-
 // generated tree-sitter token enums via `use crate::*` and `use Foo::*`
 // inside match expressions — explicit imports would list dozens of

--- a/src/metrics/nexits.rs
+++ b/src/metrics/nexits.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead, loc, nargs, nexits, nom)
-// Per-language `compute` impls are flat `match node.kind()` dispatch and
-// the `Stats` serde impls are mechanical writers; these offenders are
-// arm-count / many-fn aggregation artifacts, not per-function logic
-// complexity (cognitive stays enforced).
-
 // Per-language metric and AST modules deliberately consume the macro-
 // generated tree-sitter token enums via `use crate::*` and `use Foo::*`
 // inside match expressions — explicit imports would list dozens of

--- a/src/metrics/nom.rs
+++ b/src/metrics/nom.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead, loc, nargs, nexits, nom)
-// Per-language `compute` impls are flat `match node.kind()` dispatch and
-// the `Stats` serde impls are mechanical writers; these offenders are
-// arm-count / many-fn aggregation artifacts, not per-function logic
-// complexity (cognitive stays enforced).
-
 // Per-language metric and AST modules deliberately consume the macro-
 // generated tree-sitter token enums via `use crate::*` and `use Foo::*`
 // inside match expressions — explicit imports would list dozens of

--- a/src/metrics/npa.rs
+++ b/src/metrics/npa.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(cyclomatic, halstead, loc, nargs, nexits, nom, wmc)
-// Per-language `compute` impls are flat `match node.kind()` dispatch and
-// the `Stats` serde impls are mechanical writers; these offenders are
-// arm-count / many-fn aggregation artifacts, not per-function logic
-// complexity (cognitive stays enforced).
-
 // Per-language metric and AST modules deliberately consume the macro-
 // generated tree-sitter token enums via `use crate::*` and `use Foo::*`
 // inside match expressions — explicit imports would list dozens of

--- a/src/metrics/npm.rs
+++ b/src/metrics/npm.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(cyclomatic, halstead, loc, nargs, nexits, nom, wmc)
-// Per-language `compute` impls are flat `match node.kind()` dispatch and
-// the `Stats` serde impls are mechanical writers; these offenders are
-// arm-count / many-fn aggregation artifacts, not per-function logic
-// complexity (cognitive stays enforced).
-
 // Per-language metric and AST modules deliberately consume the macro-
 // generated tree-sitter token enums via `use crate::*` and `use Foo::*`
 // inside match expressions — explicit imports would list dozens of

--- a/src/metrics/tokens.rs
+++ b/src/metrics/tokens.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits, nom)
-// Per-language `compute` impls are flat `match node.kind()` dispatch and
-// the `Stats` serde impls are mechanical writers; these offenders are
-// arm-count / many-fn aggregation artifacts, not per-function logic
-// complexity (cognitive stays enforced).
-
 // Per-language metric and AST modules deliberately consume the macro-
 // generated tree-sitter token enums via `use crate::*` and `use Foo::*`
 // inside match expressions — explicit imports would list dozens of

--- a/src/metrics/wmc.rs
+++ b/src/metrics/wmc.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead, loc, nargs, nom)
-// Per-language `compute` impls are flat `match node.kind()` dispatch and
-// the `Stats` serde impls are mechanical writers; these offenders are
-// arm-count / many-fn aggregation artifacts, not per-function logic
-// complexity (cognitive stays enforced).
-
 // Per-language metric and AST modules deliberately consume the macro-
 // generated tree-sitter token enums via `use crate::*` and `use Foo::*`
 // inside match expressions — explicit imports would list dozens of

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits, nom, wmc)
-// AST `Node` wrapper plus per-language node-kind dispatch helpers; the
-// offenders are arm-count and many-fn aggregation artifacts, not
-// per-function logic complexity.
-
 // Metric counts (token, function, branch, argument, etc.) are stored as
 // `usize` and crossed with `f64` averages, ratios, and Halstead scores
 // across the cyclomatic / MI / Halstead computations. The `usize as f64`

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,7 +1,3 @@
-// bca: suppress-file(halstead, loc, nargs, nom)
-// Per-language operator-extraction dispatch; the offenders are arm-count
-// and many-fn aggregation artifacts, not per-function logic complexity.
-
 // Per-language metric and AST modules deliberately consume the macro-
 // generated tree-sitter token enums via `use crate::*` and `use Foo::*`
 // inside match expressions — explicit imports would list dozens of
@@ -14,7 +10,7 @@ use crate::checker::Checker;
 use crate::error::MetricsError;
 use crate::getter::Getter;
 use crate::node::Node;
-use crate::spaces::SpaceKind;
+use crate::spaces::{SpaceKind, push_children};
 
 use crate::halstead::{Halstead, HalsteadMaps};
 
@@ -252,18 +248,13 @@ pub(crate) fn ops_inner<T: ParserTrait>(
             T::Halstead::compute(&node, code, &mut state.halstead_maps);
         }
 
-        cursor.reset(&node);
-        if cursor.goto_first_child() {
-            loop {
-                children.push((cursor.node(), new_level));
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-            for child in children.drain(..).rev() {
-                stack.push(child);
-            }
-        }
+        // Shared with `metrics_inner` (issue #969): `push_children` is
+        // State-independent — it only moves the cursor over child nodes —
+        // so unlike the local `finalize` / `push_synthetic_unit_root`
+        // mirrors (which differ by `State` payload) it is reused directly
+        // rather than duplicated. The `children.drain(..).rev()` ordering
+        // it encapsulates is load-bearing for suppression attribution.
+        push_children(&mut cursor, &node, new_level, &mut children, &mut stack);
     }
 
     finalize::<T>(&mut state_stack, usize::MAX);

--- a/src/output/checkstyle.rs
+++ b/src/output/checkstyle.rs
@@ -1,7 +1,3 @@
-// bca: suppress-file(halstead, nexits)
-// Checkstyle XML serializer; file-level halstead and the serializer `nexits`
-// are mechanical-writer aggregation artifacts, not logic complexity.
-
 //! Checkstyle 4.3 XML writer for [`OffenderRecord`] batches.
 //!
 //! Checkstyle is the de-facto interchange format for Jenkins, SonarQube,

--- a/src/output/code_climate.rs
+++ b/src/output/code_climate.rs
@@ -1,7 +1,3 @@
-// bca: suppress-file(halstead, nargs, nom)
-// Code Climate JSON serializer; the offenders are mechanical-writer and
-// many-fn aggregation artifacts, not per-function logic complexity.
-
 //! GitLab Code Climate JSON writer for [`OffenderRecord`] batches.
 //!
 //! GitLab's merge-request *Code Quality* widget consumes a strict

--- a/src/output/csv.rs
+++ b/src/output/csv.rs
@@ -1,7 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits)
-// CSV serializer over the FuncSpace tree; the offenders are mechanical-writer
-// aggregation artifacts, not per-function logic complexity.
-
 //! CSV writer for [`FuncSpace`] trees.
 //!
 //! Emits one row per space (function, class, struct, unit, etc.),

--- a/src/output/dump.rs
+++ b/src/output/dump.rs
@@ -1,7 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits)
-// Terminal dump serializer; the offenders are mechanical-writer aggregation
-// artifacts, not per-function logic complexity.
-
 // Per-language metric and AST modules deliberately consume the macro-
 // generated tree-sitter token enums via `use crate::*` and `use Foo::*`
 // inside match expressions — explicit imports would list dozens of

--- a/src/output/dump_metrics.rs
+++ b/src/output/dump_metrics.rs
@@ -1,10 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits, nom)
-// Terminal colored-tree writer: the offending sums (halstead.effort, nargs,
-// nexits) are many-function aggregation artifacts, and the per-function
-// nexits come from `?`-on-every-colored-write error propagation, not logic
-// complexity — the same archetype as the sibling output writers (formats.rs,
-// check_format.rs, dispatch.rs) which carry the identical marker.
-
 //! Terminal per-metric dump serializer.
 //!
 //! The dump tree is driven by [`wire::CodeMetrics`] — the serialized

--- a/src/output/dump_ops.rs
+++ b/src/output/dump_ops.rs
@@ -1,7 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits)
-// Terminal operator-dump serializer; the offenders are mechanical-writer
-// aggregation artifacts, not per-function logic complexity.
-
 use termcolor::{Color, StandardStream, WriteColor};
 
 use crate::ops::Ops;

--- a/src/output/funcspace_row.rs
+++ b/src/output/funcspace_row.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, abc)
-// `metric_values` is a flat array literal of metric accessor calls; the
-// halstead/abc offenders are call-count aggregation artifacts, not
-// per-function logic complexity.
-
 //! Row-shape helpers for the CSV output format.
 //!
 //! The CSV writer walks the FuncSpace tree and emits a flat per-space

--- a/src/output/numfmt.rs
+++ b/src/output/numfmt.rs
@@ -1,7 +1,3 @@
-// bca: suppress-file(halstead)
-// Numeric-formatting helpers; file-level halstead is a many-fn aggregation
-// artifact, not per-function logic complexity.
-
 // Metric counts (token, function, branch, argument, etc.) are stored as
 // `usize` and crossed with `f64` averages, ratios, and Halstead scores
 // across the cyclomatic / MI / Halstead computations. The `usize as f64`

--- a/src/output/offenders.rs
+++ b/src/output/offenders.rs
@@ -1,7 +1,3 @@
-// bca: suppress-file(halstead)
-// `OffenderRecord` shape + builders; file-level halstead is a many-fn
-// aggregation artifact, not per-function logic complexity.
-
 //! Offender records consumed by CI/IDE output formats.
 //!
 //! [`OffenderRecord`] is the minimal shape every CI/IDE output format

--- a/src/output/sarif.rs
+++ b/src/output/sarif.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, nargs, nom)
-// SARIF serializer; the offenders are mechanical-writer and many-fn
-// aggregation artifacts (one small Serialize struct / writer per SARIF
-// node), not per-function logic complexity.
-
 //! SARIF 2.1.0 writer for [`OffenderRecord`] batches.
 //!
 //! SARIF (Static Analysis Results Interchange Format) is the OASIS

--- a/src/output/warning_line.rs
+++ b/src/output/warning_line.rs
@@ -1,7 +1,3 @@
-// bca: suppress-file(halstead, nargs)
-// Compiler-warning line serializers; the offenders are mechanical-writer
-// aggregation artifacts, not per-function logic complexity.
-
 //! Compiler-warning line writers for [`OffenderRecord`] batches.
 //!
 //! Editor-friendly inline warnings: one offender per line, in the

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,3 @@
-// bca: suppress-file(halstead, nargs)
-// Parser plumbing plus per-language filter tables; the offenders are
-// many-fn aggregation artifacts, not per-function logic complexity.
-
 // Per-language metric and AST modules deliberately consume the macro-
 // generated tree-sitter token enums via `use crate::*` and `use Foo::*`
 // inside match expressions — explicit imports would list dozens of

--- a/src/preproc.rs
+++ b/src/preproc.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, nargs)
-// C/C++ preprocessor extraction; file-level halstead and summed nargs are
-// many-fn aggregation artifacts. cognitive is deliberately NOT suppressed —
-// the include-graph walk is genuine nested logic and stays baselined.
-
 // Per-language metric and AST modules deliberately consume the macro-
 // generated tree-sitter token enums via `use crate::*` and `use Foo::*`
 // inside match expressions — explicit imports would list dozens of

--- a/src/spaces.rs
+++ b/src/spaces.rs
@@ -83,6 +83,34 @@ pub enum SpaceKind {
     Interface,
 }
 
+impl SpaceKind {
+    /// Parse a [`SpaceKind`] from its lowercase serialized form — the
+    /// `#[serde(rename_all = "lowercase")]` representation that appears in
+    /// the JSON / wire `kind` field. An unrecognized string maps to
+    /// [`SpaceKind::Unknown`] so a JSON-walking front-end degrades
+    /// gracefully on a future kind rather than erroring.
+    ///
+    /// This is the single source of truth for the string-to-kind mapping a
+    /// consumer needs when it reads a serialized `kind` (the Python
+    /// `to_sarif` binding uses it to apply per-metric threshold scope via
+    /// [`crate::metric_catalog::MetricScope::admits`]). A round-trip test
+    /// pins it against the serde representation so the two cannot drift.
+    #[must_use]
+    pub fn from_serialized(serialized: &str) -> Self {
+        match serialized {
+            "function" => Self::Function,
+            "class" => Self::Class,
+            "struct" => Self::Struct,
+            "trait" => Self::Trait,
+            "impl" => Self::Impl,
+            "unit" => Self::Unit,
+            "namespace" => Self::Namespace,
+            "interface" => Self::Interface,
+            _ => Self::Unknown,
+        }
+    }
+}
+
 impl fmt::Display for SpaceKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let s = match self {
@@ -1532,7 +1560,10 @@ mod tests {
     /// `SpaceKind` is `#[non_exhaustive]` (#551); the attribute is a
     /// compile-time forward-compat contract and must not change the
     /// serialized form. Every variant still round-trips through its
-    /// lowercase token, and `Display` agrees with serde.
+    /// lowercase token, `Display` agrees with serde, and
+    /// [`SpaceKind::from_serialized`] (the string-to-kind path the JSON
+    /// front-ends use for threshold scope, #969) agrees with serde
+    /// deserialization so the two cannot drift.
     #[test]
     fn space_kind_non_exhaustive_serde_roundtrip_unchanged() {
         for kind in [
@@ -1550,7 +1581,12 @@ mod tests {
             assert_eq!(json, format!("\"{kind}\""));
             let back: SpaceKind = serde_json::from_str(&json).unwrap();
             assert_eq!(back, kind);
+            // `from_serialized` consumes the bare token (no JSON quotes)
+            // and must match serde's mapping for every variant.
+            assert_eq!(SpaceKind::from_serialized(&kind.to_string()), kind);
         }
+        // An unrecognized token degrades to `Unknown` rather than panicking.
+        assert_eq!(SpaceKind::from_serialized("not_a_kind"), SpaceKind::Unknown);
     }
 
     /// Positive coverage for the C++ function-space predicates on the

--- a/src/spaces.rs
+++ b/src/spaces.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, loc, nargs, nexits, nom)
-// FuncSpace construction helpers plus the `CodeMetrics` serde / `Display`
-// impls; the offenders are mechanical-writer and many-fn aggregation
-// artifacts, not per-function logic complexity (cognitive/cyclomatic enforced).
-
 // Per-language metric and AST modules deliberately consume the macro-
 // generated tree-sitter token enums via `use crate::*` and `use Foo::*`
 // inside match expressions — explicit imports would list dozens of
@@ -1158,7 +1153,7 @@ fn apply_comment_suppression<T: ParserTrait>(
 /// line-shared suppression attribution (issue #289). The `children`
 /// scratch buffer is drained empty here so callers can reuse its
 /// allocation across iterations.
-fn push_children<'a>(
+pub(crate) fn push_children<'a>(
     cursor: &mut Cursor<'a>,
     node: &Node<'a>,
     new_level: usize,
@@ -1184,6 +1179,12 @@ pub(crate) fn metrics_inner<T: ParserTrait>(
     name: Option<String>,
     options: MetricsOptions,
 ) -> Result<FuncSpace, MetricsError> {
+    // bca: suppress(cognitive, abc)
+    // The single AST-walk loop. Per-node work is already factored into
+    // push_synthetic_unit_root / finalize / compute_per_node /
+    // apply_comment_suppression / push_children; the residual branches
+    // each guard a distinct walk invariant (#182/#289/#522/#722). There
+    // is no cohesive sub-loop to lift without inventing a `walk_part2`.
     // The suppression-warning diagnostic uses the caller-supplied
     // name when present; otherwise we fall back to a placeholder so
     // the warning still locates the offending line. All path-based

--- a/src/suppression.rs
+++ b/src/suppression.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, loc, nargs, nexits, nom)
-// The suppression scanner itself plus its extensive in-module tests; the
-// offenders are many-fn and test-volume aggregation artifacts, not
-// per-function logic complexity (cognitive/cyclomatic stay enforced).
-
 //! In-source suppression markers for metric threshold checks.
 //!
 //! This module implements the comment-based suppression scanner

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1,7 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits, nom)
-// Misc tool helpers; the offenders are many-fn aggregation artifacts, not
-// per-function logic complexity (cognitive/cyclomatic stay enforced).
-
 // Per-language metric and AST modules deliberately consume the macro-
 // generated tree-sitter token enums via `use crate::*` and `use Foo::*`
 // inside match expressions — explicit imports would list dozens of
@@ -73,6 +69,50 @@ pub fn read_file(path: &Path) -> std::io::Result<Vec<u8>> {
 /// classifier tolerates only when more file follows (see `read_file_with_eol`).
 const UTF8_PROBE_BYTES: usize = 64;
 
+/// Decides whether a file's probe prefix is decodable UTF-8 and where its
+/// real content starts. Returns the post-BOM content slice when the probe
+/// is acceptable, or `None` when the file should be skipped.
+///
+/// A UTF-16 BE/LE BOM marks a file whose body is interleaved-NUL UTF-16,
+/// which the metric engine cannot parse: stripping the BOM and continuing
+/// would let the ASCII-dominant body pass the UTF-8 probe (each NUL is a
+/// valid single-byte UTF-8 scalar) and reach the parser as garbage (issue
+/// #803). Skip such files, mirroring `is_generated`'s documented stance
+/// that UTF-16 source is unsupported. A UTF-8 BOM, by contrast, prefixes
+/// genuine UTF-8 and is stripped so the body parses normally.
+/// `starts_with` is bounds-safe for a probe shorter than the BOM.
+///
+/// Validation is at the byte level rather than via a lossy string
+/// round-trip. The probe is only the first `UTF8_PROBE_BYTES`, so a file
+/// longer than the probe may legitimately have its last multibyte
+/// character split across the window boundary. `String::from_utf8_lossy`
+/// could not distinguish that benign truncation (issue #746) from a real
+/// encoding error, and its replacement character `U+FFFD` collided with
+/// the same scalar appearing legitimately in the source (issue #758).
+/// `probe_truncated` is true only when the file continues past the probe;
+/// when the probe is the whole file there is no more data to complete a
+/// trailing partial sequence, so such a sequence is genuine corruption.
+fn probe_decodable_prefix(start: &[u8], file_size: usize, probe_len: usize) -> Option<&[u8]> {
+    let start = if start.starts_with(b"\xFE\xFF") || start.starts_with(b"\xFF\xFE") {
+        return None;
+    } else if let Some(rest) = start.strip_prefix(b"\xEF\xBB\xBF") {
+        rest
+    } else {
+        start
+    };
+
+    let probe_truncated = file_size > probe_len;
+    match std::str::from_utf8(start) {
+        Ok(_) => {}
+        // Only a trailing incomplete multibyte sequence: the bytes before
+        // `valid_up_to()` are valid UTF-8 and the truncated tail is
+        // completed by data later in the file.
+        Err(e) if e.error_len().is_none() && probe_truncated => {}
+        Err(_) => return None,
+    }
+    Some(start)
+}
+
 /// Reads a file, normalising all CR-only and CRLF line endings to LF, and ensures
 /// the buffer ends with exactly one `\n`. Returns `None` for files ≤ 3 bytes or
 /// files that appear to be non-UTF-8.
@@ -120,44 +160,12 @@ pub fn read_file_with_eol(path: &Path) -> std::io::Result<Option<Vec<u8>>> {
         Err(e) => return Err(e),
     }
 
-    // A UTF-16 BE/LE BOM marks a file whose body is interleaved-NUL UTF-16,
-    // which the metric engine cannot parse: stripping the BOM and continuing
-    // would let the ASCII-dominant body pass the UTF-8 probe (each NUL is a
-    // valid single-byte UTF-8 scalar) and reach the parser as garbage (issue
-    // #803). Skip such files, mirroring `is_generated`'s documented stance
-    // that UTF-16 source is unsupported. A UTF-8 BOM, by contrast, prefixes
-    // genuine UTF-8 and is stripped so the body parses normally. `starts_with`
-    // is bounds-safe for a probe shorter than the BOM (a file of 4..=64 bytes
-    // here, since file_size <= 3 already returned above).
-    let start = if start.starts_with(b"\xFE\xFF") || start.starts_with(b"\xFF\xFE") {
+    // Sniff the probe: reject UTF-16 / corrupt files, strip a UTF-8 BOM,
+    // and anchor the buffer at the post-BOM content. `None` means skip the
+    // file (see `probe_decodable_prefix`).
+    let Some(start) = probe_decodable_prefix(&start, file_size, probe_len) else {
         return Ok(None);
-    } else if let Some(rest) = start.strip_prefix(b"\xEF\xBB\xBF") {
-        rest
-    } else {
-        &start
     };
-
-    // Validate the probe as UTF-8 at the byte level rather than via a lossy
-    // string round-trip. The probe is only the first `UTF8_PROBE_BYTES`, so a
-    // file longer than the probe may legitimately have its last multibyte
-    // character split across the window boundary. `String::from_utf8_lossy`
-    // could not distinguish that benign truncation (issue #746) from a real
-    // encoding error, and its replacement character `U+FFFD` collided with the
-    // same scalar appearing legitimately in the source (issue #758).
-    //
-    // `probe_truncated` is true only when the file continues past the probe;
-    // when the probe is the whole file there is no more data to complete a
-    // trailing partial sequence, so such a sequence is genuine corruption.
-    let probe_truncated = file_size > probe_len;
-    match std::str::from_utf8(start) {
-        Ok(_) => {}
-        Err(e) if e.error_len().is_none() && probe_truncated => {
-            // Only a trailing incomplete multibyte sequence: the bytes before
-            // `valid_up_to()` are valid UTF-8 and the truncated tail is
-            // completed by data later in the file.
-        }
-        Err(_) => return Ok(None),
-    }
 
     let mut data = Vec::with_capacity(file_size + 2);
     data.extend_from_slice(start);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,7 +1,3 @@
-// bca: suppress-file(halstead)
-// Core trait definitions; file-level halstead is a many-fn aggregation
-// artifact, not per-function logic complexity.
-
 // Per-language metric and AST modules deliberately consume the macro-
 // generated tree-sitter token enums via `use crate::*` and `use Foo::*`
 // inside match expressions — explicit imports would list dozens of

--- a/src/vcs/bus_factor.rs
+++ b/src/vcs/bus_factor.rs
@@ -1,10 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits)
-// File-level halstead/nargs/exit are many-fn aggregation artifacts (the
-// DoA term assembly, the flat output DTOs, and the early-return guards
-// summed across a dozen small helpers — per-function nexits peaks at 2),
-// not per-function logic complexity (cognitive/cyclomatic stay enforced)
-// — mirrors the sibling `score.rs` / `jit.rs`.
-
 //! Directory- and repo-level **bus factor** (a.k.a. truck factor) over a
 //! change-history walk, via the Avelino *Degree-of-Authorship* (DoA)
 //! heuristic (issue #332).

--- a/src/vcs/cache.rs
+++ b/src/vcs/cache.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits)
-// File-level halstead/nargs/exit are many-fn aggregation artifacts (the
-// serde event types + the directory/IO helpers, each with early-return
-// guards), not per-function logic complexity (cognitive/cyclomatic stay
-// enforced).
-
 //! Persistent change-history cache, keyed by `HEAD` SHA and repo identity
 //! (issue #334).
 //!

--- a/src/vcs/entropy.rs
+++ b/src/vcs/entropy.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead, nargs)
-// File-level halstead/nargs are many-fn aggregation artifacts (the
-// CochangeGraph methods + the shannon/bump/node_entropy helpers summed
-// across the module), not per-function logic complexity
-// (cognitive/cyclomatic stay enforced).
-
 //! Shannon-entropy machinery shared by the two process-entropy signals
 //! added in issue #330.
 //!

--- a/src/vcs/error.rs
+++ b/src/vcs/error.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead)
-// File-level halstead is a many-arm aggregation artifact (the `Display`
-// match grows one arm per variant), not per-function logic complexity
-// (cognitive/cyclomatic stay enforced) — mirrors the sibling vcs modules.
-
 //! Error type for the change-history (VCS) metrics pipeline.
 //!
 //! Generic over the backend: backend-specific failures (a `gix` open
@@ -127,6 +122,12 @@ impl Error {
 
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // bca: suppress(cyclomatic)
+        // Exhaustive one-write-per-variant Display match: cyclomatic here
+        // is the variant count, not branching logic, and the arms mirror
+        // the compile-enforced `Error` enum one-to-one. Splitting it into
+        // sub-matches would be an arbitrary partition with no semantic
+        // boundary that would drift out of sync with the enum.
         match self {
             Self::NotARepository(path) => {
                 write!(

--- a/src/vcs/git/blame.rs
+++ b/src/vcs/git/blame.rs
@@ -1,10 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits, nom)
-// File-level halstead/nargs/exit/nom are many-fn aggregation artifacts
-// (the gix `?`-heavy open/resolve plumbing, the blame→bucket→finalize
-// pipeline, and the many short iterator closures it counts as functions),
-// not per-function logic complexity (cognitive/cyclomatic stay enforced)
-// — mirrors the sibling `git/` backend files and `vcs_command.rs`.
-
 //! Per-function change-history attribution via `git blame` (issue #329).
 //!
 //! Where the file-level walk in [`super::history`] diffs each commit

--- a/src/vcs/git/cached.rs
+++ b/src/vcs/git/cached.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits)
-// File-level halstead/nargs/exit are many-fn aggregation artifacts (the
-// open/resolve/load/splice/persist pipeline with many `?` error maps),
-// not per-function logic complexity (cognitive/cyclomatic stay enforced).
-
 //! Cache-aware history build: reuse a persisted event log, extend it by
 //! walking only new commits, or fall back to a fresh walk (issue #334).
 //!
@@ -47,6 +42,15 @@ pub(crate) fn build_cached(
     options: &Options,
     config: &CacheConfig,
 ) -> Result<HistoryIndex, Error> {
+    // bca: suppress(abc)
+    // Linear sequence over cache outcomes (disabled / pure hit / miss):
+    // each step is already comment-delimited and the per-step work
+    // (collect_events, incremental_events, assemble, persist) lives in its
+    // own helper. The ABC count is the call/assignment density of wiring
+    // those outcomes, not branching depth — cognitive is not flagged.
+    // Extracting the pure-hit arm would need ~9 cache-key params (tripping
+    // nargs), and a grouping struct introduced only to dodge that would be
+    // gaming, not clarity.
     let repo::OpenRepo {
         mut repo,
         workdir,

--- a/src/vcs/git/diff_parse.rs
+++ b/src/vcs/git/diff_parse.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits)
-// File-level halstead/nargs/exit are many-fn aggregation artifacts (the
-// per-line classification plus the path-quoting decoders, each with its
-// own `?`/Option early-exits), not per-function logic complexity
-// (cognitive/cyclomatic stay enforced) — mirrors the sibling `jit.rs`.
-
 //! Unified-diff parser backing [`score_diff`] (issue #580), split out of
 //! `jit.rs` (issue #585) once the parser plus its regression tests pushed
 //! that file past the self-scan limits.

--- a/src/vcs/git/history.rs
+++ b/src/vcs/git/history.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits)
-// File-level halstead/nargs/exit are many-fn aggregation artifacts (the
-// gix rev-walk + per-commit diff plumbing, with many `?` error maps),
-// not per-function logic complexity (cognitive/cyclomatic stay enforced).
-
 //! The commit-history walk: rev-walk the target ref within the long
 //! window, diff each commit against its first parent, and emit one raw
 //! [`CommitEvent`] per in-window commit.

--- a/src/vcs/git/identity.rs
+++ b/src/vcs/git/identity.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, nargs)
-// File-level halstead/nargs are many-fn aggregation artifacts (the
-// mailmap + trailer-parsing plumbing), not per-function logic
-// complexity (cognitive/cyclomatic stay enforced).
-
 //! Resolve the participant identities of a git commit.
 //!
 //! "Participants" are the commit author plus any `Co-authored-by:`

--- a/src/vcs/git/jit.rs
+++ b/src/vcs/git/jit.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits)
-// File-level halstead/nargs/exit are many-fn aggregation artifacts (the
-// gix open/resolve/diff plumbing with many `?` error maps), not
-// per-function logic complexity (cognitive/cyclomatic stay enforced) —
-// mirrors the sibling `git/` backend files.
-
 //! The `vcs-git` backend for just-in-time (commit-level) risk scoring
 //! (issue #331).
 //!

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits)
-// File-level halstead/nargs/exit are many-fn aggregation artifacts (the
-// open/resolve/enumerate/finalize pipeline), not per-function logic
-// complexity (cognitive/cyclomatic stay enforced).
-
 //! The `vcs-git` backend: a `gix`-powered history walk.
 //!
 //! `build` is the single entry point `build_history_index` delegates

--- a/src/vcs/git/repo.rs
+++ b/src/vcs/git/repo.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits)
-// File-level halstead/nargs/exit are many-fn aggregation artifacts (the
-// gix open/diff plumbing with many `?` error maps), not per-function
-// logic complexity (cognitive/cyclomatic stay enforced).
-
 //! Repository discovery and target-tree file enumeration.
 
 use std::collections::HashMap;

--- a/src/vcs/git/trend.rs
+++ b/src/vcs/git/trend.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits)
-// File-level halstead/nargs/exit are many-fn aggregation artifacts (the
-// timeline walk + per-point build loop with `?` error maps), not
-// per-function logic complexity (cognitive/cyclomatic stay enforced).
-
 //! The `vcs-git` backend for the historical metric trend (issue #333).
 //!
 //! [`build_trend`] samples the change-history metrics at several points in

--- a/src/vcs/identity.rs
+++ b/src/vcs/identity.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, nargs)
-// File-level halstead/nargs are many-fn aggregation artifacts (the hashing
-// + canonicalisation helpers, plus the bot-filter ctor), not per-function
-// logic complexity (cognitive/cyclomatic stay enforced).
-
 //! Canonical author identity and bot-author detection.
 //!
 //! Backend-agnostic: the git backend resolves a commit signature

--- a/src/vcs/jit.rs
+++ b/src/vcs/jit.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead, nargs)
-// File-level halstead/nargs are many-fn aggregation artifacts (the
-// many-term score formula plus the flat output DTOs), not per-function
-// logic complexity (cognitive/cyclomatic stay enforced) — mirrors the
-// sibling `score.rs`.
-
 //! Just-in-time (commit-level) defect-induction risk scoring (issue #331).
 //!
 //! Where [`score`](crate::vcs::score) ranks *files* at a ref, this module

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, nargs)
-// File-level halstead/nargs are many-fn aggregation artifacts (the
-// HistoryIndex accessors + entry points), not per-function logic
-// complexity (cognitive/cyclomatic stay enforced).
-
 //! Change-history (VCS) metrics: per-file signals derived from version
 //! control history rather than the AST.
 //!

--- a/src/vcs/options.rs
+++ b/src/vcs/options.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits)
-// File-level halstead/nargs/exit are many-fn aggregation artifacts (the
-// window parser's unit branches + the Options builder), not
-// per-function logic complexity (cognitive/cyclomatic stay enforced).
-
 //! Configuration for a change-history walk.
 //!
 //! [`Options`] is a plain data struct: the CLI / web / Python layers

--- a/src/vcs/replay.rs
+++ b/src/vcs/replay.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, nargs)
-// File-level halstead/nargs are many-fn aggregation artifacts (the fold +
-// finalize + replay pipeline), not per-function logic complexity
-// (cognitive/cyclomatic stay enforced).
-
 //! The per-commit fold shared by the live walk and the cache replay, plus
 //! the replay itself (issue #334).
 //!

--- a/src/vcs/score.rs
+++ b/src/vcs/score.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, nargs)
-// File-level halstead/nargs are many-fn aggregation artifacts (the
-// formula's many log/weight terms + the percentile extractor table),
-// not per-function logic complexity (cognitive/cyclomatic stay enforced).
-
 //! Composite risk-score formulas.
 //!
 //! Two scores are offered. The default **weighted** score is a

--- a/src/vcs/stats.rs
+++ b/src/vcs/stats.rs
@@ -1,8 +1,3 @@
-// bca: suppress-file(halstead, nargs)
-// File-level halstead/nargs are many-fn aggregation artifacts (the
-// 20-field Stats assembly in `finalize`), not per-function logic
-// complexity (cognitive/cyclomatic stay enforced).
-
 //! Per-file change-history statistics: the public [`Stats`] output and
 //! the internal [`Accumulator`] that the backend feeds during a walk.
 

--- a/src/vcs/trend.rs
+++ b/src/vcs/trend.rs
@@ -1,9 +1,3 @@
-// bca: suppress-file(halstead, nargs, nexits)
-// File-level halstead/nargs/exit are many-fn aggregation artifacts (the
-// Trend accessors + delta projection + validation, each with its own
-// early returns / `?`), not per-function logic complexity
-// (cognitive/cyclomatic stay enforced) — mirrors the sibling vcs modules.
-
 //! Historical metric trend: the change-history (VCS) metrics computed at
 //! several points in time, so a consumer can see whether a file's risk is
 //! improving or degrading rather than only its risk *now* (issue #333).

--- a/src/wire.rs
+++ b/src/wire.rs
@@ -1,11 +1,3 @@
-// bca: suppress-file(halstead, loc, nargs, nom)
-// This file is a flat catalogue of plain DTO structs plus mechanical
-// `From<&Compute>` field-by-field projections — one struct and one
-// projection per metric and container. The offenders are volume /
-// field-count / many-fn aggregation artifacts (the same shape as `ops.rs`),
-// not per-function logic complexity; there are no conditionals or loops
-// here. cognitive / cyclomatic stay enforced (and do not fire).
-
 //! Plain, public data-transfer structs mirroring the serialized metric
 //! wire shape — the single source of truth for the JSON / YAML / TOML /
 //! CBOR output format and the only `Deserialize`-capable view of it.


### PR DESCRIPTION
## Summary

Implements **Findings 1 and 3** of the #969 code-metrics audit. The keystone
is a per-metric **threshold scope** that fixes the self-scan gate having been
neutralized by blanket whole-file suppression.

### Finding 1 — threshold scope (the keystone)

`bca check` evaluated every `[thresholds]` limit against **every** `FuncSpace`
— the file-level `Unit` root and every container — so a metric's whole-file or
whole-`impl` aggregate fired as if it were a per-function limit. The repo
papered over this with ~120 whole-file `bca: suppress-file` markers, which in
turn blinded the gate to genuine per-function regressions (Halstead was
unmeasured for ~98% of functions).

Each metric now carries an intrinsic **scope**, owned by the shared
`metric_catalog` (new public `MetricScope`), and both front-ends gate only the
space kinds a metric measures:

| Scope | Gated spaces | Metrics |
| --- | --- | --- |
| File | file root | `loc.*` |
| Function | functions / methods / closures | `cognitive`, `cyclomatic[.modified]`, `halstead.*`, `mi.*`, `abc`, `nargs`, `nexits`, `tokens` |
| Container | class / struct / trait / impl / namespace / interface | `nom`, `wmc`, `npm`, `npa` |

No new manifest/CLI syntax — the scope is a baked-in default. Because the
`metric_catalog` is the single source of truth (the same module that owns the
lower-is-worse direction), the **Python `to_sarif` binding** applies the
identical gate; a cross-front-end parity test pins them together.

**Dogfood:** deleted the ~120 redundant `suppress-file` markers — `bca
exemptions` in-source markers dropped **122 → 10** — and refreshed
`.bca-baseline.toml` to 189 genuine per-function / per-file / per-container
offenders. Both gates (`make self-scan` hard + headroom soft) are green.

### Finding 3 — nine complex functions

Genuine, behavior-preserving clarity refactors where a real boundary existed
(`push_children` reuse in `ops_inner`, `file_set_deltas`,
`probe_decodable_prefix`, `scaffold_baseline`); honest in-source
`bca: suppress(...)` markers where the complexity is irreducible
(`metrics_inner`, `run_check`, `dispatch_metrics`, `build_cached`,
`Error::fmt`).

## SemVer

Not a break — the CLI grammar is unchanged and the file/container aggregate
firing was never a documented per-function limit. New public items
(`MetricScope`, `MetricScope::admits`, `metric_catalog::scope`,
`SpaceKind::from_serialized`, `MetricInfo::scope`) are additive (minor).
Recorded in `CHANGELOG.md`.

## Validation

- `cargo test --workspace --all-features`: all pass; **no metric values change**
  (snapshot-clean, no submodule bump).
- `make pre-commit` green end-to-end (fmt, both clippy flavours, doc, udeps,
  self-scan + self-scan-headroom, snapshot-anchors, man-page drift, and the
  Python ruff / mypy / pyright / maturin / pytest / stubtest stages).
- Scope unit tests verified via revert + mutation (they fail when the gate is
  neutralized). Reviewed via simplify-rust, rust-optimize, audit-tests, and a
  high-effort code-review — no findings.

## Scope of this PR

Findings **2** (the `abc.rs` split) and **4** (reassess Halstead hotspots, both
now under the per-function limit) remain open under the #969 tracker — their
re-exposed offenders are currently baselined.

Refs #969
