### PR TITLE
fix(report): qualify hotspot function names with their container

### DIFF
--- a/.bca-baseline.toml
+++ b/.bca-baseline.toml
@@ -35,7 +35,7 @@ value = 7.0
 [[entry]]
 path = "big-code-analysis-cli/src/baseline_diff.rs"
 qualified = "BaselineDiff::column_widths"
-start_line = 298
+start_line = 299
 metric = "nargs"
 value = 8.0
 
@@ -275,12 +275,12 @@ path = "big-code-analysis-cli/src/lib.rs"
 qualified = "<file>"
 start_line = 1
 metric = "loc.sloc"
-value = 3324.0
+value = 3325.0
 
 [[entry]]
 path = "big-code-analysis-cli/src/lib.rs"
 qualified = "legacy_hint"
-start_line = 3221
+start_line = 3222
 metric = "halstead.effort"
 value = 59351.805921378844
 
@@ -289,12 +289,12 @@ path = "big-code-analysis-cli/src/markdown_report.rs"
 qualified = "<file>"
 start_line = 1
 metric = "loc.sloc"
-value = 853.0
+value = 883.0
 
 [[entry]]
 path = "big-code-analysis-cli/src/markdown_report.rs"
 qualified = "write_language_section"
-start_line = 962
+start_line = 992
 metric = "halstead.effort"
 value = 52993.355167839094
 
@@ -345,12 +345,12 @@ path = "big-code-analysis-cli/src/thresholds.rs"
 qualified = "<file>"
 start_line = 1
 metric = "loc.sloc"
-value = 941.0
+value = 908.0
 
 [[entry]]
 path = "big-code-analysis-cli/src/thresholds.rs"
 qualified = "ThresholdSet::evaluate_with_policy"
-start_line = 823
+start_line = 790
 metric = "halstead.effort"
 value = 56531.05676283881
 
@@ -518,21 +518,21 @@ value = 6.0
 [[entry]]
 path = "big-code-analysis-py/src/sarif.rs"
 qualified = "collect_offenders"
-start_line = 558
+start_line = 559
 metric = "nexits"
 value = 6.0
 
 [[entry]]
 path = "big-code-analysis-py/src/sarif.rs"
 qualified = "extract_line_number"
-start_line = 366
+start_line = 367
 metric = "nexits"
 value = 5.0
 
 [[entry]]
 path = "big-code-analysis-py/src/sarif.rs"
 qualified = "resolve_thresholds"
-start_line = 277
+start_line = 278
 metric = "nexits"
 value = 6.0
 
@@ -1003,40 +1003,40 @@ path = "src/spaces.rs"
 qualified = "<file>"
 start_line = 1
 metric = "loc.sloc"
-value = 2113.0
+value = 2112.0
 
 [[entry]]
 path = "src/spaces.rs"
 qualified = "Ast::from_path"
-start_line = 793
+start_line = 792
 metric = "nexits"
 value = 5.0
 
 [[entry]]
 path = "src/spaces.rs"
 qualified = "CodeMetrics::fmt"
-start_line = 222
+start_line = 221
 metric = "nexits"
 value = 8.0
 
 [[entry]]
 path = "src/spaces.rs"
 qualified = "compute_per_node"
-start_line = 1062
+start_line = 1061
 metric = "halstead.effort"
 value = 66012.71705067596
 
 [[entry]]
 path = "src/spaces.rs"
 qualified = "compute_per_node"
-start_line = 1062
+start_line = 1061
 metric = "nargs"
 value = 7.0
 
 [[entry]]
 path = "src/spaces.rs"
 qualified = "metrics_inner"
-start_line = 1206
+start_line = 1205
 metric = "halstead.effort"
 value = 109810.50849120741
 

--- a/big-code-analysis-cli/src/lib.rs
+++ b/big-code-analysis-cli/src/lib.rs
@@ -47,6 +47,7 @@ mod metric_alias;
 mod metric_catalog;
 mod metric_diff;
 mod provenance;
+mod qualified_name;
 mod threshold_suggestion;
 mod thresholds;
 mod vcs_command;

--- a/big-code-analysis-cli/src/markdown_report.rs
+++ b/big-code-analysis-cli/src/markdown_report.rs
@@ -29,10 +29,12 @@ pub(crate) use sections::render_cell_md;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::fmt::Write;
+use std::rc::Rc;
 
 use big_code_analysis::{FuncSpace, LANG, Metric, SpaceKind, SuppressionPolicy, SuppressionScope};
 
 use crate::format_util::strip_path_prefix;
