### PR TITLE
fix(ci): set explicit toolchain for mutation-test job

### DIFF
--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable tip
+        with:
+          toolchain: stable
 
       - name: Cache cargo build artifacts
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1


### PR DESCRIPTION
## Problem

The scheduled **Mutation testing** workflow fails at the `Install Rust toolchain` step:

```
'toolchain' is a required input
##[error]Process completed with exit code 1.
```

Failing run: https://github.com/dekobon/big-code-analysis/actions/runs/28511806150

## Root cause

`dtolnay/rust-toolchain` infers its default toolchain from the **ref name** it is pinned to (`@stable`, `@1.94`, …). This repo pins every action to a bare commit SHA for supply-chain safety, so there is no ref for the action to parse — the `toolchain` input resolves to empty and the step aborts before `cargo-mutants` can run. (The follow-on `upload-artifact` "No files were found in target/mutants/" warning was just a downstream symptom.)

`mutation-test.yml` was the only workflow missing the explicit input; all other `rust-toolchain` invocations across `ci.yml`, `release.yml`, `pages.yml`, etc. already pass `toolchain: stable` (or a pinned version) for exactly this reason.

## Fix

Add the explicit `toolchain: stable` input, matching the sibling workflows. Validated with `make actionlint` (clean).

This workflow is `schedule` / `workflow_dispatch` only, so it is not exercised by PR CI — confirm via a manual `workflow_dispatch` run after merge.
