### PR TITLE
deps(py): bump setuptools to 83.0.0

### DIFF
--- a/big-code-analysis-py/requirements/examples.txt
+++ b/big-code-analysis-py/requirements/examples.txt
@@ -1196,9 +1196,9 @@ send2trash==2.1.0 ; python_full_version < '3.15' and sys_platform != 'emscripten
     --hash=sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c \
     --hash=sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459
     # via jupyter-server
-setuptools==82.0.1 ; python_full_version < '3.15' and sys_platform != 'emscripten' \
-    --hash=sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9 \
-    --hash=sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb
+setuptools==83.0.0 ; python_full_version < '3.15' and sys_platform != 'emscripten' \
+    --hash=sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef \
+    --hash=sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3
     # via jupyterlab
 six==1.17.0 ; python_full_version < '3.15' and sys_platform != 'emscripten' \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \

--- a/big-code-analysis-py/uv.lock
+++ b/big-code-analysis-py/uv.lock
@@ -14,8 +14,8 @@ name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "idna", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' and sys_platform != 'emscripten'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or python_full_version >= '3.15'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
@@ -36,7 +36,7 @@ name = "argon2-cffi"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "argon2-cffi-bindings", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "argon2-cffi-bindings" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
 wheels = [
@@ -48,7 +48,7 @@ name = "argon2-cffi-bindings"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "cffi" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
 wheels = [
@@ -79,8 +79,8 @@ name = "arrow"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "python-dateutil", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "tzdata", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "python-dateutil" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/33/032cdc44182491aa708d06a68b62434140d8c50820a087fac7af37703357/arrow-1.4.0.tar.gz", hash = "sha256:ed0cc050e98001b8779e84d461b0098c4ac597e88704a655582b21d116e526d7", size = 152931, upload-time = "2025-10-18T17:46:46.761Z" }
 wheels = [
@@ -168,8 +168,8 @@ name = "beautifulsoup4"
 version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "soupsieve", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
 wheels = [
@@ -182,19 +182,19 @@ source = { editable = "." }
 
 [package.optional-dependencies]
 dev = [
-    { name = "maturin", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "mypy", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "pyright", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "pytest", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "pytest-cov", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "ruff", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "maturin" },
+    { name = "mypy" },
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
 ]
 examples = [
-    { name = "jupyter", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "matplotlib", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "maturin", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "nbconvert", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "pandas", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "jupyter" },
+    { name = "matplotlib" },
+    { name = "maturin" },
+    { name = "nbconvert" },
+    { name = "pandas" },
 ]
 
 [package.metadata]
@@ -218,7 +218,7 @@ name = "bleach"
 version = "6.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "webencodings", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "webencodings" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/3c/e12ac860709702bd5ebeb9b56a4fe334f1001246ee1b8f2b7ee28912df7d/bleach-6.4.0.tar.gz", hash = "sha256:4202482733d85cedd04e59fcb2f89f4e4c7c385a78d3c3c23c30446843a37452", size = 204857, upload-time = "2026-06-05T13:01:13.734Z" }
 wheels = [
@@ -227,7 +227,7 @@ wheels = [
 
 [package.optional-dependencies]
 css = [
-    { name = "tinycss2", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "tinycss2" },
 ]
 
 [[package]]
@@ -244,7 +244,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "python_full_version < '3.15' and implementation_name != 'PyPy' and sys_platform != 'emscripten'" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -392,7 +392,7 @@ name = "contourpy"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -652,8 +652,8 @@ name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "h11", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "certifi" },
+    { name = "h11" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
@@ -665,10 +665,10 @@ name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "certifi", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "httpcore", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "idna", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
@@ -698,19 +698,19 @@ name = "ipykernel"
 version = "7.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
-    { name = "comm", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "debugpy", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "ipython", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jupyter-client", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jupyter-core", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "nest-asyncio", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "packaging", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "psutil", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "pyzmq", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "tornado", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "traitlets", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
+    { name = "comm" },
+    { name = "debugpy" },
+    { name = "ipython" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "matplotlib-inline" },
+    { name = "nest-asyncio" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ca/8d/b68b728e2d06b9e0051019640a40a9eb7a88fcd82c2e1b5ce70bef5ff044/ipykernel-7.2.0.tar.gz", hash = "sha256:18ed160b6dee2cbb16e5f3575858bc19d8f1fe6046a9a680c708494ce31d909e", size = 176046, upload-time = "2026-02-06T16:43:27.403Z" }
 wheels = [
@@ -722,17 +722,17 @@ name = "ipython"
 version = "9.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.15' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jedi", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "pexpect", marker = "python_full_version < '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "psutil", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "pygments", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "stack-data", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "traitlets", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "psutil" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/87cda5842cf5c31837c06ddb588e11c3c35d8ece89b7a0108c06b8c9b00a/ipython-9.13.0.tar.gz", hash = "sha256:7e834b6afc99f020e3f05966ced34792f40267d64cb1ea9043886dab0dde5967", size = 4430549, upload-time = "2026-04-24T12:24:55.221Z" }
 wheels = [
@@ -744,7 +744,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -756,11 +756,11 @@ name = "ipywidgets"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "comm", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "ipython", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jupyterlab-widgets", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "traitlets", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "widgetsnbextension", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "comm" },
+    { name = "ipython" },
+    { name = "jupyterlab-widgets" },
+    { name = "traitlets" },
+    { name = "widgetsnbextension" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4c/ae/c5ce1edc1afe042eadb445e95b0671b03cee61895264357956e61c0d2ac0/ipywidgets-8.1.8.tar.gz", hash = "sha256:61f969306b95f85fba6b6986b7fe45d73124d1d9e3023a8068710d47a22ea668", size = 116739, upload-time = "2025-11-01T21:18:12.393Z" }
 wheels = [
@@ -772,7 +772,7 @@ name = "isoduration"
 version = "20.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "arrow", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "arrow" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7c/1a/3c8edc664e06e6bd06cce40c6b22da5f1429aa4224d0c590f3be21c91ead/isoduration-20.11.0.tar.gz", hash = "sha256:ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9", size = 11649, upload-time = "2020-11-01T11:00:00.312Z" }
 wheels = [
@@ -784,7 +784,7 @@ name = "jedi"
 version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "parso", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "parso" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/46/b7/a3635f6a2d7cf5b5dd98064fc1d5fbbafcb25477bcea204a3a92145d158b/jedi-0.20.0.tar.gz", hash = "sha256:c3f4ccbd276696f4b19c54618d4fb18f9fc24b0aef02acf704b23f487daa1011", size = 3119416, upload-time = "2026-05-01T23:38:47.814Z" }
 wheels = [
@@ -796,7 +796,7 @@ name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markupsafe", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "markupsafe" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
@@ -826,10 +826,10 @@ name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jsonschema-specifications", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "referencing", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "rpds-py", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
 wheels = [
@@ -838,15 +838,15 @@ wheels = [
 
 [package.optional-dependencies]
 format-nongpl = [
-    { name = "fqdn", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "idna", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "isoduration", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jsonpointer", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "rfc3339-validator", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "rfc3986-validator", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "rfc3987-syntax", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "uri-template", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "webcolors", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "fqdn" },
+    { name = "idna" },
+    { name = "isoduration" },
+    { name = "jsonpointer" },
+    { name = "rfc3339-validator" },
+    { name = "rfc3986-validator" },
+    { name = "rfc3987-syntax" },
+    { name = "uri-template" },
+    { name = "webcolors" },
 ]
 
 [[package]]
@@ -854,7 +854,7 @@ name = "jsonschema-specifications"
 version = "2025.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "referencing", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "referencing" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
@@ -866,12 +866,12 @@ name = "jupyter"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ipykernel", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "ipywidgets", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jupyter-console", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jupyterlab", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "nbconvert", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "notebook", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "ipykernel" },
+    { name = "ipywidgets" },
+    { name = "jupyter-console" },
+    { name = "jupyterlab" },
+    { name = "nbconvert" },
+    { name = "notebook" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/f3/af28ea964ab8bc1e472dba2e82627d36d470c51f5cd38c37502eeffaa25e/jupyter-1.1.1.tar.gz", hash = "sha256:d55467bceabdea49d7e3624af7e33d59c37fff53ed3a350e1ac957bed731de7a", size = 5714959, upload-time = "2024-08-30T07:15:48.299Z" }
 wheels = [
@@ -883,11 +883,11 @@ name = "jupyter-client"
 version = "8.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jupyter-core", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "pyzmq", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "tornado", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "traitlets", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "jupyter-core" },
+    { name = "python-dateutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/05/e4/ba649102a3bc3fbca54e7239fb924fd434c766f855693d86de0b1f2bec81/jupyter_client-8.8.0.tar.gz", hash = "sha256:d556811419a4f2d96c869af34e854e3f059b7cc2d6d01a9cd9c85c267691be3e", size = 348020, upload-time = "2026-01-08T13:55:47.938Z" }
 wheels = [
@@ -899,14 +899,14 @@ name = "jupyter-console"
 version = "6.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ipykernel", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "ipython", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jupyter-client", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jupyter-core", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "pygments", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "pyzmq", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "traitlets", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "ipykernel" },
+    { name = "ipython" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "pyzmq" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bd/2d/e2fd31e2fc41c14e2bcb6c976ab732597e907523f6b2420305f9fc7fdbdb/jupyter_console-6.6.3.tar.gz", hash = "sha256:566a4bf31c87adbfadf22cdf846e3069b59a71ed5da71d6ba4d8aaad14a53539", size = 34363, upload-time = "2023-03-06T14:13:31.02Z" }
 wheels = [
@@ -918,8 +918,8 @@ name = "jupyter-core"
 version = "5.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "platformdirs", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "traitlets", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "platformdirs" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/49/9d1284d0dc65e2c757b74c6687b6d319b02f822ad039e5c512df9194d9dd/jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508", size = 89814, upload-time = "2025-10-16T19:19:18.444Z" }
 wheels = [
@@ -931,14 +931,14 @@ name = "jupyter-events"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jsonschema", extra = ["format-nongpl"], marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "packaging", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "python-json-logger", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "pyyaml", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "referencing", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "rfc3339-validator", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "rfc3986-validator", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "traitlets", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "jsonschema", extra = ["format-nongpl"] },
+    { name = "packaging" },
+    { name = "python-json-logger" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+    { name = "rfc3339-validator" },
+    { name = "rfc3986-validator" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/18/f8/475c4241b2b75af0deaae453ed003c6c851766dbc44d332d8baf245dc931/jupyter_events-0.12.1.tar.gz", hash = "sha256:faff25f77218335752f35f23c5fe6e4a392a7bd99a5939ccb9b8fbf594636cf3", size = 62854, upload-time = "2026-04-20T23:17:50.66Z" }
 wheels = [
@@ -950,7 +950,7 @@ name = "jupyter-lsp"
 version = "2.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jupyter-server", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "jupyter-server" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/36/ff/1e4a61f5170a9a1d978f3ac3872449de6c01fc71eaf89657824c878b1549/jupyter_lsp-2.3.1.tar.gz", hash = "sha256:fdf8a4aa7d85813976d6e29e95e6a2c8f752701f926f2715305249a3829805a6", size = 55677, upload-time = "2026-04-02T08:10:06.749Z" }
 wheels = [
@@ -962,24 +962,24 @@ name = "jupyter-server"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "argon2-cffi", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jinja2", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jupyter-client", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jupyter-core", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jupyter-events", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jupyter-server-terminals", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "nbconvert", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "nbformat", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "packaging", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "prometheus-client", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "pywinpty", marker = "python_full_version < '3.15' and os_name == 'nt' and sys_platform != 'emscripten'" },
-    { name = "pyzmq", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "send2trash", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "terminado", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "tornado", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "traitlets", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "websocket-client", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "anyio" },
+    { name = "argon2-cffi" },
+    { name = "jinja2" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "jupyter-events" },
+    { name = "jupyter-server-terminals" },
+    { name = "nbconvert" },
+    { name = "nbformat" },
+    { name = "packaging" },
+    { name = "prometheus-client" },
+    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "pyzmq" },
+    { name = "send2trash" },
+    { name = "terminado" },
+    { name = "tornado" },
+    { name = "traitlets" },
+    { name = "websocket-client" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6b/dc/db3a582633170186f8c8b31298d7eb26ad0eb031a1f53476c258b64eed05/jupyter_server-2.20.0.tar.gz", hash = "sha256:b5778ba337d8015a3dc2b80803ecdd5ac18d3797fddf61a50ea5fb472b4ebe14", size = 756523, upload-time = "2026-06-17T12:09:09.435Z" }
 wheels = [
@@ -991,8 +991,8 @@ name = "jupyter-server-terminals"
 version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywinpty", marker = "python_full_version < '3.15' and os_name == 'nt' and sys_platform != 'emscripten'" },
-    { name = "terminado", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "terminado" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f4/a7/bcd0a9b0cbba88986fe944aaaf91bfda603e5a50bda8ed15123f381a3b2f/jupyter_server_terminals-0.5.4.tar.gz", hash = "sha256:bbda128ed41d0be9020349f9f1f2a4ab9952a73ed5f5ac9f1419794761fb87f5", size = 31770, upload-time = "2026-01-14T16:53:20.213Z" }
 wheels = [
@@ -1004,19 +1004,19 @@ name = "jupyterlab"
 version = "4.5.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "async-lru", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "httpx", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "ipykernel", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jinja2", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jupyter-core", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jupyter-lsp", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jupyter-server", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jupyterlab-server", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "notebook-shim", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "packaging", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "setuptools", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "tornado", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "traitlets", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "async-lru" },
+    { name = "httpx" },
+    { name = "ipykernel" },
+    { name = "jinja2" },
+    { name = "jupyter-core" },
+    { name = "jupyter-lsp" },
+    { name = "jupyter-server" },
+    { name = "jupyterlab-server" },
+    { name = "notebook-shim" },
+    { name = "packaging" },
+    { name = "setuptools" },
+    { name = "tornado" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e8/52/a8d4895bef501ffeb6af448e8bf7079541c7772978211963aa653518c2d9/jupyterlab-4.5.9.tar.gz", hash = "sha256:dd79a073fecae7a39066ea99e4627ed6c76269ac926e95a810e1e1df6358d865", size = 23994445, upload-time = "2026-06-17T15:42:16.406Z" }
 wheels = [
@@ -1037,13 +1037,13 @@ name = "jupyterlab-server"
 version = "2.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "babel", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jinja2", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "json5", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jsonschema", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jupyter-server", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "packaging", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "requests", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "babel" },
+    { name = "jinja2" },
+    { name = "json5" },
+    { name = "jsonschema" },
+    { name = "jupyter-server" },
+    { name = "packaging" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d6/2c/90153f189e421e93c4bb4f9e3f59802a1f01abd2ac5cf40b152d7f735232/jupyterlab_server-2.28.0.tar.gz", hash = "sha256:35baa81898b15f93573e2deca50d11ac0ae407ebb688299d3a5213265033712c", size = 76996, upload-time = "2025-10-22T13:59:18.37Z" }
 wheels = [
@@ -1282,15 +1282,15 @@ name = "matplotlib"
 version = "3.10.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "contourpy", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "cycler", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "fonttools", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "kiwisolver", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "numpy", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "packaging", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "pillow", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "pyparsing", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "contourpy" },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
 wheels = [
@@ -1336,7 +1336,7 @@ name = "matplotlib-inline"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "traitlets", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bd/c0/9f7c9a46090390368a4d7bcb76bb87a4a36c421e4c0792cdb53486ffac7a/matplotlib_inline-0.2.2.tar.gz", hash = "sha256:72f3fe8fce36b70d4a5b612f899090cd0401deddc4ea90e1572b9f4bfb058c79", size = 8150, upload-time = "2026-05-08T17:33:33.49Z" }
 wheels = [
@@ -1378,11 +1378,11 @@ name = "mypy"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ast-serialize", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "librt", marker = "python_full_version < '3.15' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'" },
-    { name = "mypy-extensions", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "pathspec", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/82/15/cca9d88503549ed6fedeaa1d448cdddd542ee8a490232d732e278036fbf2/mypy-2.1.0.tar.gz", hash = "sha256:81e76ad12c2d804512e9b13240d1588316531bfba07558286078bfbce9613633", size = 3898359, upload-time = "2026-05-11T18:37:36.237Z" }
 wheels = [
@@ -1431,10 +1431,10 @@ name = "nbclient"
 version = "0.10.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jupyter-client", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jupyter-core", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "nbformat", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "traitlets", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "nbformat" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/56/91/1c1d5a4b9a9ebba2b4e32b8c852c2975c872aec1fe42ab5e516b2cecd193/nbclient-0.10.4.tar.gz", hash = "sha256:1e54091b16e6da39e297b0ece3e10f6f29f4ac4e8ee515d29f8a7099bd6553c9", size = 62554, upload-time = "2025-12-23T07:45:46.369Z" }
 wheels = [
@@ -1446,20 +1446,20 @@ name = "nbconvert"
 version = "7.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "beautifulsoup4", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "bleach", extra = ["css"], marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "defusedxml", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jinja2", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jupyter-core", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jupyterlab-pygments", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "markupsafe", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "mistune", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "nbclient", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "nbformat", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "packaging", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "pandocfilters", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "pygments", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "traitlets", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "beautifulsoup4" },
+    { name = "bleach", extra = ["css"] },
+    { name = "defusedxml" },
+    { name = "jinja2" },
+    { name = "jupyter-core" },
+    { name = "jupyterlab-pygments" },
+    { name = "markupsafe" },
+    { name = "mistune" },
+    { name = "nbclient" },
+    { name = "nbformat" },
+    { name = "packaging" },
+    { name = "pandocfilters" },
+    { name = "pygments" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/01/b1/708e53fe2e429c103c6e6e159106bcf0357ac41aa4c28772bd8402339051/nbconvert-7.17.1.tar.gz", hash = "sha256:34d0d0a7e73ce3cbab6c5aae8f4f468797280b01fd8bd2ca746da8569eddd7d2", size = 865311, upload-time = "2026-04-08T00:44:14.914Z" }
 wheels = [
@@ -1471,10 +1471,10 @@ name = "nbformat"
 version = "5.10.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "fastjsonschema", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jsonschema", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jupyter-core", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "traitlets", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "fastjsonschema" },
+    { name = "jsonschema" },
+    { name = "jupyter-core" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6d/fd/91545e604bc3dad7dca9ed03284086039b294c6b3d75c0d2fa45f9e9caf3/nbformat-5.10.4.tar.gz", hash = "sha256:322168b14f937a5d11362988ecac2a4952d3d8e3a2cbeb2319584631226d5b3a", size = 142749, upload-time = "2024-04-04T11:20:37.371Z" }
 wheels = [
@@ -1504,11 +1504,11 @@ name = "notebook"
 version = "7.5.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jupyter-server", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jupyterlab", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "jupyterlab-server", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "notebook-shim", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "tornado", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "jupyter-server" },
+    { name = "jupyterlab" },
+    { name = "jupyterlab-server" },
+    { name = "notebook-shim" },
+    { name = "tornado" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2a/c2/cf59bd2e6f2c8b976b52477e3e53bf6f97bc714ed046a51821afb428eaee/notebook-7.5.6.tar.gz", hash = "sha256:621174aade80108f0020b0f00738000b215f75fa3cd90771ad7aa0f24536a4e1", size = 14170814, upload-time = "2026-04-30T11:46:26.613Z" }
 wheels = [
@@ -1520,7 +1520,7 @@ name = "notebook-shim"
 version = "0.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jupyter-server", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "jupyter-server" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/54/d2/92fa3243712b9a3e8bafaf60aac366da1cada3639ca767ff4b5b3654ec28/notebook_shim-0.2.4.tar.gz", hash = "sha256:b4b2cfa1b65d98307ca24361f5b30fe785b53c3fd07b7a47e89acb5e6ac638cb", size = 13167, upload-time = "2024-02-14T23:35:18.353Z" }
 wheels = [
@@ -1602,9 +1602,9 @@ name = "pandas"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "tzdata", marker = "python_full_version < '3.15' and sys_platform == 'win32'" },
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
 wheels = [
@@ -1681,7 +1681,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -1791,7 +1791,7 @@ name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wcwidth", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "wcwidth" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
 wheels = [
@@ -1876,8 +1876,8 @@ name = "pyright"
 version = "1.1.409"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nodeenv", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
 wheels = [
@@ -1889,11 +1889,11 @@ name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.15' and sys_platform == 'win32'" },
-    { name = "iniconfig", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "packaging", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "pluggy", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "pygments", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
@@ -1905,9 +1905,9 @@ name = "pytest-cov"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "coverage", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "pluggy", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "pytest", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
@@ -1919,7 +1919,7 @@ name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "six", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "six" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
@@ -2004,7 +2004,7 @@ name = "pyzmq"
 version = "27.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "python_full_version < '3.15' and implementation_name == 'pypy' and sys_platform != 'emscripten'" },
+    { name = "cffi", marker = "implementation_name == 'pypy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
 wheels = [
@@ -2047,9 +2047,9 @@ name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "rpds-py", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' and sys_platform != 'emscripten'" },
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or python_full_version >= '3.15'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
@@ -2061,10 +2061,10 @@ name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "charset-normalizer", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "idna", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "urllib3", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
@@ -2076,7 +2076,7 @@ name = "rfc3339-validator"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "six", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "six" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b", size = 5513, upload-time = "2021-05-12T16:37:54.178Z" }
 wheels = [
@@ -2097,7 +2097,7 @@ name = "rfc3987-syntax"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "lark", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "lark" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2c/06/37c1a5557acf449e8e406a830a05bf885ac47d33270aec454ef78675008d/rfc3987_syntax-1.1.0.tar.gz", hash = "sha256:717a62cbf33cffdd16dfa3a497d81ce48a660ea691b1ddd7be710c22f00b4a0d", size = 14239, upload-time = "2025-07-18T01:05:05.015Z" }
 wheels = [
@@ -2221,11 +2221,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]
@@ -2251,9 +2251,9 @@ name = "stack-data"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "asttokens", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "executing", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "pure-eval", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "pure-eval" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
 wheels = [
@@ -2265,9 +2265,9 @@ name = "terminado"
 version = "0.18.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "python_full_version < '3.15' and os_name != 'nt' and sys_platform != 'emscripten'" },
-    { name = "pywinpty", marker = "python_full_version < '3.15' and os_name == 'nt' and sys_platform != 'emscripten'" },
-    { name = "tornado", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "ptyprocess", marker = "os_name != 'nt'" },
+    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "tornado" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }
 wheels = [
@@ -2279,7 +2279,7 @@ name = "tinycss2"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "webencodings", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
+    { name = "webencodings" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/fd/7a5ee21fd08ff70d3d33a5781c255cbe779659bd03278feb98b19ee550f4/tinycss2-1.4.0.tar.gz", hash = "sha256:10c0972f6fc0fbee87c3edb76549357415e94548c1ae10ebccdea16fb404a9b7", size = 87085, upload-time = "2024-10-24T14:58:29.895Z" }
 wheels = [


### PR DESCRIPTION
## Summary
- Fixes Dependabot alerts [#38](https://github.com/dekobon/big-code-analysis/security/dependabot/38) and [#39](https://github.com/dekobon/big-code-analysis/security/dependabot/39): `setuptools < 83.0.0` has a MANIFEST.in exclusion-bypass vulnerability in sdist builds via Unicode NFC/NFD normalization collisions on macOS APFS/HFS+.
- `setuptools` is a transitive dependency pulled in via the `examples` extra's `jupyterlab` dependency (not referenced directly in `pyproject.toml`). Bumped with `uv lock --upgrade-package setuptools` (82.0.1 → 83.0.0) and re-exported `requirements/examples.txt` via the same commands `make py-relock` runs.
- `requirements/dev.txt` is untouched since `setuptools` isn't reachable from the `dev` extra.
- The bulk of the `uv.lock` diff is marker-expression reformatting produced by the current `uv` release relative to the `[tool.uv].environments` restriction in `pyproject.toml` — verified algebraically equivalent to the prior markers, not a semantic change.

## Test plan
- [x] `uv sync --locked --extra dev` succeeds (lockfile self-consistent)
- [x] `make py-test` — 362 passed, 1 xfailed
- [x] Verified setuptools hashes/version in both flagged files (`uv.lock`, `requirements/examples.txt`)
- [x] Confirmed no other package version/hash changed as a side effect