### PR TITLE
fix(metrics/loc): guard doc-comment row discount at EOF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,22 @@ for historical reference.
 
 ### Fixed
 
+- A Rust doc comment ending at EOF without a trailing newline no longer
+  panics the analyzer (#1051). `Loc` discounts the row that a
+  `DocComment`'s scanner consumes along with its newline, but at EOF
+  there is no newline left to consume, so the node ends on its own start
+  row and the unconditional `end - 1` underflowed. Debug builds panicked
+  at the subtraction; release builds wrapped to `usize::MAX` and
+  surfaced far away as a hash-table capacity overflow while inserting
+  comment rows. Inputs as small as `/// x` were affected. The first-party
+  binaries never reached this — `bca`, `bca-web`, and the Python bindings
+  all normalize line endings, which appends a trailing newline — but
+  library callers using `analyze` / `Source` directly (the documented
+  entry point, and the shape a fuzz harness would use) did. `Loc` now
+  discounts the row only when the node actually spans one, and
+  `add_cloc_lines` carries a `debug_assert` documenting its
+  `end >= start` precondition so a future caller cannot reintroduce the
+  wrap silently. Metric values for all other inputs are unchanged.
 - docs.rs now publishes the **complete** API reference. The published
   build previously used default features only, silently dropping the
   entire feature-gated `vcs` module (change-history metrics, #328) from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,21 +57,29 @@ for historical reference.
 ### Fixed
 
 - A Rust doc comment ending at EOF without a trailing newline no longer
-  panics the analyzer (#1051). `Loc` discounts the row that a
+  crashes or miscounts (#1051). `Loc` discounts the row that a
   `DocComment`'s scanner consumes along with its newline, but at EOF
   there is no newline left to consume, so the node ends on its own start
-  row and the unconditional `end - 1` underflowed. Debug builds panicked
-  at the subtraction; release builds wrapped to `usize::MAX` and
-  surfaced far away as a hash-table capacity overflow while inserting
-  comment rows. Inputs as small as `/// x` were affected. The first-party
-  binaries never reached this — `bca`, `bca-web`, and the Python bindings
-  all normalize line endings, which appends a trailing newline — but
-  library callers using `analyze` / `Source` directly (the documented
-  entry point, and the shape a fuzz harness would use) did. `Loc` now
-  discounts the row only when the node actually spans one, and
-  `add_cloc_lines` carries a `debug_assert` documenting its
-  `end >= start` precondition so a future caller cannot reintroduce the
-  wrap silently. Metric values for all other inputs are unchanged.
+  row and the row was discounted anyway. The symptom split by where the
+  comment sat:
+  - **On the first row** (`/// x` as the whole file): the analyzer
+    panicked — in debug at the subtraction, in release as a hash-table
+    capacity overflow while inserting comment rows.
+  - **On any later row** (`fn f() {}\n/// x`): release builds did **not**
+    crash. They silently reported `cloc` one too low, which also shifted
+    `blank` and the Maintainability Index's comment percentage.
+
+  **This changes metric values.** Any Rust file whose last line is a doc
+  comment with no trailing newline now reports one more `cloc` (and one
+  fewer `blank`) than a `2.0.1` release build did; two such comments
+  shift by two. Re-check `.bca-baseline.toml` entries and thresholds for
+  affected files.
+
+  Reachable from `analyze` / `Source` (the documented library entry
+  point) and from the Python `Ast.parse(...).metrics()` fast path, which
+  — unlike `analyze_source` and `Ast.from_path` — does not normalize
+  line endings. The `bca` CLI and every `bca-web` endpoint that computes
+  metrics normalize their input and were unaffected.
 - docs.rs now publishes the **complete** API reference. The published
   build previously used default features only, silently dropping the
   entire feature-gated `vcs` module (change-history metrics, #328) from

--- a/docs/development/lessons_learned.md
+++ b/docs/development/lessons_learned.md
@@ -422,17 +422,21 @@ spans when its scanner consumes the trailing newline; at EOF there is
 none to consume, so the unconditional `end - 1` underflowed —
 panicking in debug, and in release wrapping to `usize::MAX` and
 surfacing far away as a hash-table capacity overflow while inserting
-comment rows. Every LOC test routes through `check_metrics` →
+comment rows. The unit LOC tests route through `check_metrics` →
 `tools::check_func_space`, which does `trim_end().trim_matches('\n')`
 and then `push(b'\n')`: it strips trailing newlines and appends one.
-"A node ending at EOF" is therefore unreachable through the helper, so
-the suite had no path to the bug — and a regression test written the
-ordinary way would have passed against the unfixed code. The fix added
-a `loc_verbatim` helper calling `analyze(Source::new(..))` with no
-normalization, carrying a doc comment explaining why it must not be
-"simplified" back to `check_metrics`. Sharper than the NaN case above:
-there the filter sat in one test's call path; here it is in the
-canonical helper an entire metric family shares.
+The integration snapshot suites (`tests/serde_test.rs` and siblings)
+bypass that helper entirely — but reach the same wall, because
+`read_file_with_eol` → `normalize_line_endings` ends with an
+unconditional `data.push(b'\n')`. "A node ending at EOF" is therefore
+unreachable from *either* harness, so the suite had no path to the bug
+— and a regression test written the ordinary way would have passed
+against the unfixed code. The fix added a `loc_verbatim` helper calling
+`analyze(Source::new(..))` with no normalization, carrying a doc
+comment explaining why it must not be "simplified" back to
+`check_metrics`. Sharper than the NaN case above: there the filter sat
+in one test's call path; here two independent chokepoints normalize the
+input class out of reach of the whole suite.
 
 **Section-presence tests with no value assertions** (`df84dd27`).
 `wmc_section_present_with_class_summaries`,

--- a/docs/development/lessons_learned.md
+++ b/docs/development/lessons_learned.md
@@ -416,6 +416,24 @@ intermediate stage filters, normalizes, or short-circuits the
 input. Always pair end-to-end tests with direct unit tests on the
 function whose contract is being verified.
 
+**A normalizing shared helper made an entire input class untestable**
+(#1051, `aaddda98`). `Loc` discounts the extra row a Rust `DocComment`
+spans when its scanner consumes the trailing newline; at EOF there is
+none to consume, so the unconditional `end - 1` underflowed —
+panicking in debug, and in release wrapping to `usize::MAX` and
+surfacing far away as a hash-table capacity overflow while inserting
+comment rows. Every LOC test routes through `check_metrics` →
+`tools::check_func_space`, which does `trim_end().trim_matches('\n')`
+and then `push(b'\n')`: it strips trailing newlines and appends one.
+"A node ending at EOF" is therefore unreachable through the helper, so
+the suite had no path to the bug — and a regression test written the
+ordinary way would have passed against the unfixed code. The fix added
+a `loc_verbatim` helper calling `analyze(Source::new(..))` with no
+normalization, carrying a doc comment explaining why it must not be
+"simplified" back to `check_metrics`. Sharper than the NaN case above:
+there the filter sat in one test's call path; here it is in the
+canonical helper an entire metric family shares.
+
 **Section-presence tests with no value assertions** (`df84dd27`).
 `wmc_section_present_with_class_summaries`,
 `nexits_section_present`, and `abc_section_present` originally

--- a/src/metrics/loc.rs
+++ b/src/metrics/loc.rs
@@ -9853,4 +9853,90 @@ class A {
             },
         );
     }
+
+    /// Analyses `source` **verbatim**.
+    ///
+    /// `check_metrics` cannot be used for the #1051 cases: it routes through
+    /// `tools::check_func_space`, which trims trailing newlines and appends
+    /// one, so a node ending at EOF is unreachable through it and any such
+    /// test would pass vacuously. `Source` applies no normalisation of its
+    /// own, so this is the in-tree path that reproduces the bug.
+    fn loc_verbatim(source: &[u8]) -> Stats {
+        crate::analyze(
+            crate::Source::new(crate::LANG::Rust, source),
+            crate::MetricsOptions::default(),
+        )
+        .expect("verbatim source must analyse")
+        .metrics
+        .loc
+    }
+
+    /// #1051: a Rust doc comment ending at EOF has no trailing newline for
+    /// the scanner to consume, so its `LineComment` node ends on its own
+    /// start row and the `end - 1` adjustment underflowed. Debug builds
+    /// panicked at the subtraction; release builds wrapped to `usize::MAX`
+    /// and surfaced far away as a hash-table capacity overflow inside
+    /// `add_only_comment_lines`.
+    #[test]
+    fn rust_doc_comment_at_eof_does_not_underflow() {
+        // `end == start == 0` — underflowed at the subtraction itself.
+        // expected: the sole row is one comment-only line, no code.
+        let outer = loc_verbatim(b"/// x");
+        assert_eq!(outer.cloc(), 1);
+        assert_eq!(outer.ploc(), 0);
+
+        let inner = loc_verbatim(b"//! x");
+        assert_eq!(inner.cloc(), 1);
+        assert_eq!(inner.ploc(), 0);
+
+        // `end == start > 0` — the subtraction succeeded but drove `end`
+        // below `start`, underflowing `add_cloc_lines` instead.
+        // expected: row 0 is code, row 1 is comment-only.
+        let after_code = loc_verbatim(b"fn f(){}\n/// x");
+        assert_eq!(after_code.cloc(), 1);
+        assert_eq!(after_code.ploc(), 1);
+
+        // A doc comment sharing its row with code: one code line that also
+        // carries a comment.
+        let trailing = loc_verbatim(b"let x = 1; /// d");
+        assert_eq!(trailing.cloc(), 1);
+        assert_eq!(trailing.ploc(), 1);
+    }
+
+    /// A doc comment at EOF must count exactly like a plain line comment at
+    /// EOF. The `DocComment` adjustment exists only to discount the newline
+    /// the scanner consumes; at EOF there is none to discount, so the two
+    /// shapes are indistinguishable for LOC purposes. Asserting parity
+    /// rather than literal numbers keeps this honest if the LOC accounting
+    /// is ever retuned.
+    #[test]
+    fn rust_doc_comment_at_eof_matches_plain_comment() {
+        let plain = loc_verbatim(b"// x");
+        for doc in [&b"/// x"[..], &b"//! x"[..]] {
+            let doc = loc_verbatim(doc);
+            assert_eq!(doc.cloc(), plain.cloc());
+            assert_eq!(doc.ploc(), plain.ploc());
+            assert_eq!(doc.sloc(), plain.sloc());
+            assert_eq!(doc.blank(), plain.blank());
+        }
+    }
+
+    /// The newline-terminated path must stay unchanged by the #1051 guard.
+    /// A `DocComment` node really does span one row more than it renders
+    /// whenever the scanner consumed a newline, and that row must still be
+    /// excluded — otherwise the guard would silently become a no-op and
+    /// inflate CLOC for every doc-commented Rust file.
+    #[test]
+    fn rust_doc_comment_with_trailing_newline_still_discounts_the_row() {
+        // expected: one rendered comment row, not two.
+        assert_eq!(loc_verbatim(b"/// x\n").cloc(), 1);
+        // expected: two consecutive doc comments are two rows, not four.
+        assert_eq!(loc_verbatim(b"/// a\n/// b\n").cloc(), 2);
+
+        // The common real-world shape: doc comment attached to an item.
+        // expected: row 0 comment-only, row 1 code.
+        let documented = loc_verbatim(b"/// doc\nfn f() {}\n");
+        assert_eq!(documented.cloc(), 1);
+        assert_eq!(documented.ploc(), 1);
+    }
 }

--- a/src/metrics/loc.rs
+++ b/src/metrics/loc.rs
@@ -9854,16 +9854,19 @@ class A {
         );
     }
 
-    /// Analyses `source` **verbatim**.
+    /// Analyses `source` **verbatim** in `lang`.
     ///
     /// `check_metrics` cannot be used for the #1051 cases: it routes through
     /// `tools::check_func_space`, which trims trailing newlines and appends
     /// one, so a node ending at EOF is unreachable through it and any such
     /// test would pass vacuously. `Source` applies no normalisation of its
     /// own, so this is the in-tree path that reproduces the bug.
-    fn loc_verbatim(source: &[u8]) -> Stats {
+    ///
+    /// Takes `lang` rather than hard-coding one: the untestable-at-EOF class
+    /// is shared by every `Loc` submodule, not just Rust's.
+    fn loc_verbatim(lang: crate::LANG, source: &[u8]) -> Stats {
         crate::analyze(
-            crate::Source::new(crate::LANG::Rust, source),
+            crate::Source::new(lang, source),
             crate::MetricsOptions::default(),
         )
         .expect("verbatim source must analyse")
@@ -9871,34 +9874,45 @@ class A {
         .loc
     }
 
+    /// `loc_verbatim` bound to Rust, which is where #1051 lives.
+    fn rust_loc(source: &[u8]) -> Stats {
+        loc_verbatim(crate::LANG::Rust, source)
+    }
+
     /// #1051: a Rust doc comment ending at EOF has no trailing newline for
     /// the scanner to consume, so its `LineComment` node ends on its own
-    /// start row and the `end - 1` adjustment underflowed. Debug builds
-    /// panicked at the subtraction; release builds wrapped to `usize::MAX`
-    /// and surfaced far away as a hash-table capacity overflow inside
-    /// `add_only_comment_lines`.
+    /// start row and discounting a row underflowed. On row 0 that panicked
+    /// (debug: the subtraction; release: a hash-table capacity overflow in
+    /// `add_only_comment_lines`). On any later row release did not crash —
+    /// it silently reported one `cloc` too few.
     #[test]
     fn rust_doc_comment_at_eof_does_not_underflow() {
         // `end == start == 0` — underflowed at the subtraction itself.
         // expected: the sole row is one comment-only line, no code.
-        let outer = loc_verbatim(b"/// x");
+        let outer = rust_loc(b"/// x");
         assert_eq!(outer.cloc(), 1);
         assert_eq!(outer.ploc(), 0);
 
-        let inner = loc_verbatim(b"//! x");
+        let inner = rust_loc(b"//! x");
         assert_eq!(inner.cloc(), 1);
         assert_eq!(inner.ploc(), 0);
 
         // `end == start > 0` — the subtraction succeeded but drove `end`
-        // below `start`, underflowing `add_cloc_lines` instead.
+        // below `start`. Release silently counted `cloc == 0` here.
         // expected: row 0 is code, row 1 is comment-only.
-        let after_code = loc_verbatim(b"fn f(){}\n/// x");
+        let after_code = rust_loc(b"fn f(){}\n/// x");
         assert_eq!(after_code.cloc(), 1);
         assert_eq!(after_code.ploc(), 1);
 
-        // A doc comment sharing its row with code: one code line that also
-        // carries a comment.
-        let trailing = loc_verbatim(b"let x = 1; /// d");
+        // Two doc comments, the second at EOF: both rows are comment-only.
+        // Pre-fix release reported 1 here, not 2.
+        assert_eq!(rust_loc(b"/// a\n/// b").cloc(), 2);
+
+        // A doc comment sharing its row with code. `let` is not valid at
+        // file scope, but tree-sitter parses it as a clean `let_declaration`
+        // + `line_comment`, which is the only way to reach the
+        // comment-after-code branch (no *valid* Rust puts `///` after code).
+        let trailing = rust_loc(b"let x = 1; /// d");
         assert_eq!(trailing.cloc(), 1);
         assert_eq!(trailing.ploc(), 1);
     }
@@ -9906,14 +9920,18 @@ class A {
     /// A doc comment at EOF must count exactly like a plain line comment at
     /// EOF. The `DocComment` adjustment exists only to discount the newline
     /// the scanner consumes; at EOF there is none to discount, so the two
-    /// shapes are indistinguishable for LOC purposes. Asserting parity
-    /// rather than literal numbers keeps this honest if the LOC accounting
-    /// is ever retuned.
+    /// shapes are indistinguishable for LOC purposes.
     #[test]
     fn rust_doc_comment_at_eof_matches_plain_comment() {
-        let plain = loc_verbatim(b"// x");
+        let plain = rust_loc(b"// x");
+        // Pin the baseline absolutely too: parity alone would still hold if
+        // both sides moved together, and would then read as a regression
+        // when the un-newline-terminated `sloc` accounting is corrected.
+        assert_eq!(plain.cloc(), 1);
+        assert_eq!(plain.ploc(), 0);
+
         for doc in [&b"/// x"[..], &b"//! x"[..]] {
-            let doc = loc_verbatim(doc);
+            let doc = rust_loc(doc);
             assert_eq!(doc.cloc(), plain.cloc());
             assert_eq!(doc.ploc(), plain.ploc());
             assert_eq!(doc.sloc(), plain.sloc());
@@ -9929,14 +9947,32 @@ class A {
     #[test]
     fn rust_doc_comment_with_trailing_newline_still_discounts_the_row() {
         // expected: one rendered comment row, not two.
-        assert_eq!(loc_verbatim(b"/// x\n").cloc(), 1);
+        assert_eq!(rust_loc(b"/// x\n").cloc(), 1);
         // expected: two consecutive doc comments are two rows, not four.
-        assert_eq!(loc_verbatim(b"/// a\n/// b\n").cloc(), 2);
+        assert_eq!(rust_loc(b"/// a\n/// b\n").cloc(), 2);
 
         // The common real-world shape: doc comment attached to an item.
         // expected: row 0 comment-only, row 1 code.
-        let documented = loc_verbatim(b"/// doc\nfn f() {}\n");
+        let documented = rust_loc(b"/// doc\nfn f() {}\n");
         assert_eq!(documented.cloc(), 1);
         assert_eq!(documented.ploc(), 1);
+    }
+
+    /// CRLF is the boundary the guard must *not* fire on. `\r` is ordinary
+    /// content to `process_line_doc_content`, so it consumes the following
+    /// `\n` and the node does span an extra row — the discount is still
+    /// owed. A lone trailing `\r` at EOF is the opposite case. Without this,
+    /// a future grammar bump that stops consuming the newline would leave
+    /// every LF test passing while the discount silently became dead code.
+    #[test]
+    fn rust_doc_comment_crlf_still_discounts_the_row() {
+        // Newline consumed despite the `\r`: discount applies.
+        assert_eq!(rust_loc(b"/// x\r\n").cloc(), 1);
+        // expected: row 0 code, row 1 comment-only.
+        let after_code = rust_loc(b"fn f(){}\r\n/// x");
+        assert_eq!(after_code.cloc(), 1);
+        assert_eq!(after_code.ploc(), 1);
+        // Lone `\r`, then EOF: no newline consumed, so no discount is owed.
+        assert_eq!(rust_loc(b"/// x\r").cloc(), 1);
     }
 }

--- a/src/metrics/loc/rust.rs
+++ b/src/metrics/loc/rust.rs
@@ -41,17 +41,17 @@ impl Loc for RustCode {
                 add_cloc_lines(stats, start, end);
             }
             LineComment => {
-                // Exclude the last line for `LineComment` containing a `DocComment`,
-                // since the `DocComment` includes the newline,
-                // as explained here: https://github.com/tree-sitter/tree-sitter-rust/blob/2eaf126458a4d6a69401089b6ba78c5e5d6c1ced/src/scanner.c#L194-L195
+                // tree-sitter-rust's `process_line_doc_content` (see
+                // `src/scanner.c` in the pinned grammar crate) consumes the
+                // trailing newline into the `DocComment`, so the node spans
+                // one row more than it renders — except at EOF, where it
+                // returns without consuming one. Discount that row only when
+                // the node really spans it; discounting unconditionally
+                // underflowed (#1051).
                 //
-                // The `end > start` guard covers the one case where that
-                // does not hold: a doc comment ending at EOF has no newline
-                // left to consume, so the node ends on its own start row and
-                // there is no extra row to exclude. Subtracting anyway
-                // underflows `end` (or drives it below `start`, underflowing
-                // `add_cloc_lines`) — see #1051.
-                let end = if node.is_child(DocComment as u16) && end > start {
+                // Cheap operand first: `end > start` is false for every plain
+                // line comment, short-circuiting `is_child`'s child walk.
+                let end = if end > start && node.is_child(DocComment as u16) {
                     end - 1
                 } else {
                     end

--- a/src/metrics/loc/rust.rs
+++ b/src/metrics/loc/rust.rs
@@ -44,7 +44,14 @@ impl Loc for RustCode {
                 // Exclude the last line for `LineComment` containing a `DocComment`,
                 // since the `DocComment` includes the newline,
                 // as explained here: https://github.com/tree-sitter/tree-sitter-rust/blob/2eaf126458a4d6a69401089b6ba78c5e5d6c1ced/src/scanner.c#L194-L195
-                let end = if node.is_child(DocComment as u16) {
+                //
+                // The `end > start` guard covers the one case where that
+                // does not hold: a doc comment ending at EOF has no newline
+                // left to consume, so the node ends on its own start row and
+                // there is no extra row to exclude. Subtracting anyway
+                // underflows `end` (or drives it below `start`, underflowing
+                // `add_cloc_lines`) — see #1051.
+                let end = if node.is_child(DocComment as u16) && end > start {
                     end - 1
                 } else {
                     end

--- a/src/metrics/loc/shared.rs
+++ b/src/metrics/loc/shared.rs
@@ -42,7 +42,16 @@ pub(crate) fn init(
 // the ones that are on an independent line.
 // This difference is necessary in order to avoid having
 // a wrong count for the blank metric.
+//
+// Requires `end >= start`. Every caller passes the row span returned by
+// `init`, and tree-sitter guarantees a node's end row is never before its
+// start row — so the only way to violate this is for a caller to adjust
+// `end` downwards itself, as Rust's `LineComment` arm does for doc
+// comments (#1051). The assert keeps such a regression loud in tests
+// instead of wrapping to `usize::MAX` in release and surfacing far away
+// as a hash-table capacity overflow.
 pub(crate) fn add_cloc_lines(stats: &mut Stats, start: usize, end: usize) {
+    debug_assert!(end >= start, "add_cloc_lines: end {end} < start {start}");
     let comment_diff = end - start;
     let is_comment_after_code_line = stats.ploc.lines.contains(&start);
     if is_comment_after_code_line && comment_diff == 0 {

--- a/src/metrics/loc/shared.rs
+++ b/src/metrics/loc/shared.rs
@@ -47,9 +47,14 @@ pub(crate) fn init(
 // `init`, and tree-sitter guarantees a node's end row is never before its
 // start row — so the only way to violate this is for a caller to adjust
 // `end` downwards itself, as Rust's `LineComment` arm does for doc
-// comments (#1051). The assert keeps such a regression loud in tests
-// instead of wrapping to `usize::MAX` in release and surfacing far away
-// as a hash-table capacity overflow.
+// comments (#1051).
+//
+// Scope of the assert, deliberately narrow: it fires only for
+// `end < start`, and only in debug — the release profile disables both
+// `debug-assertions` and `overflow-checks`. It cannot catch a caller
+// whose own arithmetic already wrapped, because `(0, usize::MAX)`
+// satisfies `end >= start`. The real guard against that is refusing to
+// underflow in the first place, at the site that adjusts the span.
 pub(crate) fn add_cloc_lines(stats: &mut Stats, start: usize, end: usize) {
     debug_assert!(end >= start, "add_cloc_lines: end {end} < start {start}");
     let comment_diff = end - start;


### PR DESCRIPTION
## Problem

A Rust doc comment ending at EOF without a trailing newline panicked the
analyzer, from inputs as small as `/// x`:

| input | debug | release |
|---|---|---|
| `/// x` | `attempt to subtract with overflow` | `Hash table capacity overflow` |
| `//! x` | panic | panic |
| `fn f(){}\n/// x` | panic | panic |
| `let x = 1; /// d` | panic | panic |
| `/// x\n` (control) | ok | ok |

Release builds do not save us: `end` wraps to `usize::MAX`, flows into
`add_only_comment_lines`, and blows up inside hashbrown while extending a
near-`usize::MAX` range.

Reachable from `analyze` / `Source` directly — the documented library entry
point, whose own rustdoc example uses exactly that path — **and from the
Python `Ast.parse(...).metrics()` fast path**, which hands raw bytes to
`Source::from_bytes` with no `normalize_eol`, unlike `analyze_source` and
`Ast.from_path` (`big-code-analysis-py/src/ast.rs:123,131`). The `bca` CLI
and every `bca-web` endpoint that computes metrics normalize their input
and were unaffected.

## Root cause

`Loc` discounts the extra row a `DocComment` spans, because the
tree-sitter-rust scanner consumes the trailing newline as part of the
token. At EOF there is no newline left to consume, so the node ends on its
own start row and the unconditional `end - 1` underflows.

**The two reported panic sites are one bug, and that distinction drove the
fix.** `init()` returns `(start_row, end_row)` and tree-sitter guarantees
the span is non-decreasing, so all 25 `add_cloc_lines` call sites are safe
— except Rust's `LineComment` arm, the only one that adjusts `end` itself:

| shape | rows | lands at |
|---|---|---|
| `/// x` | `start == end == 0` | underflows in `loc/rust.rs` directly |
| `fn f(){}\n/// x` | `start == end > 0` | subtraction succeeds, drives `end` **below** `start`, underflows `loc/shared.rs` |

A guard of `end > 0` — the obvious reading of the debug panic — fixes only
the first row. The correct guard is **`end > start`**, which is also
exactly the semantics of "exclude the last line": discount the row only
when the node really spans one.

## Changes

- **`src/metrics/loc/rust.rs`** — add the `end > start` guard, ordered
  cheap-operand-first so it short-circuits `is_child`'s FFI child walk on
  plain line comments. The comment records the EOF exception and cites
  `process_line_doc_content` by name rather than a line range, which was
  already one off against the pinned tree-sitter-rust 0.24.2.
- **`src/metrics/loc/shared.rs`** — `add_cloc_lines` gains a
  `debug_assert!(end >= start)` and a documented precondition. It needed no
  behavioural change: the precondition is real and every caller satisfies
  it once `rust.rs` is fixed. Saturating arithmetic here would have traded
  wrong crashes for silently wrong comment counts, which is worse in an
  analysis tool. The comment states the assert's **narrow** scope: it fires
  only for `end < start`, only in debug, and cannot catch a caller whose own
  arithmetic already wrapped — `(0, usize::MAX)` satisfies `end >= start`.
- **`src/metrics/loc.rs`** — four tests plus a `loc_verbatim(lang, source)`
  helper and its Rust binding `rust_loc`.
- **`docs/development/lessons_learned.md`** — records the test-helper trap
  as a sub-example under lesson 7 (see below).

## This changes metric values

Only the **row-0** shapes panicked. When the EOF doc comment sat on any
**later** row, release builds did not crash — they silently reported one
`cloc` too few, which also shifted `blank` and MI's comment percentage.
Measured against pre-fix code under release arithmetic:

| input | pre-fix (release) | post-fix |
|---|---|---|
| `/// x`, `//! x`, `let x = 1; /// d` | **panic** | `cloc=1` |
| `fn f(){}\n/// x` | `cloc=0` *(no panic)* | `cloc=1` |
| `fn f(){}\r\n/// x` | `cloc=0` *(no panic)* | `cloc=1` |
| `/// a\n/// b` (EOF) | `cloc=1` *(no panic)* | `cloc=2` |
| any newline-terminated input | identical | identical |

So any Rust file whose last line is an unterminated doc comment now reports
one more `cloc` (and one fewer `blank`) than a `2.0.1` release build did.
Downstreams should re-check `.bca-baseline.toml` entries and thresholds.

No in-tree snapshots move — every fixture is newline-terminated — confirmed
by a clean `git status` after the full gate.

## Testing

The tests deliberately bypass `check_metrics`. It routes through
`tools::check_func_space`, which does `trim_end().trim_matches('\n')` then
`push(b'\n')` — it strips trailing newlines and appends one, making "a node
ending at EOF" structurally unreachable. The integration suites bypass that
helper but hit the same wall — `read_file_with_eol` also appends a trailing
newline. **No test written the ordinary way could have caught this, and a
regression test added that way would have passed against the unfixed
code.** `loc_verbatim` goes through `analyze(Source::new(..))` with no
normalization, takes a `LANG` (the untestable-at-EOF class is shared by
every `Loc` submodule), and carries a doc comment explaining why it must not
be "simplified" back.

- `rust_doc_comment_at_eof_does_not_underflow` — all five shapes, including
  `/// a\n/// b` at EOF, which release under-counted as 1.
- `rust_doc_comment_at_eof_matches_plain_comment` — parity with `// x`,
  plus absolute pins on the baseline so it cannot certify a wrong value on
  both sides at once.
- `rust_doc_comment_with_trailing_newline_still_discounts_the_row` — the
  no-regression guard, proving the new condition did not become a no-op.
- `rust_doc_comment_crlf_still_discounts_the_row` — the boundary where the
  discount is still owed (`\r` is ordinary content, so the `\n` is still
  consumed), plus the lone-trailing-`\r` case where it is not.

**Test-via-revert** per `.claude/rules/testing.md`, using a precise inverse
edit rather than a file-level restore (which would have wiped the
uncommitted fix): with the guard removed, the bug-pinning tests fail with
the expected panic, while the no-regression tests pass against both
versions — which is their job.

## Sibling sweep

`end - 1` appears in no other `loc` module; the doc-comment newline
adjustment is unique to Rust. Every other `- 1` under `src/metrics/` is
inside a test fixture's source string or unrelated `cyclomatic()`
arithmetic.

## Lessons learned

Recorded as a sub-example under **lesson 7**, not as a new lesson — #7
already states the general pattern (an intermediate stage that "filters,
normalizes, or short-circuits the input") and its prescription. What this
case adds is severity: #7's existing example is a filter in one test's call
path, whereas here two independent chokepoints (`check_func_space` for unit
tests, `read_file_with_eol` for the integration suites) put the input class
out of reach of the whole suite. Lesson numbering is unchanged, so
index-based references from other skills still resolve.

## Validation

`make pre-commit` green — 3,065 lib tests, clippy clean on default and
`--all-features`, markdown lint, self-scan threshold gates, no snapshot
drift, no baseline refresh.

A high-effort code review over this branch found 10 issues, all fixed in
`6b30fca0` and `a0ae4398`; three were factual errors in this description,
corrected above. See the review comment below for the full list.

Fixes #1051

