### PR TITLE
perf(metrics/tokens): drop per-leaf ancestor walk (DoS)

### DIFF
--- a/.bca-baseline.toml
+++ b/.bca-baseline.toml
@@ -938,23 +938,16 @@ value = 8.0
 [[entry]]
 path = "src/spaces/compute.rs"
 qualified = "compute_per_node"
-start_line = 202
+start_line = 217
 metric = "halstead.effort"
-value = 66012.71705067596
-
-[[entry]]
-path = "src/spaces/compute.rs"
-qualified = "compute_per_node"
-start_line = 202
-metric = "nargs"
-value = 7.0
+value = 61523.95778223676
 
 [[entry]]
 path = "src/spaces/compute.rs"
 qualified = "metrics_inner"
-start_line = 346
+start_line = 386
 metric = "halstead.effort"
-value = 109810.50849120741
+value = 122486.96209573474
 
 [[entry]]
 path = "src/suppression.rs"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,30 @@ for historical reference.
 
 ### Fixed
 
+- Deeply nested source no longer costs quadratic time in the `tokens`
+  metric (#1052). `Tokens` decided whether a leaf sat inside a comment by
+  walking that leaf's ancestor chain — and `Node::parent` is itself
+  `O(depth)`, so the metric ran in `O(leaves × depth²)`. A 2 KB file of
+  nested parentheses took ~19 s and a 4 KB one over two minutes, with
+  parsing itself staying flat, which made it an unauthenticated CPU
+  exhaustion vector against `bca-web` and a way to stall `bca check` in
+  CI. The walker now propagates comment membership down the traversal in
+  `O(1)` per node, so `tokens` is linear: measured at nesting depths
+  1000 / 2000 / 4000, the metric now costs 4 / 5 / 6 ms, and the same
+  files analyse end-to-end in 74 ms / 285 ms / 1.1 s. Token counts are
+  unchanged — comment-internal leaves (Rust doc-comment markers and
+  content) are still excluded, now by an inherited flag rather than a
+  rediscovered one.
+
+  Nesting-heavy input is **faster but still superlinear overall**, so
+  untrusted deeply-nested source is not yet safe to analyse unbounded.
+  `Node::parent` is `O(depth)` and is used per-node in several other
+  places: `cognitive`'s nesting-map lookup dominates the nested-paren
+  shape measured above, while `Loc`'s `count_specific_ancestors`
+  (C-family, Java, C#, Go, Groovy, Objective-C) and Elixir's
+  `is_inside_quote_block` are superlinear on other shapes — the latter
+  behind no metric selection, so it cannot be deselected. Tracked in
+  #1062.
 - A Rust doc comment ending at EOF without a trailing newline no longer
   crashes or miscounts (#1051). `Loc` discounts the row that a
   `DocComment`'s scanner consumes along with its newline, but at EOF
@@ -92,6 +116,13 @@ for historical reference.
 
 ### Security
 
+- Removed a remotely-triggerable CPU-exhaustion vector in the `tokens`
+  metric — a few kilobytes of deeply nested source could pin a core for
+  minutes against the unauthenticated `bca-web` endpoints, whose parse
+  deadline frees the client but cannot cancel the blocking task. See the
+  `tokens` entry under **Fixed** (#1052) for detail and for the residual
+  superlinear paths that remain (#1062); operators analysing untrusted
+  input should still bound request concurrency.
 - Cleared the two RUSTSEC advisories behind the OpenSSF Scorecard
   Vulnerabilities alert: `anyhow` `1.0.102` → `1.0.103` (unsound
   `Error::downcast_mut()`, RUSTSEC-2026-0190) and `memmap2` `0.9.10`

--- a/src/metrics/tokens.rs
+++ b/src/metrics/tokens.rs
@@ -25,8 +25,11 @@ use crate::macros::implement_metric_trait;
 use crate::*;
 
 /// The `Tokens` metric: per-function and per-file count of tree-sitter
-/// leaf tokens, excluding any leaf whose ancestor chain includes a
-/// comment node.
+/// leaf tokens, excluding any leaf that is itself a comment or has a
+/// comment among its ancestors. Both halves matter: most grammars emit
+/// comments as bare leaves, while some (Rust doc comments, Groovy
+/// groovydoc, JSX `html_comment`) give them structured children whose
+/// own leaves are not comment kinds.
 ///
 /// This is a token-based size proxy: it counts the lexer's tokens
 /// (identifiers, literals, keywords, punctuation) rather than lines or
@@ -139,20 +142,20 @@ where
 {
     /// Walk `node` and update `stats` with this metric for the language
     /// implementing the trait.
-    fn compute(node: &Node, stats: &mut Stats) {
-        if node.child_count() != 0 {
+    ///
+    /// `in_comment` is true when the node itself or any ancestor is a
+    /// comment, so grammars whose comments have internal structure (e.g.
+    /// Rust doc comments split into markers and content) exclude their
+    /// inner leaves too. The walker propagates it down the traversal
+    /// rather than having this function rediscover it per leaf: the old
+    /// ancestor walk was `O(depth)` per leaf over an `O(depth)`
+    /// `Node::parent`, which made the metric `O(leaves × depth²)` and let
+    /// a few kilobytes of nested source burn minutes of CPU (#1052).
+    fn compute(node: &Node, stats: &mut Stats, in_comment: bool) {
+        if in_comment || node.child_count() != 0 {
             return;
         }
-        // Walk the leaf's ancestors so grammars whose comments have
-        // internal structure (e.g. Rust doc comments split into
-        // markers and content) also exclude inner leaves; the leaf
-        // itself is the first item, so bare comment nodes are caught
-        // immediately.
-        let in_comment =
-            std::iter::successors(Some(*node), Node::parent).any(|n| Self::is_comment(&n));
-        if !in_comment {
-            stats.tokens += 1;
-        }
+        stats.tokens += 1;
     }
 }
 
@@ -419,8 +422,110 @@ mod tests {
         });
     }
 
-    /// Rust doc comments may split into structured children under
-    /// some grammars; the ancestor walk must filter every inner leaf.
+    /// Analyses `source` verbatim and returns its total token count.
+    ///
+    /// Used by the tests below that need to *compare* counts across
+    /// inputs, which `check_metrics` cannot express: it takes an `F: Fn`
+    /// that cannot return a value, and it normalises the source before
+    /// parsing.
+    ///
+    /// Restricted to `Tokens` so these tests measure only the metric
+    /// they guard. With every metric enabled, `cognitive`'s own
+    /// superlinear nesting lookup (#1062) dominates the deep-nesting
+    /// case below — a `cognitive` regression would look like a `tokens`
+    /// one, and a `cognitive` fix would mask a `tokens` regression.
+    fn tokens_of(source: &str) -> u64 {
+        crate::analyze(
+            crate::Source::new(crate::LANG::Rust, source.as_bytes()),
+            crate::MetricsOptions::default().with_only(&[crate::Metric::Tokens]),
+        )
+        .expect("source must analyse")
+        .metrics
+        .tokens
+        .tokens_sum()
+    }
+
+    fn nested_parens(depth: usize) -> String {
+        format!(
+            "fn f() -> i32 {{ {}1{} }}\n",
+            "(".repeat(depth),
+            ")".repeat(depth)
+        )
+    }
+
+    /// Deeply nested input must stay tractable (#1052).
+    ///
+    /// The metric used to walk each leaf's ancestor chain to decide
+    /// comment membership. `Node::parent` is itself `O(depth)`, so that
+    /// cost `O(leaves × depth²)`: depth 1000 took ~19 s and depth 2000
+    /// over two minutes, which would hang CI rather than fail it. The
+    /// walker now propagates the flag down the traversal in `O(1)` per
+    /// node, and this runs in milliseconds.
+    ///
+    /// The count is asserted by formula rather than hand-counted: each
+    /// added paren pair contributes exactly two leaves, so the delta
+    /// between consecutive depths pins the metric without depending on
+    /// how the grammar tokenises the surrounding function.
+    #[test]
+    fn tokens_deep_nesting_is_tractable() {
+        let shallow = tokens_of(&nested_parens(1));
+        assert_eq!(tokens_of(&nested_parens(2)), shallow + 2);
+
+        // Bound the wall clock, not just the count: the pre-#1052
+        // implementation produced the *same* counts, only quadratically,
+        // so a count assertion alone turns a reintroduced ancestor walk
+        // into a hung CI job rather than a failure. The budget is ~500x
+        // the observed cost (single-digit ms with `Tokens` alone), so it
+        // discriminates a quadratic blow-up without being timing-flaky.
+        let started = std::time::Instant::now();
+        assert_eq!(tokens_of(&nested_parens(2000)), shallow + 2 * 1999);
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed < std::time::Duration::from_secs(5),
+            "depth-2000 token count took {elapsed:?}; the per-leaf \
+             ancestor walk (#1052) is quadratic in nesting depth and \
+             took minutes at this depth"
+        );
+    }
+
+    /// A comment deep in the tree still contributes nothing.
+    ///
+    /// Honest scope: the comment's *own* subtree is only one level deep
+    /// (`line_comment` → marker / `doc_comment`), so the enclosing block
+    /// nesting exercises the walker's inheritance rather than any extra
+    /// level of comment-internal structure —
+    /// `rust_tokens_doc_comments_excluded` already covers the latter at
+    /// depth 1. What this adds is the anchored differential below: a
+    /// count that would not survive an `in_comment` wired to a constant.
+    #[test]
+    fn rust_tokens_comment_excluded_at_depth() {
+        let deep_block = format!(
+            "fn f() {{ {}let x = 1;{} }}\n",
+            "{ ".repeat(50),
+            " }".repeat(50)
+        );
+        let with_doc = deep_block.replace("let x = 1;", "/// doc\nlet x = 1;");
+        let baseline = tokens_of(&deep_block);
+        // Anchor the differential: without this, an `in_comment` wired
+        // to always-true would return 0 on both sides and pass.
+        assert_eq!(
+            baseline, 111,
+            // 4 (`fn f ( )`) + 2 (outer braces) + 100 (50 nested brace
+            // pairs) + 5 (`let x = 1 ;`).
+            "expected 111 tokens for the comment-free baseline"
+        );
+        assert_eq!(
+            tokens_of(&with_doc),
+            baseline,
+            "a doc comment 50 blocks deep must contribute no tokens, \
+             including its structured inner leaves"
+        );
+    }
+
+    /// Rust doc comments split into structured children whose leaves are
+    /// not themselves comment kinds (`//`, `outer_doc_comment_marker`,
+    /// `doc_comment`), so excluding only the comment node is not enough
+    /// — every leaf beneath it must be filtered too.
     #[test]
     fn rust_tokens_doc_comments_excluded() {
         check_metrics::<RustParser>(

--- a/src/node.rs
+++ b/src/node.rs
@@ -140,6 +140,20 @@ impl<'a> Node<'a> {
         self.0.end_position().row
     }
 
+    /// Returns this node's parent.
+    ///
+    /// **`O(depth)`, not `O(1)`.** tree-sitter stores no parent pointer:
+    /// `ts_node_parent` restarts at the tree root and descends. A single
+    /// call in a per-node metric therefore costs `O(nodes × depth)` over
+    /// a walk, and an ancestor *loop* built on it costs `O(depth²)` per
+    /// call.
+    ///
+    /// This has bitten the analyzer for real: #1052 was a per-leaf
+    /// `successors(node, Node::parent)` walk in `Tokens` that made the
+    /// metric `O(leaves × depth²)`, so a 2 KB file of nested parentheses
+    /// took ~19 s. Prefer inheriting state downward through the
+    /// traversal (see `Walk` in `spaces::compute`) over rediscovering it
+    /// upward. Remaining known instances are tracked in #1062.
     pub(crate) fn parent(&self) -> Option<Node<'a>> {
         self.0.parent().map(Node)
     }

--- a/src/spaces/compute.rs
+++ b/src/spaces/compute.rs
@@ -190,6 +190,22 @@ pub fn analyze(source: Source<'_>, options: MetricsOptions) -> Result<FuncSpace,
     Ast::parse(source)?.metrics(options)
 }
 
+/// Per-node classification the walker derives once and the metrics
+/// consume. Bundled rather than passed as three loose `bool`s so the
+/// call site cannot transpose them — they are all same-typed flags
+/// about the node currently being visited.
+#[derive(Clone, Copy)]
+struct NodeFacts {
+    /// This node opens a new [`FuncSpace`].
+    func_space: bool,
+    /// This node's space kind is [`SpaceKind::Unit`].
+    unit: bool,
+    /// Whether this node lies inside a comment subtree — the node
+    /// **itself** or any ancestor is a comment. Contrast
+    /// [`Walk::in_comment`], which covers ancestors only (#1052).
+    in_comment: bool,
+}
+
 // Per-node metric dispatch. Each `compute` call is paired with a bit
 // check against the caller's selection. The bit tests are cheap
 // (single AND-and-compare on the `MetricSet` bitfield) and an
@@ -204,10 +220,14 @@ fn compute_per_node<'a, T: ParserTrait>(
     node: &Node<'a>,
     code: &'a [u8],
     options: MetricsOptions,
-    func_space: bool,
-    unit: bool,
+    facts: NodeFacts,
     nesting_map: &mut HashMap<usize, (usize, usize, usize)>,
 ) {
+    let NodeFacts {
+        func_space,
+        unit,
+        in_comment,
+    } = facts;
     let selected = options.metrics;
     let last = &mut state.space;
     if selected.contains(Metric::Cognitive) {
@@ -231,7 +251,7 @@ fn compute_per_node<'a, T: ParserTrait>(
         T::Nom::compute(node, code, &mut last.metrics.nom);
     }
     if selected.contains(Metric::Tokens) {
-        T::Tokens::compute(node, &mut last.metrics.tokens);
+        T::Tokens::compute(node, &mut last.metrics.tokens, in_comment);
     }
     if selected.contains(Metric::Nargs) {
         T::NArgs::compute(node, &mut last.metrics.nargs);
@@ -292,15 +312,14 @@ fn push_synthetic_unit_root<T: ParserTrait>(
 /// than aborting the walk: a typo in one file must not derail a
 /// workspace-wide pass, and dropping is the conservative choice — a typo
 /// should not accidentally silence anything.
-fn apply_comment_suppression<T: ParserTrait>(
+fn apply_comment_suppression(
     state_stack: &mut Vec<State>,
     node: &Node,
     code: &[u8],
     diagnostic_path: &str,
+    is_comment: bool,
 ) {
-    if T::Checker::is_comment(node)
-        && let Some(text) = node.utf8_text(code)
-    {
+    if is_comment && let Some(text) = node.utf8_text(code) {
         match parse_suppression_marker(text) {
             Ok(Some(s)) => apply_suppression(state_stack, &s),
             Ok(None) => {}
@@ -314,25 +333,53 @@ fn apply_comment_suppression<T: ParserTrait>(
     }
 }
 
+/// Context carried down the metrics walk alongside each node.
+///
+/// `in_comment` replaces the per-leaf ancestor walk `Tokens::compute` used
+/// to do. That walk was `O(depth)` per leaf and, because `Node::parent`
+/// is itself `O(depth)`, made the metric `O(leaves × depth²)` — a few
+/// kilobytes of deeply nested source burned minutes of CPU (issue #1052).
+/// Propagating the flag down the traversal computes the same predicate in
+/// `O(1)` per node: a node is inside a comment iff its parent was, or the
+/// node itself is a comment.
+#[derive(Clone, Copy)]
+struct Walk {
+    /// Nesting level, used to close func-spaces on the way back up.
+    level: usize,
+    /// Whether an **ancestor** of this node is a comment.
+    ///
+    /// Deliberately excludes the node itself — the walk ORs in
+    /// `is_comment(node)` on arrival to get the node's own membership,
+    /// and tags its children with that. Note this differs from
+    /// [`NodeFacts::in_comment`], which *does* include the node: passing
+    /// this field where that one is expected would stop excluding a
+    /// comment's own leaves and reintroduce the #1052 miscount.
+    in_comment: bool,
+}
+
 /// Pushes `node`'s direct children onto the traversal `stack`, each tagged
-/// with `new_level`.
+/// with `tag`.
 ///
 /// The `children.drain(..).rev()` ordering is load-bearing: it makes the
 /// LIFO `stack` yield children in source order, which in turn governs
 /// line-shared suppression attribution (issue #289). The `children`
 /// scratch buffer is drained empty here so callers can reuse its
 /// allocation across iterations.
-pub(crate) fn push_children<'a>(
+///
+/// `Tag` is generic because the two walkers carry different context down
+/// the tree: `ops` needs only the nesting level, while `metrics_inner`
+/// also propagates comment membership ([`Walk`], issue #1052).
+pub(crate) fn push_children<'a, Tag: Copy>(
     cursor: &mut Cursor<'a>,
     node: &Node<'a>,
-    new_level: usize,
-    children: &mut Vec<(Node<'a>, usize)>,
-    stack: &mut Vec<(Node<'a>, usize)>,
+    tag: Tag,
+    children: &mut Vec<(Node<'a>, Tag)>,
+    stack: &mut Vec<(Node<'a>, Tag)>,
 ) {
     cursor.reset(node);
     if cursor.goto_first_child() {
         loop {
-            children.push((cursor.node(), new_level));
+            children.push((cursor.node(), tag));
             if !cursor.goto_next_sibling() {
                 break;
             }
@@ -384,9 +431,15 @@ pub(crate) fn metrics_inner<T: ParserTrait>(
 
     push_synthetic_unit_root::<T>(&mut state_stack, &node, code, selected);
 
-    stack.push((node, 0));
+    stack.push((
+        node,
+        Walk {
+            level: 0,
+            in_comment: false,
+        },
+    ));
 
-    while let Some((node, level)) = stack.pop() {
+    while let Some((node, Walk { level, in_comment })) = stack.pop() {
         // Close any spaces left open by a deeper, already-walked subtree
         // before doing anything else with this node. This must run before
         // the test-subtree prune below so that, when we skip a pruned
@@ -456,9 +509,18 @@ pub(crate) fn metrics_inner<T: ParserTrait>(
             level
         };
 
+        // Computed once and reused: suppression needs it for this node,
+        // and the children need it to inherit comment membership (#1052).
+        let is_comment = T::Checker::is_comment(&node);
+
         // Pin each suppression marker to its innermost enclosing
         // function space (issue #289); see `apply_comment_suppression`.
-        apply_comment_suppression::<T>(&mut state_stack, &node, code, diagnostic_path);
+        // Deliberately called before `subtree_in_comment` is bound: the
+        // two are adjacent same-typed `bool`s, and passing the inclusive
+        // one here would re-apply a marker once per descendant leaf.
+        apply_comment_suppression(&mut state_stack, &node, code, diagnostic_path, is_comment);
+
+        let subtree_in_comment = in_comment || is_comment;
 
         if let Some(state) = state_stack.last_mut() {
             compute_per_node::<T>(
@@ -466,13 +528,25 @@ pub(crate) fn metrics_inner<T: ParserTrait>(
                 &node,
                 code,
                 options,
-                func_space,
-                unit,
+                NodeFacts {
+                    func_space,
+                    unit,
+                    in_comment: subtree_in_comment,
+                },
                 &mut nesting_map,
             );
         }
 
-        push_children(&mut cursor, &node, new_level, &mut children, &mut stack);
+        push_children(
+            &mut cursor,
+            &node,
+            Walk {
+                level: new_level,
+                in_comment: subtree_in_comment,
+            },
+            &mut children,
+            &mut stack,
+        );
     }
 
     finalize::<T>(&mut state_stack, usize::MAX, selected);


### PR DESCRIPTION
## Problem

`Tokens::compute` decided whether a leaf sat inside a comment by walking that
leaf's ancestor chain:

```rust
std::iter::successors(Some(*node), Node::parent).any(|n| Self::is_comment(&n))
```

`Node::parent` is itself `O(depth)` — tree-sitter stores no parent pointer, so
`ts_node_parent` restarts at the root and descends — which made the metric
`O(leaves × depth²)`.

| depth | input | before | after | tokens only |
|---|---|---|---|---|
| 1000 | 2.0 KB | 19,022 ms | **74 ms** | 4 ms |
| 2000 | 4.0 KB | >120,000 ms (timeout) | **285 ms** | 5 ms |
| 4000 | 8.0 KB | — | 1,122 ms | 6 ms |

Parsing the same files stayed flat (`bca dump` 75 ms, `bca ops` 9 ms at depth
1000), so this was ours, not tree-sitter's. It made a few kilobytes of legal
nested source an unauthenticated CPU-exhaustion vector against `bca-web` —
whose parse deadline frees the client but cannot cancel the `spawn_blocking`
task — and a way to stall `bca check` in CI.

## Fix

The walker propagates comment membership down the traversal instead of each
leaf rediscovering it. `Walk` carries an `in_comment` flag beside the nesting
level; each node ORs in its own `is_comment` on arrival and tags its children
with the result. By induction that is exactly the old predicate, so **token
counts are unchanged** — including the case that motivated the walk, where a
comment's inner leaves are not themselves comment kinds:

```
line_comment                 <- the only node `is_comment` matches
├─ //                        <- leaf, not a comment kind
├─ outer_doc_comment_marker
│  ╰─ /                      <- leaf, not a comment kind
╰─ doc_comment               <- leaf, not a comment kind
```

`is_comment` is now computed once per node and shared with suppression, which
previously called it separately. `push_children` became generic over its tag so
`ops` keeps a plain `usize`.

## Scope: this narrows the DoS, it does not close it

Per-metric isolation at depth 4000 after the fix — `tokens` is flat, and
`cognitive` is now the dominant term on this shape:

| metric | time |
|---|---|
| **cognitive** | **1080 ms** |
| every other metric | ~5 ms |

`Node::parent` is used per-node in three other places, tracked in #1062:

- `cognitive::get_nesting_from_map` — one `parent()` per node, dominates the
  nested-paren shape measured above.
- `Loc::count_specific_ancestors` (C-family, Java, C#, Go, Groovy, Objective-C)
  — fires on `Declaration` nodes, so nested *parens* leave `--metrics sloc`
  flat at 4-8 ms; nested *declarations* are superlinear (35 KB → 153 ms).
- `elixir_is_inside_quote_block` — `O(depth²)` per call, reached from
  `promotes_to_func_space_with_code`, which the walker calls for **every node
  behind no metric selection**, so it cannot be deselected.

The CHANGELOG says this plainly rather than implying the problem is closed, and
cross-references from `### Security` since the entry describes a
remotely-triggerable DoS.

## Testing

- `tokens_deep_nesting_is_tractable` — restricted to `Metric::Tokens` so it
  measures the metric it guards (with all metrics enabled, ~97% of its runtime
  was cognitive; the module went 1.23 s → 0.01 s). Asserts the count by formula
  (each paren pair contributes exactly two leaves) **and** a wall-clock bound,
  so a reintroduced walk fails rather than hanging CI.
- `rust_tokens_comment_excluded_at_depth` — anchored (`baseline == 111`,
  derived as 4 + 2 + 100 + 5) so an `in_comment` wired to a constant cannot
  pass it.

**Test-via-revert** per `.claude/rules/testing.md`, using a precise inverse edit
(the work was uncommitted, so a file-level restore would have wiped it): the
deep-nesting test **hangs past 60 s** against the old ancestor-walk body and was
killed at 90 s; `rust_tokens_comment_excluded_at_depth` passes against both,
which is its job as the behaviour-preservation guard.

All 3,067 lib tests pass, token counts unchanged workspace-wide, no snapshot
drift.

## Incidental

Threading the flag pushed `compute_per_node` to 8 arguments, over clippy's
limit. Bundling the three per-node flags into `NodeFacts` — same-typed booleans
about one node, so this also removes the transposition hazard AGENTS.md warns
about — took it to 6, which **retired its `nargs` baseline entry** and lowered
its halstead effort ~7%. `metrics_inner` grew 12% in halstead effort past its
recorded value; the baseline is refreshed in the same commit per the same-PR
discipline. Net baseline entries 176 → 175.

`Node::parent` now documents its `O(depth)` cost at the definition — it was the
only accessor in `node.rs` without a cost note, while its neighbours gained one
after #217/#521, and it is the one that reads like `O(1)`.

## Review

A high-effort review over this branch found 10 issues, all fixed before this
was pushed. Two were real defects introduced by the change itself, both
tending to quietly undo it:

- `Walk::in_comment`'s doc stated the opposite of the value it carries (it
  excludes the node itself), in wording identical to `NodeFacts::in_comment`,
  which includes it. Trusting it would make the `|| is_comment` at the read
  site look redundant.
- `apply_comment_suppression` took a loose positional `bool` one line from its
  inverse-meaning twin. Passing the wrong one compiles silently and re-applies
  a suppression marker once per descendant leaf. Fixed by ordering, so the
  wrong value is not yet bound at the call site.

## Validation

`make pre-commit` green — 3,067 lib tests, clippy clean on default and
`--all-features`, markdown lint, man-page drift, both self-scan tiers.

Fixes #1052
