### PR TITLE
docs(readme): surface live example report links

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -32,6 +32,14 @@
 - ライブラリバインディング — 同じエンジンを Rust クレート、
   [Python パッケージ](https://pypi.org/project/big-code-analysis/)、REST サーバー（`bca-web`）として利用できます。
 
+インストール前に出力を確認したい場合は、`bca` が `main` へのプッシュのたびに
+自分自身のソースを解析して公開している結果をご覧ください。
+
+- [**HTML ホットスポットレポート（実例）**](https://dekobon.github.io/big-code-analysis/reports/index.html)
+  — ファイル単位・関数単位でブラウズできるビュー（英語）。
+- [**Markdown レポート（実例）**](https://dekobon.github.io/big-code-analysis/reports/report.md)
+  — 同じ実行結果をプルリクエストのコメント形式にしたもの（英語）。
+
 完全なドキュメントは[**ドキュメントブック（日本語版）**](https://dekobon.github.io/big-code-analysis/ja/)にあります。
 メトリクスの定義、コマンドリファレンス、CI レシピ、ライブラリガイドを収録しています。
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ that grows the metric engine into a code-quality toolchain:
   [Python package](https://pypi.org/project/big-code-analysis/), and a
   REST server (`bca-web`).
 
+`bca` analyses its own source on every push to `main` and publishes
+the result, so you can see what a real run looks like before
+installing anything:
+
+- [**Live HTML hotspot report**](https://dekobon.github.io/big-code-analysis/reports/index.html)
+  — the browsable per-file, per-function view.
+- [**Live Markdown report**](https://dekobon.github.io/big-code-analysis/reports/report.md)
+  — the same run as a pull-request comment.
+
 The full documentation lives in
 [**the book**](https://dekobon.github.io/big-code-analysis/): metrics
 definitions, command reference, CI recipes, and library guides.


### PR DESCRIPTION
## What

Restores prominent links to the live example reports in `README.md`
and `README.ja.md`, adding a labelled link pair directly after the
feature bullets:

- [Live HTML hotspot report](https://dekobon.github.io/big-code-analysis/reports/index.html)
- [Live Markdown report](https://dekobon.github.io/big-code-analysis/reports/report.md)

## Why

Those URLs were not lost, but the README rewrite in `ec8184c2` folded
the top-level `## Live example reports` section into
`## Quality gates and reports in CI`, pushing them roughly a hundred
lines down the page. They are the fastest way for a new reader to see
what the analysis actually looks like, so they belong above the fold.

The CI section keeps its copy of the URLs — there they document what
`.github/workflows/pages.yml` publishes, which is a different reader's
question.

`README.ja.md` gets the same pair, marked 「（英語）」: the reports are
published at `/reports/`, not under `/ja/`, so they are English-only.

## Validation

- `rumdl check README.md README.ja.md` — clean.
- Both report URLs return HTTP 200.
- Docs-only; no code, public API, or metric behaviour touched, so no
  `CHANGELOG.md` entry (matching how `ec8184c2` was handled).
