### PR TITLE
ci(scorecard): add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,57 @@
+name: Scorecard
+
+on:
+  # Re-run when branch protection rules change, since several checks
+  # (Branch-Protection, Code-Review) score that configuration directly.
+  branch_protection_rule:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "41 7 * * 2"
+
+# Declare default permissions as read-only.
+permissions: read-all
+
+concurrency:
+  group: scorecard-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+# All `uses:` below are pinned to commit SHAs to eliminate supply-chain
+# risk from action-release spoofing. Bump via Dependabot (see
+# .github/dependabot.yml), which rewrites the SHA + version comment.
+jobs:
+  analysis:
+    name: analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the SARIF results to the code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and obtain a badge (OIDC token).
+      id-token: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish results to the OpenSSF REST API. Required for the
+          # public badge and the scorecard.dev viewer; only takes effect
+          # on default-branch runs.
+          publish_results: true
+
+      # Retain the SARIF for download from the Actions run (optional).
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![CI](https://github.com/dekobon/big-code-analysis/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/dekobon/big-code-analysis/actions/workflows/ci.yml?query=branch%3Amain+event%3Apush)
 [![codecov](https://codecov.io/gh/dekobon/big-code-analysis/graph/badge.svg)](https://codecov.io/gh/dekobon/big-code-analysis)
 [![CodeQL](https://github.com/dekobon/big-code-analysis/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/dekobon/big-code-analysis/actions/workflows/codeql.yml?query=branch%3Amain)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/dekobon/big-code-analysis/badge)](https://scorecard.dev/viewer/?uri=github.com/dekobon/big-code-analysis)
 [![docs.rs](https://docs.rs/big-code-analysis/badge.svg)](https://docs.rs/big-code-analysis)
 [![License](https://img.shields.io/crates/l/big-code-analysis.svg)](LICENSE)
 


### PR DESCRIPTION
## Summary

Installs [OpenSSF Scorecard](https://github.com/ossf/scorecard) as a
GitHub Actions workflow and adds its badge to the README.

`.github/workflows/scorecard.yml` runs the Scorecard analyzer, uploads
the SARIF to the code-scanning dashboard, and publishes the score to
the public OpenSSF API so the badge and the
[scorecard.dev viewer](https://scorecard.dev/viewer/?uri=github.com/dekobon/big-code-analysis)
work.

## Conventions followed

Mirrors the existing `codeql.yml`:

- **SHA-pinned actions** with version comments, auto-tracked by the
  existing `github-actions` Dependabot entry (`directory: /`, `*`):
  - `ossf/scorecard-action@…` v2.4.3
  - `actions/checkout@…` v7.0.0 (repo pin), `persist-credentials: false`
  - `actions/upload-artifact@…` v7.0.1
  - `github/codeql-action/upload-sarif@…` v4.36.2 (repo pin)
- `permissions: read-all` default; the job adds only
  `security-events: write` and `id-token: write`.
- Matching `concurrency` block.

## Triggers

- `push` to `main`
- weekly `schedule` (Tue 07:41, offset from CodeQL's Mon 06:23)
- `branch_protection_rule` (re-scores when protection settings change)

## Notes

- `publish_results: true` sends the score to the public OpenSSF API on
  default-branch runs — this powers the badge. Flip to `false` to keep
  results private (code-scanning only) and drop the README badge.
- The badge shows grey until the first published run on `main` completes
  after merge.
- `make actionlint` passes clean.