+use crate::qualified_name::space_segment;
 
 /// Compact per-function/class metric record for the markdown report pipeline.
 #[derive(Debug)]
@@ -129,6 +131,11 @@ fn extract_summaries_inner(
     language: LANG,
     out: &mut Vec<FunctionSummary>,
 ) {
+    // bca: suppress(halstead)
+    // halstead.effort here is the volume of the mechanical, field-by-field
+    // `CodeMetrics` -> `FunctionSummary` projection below (~30 accessor
+    // reads), not per-function logic complexity — the walk itself is a
+    // simple iterative pre-order traversal.
     // The root space IS the top-level `Unit`; its `suppressed` scope
     // carries any `bca: suppress-file` markers, which apply to every
     // function in the file. Capture it once so each summary's effective
@@ -136,18 +143,39 @@ fn extract_summaries_inner(
     // gate forms in `ThresholdSet::evaluate_with_policy` (issue #501).
     let file_scope = &space.suppressed;
 
-    // Iterative pre-order walk over the FuncSpace tree. Children are
-    // pushed in reverse so `pop()` visits them in source order — this
-    // produces the same FunctionSummary ordering as the prior recursive
-    // form, preserving snapshot stability.
-    let mut stack: Vec<&FuncSpace> = vec![space];
-    while let Some(current) = stack.pop() {
+    // Iterative pre-order walk over the FuncSpace tree. Each frame carries
+    // the segment of its *immediate* enclosing container so a nested
+    // function's `name` is `Container::function` (`RustCode::compute`) —
+    // disambiguating the per-language `impl Abc for <Lang>Code { compute }`
+    // family in `src/metrics/abc.rs` that otherwise collapses to ~20
+    // identical-looking bare `compute` rows. Only the immediate container
+    // is prefixed (not the full `bca check` chain) so the name stays O(1)
+    // per space — a pathologically deep AST therefore cannot blow report
+    // memory to O(depth²); for the shallow nesting real code produces the
+    // two agree. The `Unit` file row keeps the file path as its name (its
+    // identity, shown in the file-level tables). Children are pushed in
+    // reverse so `pop()` visits them in source order, matching the prior
+    // recursive form and preserving snapshot ordering.
+    let mut stack: Vec<(&FuncSpace, Rc<str>)> = vec![(space, Rc::from(""))];
+    while let Some((current, container)) = stack.pop() {
         let m = &current.metrics;
         let mut suppressed = file_scope.clone();
         suppressed.merge(&current.suppressed);
+        let is_unit = matches!(current.kind, SpaceKind::Unit);
+        let (name, child_container): (String, Rc<str>) = if is_unit {
+            (current.name.clone().unwrap_or_default(), Rc::from(""))
+        } else {
+            let segment = space_segment(current);
+            let name = if container.is_empty() {
+                segment.clone()
+            } else {
+                format!("{container}::{segment}")
+            };
+            (name, Rc::from(segment))
+        };
         out.push(FunctionSummary {
             file: display_file.to_string(),
-            name: current.name.clone().unwrap_or_default(),
+            name,
             kind: current.kind,
             language,
             suppressed,
@@ -177,7 +205,9 @@ fn extract_summaries_inner(
             npm: m.npm.total_npm() as f64,
         });
 
-        stack.extend(current.spaces.iter().rev());
+        for child in current.spaces.iter().rev() {
+            stack.push((child, Rc::clone(&child_container)));
+        }
     }
 }
 
@@ -1345,13 +1375,19 @@ mod tests {
         extract_summaries(&root, "src/root.rs", LANG::Rust, "", &mut out);
 
         assert_eq!(out.len(), 4);
+        // The `Unit` row keeps the file path as its name; nested spaces
+        // carry their container-qualified symbol so two methods sharing a
+        // bare name stay distinguishable (the abc.rs `compute` family).
         assert_eq!(out[0].kind, SpaceKind::Unit);
+        assert_eq!(out[0].name, "root.rs");
+        // Top-level spaces have no container prefix.
         assert_eq!(out[1].kind, SpaceKind::Function);
         assert_eq!(out[1].name, "func_a");
         assert_eq!(out[2].kind, SpaceKind::Class);
         assert_eq!(out[2].name, "ClassB");
+        // The method nested in `ClassB` is qualified by its container.
         assert_eq!(out[3].kind, SpaceKind::Function);
-        assert_eq!(out[3].name, "method_c");
+        assert_eq!(out[3].name, "ClassB::method_c");
         assert_eq!(out[3].start_line, 12);
         assert_eq!(out[3].end_line, 16);
     }
@@ -1438,10 +1474,14 @@ mod tests {
                 // DEPTH+1 because the chain has DEPTH wrappers plus
                 // the innermost `f_inner` leaf.
                 assert_eq!(out.len(), DEPTH + 1);
-                // Pre-order: root first, innermost last.
+                // Pre-order: root first, innermost last. The `Unit` row
+                // keeps the file path; the innermost is qualified by its
+                // immediate container (`f_{DEPTH-1}::f_inner`) — O(1) per
+                // name, so qualification does not turn this deep chain into
+                // O(depth²) memory.
                 assert_eq!(out[0].kind, SpaceKind::Unit);
                 assert_eq!(out[0].name, "root.rs");
-                assert_eq!(out[DEPTH].name, "f_inner");
+                assert_eq!(out[DEPTH].name, format!("f_{}::f_inner", DEPTH - 1));
 
                 // FuncSpace contains `spaces: Vec<FuncSpace>`, so
                 // letting the chained tree drop at scope exit walks

--- a/big-code-analysis-cli/src/qualified_name.rs
+++ b/big-code-analysis-cli/src/qualified_name.rs
@@ -1,0 +1,58 @@
+//! Container-qualified symbol names for [`FuncSpace`]s.
+//!
+//! Both the `bca check` offender output and the `bca report` hotspot
+//! tables identify a nested function by its enclosing container so two
+//! functions that share a bare AST name stay distinguishable. The
+//! motivating case is the per-language `impl Abc for <Lang>Code { fn
+//! compute(...) }` family in `src/metrics/abc.rs`: ~20 distinct methods
+//! all named `compute`, which the bare AST name collapses into
+//! indistinguishable rows.
+//!
+//! The two surfaces share the [`space_segment`] primitive but differ in
+//! how much chain they prefix:
+//!
+//! - `bca check` uses [`qualified_symbol`] — the full `::`-joined
+//!   enclosing chain (`Outer::Inner::method`) — because an offender line
+//!   is a precise location key (baseline matching, suppression).
+//! - `bca report` prefixes only the *immediate* container
+//!   (`RustCode::compute`), keeping each name O(1) so a pathologically
+//!   deep AST cannot blow report memory to O(depth²). For the shallow
+//!   nesting real code produces the two forms agree.
+
+use big_code_analysis::{FuncSpace, SpaceKind};
+
+/// One `::`-segment for a space in the qualified-symbol chain.
+///
+/// Named spaces contribute their AST-derived name. Anonymous spaces —
+/// closures and lambdas, which every grammar surfaces as the literal
+/// `<anonymous>`, plus the `None`-name parse-failure case — collapse to
+/// `<anon@L{start_line}>` so they keep a stable-within-a-snapshot
+/// identity. Baking the line into the segment means an anonymous function
+/// re-keys when it moves (the documented degradation in
+/// `recipes/baselines.md`); named functions do not.
+pub(crate) fn space_segment(space: &FuncSpace) -> String {
+    const ANONYMOUS: &str = "<anonymous>";
+    match space.name.as_deref() {
+        Some(name) if name != ANONYMOUS => name.to_owned(),
+        _ => format!("<anon@L{}>", space.start_line),
+    }
+}
+
+/// The qualified symbol of `space`, given the `::`-joined symbol of its
+/// enclosing chain (`parent_prefix`, empty at file top level).
+///
+/// The top-level (`Unit`) space is the file itself; it carries no symbol
+/// segment (its identity is the `path` key) so it collapses to `<file>`
+/// and never prefixes the functions inside it. Everything else appends
+/// its [`space_segment`] to the parent prefix.
+pub(crate) fn qualified_symbol(space: &FuncSpace, parent_prefix: &str) -> String {
+    if matches!(space.kind, SpaceKind::Unit) {
+        return "<file>".to_owned();
+    }
+    let segment = space_segment(space);
+    if parent_prefix.is_empty() {
+        segment
+    } else {
+        format!("{parent_prefix}::{segment}")
+    }
+}

--- a/big-code-analysis-cli/src/thresholds.rs
+++ b/big-code-analysis-cli/src/thresholds.rs
@@ -26,6 +26,7 @@ use serde::Deserialize;
 
 use crate::baseline::Coverage;
 use crate::format_util::MetricScalar;
+use crate::qualified_name::qualified_symbol;
 
 /// The space kind each metric's threshold gates (issue #969) — owned by
 /// the library catalog so the CLI gate and the Python `to_sarif` binding
@@ -654,40 +655,6 @@ fn format_regressed_tag(recorded: f64, value: f64) -> String {
     // because the classifier only emits Regressed when
     // `value > recorded`.
     format!("[regr +{pct:.0}%]")
-}
-
-/// One `::`-segment for a space in the qualified-symbol chain.
-///
-/// The top-level (`Unit`) space is the file itself; it carries no
-/// symbol segment (its identity is the `path` key) so it never prefixes
-/// the functions inside it. Named spaces contribute their AST-derived
-/// name. Anonymous spaces — closures and lambdas, which every grammar
-/// surfaces as the literal `<anonymous>`, plus the `None`-name
-/// parse-failure case — collapse to `<anon@L{start_line}>` so they keep
-/// a stable-within-a-snapshot identity. Baking the line into the segment
-/// means an anonymous function re-keys when it moves (the documented
-/// degradation in `recipes/baselines.md`); named functions do not.
-fn space_segment(space: &FuncSpace) -> String {
-    const ANONYMOUS: &str = "<anonymous>";
-    match space.name.as_deref() {
-        Some(name) if name != ANONYMOUS => name.to_owned(),
-        _ => format!("<anon@L{}>", space.start_line),
-    }
-}
-
-/// The qualified symbol of `space`, given the `::`-joined symbol of its
-/// enclosing chain (`parent_prefix`, empty at file top level). `Unit`
-/// collapses to `<file>`; everything else appends its [`space_segment`].
-fn qualified_symbol(space: &FuncSpace, parent_prefix: &str) -> String {
-    if matches!(space.kind, SpaceKind::Unit) {
-        return "<file>".to_owned();
-    }
-    let segment = space_segment(space);
-    if parent_prefix.is_empty() {
-        segment
-    } else {
-        format!("{parent_prefix}::{segment}")
-    }
 }
 
 /// One resolved threshold: the registry extractor, the configured limit,


### PR DESCRIPTION
## Summary

`bca report markdown|html` rendered the **bare** AST name for each
function, so the ~20 per-language `impl Abc for <Lang>Code { fn
compute(...) }` methods in `src/metrics/abc.rs` all appeared as an
indistinguishable `compute` row in the published GitHub Pages report.
They are distinct functions (distinct line spans, distinct complexity) —
not a double-count — but the bare name made them look like duplicates.

The hotspot walk now prefixes a nested function with its **immediate
enclosing container**, so the rows read `RustCode::compute`,
`KotlinCode::compute`, … — the same disambiguation `bca check` already
applies to offender lines. Both the Markdown and HTML renderers share the
single `extract_summaries` pass, so the HTML Pages site is fixed too.

## Details

- Extracts the shared `space_segment` / `qualified_symbol` helpers out of
  `thresholds.rs` into a new `qualified_name` module.
- `bca check` keeps the full `::`-joined chain (`Outer::Inner::method`)
  for precise offender identity (baseline matching, suppression); the
  **report** uses only the immediate container via `space_segment`,
  keeping each name **O(1)** so a pathologically deep AST cannot inflate
  report memory to **O(depth²)**. For the shallow nesting real code
  produces, the two forms agree (e.g. `RustCode::compute` either way).
- The file-level (`Unit`) rows keep the file path as their name.
- `extract_summaries_inner`'s halstead.effort is suppressed in-source with
  a rationale: it is the volume of the mechanical 30-field `CodeMetrics`
  → `FunctionSummary` projection, not logic complexity.

## Validation

- `extract_nested_spaces` and the 50,000-deep `deeply_nested_spaces_do_not_overflow_stack`
  test now assert the qualified forms (`ClassB::method_c`,
  `f_{DEPTH-1}::f_inner`); the deep test stays at full depth, confirming
  qualification does not reintroduce O(depth²) memory or a stack overflow.
- Verified end-to-end: `bca report html --paths src/metrics/abc.rs` emits
  `BashCode::compute`, `RustCode::compute`, … (previously all `compute`).
- `make pre-commit` green (fmt, clippy, tests, self-scan hard+soft,
  snapshot-anchors, markdown lint, Python stages). `.bca-baseline.toml`
  refreshed for the +1 `mod` line and the report walk's growth.

Found while diagnosing the Pages site report; complements #969 Finding 2
(splitting `abc.rs`), which remains open separately.
