### PR TITLE
test(spaces): expand coverage on refactored modules

### DIFF
--- a/src/spaces_tests.rs
+++ b/src/spaces_tests.rs
@@ -1714,6 +1714,11 @@ fn code_metrics_display_concatenates_reported_submetrics_in_order() {
 /// `name` via `finish_non_exhaustive` (the held tree-sitter tree and
 /// raw source have no meaningful `Debug` projection), without panicking
 /// or leaking the opaque internals.
+// `Ast` is uninhabited when no language grammar is compiled in, so this
+// test (which builds an `Ast` via `Ast::parse`) is gated on a concrete
+// language feature — `cpp`, the language it parses — mirroring the
+// `#[cfg(feature = "rust")]` gate on the `from_path_tests` module below.
+#[cfg(feature = "cpp")]
 #[test]
 fn ast_debug_reports_language_and_name_non_exhaustively() {
     use crate::{Ast, Source};

--- a/src/spaces_tests.rs
+++ b/src/spaces_tests.rs
@@ -1724,21 +1724,26 @@ fn ast_debug_reports_language_and_name_non_exhaustively() {
     .expect("parse of a trivial C++ snippet must succeed");
     let shown = format!("{ast:?}");
 
+    // `debug_struct` renders `Ast { language: <lang>, name: <name>, .. }`.
+    // Assert the field *values* — not just the labels — so a wrong
+    // `language()` or a dropped name is caught, and that
+    // `finish_non_exhaustive` elides the opaque tree/source (the trailing
+    // `..`) rather than printing them.
     assert!(
-        shown.contains("Ast"),
-        "Debug must name the struct: {shown:?}"
+        shown.starts_with("Ast {"),
+        "Debug must render the struct by name: {shown:?}"
     );
     assert!(
-        shown.contains("language"),
-        "Debug must report the language field: {shown:?}"
+        shown.contains("language: Cpp"),
+        "Debug must report the resolved language value, not merely the label: {shown:?}"
     );
     assert!(
-        shown.contains("dbg.cpp"),
-        "Debug must report the caller-supplied name: {shown:?}"
+        shown.contains("name: Some(\"dbg.cpp\")"),
+        "Debug must report the caller-supplied name value: {shown:?}"
     );
     assert!(
-        shown.contains(".."),
-        "finish_non_exhaustive must mark the elided tree/source fields: {shown:?}"
+        shown.trim_end().ends_with(".. }"),
+        "finish_non_exhaustive must elide the tree/source as a trailing `..`: {shown:?}"
     );
 }
 

--- a/src/spaces_tests.rs
+++ b/src/spaces_tests.rs
@@ -1741,3 +1741,58 @@ fn ast_debug_reports_language_and_name_non_exhaustively() {
         "finish_non_exhaustive must mark the elided tree/source fields: {shown:?}"
     );
 }
+
+/// ObjC FuncSpace naming + kind. The per-type getter split isolated
+/// `ObjcCode::get_func_space_name` / `get_space_kind`, and the existing
+/// ObjC `check_func_space` test asserts only a metric sum — which
+/// passes even if a container's name resolves to `None`. Pin the
+/// names *and* kinds for an `@interface`, an `@implementation` + its
+/// method, and a free function, so an ObjC naming regression cannot
+/// hide behind a vacuous metric assertion (#724; lessons 2 & 31).
+#[test]
+fn objc_func_space_tree_carries_names_and_kinds() {
+    use crate::ObjcParser;
+
+    let src = "\
+@interface Greeter : NSObject
+- (int)compute:(int)x;
+@end
+
+@implementation Greeter
+- (int)compute:(int)x {
+    return x + 1;
+}
+@end
+
+int helper(int y) {
+    return y * 2;
+}
+";
+    check_func_space::<ObjcParser, _>(src, "greeter.m", |root| {
+        assert_eq!(root.kind, SpaceKind::Unit, "root is the translation unit");
+        let top: Vec<(SpaceKind, Option<&str>)> = root
+            .spaces
+            .iter()
+            .map(|s| (s.kind, s.name.as_deref()))
+            .collect();
+        assert_eq!(
+            top,
+            vec![
+                (SpaceKind::Interface, Some("Greeter")),
+                (SpaceKind::Class, Some("Greeter")),
+                (SpaceKind::Function, Some("helper")),
+            ],
+            "ObjC top-level spaces (kind, name) in source order; got {top:?}"
+        );
+        let impl_methods: Vec<Option<&str>> = root.spaces[1]
+            .spaces
+            .iter()
+            .map(|s| s.name.as_deref())
+            .collect();
+        assert_eq!(
+            impl_methods,
+            vec![Some("compute")],
+            "the @implementation's method is a named nested Function space"
+        );
+    });
+}

--- a/src/spaces_tests.rs
+++ b/src/spaces_tests.rs
@@ -1676,3 +1676,68 @@ mod from_path_tests {
         ));
     }
 }
