### PR TITLE
docs: PyO3 unsafe carve-out + stale-comment fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,17 @@ and `cargo run -p big-code-analysis-web --`.
 
 ## Rust conventions
 
-- No `unsafe` code anywhere in the workspace.
+- No `unsafe` code anywhere in the workspace, with one narrow,
+  documented exception: the PyO3 bindings (`big-code-analysis-py`)
+  erase the lifetime brand on a `Copy`, borrow-free `tree_sitter` FFI
+  value so a `#[pyclass]` (which cannot carry a lifetime) can hold it,
+  keeping the owning tree alive through a strong `Py<...>` handle. The
+  canonical soundness argument lives at
+  `big-code-analysis-py/src/node.rs` (the `# Safety` module doc and
+  `detach`). Any `unsafe` outside this exact pattern remains banned and
+  needs a deliberate amendment to this rule. (The PyO3-macro-generated
+  FFI shims under `#![allow(unsafe_op_in_unsafe_fn)]` in `src/lib.rs`
+  are source-level `unsafe`-free and not covered by this exception.)
 - No `unwrap()` / `expect()` / `panic!()` / `assert!()` in non-test code;
   propagate errors with `?`. `expect("reason")` and `assert!()` are
   acceptable in tests and may be acceptable in production for

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,7 +189,8 @@ for why this matters.
 ## Project conventions
 
 - **Rust style**: `cargo fmt`, clippy clean with
-  `--workspace --all-targets -- -D warnings`. No `unsafe` code. Avoid
+  `--workspace --all-targets -- -D warnings`. No `unsafe` code (one
+  narrow PyO3 FFI exception — see `AGENTS.md`). Avoid
   `unwrap` / `expect` / `panic!` / `assert!` in non-test code;
   propagate errors with `?`.
 - **Visibility**: prefer `pub(crate)` over `pub`; widen visibility

--- a/big-code-analysis-cli/src/baseline_diff.rs
+++ b/big-code-analysis-cli/src/baseline_diff.rs
@@ -141,8 +141,9 @@ impl BaselineDiff {
                 // Direction-aware bucketing: for the lower-is-worse
                 // `mi.*` family a value *drop* is the regression and a
                 // *rise* the improvement, so the Greater/Less mapping
-                // inverts. Reuse the central catalog predicate (the same
-                // one the threshold gate consults at `thresholds.rs:818`)
+                // inverts. Reuse the central catalog predicate
+                // (`metric_catalog::lower_is_worse`, the same one the
+                // threshold gate consults via `thresholds::breaches_limit`)
                 // rather than hard-coding the `mi.*` list here.
                 let (worse, better) =
                     if big_code_analysis::metric_catalog::lower_is_worse(&n.metric) {

--- a/big-code-analysis-cli/src/thresholds.rs
+++ b/big-code-analysis-cli/src/thresholds.rs
@@ -188,8 +188,8 @@ fn lookup_extractor(name: &str) -> Option<&'static MetricExtractor> {
 }
 
 /// Reject a metric-gate threshold that is not a finite, non-negative
-/// `f64`. NaN and infinities silently disable an `x >= threshold` gate
-/// (`x >= NaN`/`x >= inf` is always `false`), and a negative limit trips
+/// `f64`. NaN and infinities silently disable an `x > threshold` gate
+/// (`x > NaN`/`x > inf` is always `false`), and a negative limit trips
 /// on every non-negative score; both are user errors, not gates.
 pub(crate) fn validate_threshold_value(value: f64, name: &str) -> Result<(), String> {
     if !value.is_finite() || value < 0.0 {

--- a/big-code-analysis-cli/src/vcs_command.rs
+++ b/big-code-analysis-cli/src/vcs_command.rs
@@ -280,9 +280,9 @@ pub(crate) fn build_options(args: &VcsArgs) -> Options {
     options
 }
 
-/// Environment variable holding the author-hash key, preferred over the
-/// `--author-hash-key` flag so the secret stays off the process list and
-/// out of shell history (issue #956).
+/// Environment variable holding the author-hash key: the recommended,
+/// security-preferred channel (off the process list and shell history),
+/// though the `--author-hash-key` flag wins when both are set (#956).
 const AUTHOR_HASH_KEY_ENV: &str = "BCA_AUTHOR_HASH_KEY";
 
 /// Resolve the optional author-hash key (issue #956): the


### PR DESCRIPTION
## Summary

A small batch of **documentation and comment-only** corrections — no code
logic changes.

### Convention carve-out

- **AGENTS.md / CONTRIBUTING.md**: the workspace-wide "no `unsafe`" rule now
  documents its one narrow, deliberate exception — the PyO3 bindings erase the
  lifetime brand on a `Copy`, borrow-free `tree_sitter` FFI value so a
  `#[pyclass]` (which cannot carry a lifetime) can hold it, keeping the owning
  tree alive via a strong `Py<...>` handle. The canonical soundness argument
  lives in `big-code-analysis-py/src/node.rs`. Any `unsafe` outside this exact
  pattern stays banned.

### Stale-comment fixes

- **baseline_diff.rs**: the comment referenced `thresholds.rs:818` (a line
  number that drifts); now names `metric_catalog::lower_is_worse` /
  `thresholds::breaches_limit` instead.
- **thresholds.rs**: `validate_threshold_value`'s doc said the gate is
  `x >= threshold`; the actual `breaches_limit` uses a strict `x > threshold`,
  so the NaN/inf explanation now matches the code.
- **vcs_command.rs**: the `BCA_AUTHOR_HASH_KEY` doc implied the env var is
  "preferred over" the `--author-hash-key` flag; in fact the flag wins when
  both are set. Reworded to: env var is the security-recommended channel, but
  the flag takes precedence (#956).

## Validation

Comment/doc-only; behavior unchanged. Leaving CI to confirm fmt / clippy /
markdown lint.