+
+/// `CodeMetrics`'s `Display` (extracted to `spaces/code_metrics.rs` in
+/// the per-type split) was exercised by no test. It must concatenate
+/// the nine reported sub-metrics in a fixed order — nargs, nexits,
+/// cognitive, cyclomatic, halstead, loc, nom, tokens, mi — each
+/// `writeln!`-separated, with `mi` last and no trailing newline. Pin
+/// that contract so a future reorder or stray newline is caught.
+#[test]
+fn code_metrics_display_concatenates_reported_submetrics_in_order() {
+    use crate::{Source, analyze};
+
+    let space = analyze(
+        Source::new(crate::LANG::Cpp, b"int add(int a, int b) { return a + b; }"),
+        MetricsOptions::default(),
+    )
+    .expect("analyze must yield a top-level space");
+    let m = &space.metrics;
+
+    let shown = format!("{m}");
+    let expected = format!(
+        "{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}",
+        m.nargs, m.nexits, m.cognitive, m.cyclomatic, m.halstead, m.loc, m.nom, m.tokens, m.mi
+    );
+    assert_eq!(
+        shown, expected,
+        "CodeMetrics Display must be the nine sub-metric Displays in order, newline-joined"
+    );
+    assert!(
+        !shown.ends_with('\n'),
+        "mi is the final block, so Display must not end with a trailing newline: {shown:?}"
+    );
+}
+
+/// `Ast`'s `Debug` (extracted to `spaces/ast.rs`) was untested. It must
+/// honor the public `Ast: Debug` promise by reporting `language` and
+/// `name` via `finish_non_exhaustive` (the held tree-sitter tree and
+/// raw source have no meaningful `Debug` projection), without panicking
+/// or leaking the opaque internals.
+#[test]
+fn ast_debug_reports_language_and_name_non_exhaustively() {
+    use crate::{Ast, Source};
+
+    let ast = Ast::parse(
+        Source::new(crate::LANG::Cpp, b"int a = 42;").with_name(Some("dbg.cpp".to_owned())),
+    )
+    .expect("parse of a trivial C++ snippet must succeed");
+    let shown = format!("{ast:?}");
+
+    assert!(
+        shown.contains("Ast"),
+        "Debug must name the struct: {shown:?}"
+    );
+    assert!(
+        shown.contains("language"),
+        "Debug must report the language field: {shown:?}"
+    );
+    assert!(
+        shown.contains("dbg.cpp"),
+        "Debug must report the caller-supplied name: {shown:?}"
+    );
+    assert!(
+        shown.contains(".."),
+        "finish_non_exhaustive must mark the elided tree/source fields: {shown:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Follow-up to the god-file split (#978): the per-type/per-language split
isolated trait impls and language logic into small modules, which made
several **untested public behaviors** visible in the coverage report.
This adds three focused tests for genuine gaps — no production code
changes.

## Tests added

| Test | Target | Coverage |
|------|--------|----------|
| `CodeMetrics: Display` | `spaces/code_metrics.rs` | region 65% → **90%**, line 72% → **100%** |
| `Ast: Debug` | `spaces/ast.rs` | region 90% → **98%** |
| ObjC FuncSpace names + kinds | `getter/objc.rs` naming arm | structural assertion where ObjC had only metric-sum tests |

- **`CodeMetrics: Display`** pins the nine reported sub-metrics in
  order (nargs … mi), newline-separated, with no trailing newline. The
  `expected` string hard-codes the order independently of the impl, so a
  reorder, dropped/added metric, or stray newline fails it.
- **`Ast: Debug`** asserts the resolved field *values*
  (`language: Cpp`, `name: Some("dbg.cpp")`) and the
  `finish_non_exhaustive` trailing `..`, not just label presence — so a
  wrong `language()` or dropped name is caught.
- **ObjC FuncSpace** asserts the `(kind, name)` tree for an
  `@interface` / `@implementation` + method / free function
  (Interface/Class/Function + Greeter/compute/helper). ObjC (#724)
  previously had only a cognitive-*sum* assertion, which passes even if
  a container name silently resolves to `None` (the vacuous-test failure
  mode of lessons 2 & 31).

## Scope discipline

I triaged every uncovered line across the refactored per-language
modules (`metrics/*/`, `getter/`, `checker/`). The remaining sub-100%
lines are **not** clean behavior gaps — they are defensive guards
(`node.parent() == None`), obscure grammar aliases, and thin
per-language predicates whose shared logic is already tested via other
languages (and `npa/rust`'s associated-const/type behavior is already
covered at npa.rs:3800/3823). Testing those would lower the number
without adding protection, so they were left alone per the project's
"do not game the metric" guideline.

## Validation

`make pre-commit` green (fmt, clippy ×2, full `--workspace
--all-features` tests, doc, udeps, man-page drift, self-scan, Python
stages). Coverage deltas confirmed via a local `cargo llvm-cov nextest
--all-features --workspace` run before and after. Tests live in the
`.bcaignore`'d `spaces_tests.rs`, so no self-scan/baseline impact.
