### PR TITLE
perf(output): remove the dump walk's quadratic prefix and parent lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,32 @@ for historical reference.
 
 ### Fixed
 
+- The `dump` AST walk no longer rebuilds its indentation prefix per
+  node, and no longer resolves a node's parent per node (#1054). Each
+  queued node carried an owned copy of its ancestors' box-drawing
+  prefix — a string that grows ~3 bytes per nesting level — so a
+  wide-and-deep tree held O(depth²) resident bytes and copied O(depth)
+  per node; separately, the flush-left check called
+  `tree_sitter::Node::parent`, which resolves by descending from the
+  root, once per node. The walk now keeps one shared prefix buffer that
+  is extended on descent and truncated on the next visit, and carries
+  each node's connector glyph on the work stack so only the node the
+  walk starts from needs a parent lookup. On the issue's fixture
+  (`int main(){return ((((…1…))));}`) `bca dump` goes from 1.18 s to
+  0.05 s at nesting depth 4000 with peak RSS falling from 66 MB to
+  13 MB; on a wide-and-deep JavaScript fixture (1500 nested functions,
+  two siblings each) it goes from 4.00 s to 0.05 s. The rendered text
+  is byte-identical — verified across 300 files spanning the corpus
+  submodules — and the *emitted* size stays O(nodes × depth), which is
+  inherent to a tree drawing where every line carries its own
+  indentation. The mirrored `metrics` and `ops` text dumps
+  (`dump_metrics`, `dump_ops`) carried the same per-entry owned prefix
+  and got the same shared-buffer treatment; their measured cost is
+  unchanged on the fixtures tried — a nested-closure chain keeps only
+  one stack entry alive at a time, so the quadratic term needs a tree
+  that is wide *and* deep — but the O(depth) copy per rendered line is
+  gone and the three walks no longer differ in shape.
+
 - `loc.sloc` no longer drops the final line of source that is not
   newline-terminated (#1067). `Sloc` derived its row count from an
   "is this the unit span?" flag; the unit branch was correct only

--- a/src/output/dump.rs
+++ b/src/output/dump.rs
@@ -354,14 +354,22 @@ mod tests {
     use super::*;
 
     #[test]
-    fn dump_node_non_utf8_source_does_not_panic() {
-        // Regression: `stdout.write_all(code).unwrap()` panicked when the raw-bytes
-        // fallback branch was taken for non-UTF-8 source content.
+    fn dump_node_non_utf8_source_emits_the_raw_snippet() {
+        // Regression: `stdout.write_all(code).unwrap()` panicked when the
+        // raw-bytes fallback branch was taken for non-UTF-8 source
+        // content. Reaching the assertion at all covers the panic; the
+        // assertion itself covers the other half — that the fallback
+        // *writes* the bytes. A bare `is_ok()` here passed even with the
+        // fallback arm stubbed out to `Ok(())`, silently dropping the
+        // snippet it exists to render.
         let code = b"char c = '\xff';";
         let path = PathBuf::from("test.c");
         let parser = CppParser::new(code.to_vec(), &path, None);
-        let root = parser.root();
-        assert!(dump_node(code, &root, -1, None, None).is_ok());
+        let out = render_raw(code, &parser.root(), -1, None, None);
+        assert!(
+            out.contains(&0xff),
+            "the non-UTF-8 snippet must reach the output: {out:?}"
+        );
     }
 
     #[test]
@@ -437,15 +445,16 @@ mod tests {
         assert_eq!(render(code, &parser.root(), -1), expected);
     }
 
-    /// Render `node` to an in-memory sink under the given line filter, the
-    /// way the CLI would minus the color escapes.
-    fn render_range(
+    /// Render `node` to an in-memory sink under the given line filter and
+    /// return the raw bytes. Not necessarily UTF-8: a non-UTF-8 source
+    /// snippet is written through verbatim by `write_node_snippet`.
+    fn render_raw(
         code: &[u8],
         node: &Node,
         depth: i32,
         line_start: Option<usize>,
         line_end: Option<usize>,
-    ) -> String {
+    ) -> Vec<u8> {
         let mut sink = NoColor::new(Vec::new());
         {
             let mut state = DumpState {
@@ -456,7 +465,19 @@ mod tests {
             };
             dump_tree_helper(&mut state, node, depth).expect("dump to in-memory sink");
         }
-        String::from_utf8(sink.into_inner()).expect("dump output is utf-8")
+        sink.into_inner()
+    }
+
+    /// [`render_raw`] as text, for the (usual) UTF-8 case.
+    fn render_range(
+        code: &[u8],
+        node: &Node,
+        depth: i32,
+        line_start: Option<usize>,
+        line_end: Option<usize>,
+    ) -> String {
+        String::from_utf8(render_raw(code, node, depth, line_start, line_end))
+            .expect("dump output is utf-8")
     }
 
     /// [`render_range`] with the filter disabled — the `bca dump` default.

--- a/src/output/dump.rs
+++ b/src/output/dump.rs
@@ -182,7 +182,6 @@ fn start_connector(node: &Node) -> Connector {
 /// which is inherent to the tree drawing.
 fn dump_tree_helper<'a>(state: &mut DumpState, node: &Node<'a>, depth: i32) -> std::io::Result<()> {
     let mut prefix = String::new();
-    let mut children: Vec<Node<'a>> = Vec::new();
     let mut stack: Vec<Frame<'a>> = vec![Frame {
         node: *node,
         prefix_len: 0,
@@ -213,40 +212,46 @@ fn dump_tree_helper<'a>(state: &mut DumpState, node: &Node<'a>, depth: i32) -> s
             continue;
         }
 
-        children.clear();
-        children.extend(frame.node.children());
         prefix.push_str(pref_child);
-        push_children(&mut stack, &children, prefix.len(), frame.depth - 1);
+        push_children(
+            &mut stack,
+            frame.node.children(),
+            prefix.len(),
+            frame.depth - 1,
+        );
     }
 
     Ok(())
 }
 
 /// Queue `children` so `pop()` visits them in source order, matching the
-/// recursive form's pre-order traversal.
+/// recursive form's pre-order traversal. The frames go on in source order
+/// and the new tail is then reversed in place, so the walk needs no
+/// separate staging buffer and copies each node once.
 ///
-/// Last-child detection uses the number of children actually walked, not
+/// Last-child detection uses the child actually walked last, not
 /// `Node::child_count`: [`crate::node::Children`] is cursor-driven and
 /// documents that the two can disagree on a malformed tree, in which case
 /// counting from `child_count` would leave the real last child rendering
 /// as `├─` with a dangling bar below it.
 fn push_children<'a>(
     stack: &mut Vec<Frame<'a>>,
-    children: &[Node<'a>],
+    children: impl Iterator<Item = Node<'a>>,
     prefix_len: usize,
     depth: i32,
 ) {
-    for (i, child) in children.iter().enumerate().rev() {
-        stack.push(Frame {
-            node: *child,
-            prefix_len,
-            connector: if i + 1 == children.len() {
-                Connector::Last
-            } else {
-                Connector::Inner
-            },
-            depth,
-        });
+    let first_pushed = stack.len();
+    stack.extend(children.map(|node| Frame {
+        node,
+        prefix_len,
+        connector: Connector::Inner,
+        depth,
+    }));
+    stack[first_pushed..].reverse();
+    // After the reversal the source-order-last child sits at the bottom
+    // of the new tail, so it is popped last and closes the subtree.
+    if let Some(last_child) = stack.get_mut(first_pushed) {
+        last_child.connector = Connector::Last;
     }
 }
 
@@ -314,7 +319,7 @@ fn write_node_location(stdout: &mut dyn WriteColor, node: &Node) -> std::io::Res
 /// Source snippet for single-row nodes only. Multi-row nodes return
 /// without writing (the caller still emits the trailing newline).
 /// Non-UTF-8 spans fall back to raw bytes — regression guard
-/// `dump_node_non_utf8_source_does_not_panic`.
+/// `dump_node_non_utf8_source_emits_the_raw_snippet`.
 fn write_node_snippet(
     stdout: &mut dyn WriteColor,
     code: &[u8],

--- a/src/output/dump.rs
+++ b/src/output/dump.rs
@@ -87,7 +87,7 @@ pub fn dump_node_with_color(
         line_end: &line_end,
         stdout: &mut stdout,
     };
-    let ret = dump_tree_helper(&mut state, node, "", true, depth);
+    let ret = dump_tree_helper(&mut state, node, depth);
 
     color(&mut stdout, Color::White)?;
 
@@ -107,15 +107,64 @@ struct DumpState<'a> {
     stdout: &'a mut dyn WriteColor,
 }
 
-/// One pending node in the iterative AST walk: the node, the box-drawing
-/// prefix accumulated from its ancestors, whether it is the last child of
-/// its parent (which selects its connector glyph), and the remaining
-/// depth budget.
+/// One pending node in the iterative AST walk: the node, the length its
+/// ancestors' box-drawing prefix has in the shared prefix buffer, the
+/// connector glyph it renders with, and the remaining depth budget.
+///
+/// The prefix is stored as a *length* rather than an owned `String`
+/// (#1054). Prefixes only grow by appending as the walk descends, so the
+/// first `prefix_len` bytes of the shared buffer are exactly this node's
+/// prefix for as long as the frame is queued: nothing visited between the
+/// push and the pop can rewrite them (every other queued frame sits at
+/// this level or deeper, so it truncates to `prefix_len` or beyond). One
+/// owned prefix per frame made a depth-`d` chain cost O(d²) resident
+/// bytes plus an O(d) copy per node.
 struct Frame<'a> {
     node: Node<'a>,
-    prefix: String,
-    last: bool,
+    prefix_len: usize,
+    connector: Connector,
     depth: i32,
+}
+
+/// Which box-drawing connector a node renders with.
+///
+/// Deriving this when the node is *pushed* keeps [`Node::parent`] — an
+/// O(depth) walk in tree-sitter — off the per-node path (#1054): only the
+/// node a walk starts from can lack a parent, and every other node is
+/// reached as a child of a node already on the stack.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Connector {
+    /// No parent: renders flush left, with no glyphs of its own.
+    Flush,
+    /// Last child of its parent, so nothing continues below it.
+    Last,
+    /// Has at least one following sibling, whose line the trailing bar
+    /// must reach.
+    Inner,
+}
+
+impl Connector {
+    /// The `(child, own)` prefix pair: what this node contributes to its
+    /// children's indentation, and the glyph run on its own line.
+    const fn glyphs(self) -> (&'static str, &'static str) {
+        match self {
+            Self::Flush => ("", ""),
+            Self::Last => ("   ", "╰─ "),
+            Self::Inner => ("│  ", "├─ "),
+        }
+    }
+}
+
+/// The connector for the node a walk starts from — the only node whose
+/// parent has to be looked up. A start node with a parent renders as a
+/// last child (`bca find` dumps a matched node this way), matching the
+/// `last = true` the recursive form passed for the root.
+fn start_connector(node: &Node) -> Connector {
+    if node.parent().is_none() {
+        Connector::Flush
+    } else {
+        Connector::Last
+    }
 }
 
 /// Render the subtree rooted at `node` with an explicit work stack rather
@@ -125,73 +174,79 @@ struct Frame<'a> {
 /// — an uncatchable abort, forbidden by the no-panic rule. The traversal
 /// order, per-node glyphs, and depth semantics are byte-identical to the
 /// prior recursive form (#700).
-fn dump_tree_helper(
-    state: &mut DumpState,
-    node: &Node,
-    prefix: &str,
-    last: bool,
-    depth: i32,
-) -> std::io::Result<()> {
-    let mut stack: Vec<Frame> = vec![Frame {
+///
+/// The indentation prefix lives in one buffer that is pushed on descent
+/// and truncated back on the next visit, so the walk costs O(depth)
+/// bytes rather than O(depth²) (#1054). The emitted output stays
+/// O(nodes × depth) — every rendered line contains its own indentation,
+/// which is inherent to the tree drawing.
+fn dump_tree_helper<'a>(state: &mut DumpState, node: &Node<'a>, depth: i32) -> std::io::Result<()> {
+    let mut prefix = String::new();
+    let mut children: Vec<Node<'a>> = Vec::new();
+    let mut stack: Vec<Frame<'a>> = vec![Frame {
         node: *node,
-        prefix: prefix.to_owned(),
-        last,
+        prefix_len: 0,
+        connector: start_connector(node),
         depth,
     }];
 
-    while let Some(Frame {
-        node,
-        prefix,
-        last,
-        depth,
-    }) = stack.pop()
-    {
-        if depth == 0 {
+    while let Some(frame) = stack.pop() {
+        if frame.depth == 0 {
             continue;
         }
 
-        let (pref_child, pref) = branch_glyphs(&node, last);
+        // Truncating on every visit — not on the way back up — is what
+        // lets a frame carry a bare length: whatever a sibling's subtree
+        // appended is dropped here. Every recorded length came from
+        // `String::len` after appending a whole glyph run, so it is
+        // always a char boundary.
+        prefix.truncate(frame.prefix_len);
+        let (pref_child, pref) = frame.connector.glyphs();
 
-        if line_in_range(node.start_row() + 1, state.line_start, state.line_end) {
-            write_node_line(state.stdout, state.code, &node, &prefix, pref)?;
+        if line_in_range(frame.node.start_row() + 1, state.line_start, state.line_end) {
+            write_node_line(state.stdout, state.code, &frame.node, &prefix, pref)?;
         }
 
-        let count = node.child_count();
-        if count == 0 {
+        // Leaves are roughly half the nodes and `child_count` is O(1),
+        // so check it before building a cursor for the child walk.
+        if frame.node.child_count() == 0 {
             continue;
         }
 
-        // Children share one extended prefix. Push them in reverse so
-        // `pop()` visits them in source order, matching the recursive
-        // form's pre-order traversal. `Children` is not a
-        // `DoubleEndedIterator`, so collect first, then walk the indices
-        // backwards.
-        let child_prefix = format!("{prefix}{pref_child}");
-        let child_depth = depth - 1;
-        let children: Vec<Node> = node.children().collect();
-        for (i, child) in children.into_iter().enumerate().rev() {
-            stack.push(Frame {
-                node: child,
-                prefix: child_prefix.clone(),
-                last: i + 1 == count,
-                depth: child_depth,
-            });
-        }
+        children.clear();
+        children.extend(frame.node.children());
+        prefix.push_str(pref_child);
+        push_children(&mut stack, &children, prefix.len(), frame.depth - 1);
     }
 
     Ok(())
 }
 
-/// Box-drawing prefixes for `node` as `(pref_child, pref)`. The root
-/// (no parent) renders flush-left regardless of `last`; this check must
-/// stay first because `dump_node` passes `last = true` for the root.
-fn branch_glyphs(node: &Node, last: bool) -> (&'static str, &'static str) {
-    if node.parent().is_none() {
-        ("", "")
-    } else if last {
-        ("   ", "╰─ ")
-    } else {
-        ("│  ", "├─ ")
+/// Queue `children` so `pop()` visits them in source order, matching the
+/// recursive form's pre-order traversal.
+///
+/// Last-child detection uses the number of children actually walked, not
+/// `Node::child_count`: [`crate::node::Children`] is cursor-driven and
+/// documents that the two can disagree on a malformed tree, in which case
+/// counting from `child_count` would leave the real last child rendering
+/// as `├─` with a dangling bar below it.
+fn push_children<'a>(
+    stack: &mut Vec<Frame<'a>>,
+    children: &[Node<'a>],
+    prefix_len: usize,
+    depth: i32,
+) {
+    for (i, child) in children.iter().enumerate().rev() {
+        stack.push(Frame {
+            node: *child,
+            prefix_len,
+            connector: if i + 1 == children.len() {
+                Connector::Last
+            } else {
+                Connector::Inner
+            },
+            depth,
+        });
     }
 }
 
@@ -333,20 +388,31 @@ mod tests {
     }
 
     #[test]
-    fn branch_glyphs_root_is_flush_left_regardless_of_last() {
+    fn connector_glyphs_are_stable() {
+        // The rendered tree is these three pairs and nothing else; the
+        // byte-exact walk tests below depend on them verbatim.
+        assert_eq!(Connector::Flush.glyphs(), ("", ""));
+        assert_eq!(Connector::Last.glyphs(), ("   ", "╰─ "));
+        assert_eq!(Connector::Inner.glyphs(), ("│  ", "├─ "));
+    }
+
+    #[test]
+    fn start_connector_distinguishes_parentless_from_parented() {
+        // `start_connector` is the walk's only `Node::parent` call
+        // (#1054), so it carries the whole "is this flush-left?"
+        // decision. A parentless node renders flush left; a start node
+        // that *does* have a parent — how `bca find` dumps a matched
+        // node — renders as a last child.
         let code = b"int a = 42;\n";
         let parser = CppParser::new(code.to_vec(), &PathBuf::from("t.c"), None);
         let root = parser.root();
-        // The root has no parent: empty prefixes whatever `last` says.
-        assert_eq!(branch_glyphs(&root, true), ("", ""));
-        assert_eq!(branch_glyphs(&root, false), ("", ""));
+        assert_eq!(start_connector(&root), Connector::Flush);
 
         let child = root
             .children()
             .next()
             .expect("translation_unit has a child");
-        assert_eq!(branch_glyphs(&child, true), ("   ", "╰─ "));
-        assert_eq!(branch_glyphs(&child, false), ("│  ", "├─ "));
+        assert_eq!(start_connector(&child), Connector::Last);
     }
 
     #[test]
@@ -357,21 +423,6 @@ mod tests {
         // ANSI). Expected values were captured from the pre-split code.
         let code = b"int a = 42;\n";
         let parser = CppParser::new(code.to_vec(), &PathBuf::from("t.c"), None);
-        let root = parser.root();
-
-        let no_start: Option<usize> = None;
-        let no_end: Option<usize> = None;
-        let mut sink = NoColor::new(Vec::new());
-        {
-            let mut state = DumpState {
-                code,
-                line_start: &no_start,
-                line_end: &no_end,
-                stdout: &mut sink,
-            };
-            dump_tree_helper(&mut state, &root, "", true, -1).expect("dump to in-memory sink");
-        }
-        let rendered = String::from_utf8(sink.into_inner()).expect("dump output is utf-8");
 
         let expected = concat!(
             "{translation_unit:219} from (1, 1) to (2, 1) \n",
@@ -383,7 +434,103 @@ mod tests {
             "   │  ╰─ {number_literal:158} from (1, 9) to (1, 11) : 42 \n",
             "   ╰─ {;:42} from (1, 11) to (1, 12) : ; \n",
         );
+        assert_eq!(render(code, &parser.root(), -1), expected);
+    }
+
+    /// Render `node` to an in-memory sink under the given line filter, the
+    /// way the CLI would minus the color escapes.
+    fn render_range(
+        code: &[u8],
+        node: &Node,
+        depth: i32,
+        line_start: Option<usize>,
+        line_end: Option<usize>,
+    ) -> String {
+        let mut sink = NoColor::new(Vec::new());
+        {
+            let mut state = DumpState {
+                code,
+                line_start: &line_start,
+                line_end: &line_end,
+                stdout: &mut sink,
+            };
+            dump_tree_helper(&mut state, node, depth).expect("dump to in-memory sink");
+        }
+        String::from_utf8(sink.into_inner()).expect("dump output is utf-8")
+    }
+
+    /// [`render_range`] with the filter disabled — the `bca dump` default.
+    fn render(code: &[u8], node: &Node, depth: i32) -> String {
+        render_range(code, node, depth, None, None)
+    }
+
+    #[test]
+    fn dump_output_restores_prefix_after_nested_subtree() {
+        // The walk keeps one shared prefix buffer that is appended to on
+        // descent and truncated back on the next visit (#1054), so a
+        // sibling that follows a deeper subtree is where a truncation
+        // bug shows up. Here `+` and the second `number_literal` follow
+        // the three-level `parenthesized_expression` subtree, and the
+        // trailing `;` follows the whole `init_declarator` subtree —
+        // each must resume its own level's indentation exactly.
+        //
+        // Expected text was captured from the pre-#1054 binary (`bca
+        // dump --color never`) on this same source, so it pins byte
+        // identity across the change rather than re-recording whatever
+        // the new walk emits.
+        let code = b"int a = (1) + 2;\n";
+        let parser = CppParser::new(code.to_vec(), &PathBuf::from("t.c"), None);
+        let rendered = render(code, &parser.root(), -1);
+
+        let expected = concat!(
+            "{translation_unit:219} from (1, 1) to (2, 1) \n",
+            "╰─ {declaration:255} from (1, 1) to (1, 17) : int a = (1) + 2; \n",
+            "   ├─ {primitive_type:96} from (1, 1) to (1, 4) : int \n",
+            "   ├─ {init_declarator:294} from (1, 5) to (1, 16) : a = (1) + 2 \n",
+            "   │  ├─ {identifier:1} from (1, 5) to (1, 6) : a \n",
+            "   │  ├─ {=:74} from (1, 7) to (1, 8) : = \n",
+            "   │  ╰─ {binary_expression:341} from (1, 9) to (1, 16) : (1) + 2 \n",
+            "   │     ├─ {parenthesized_expression:363} from (1, 9) to (1, 12) : (1) \n",
+            "   │     │  ├─ {(:5} from (1, 9) to (1, 10) : ( \n",
+            "   │     │  ├─ {number_literal:158} from (1, 10) to (1, 11) : 1 \n",
+            "   │     │  ╰─ {):8} from (1, 11) to (1, 12) : ) \n",
+            "   │     ├─ {+:25} from (1, 13) to (1, 14) : + \n",
+            "   │     ╰─ {number_literal:158} from (1, 15) to (1, 16) : 2 \n",
+            "   ╰─ {;:42} from (1, 16) to (1, 17) : ; \n",
+        );
         assert_eq!(rendered, expected);
+    }
+
+    #[test]
+    fn dump_output_from_a_parented_start_node_indents_as_a_last_child() {
+        // `bca find` dumps the matched node, not the file root, so the
+        // start node usually has a parent and renders `╰─` with its
+        // subtree indented under it. `start_connector` is the only place
+        // that distinction is made now that the walk carries connectors
+        // on the stack (#1054) — this pins it end to end.
+        let code = b"int a = (1) + 2;\n";
+        let parser = CppParser::new(code.to_vec(), &PathBuf::from("t.c"), None);
+        let root = parser.root();
+        let paren = root
+            .descendants_by_kind(&["parenthesized_expression"])
+            .into_iter()
+            .next()
+            .expect("source has a parenthesized expression");
+
+        let expected = concat!(
+            "╰─ {parenthesized_expression:363} from (1, 9) to (1, 12) : (1) \n",
+            "   ├─ {(:5} from (1, 9) to (1, 10) : ( \n",
+            "   ├─ {number_literal:158} from (1, 10) to (1, 11) : 1 \n",
+            "   ╰─ {):8} from (1, 11) to (1, 12) : ) \n",
+        );
+        assert_eq!(render(code, &paren, -1), expected);
+
+        // Depth 1 is what `bca find` actually passes: the matched node
+        // alone, still as a last child.
+        assert_eq!(
+            render(code, &paren, 1),
+            "╰─ {parenthesized_expression:363} from (1, 9) to (1, 12) : (1) \n"
+        );
     }
 
     #[test]
@@ -392,21 +539,7 @@ mod tests {
         // exercising `line_in_range` end to end through the walk.
         let code = b"int a = 1;\nint b = 2;\n";
         let parser = CppParser::new(code.to_vec(), &PathBuf::from("t.c"), None);
-        let root = parser.root();
-
-        let start: Option<usize> = Some(2);
-        let end: Option<usize> = Some(2);
-        let mut sink = NoColor::new(Vec::new());
-        {
-            let mut state = DumpState {
-                code,
-                line_start: &start,
-                line_end: &end,
-                stdout: &mut sink,
-            };
-            dump_tree_helper(&mut state, &root, "", true, -1).expect("dump to in-memory sink");
-        }
-        let rendered = String::from_utf8(sink.into_inner()).expect("dump output is utf-8");
+        let rendered = render_range(code, &parser.root(), -1, Some(2), Some(2));
 
         // Row-1 nodes (`int a = 1;` and the root, which starts on row 1)
         // are filtered out; only row-2 nodes survive.
@@ -445,14 +578,18 @@ mod tests {
                 let root = parser.root();
                 let no_start: Option<usize> = None;
                 let no_end: Option<usize> = None;
-                let mut sink = NoColor::new(Vec::new());
+                // Discard the bytes rather than buffering them: every
+                // line of a depth-4000 chain carries ~3 x depth bytes of
+                // indentation, so a `Vec` sink held ~140 MB for a test
+                // that only asserts the walk completes.
+                let mut sink = NoColor::new(std::io::sink());
                 let mut state = DumpState {
                     code: &src,
                     line_start: &no_start,
                     line_end: &no_end,
                     stdout: &mut sink,
                 };
-                dump_tree_helper(&mut state, &root, "", true, -1).is_ok()
+                dump_tree_helper(&mut state, &root, -1).is_ok()
             })
             .expect("spawn dump thread");
         assert!(
@@ -474,21 +611,9 @@ mod tests {
         let code = b"int a = 42;\n";
         let parser = CppParser::new(code.to_vec(), &PathBuf::from("t.c"), None);
         let root = parser.root();
-        let no_start: Option<usize> = None;
-        let no_end: Option<usize> = None;
 
-        // depth = 1: the root renders, but recursion stops before children.
-        let mut sink = NoColor::new(Vec::new());
-        {
-            let mut state = DumpState {
-                code,
-                line_start: &no_start,
-                line_end: &no_end,
-                stdout: &mut sink,
-            };
-            dump_tree_helper(&mut state, &root, "", true, 1).expect("dump to in-memory sink");
-        }
-        let rendered = String::from_utf8(sink.into_inner()).expect("dump output is utf-8");
+        // depth = 1: the root renders, but the walk stops before children.
+        let rendered = render(code, &root, 1);
         assert!(
             rendered.contains("{translation_unit:"),
             "depth=1 should render the root:\n{rendered}"
@@ -504,16 +629,6 @@ mod tests {
         );
 
         // depth = 0: nothing renders at all.
-        let mut sink_zero = NoColor::new(Vec::new());
-        {
-            let mut state = DumpState {
-                code,
-                line_start: &no_start,
-                line_end: &no_end,
-                stdout: &mut sink_zero,
-            };
-            dump_tree_helper(&mut state, &root, "", true, 0).expect("dump to in-memory sink");
-        }
-        assert!(sink_zero.into_inner().is_empty(), "depth=0 renders nothing");
+        assert!(render(code, &root, 0).is_empty(), "depth=0 renders nothing");
     }
 }

--- a/src/output/dump_metrics.rs
+++ b/src/output/dump_metrics.rs
@@ -26,8 +26,8 @@ use termcolor::{Color, StandardStream, WriteColor};
 
 use serde_json::Value;
 
-use crate::output::ColorMode;
 use crate::output::numfmt::F64_SAFE_INT_BOUND;
+use crate::output::{ColorMode, branch_glyphs};
 use crate::spaces::{CodeMetrics, FuncSpace};
 use crate::wire;
 
@@ -80,11 +80,21 @@ pub fn dump_root(space: &FuncSpace) -> std::io::Result<()> {
 pub fn dump_root_with_color(space: &FuncSpace, color_mode: ColorMode) -> std::io::Result<()> {
     let stdout = StandardStream::stdout(color_mode.to_color_choice());
     let mut stdout = stdout.lock();
-    dump_space(space, "", true, &mut stdout)?;
+    dump_space(space, &mut stdout)?;
     color(&mut stdout, Color::White)?;
 
     Ok(())
 }
+
+/// One pending space in the walk: the space, the length its indentation
+/// prefix has in the shared buffer, and whether it is its parent's last
+/// child.
+///
+/// The prefix is a *length* rather than an owned copy (#1054): prefixes
+/// only grow as the walk descends, so the first `prefix_len` bytes stay
+/// this space's prefix until it is popped. Owning one prefix per stack
+/// entry cost O(depth²) resident bytes on a deep closure nest.
+type SpaceFrame<'a> = (&'a FuncSpace, usize, bool);
 
 /// Dump the `FuncSpace` metric tree with an explicit work stack rather
 /// than recursion, so a pathologically deep space nesting (closures
@@ -92,16 +102,17 @@ pub fn dump_root_with_color(space: &FuncSpace, color_mode: ColorMode) -> std::io
 /// uncatchable abort, forbidden by the no-panic rule (#700). Traversal
 /// order and per-node glyphs are byte-identical to the prior recursive
 /// form.
-fn dump_space(
-    space: &FuncSpace,
-    prefix: &str,
-    last: bool,
-    stdout: &mut dyn WriteColor,
-) -> std::io::Result<()> {
-    let mut stack: Vec<(&FuncSpace, String, bool)> = vec![(space, prefix.to_owned(), last)];
+fn dump_space(space: &FuncSpace, stdout: &mut dyn WriteColor) -> std::io::Result<()> {
+    let mut prefix = String::new();
+    let mut stack: Vec<SpaceFrame> = vec![(space, 0, true)];
 
-    while let Some((space, prefix, last)) = stack.pop() {
-        let (pref_child, pref) = if last { ("   ", "`- ") } else { ("|  ", "|- ") };
+    while let Some((space, prefix_len, last)) = stack.pop() {
+        // Truncating on every visit — rather than on the way back up —
+        // is what lets a frame carry a bare length: whatever a sibling's
+        // subtree appended is dropped here. Recorded lengths always sit
+        // on a char boundary because only whole glyph runs are appended.
+        prefix.truncate(prefix_len);
+        let (pref_child, pref) = branch_glyphs(last);
 
         color(stdout, Color::Blue)?;
         write!(stdout, "{prefix}{pref}")?;
@@ -115,33 +126,33 @@ fn dump_space(
         intense_color(stdout, Color::Red)?;
         writeln!(stdout, " (@{})", space.start_line)?;
 
-        let child_prefix = format!("{prefix}{pref_child}");
-        dump_metrics(
-            &space.metrics,
-            &child_prefix,
-            space.spaces.is_empty(),
-            stdout,
-        )?;
+        prefix.push_str(pref_child);
+        let child_prefix_len = prefix.len();
+        dump_metrics(&space.metrics, &mut prefix, space.spaces.is_empty(), stdout)?;
 
         // Push children in reverse so `pop()` visits them in source
         // order; the final child carries `last = true` for the closing
         // `` `- `` glyph, matching the recursive `split_last` form.
         let count = space.spaces.len();
         for (i, child) in space.spaces.iter().enumerate().rev() {
-            stack.push((child, child_prefix.clone(), i + 1 == count));
+            stack.push((child, child_prefix_len, i + 1 == count));
         }
     }
 
     Ok(())
 }
 
+/// Render a space's `metrics` subtree. `prefix` is the shared
+/// indentation buffer; it is extended in place for the metric groups and
+/// left extended — every caller either truncates back or is the space
+/// walk, which re-truncates on its next visit.
 fn dump_metrics(
     metrics: &CodeMetrics,
-    prefix: &str,
+    prefix: &mut String,
     last: bool,
     stdout: &mut dyn WriteColor,
 ) -> std::io::Result<()> {
-    let (pref_child, pref) = if last { ("   ", "`- ") } else { ("|  ", "|- ") };
+    let (pref_child, pref) = branch_glyphs(last);
 
     color(stdout, Color::Blue)?;
     write!(stdout, "{prefix}{pref}")?;
@@ -159,10 +170,12 @@ fn dump_metrics(
         return Ok(());
     };
 
-    let prefix = format!("{prefix}{pref_child}");
+    prefix.push_str(pref_child);
+    let group_prefix_len = prefix.len();
     let last_index = groups.len().saturating_sub(1);
     for (index, (name, value)) in groups.iter().enumerate() {
-        dump_group(name, value, &prefix, index == last_index, stdout)?;
+        prefix.truncate(group_prefix_len);
+        dump_group(name, value, prefix, index == last_index, stdout)?;
     }
     Ok(())
 }
@@ -171,14 +184,17 @@ fn dump_metrics(
 /// subtree, then walk its leaves. A nested object leaf (e.g.
 /// `cyclomatic.modified`) recurses as its own subtree, so the rendered
 /// shape always mirrors the JSON nesting.
+///
+/// Extends the shared `prefix` in place for the group's leaves and leaves
+/// it extended; callers truncate back before the next sibling.
 fn dump_group(
     name: &str,
     value: &Value,
-    prefix: &str,
+    prefix: &mut String,
     last: bool,
     stdout: &mut dyn WriteColor,
 ) -> std::io::Result<()> {
-    let (pref_child, pref) = if last { ("   ", "`- ") } else { ("|  ", "|- ") };
+    let (pref_child, pref) = branch_glyphs(last);
 
     color(stdout, Color::Blue)?;
     write!(stdout, "{prefix}{pref}")?;
@@ -186,21 +202,30 @@ fn dump_group(
     intense_color(stdout, Color::Green)?;
     writeln!(stdout, "{name}")?;
 
-    let prefix = format!("{prefix}{pref_child}");
-    dump_object(value, &prefix, stdout)
+    prefix.push_str(pref_child);
+    dump_object(value, prefix, stdout)
 }
 
 /// Walk the leaves of a metric object, emitting one `name: value` line
 /// per scalar and recursing into any nested object (rendered as a green
 /// subtree, matching the JSON nesting). A non-object value is ignored
 /// (the wire metric groups are always objects).
-fn dump_object(value: &Value, prefix: &str, stdout: &mut dyn WriteColor) -> std::io::Result<()> {
+///
+/// Truncating the shared `prefix` back to this object's level before each
+/// field is what keeps a nested group from indenting its siblings.
+fn dump_object(
+    value: &Value,
+    prefix: &mut String,
+    stdout: &mut dyn WriteColor,
+) -> std::io::Result<()> {
     let Value::Object(fields) = value else {
         return Ok(());
     };
+    let field_prefix_len = prefix.len();
     let last_index = fields.len().saturating_sub(1);
     for (index, (name, leaf)) in fields.iter().enumerate() {
         let last = index == last_index;
+        prefix.truncate(field_prefix_len);
         if leaf.is_object() {
             dump_group(name, leaf, prefix, last, stdout)?;
         } else {
@@ -280,8 +305,123 @@ mod tests {
 
     fn render(space: &FuncSpace) -> String {
         let mut buf = termcolor::NoColor::new(Vec::new());
-        dump_space(space, "", true, &mut buf).expect("dump to in-memory buffer");
+        dump_space(space, &mut buf).expect("dump to in-memory buffer");
         String::from_utf8(buf.into_inner()).expect("utf-8 dump")
+    }
+
+    #[test]
+    fn fields_after_a_nested_metric_object_resume_the_group_rail() {
+        // `cyclomatic.modified` is the one metric group that nests
+        // another object, and `sum` / `value` follow it. Rendering the
+        // nested group extends the shared indentation buffer (#1054), so
+        // those two trailing fields only land back on the `cyclomatic`
+        // rail if `dump_object` truncates before each field, and the
+        // group *after* cyclomatic only lands back on the metrics rail
+        // if the group loop truncates too. Nothing else in the suite
+        // exercises a nested group's siblings.
+        //
+        // The whole block is compared as a line sequence rather than
+        // with per-rail `contains` checks: `sum` and `value` are fields
+        // of several groups, and a deeper rail ends with the shallower
+        // one, so a substring search accepts both the wrong group and
+        // the exact mis-indentation this test exists to catch.
+        let space = analyze(
+            Source::new(LANG::Cpp, b"int a = 42;"),
+            MetricsOptions::default(),
+        )
+        .expect("snippet has a top-level FuncSpace");
+        let out = render(&space);
+
+        // Values are dropped: this pins indentation, not metric numbers.
+        let rails: Vec<&str> = out
+            .lines()
+            .skip_while(|line| *line != "      |- cyclomatic")
+            .take_while(|line| !line.starts_with("      |- halstead"))
+            .map(|line| line.split_once(": ").map_or(line, |(rail, _)| rail))
+            .collect();
+        assert_eq!(
+            rails,
+            vec![
+                "      |- cyclomatic",
+                "      |  |- average",
+                "      |  |- max",
+                "      |  |- min",
+                "      |  |- modified",
+                "      |  |  |- average",
+                "      |  |  |- max",
+                "      |  |  |- min",
+                "      |  |  |- sum",
+                "      |  |  `- value",
+                "      |  |- sum",
+                "      |  `- value",
+            ],
+            "cyclomatic's rails must survive the nested `modified` \
+             object:\n{out}"
+        );
+        assert!(
+            out.lines().any(|line| line == "      |- halstead"),
+            "the group after cyclomatic must be back on the metrics \
+             rail:\n{out}"
+        );
+    }
+
+    #[test]
+    fn sibling_space_after_a_nested_one_resumes_its_own_rail() {
+        // The walk keeps one shared indentation buffer that is extended
+        // on descent and truncated on the next visit (#1054), and the
+        // metric groups under each space extend it further still. `after`
+        // is a top-level sibling that follows `outer`'s deeper subtree
+        // and its whole metrics block, so a truncation bug leaves it
+        // indented under `inner`'s rail. Built by hand — `FuncSpace` has
+        // an iterative `Drop` (#1056), so struct-update syntax cannot
+        // move fields out of it.
+        //
+        // The expected rails are what the pre-#1054 binary emits for the
+        // equivalent parsed tree (`function outer(){function inner(){}}
+        // function after(){}`).
+        use crate::spaces::SpaceKind;
+        let func = |name: &str, line: usize, spaces: Vec<FuncSpace>| FuncSpace {
+            name: Some(name.to_string()),
+            start_line: line,
+            end_line: line,
+            kind: SpaceKind::Function,
+            spaces,
+            metrics: CodeMetrics::default(),
+            suppressed: crate::SuppressionScope::default(),
+        };
+        let space = FuncSpace {
+            name: Some("u".to_string()),
+            start_line: 1,
+            end_line: 4,
+            kind: SpaceKind::Unit,
+            spaces: vec![
+                func("outer", 1, vec![func("inner", 2, vec![])]),
+                func("after", 4, vec![]),
+            ],
+            metrics: CodeMetrics::default(),
+            suppressed: crate::SuppressionScope::default(),
+        };
+
+        let out = render(&space);
+        let rails: Vec<&str> = out
+            .lines()
+            .filter(|line| line.contains("(@") || line.ends_with("- metrics"))
+            .collect();
+        assert_eq!(
+            rails,
+            vec![
+                "`- unit: u (@1)",
+                "   |- metrics",
+                "   |- function: outer (@1)",
+                "   |  |- metrics",
+                "   |  `- function: inner (@2)",
+                "   |     `- metrics",
+                "   `- function: after (@4)",
+                "      `- metrics",
+            ],
+            "space and metric-block rails must survive the shared prefix \
+             buffer's truncate/extend cycle:\n{out}"
+        );
     }
 
     #[test]
@@ -364,8 +504,14 @@ mod tests {
                     cursor.spaces.push(leaf());
                     cursor = cursor.spaces.last_mut().expect("just pushed");
                 }
-                let mut sink = termcolor::NoColor::new(Vec::new());
-                let ok = dump_space(&root, "", true, &mut sink).is_ok();
+                // Discard the bytes rather than buffering them: a
+                // depth-8000 chain renders ~8000 metric blocks, each
+                // line carrying ~3 x depth bytes of indentation, so a
+                // `Vec` sink held ~10 GB and made the unit suite an
+                // out-of-memory hazard. Nothing here asserts on the
+                // text, and every write still runs.
+                let mut sink = termcolor::NoColor::new(std::io::sink());
+                let ok = dump_space(&root, &mut sink).is_ok();
                 // `root` drops here without flattening: `FuncSpace`'s
                 // `Drop` is iterative as of #1056, so teardown costs no
                 // stack depth and cannot mask the dump result.
@@ -410,7 +556,7 @@ mod tests {
         .expect("snippet has a top-level FuncSpace");
 
         let mut buf = termcolor::NoColor::new(Vec::new());
-        dump_space(&space, "", true, &mut buf).expect("dump to in-memory buffer");
+        dump_space(&space, &mut buf).expect("dump to in-memory buffer");
         let out = String::from_utf8(buf.into_inner()).expect("utf-8 dump");
 
         assert_ne!(
@@ -438,7 +584,7 @@ mod tests {
         .expect("snippet has a top-level FuncSpace");
 
         let mut buf = termcolor::NoColor::new(Vec::new());
-        dump_space(&space, "", true, &mut buf).expect("dump to in-memory buffer");
+        dump_space(&space, &mut buf).expect("dump to in-memory buffer");
         let out = String::from_utf8(buf.into_inner()).expect("utf-8 dump");
 
         assert!(

--- a/src/output/dump_metrics.rs
+++ b/src/output/dump_metrics.rs
@@ -453,28 +453,37 @@ mod tests {
         // dynamic by the wire projection in #674). For a non-class C
         // dump, the wmc/npm/npa class-only groups are elided, so the last
         // group line under the root `metrics` subtree must end the
-        // subtree with `` `- ``. We locate the final group connector
-        // (a `<rail>`- ` or `<rail>|- ` line whose label is a top-level
-        // group, i.e. indented directly under `metrics`) and assert it is
-        // the closing form.
+        // subtree with `` `- ``.
         let space = analyze(
             Source::new(LANG::Cpp, b"int a = 42;"),
             MetricsOptions::default(),
         )
         .expect("snippet has a top-level FuncSpace");
         let out = render(&space);
-        // The root metrics subtree indents its groups under `   ` (root
-        // is the last/only space). The last such group line must use
-        // `` `- ``; if any group dangled, the final group line would read
-        // `|- `.
+
+        // Group lines sit six columns in: three for the root space's own
+        // `` `- `` (it is the only space) and three more for the
+        // `metrics` line's. Filtering at three columns instead matched
+        // only the `metrics` line itself, so this test passed even with
+        // every group rendering `|-`.
         let group_lines: Vec<&str> = out
             .lines()
-            .filter(|l| l.starts_with("   |- ") || l.starts_with("   `- "))
+            .filter(|line| line.starts_with("      |- ") || line.starts_with("      `- "))
             .collect();
+        assert!(
+            group_lines.len() > 1,
+            "expected several metric groups under the root:\n{out}"
+        );
         let last_group = group_lines.last().expect("at least one metric group");
         assert!(
-            last_group.starts_with("   `- "),
+            last_group.starts_with("      `- "),
             "the last emitted metric group must use the closing connector, got: {last_group:?}\n{out}"
+        );
+        assert!(
+            group_lines[..group_lines.len() - 1]
+                .iter()
+                .all(|line| line.starts_with("      |- ")),
+            "every group but the last must use the mid-child connector:\n{out}"
         );
     }
 

--- a/src/output/dump_ops.rs
+++ b/src/output/dump_ops.rs
@@ -267,11 +267,21 @@ mod tests {
     }
 
     #[test]
-    fn dump_ops_empty_operators_and_operands_does_not_panic() {
-        // Regression: `ops.len() - 1` underflowed (usize) when ops was empty,
-        // then `ops.last().unwrap()` panicked. A space with no Halstead
-        // operators or operands is a realistic input.
-        assert!(dump_ops(&leaf_ops(vec![], vec![])).is_ok());
+    fn dump_ops_empty_operators_and_operands_renders_bare_headers() {
+        // Regression: `ops.len() - 1` underflowed (usize) when ops was
+        // empty, then `ops.last().unwrap()` panicked. A space with no
+        // Halstead operators or operands is a realistic input. Asserting
+        // the rendered text rather than `dump_ops(..).is_ok()` keeps the
+        // no-panic guard while also pinning what an empty block looks
+        // like — and keeps the test off the process's real stdout.
+        assert_eq!(
+            render(&leaf_ops(vec![], vec![])),
+            concat!(
+                "`- unit: unit (@1)\n",
+                "   |- operators\n",
+                "   `- operands\n",
+            )
+        );
     }
 
     #[test]

--- a/src/output/dump_ops.rs
+++ b/src/output/dump_ops.rs
@@ -1,7 +1,7 @@
 use termcolor::{Color, StandardStream, WriteColor};
 
 use crate::ops::Ops;
-use crate::output::ColorMode;
+use crate::output::{ColorMode, branch_glyphs};
 
 use crate::tools::{color, intense_color};
 
@@ -51,11 +51,21 @@ pub fn dump_ops(ops: &Ops) -> std::io::Result<()> {
 pub fn dump_ops_with_color(ops: &Ops, color_mode: ColorMode) -> std::io::Result<()> {
     let stdout = StandardStream::stdout(color_mode.to_color_choice());
     let mut stdout = stdout.lock();
-    dump_space(ops, "", true, &mut stdout)?;
+    dump_space(ops, &mut stdout)?;
     color(&mut stdout, Color::White)?;
 
     Ok(())
 }
+
+/// One pending space in the walk: the space, the length its indentation
+/// prefix has in the shared buffer, and whether it is its parent's last
+/// child.
+///
+/// The prefix is a *length* rather than an owned copy (#1054): prefixes
+/// only grow as the walk descends, so the first `prefix_len` bytes stay
+/// this space's prefix until it is popped. Owning one prefix per stack
+/// entry cost O(depth²) resident bytes on a deep closure nest.
+type OpsFrame<'a> = (&'a Ops, usize, bool);
 
 /// Dump the `Ops` space tree with an explicit work stack rather than
 /// recursion, so a pathologically deep space nesting (closures within
@@ -63,16 +73,17 @@ pub fn dump_ops_with_color(ops: &Ops, color_mode: ColorMode) -> std::io::Result<
 /// uncatchable abort, forbidden by the no-panic rule (#700). Traversal
 /// order and per-node glyphs are byte-identical to the prior recursive
 /// form.
-fn dump_space(
-    space: &Ops,
-    prefix: &str,
-    last: bool,
-    stdout: &mut dyn WriteColor,
-) -> std::io::Result<()> {
-    let mut stack: Vec<(&Ops, String, bool)> = vec![(space, prefix.to_owned(), last)];
+fn dump_space(space: &Ops, stdout: &mut dyn WriteColor) -> std::io::Result<()> {
+    let mut prefix = String::new();
+    let mut stack: Vec<OpsFrame> = vec![(space, 0, true)];
 
-    while let Some((space, prefix, last)) = stack.pop() {
-        let (pref_child, pref) = if last { ("   ", "`- ") } else { ("|  ", "|- ") };
+    while let Some((space, prefix_len, last)) = stack.pop() {
+        // Truncating on every visit — rather than on the way back up —
+        // is what lets a frame carry a bare length: whatever a sibling's
+        // subtree appended is dropped here. Recorded lengths always sit
+        // on a char boundary because only whole glyph runs are appended.
+        prefix.truncate(prefix_len);
+        let (pref_child, pref) = branch_glyphs(last);
 
         color(stdout, Color::Blue)?;
         write!(stdout, "{prefix}{pref}")?;
@@ -86,27 +97,32 @@ fn dump_space(
         intense_color(stdout, Color::Red)?;
         writeln!(stdout, " (@{})", space.start_line)?;
 
-        let child_prefix = format!("{prefix}{pref_child}");
-        dump_space_ops(space, &child_prefix, space.spaces.is_empty(), stdout)?;
+        prefix.push_str(pref_child);
+        let child_prefix_len = prefix.len();
+        dump_space_ops(space, &mut prefix, space.spaces.is_empty(), stdout)?;
 
         // Push children in reverse so `pop()` visits them in source
         // order; the final child carries `last = true` for the closing
         // `` `- `` glyph, matching the recursive `split_last` form.
         let count = space.spaces.len();
         for (i, child) in space.spaces.iter().enumerate().rev() {
-            stack.push((child, child_prefix.clone(), i + 1 == count));
+            stack.push((child, child_prefix_len, i + 1 == count));
         }
     }
 
     Ok(())
 }
 
+/// Render a space's `operators` / `operands` blocks. `prefix` is the
+/// shared indentation buffer; each block extends it in place and the
+/// truncation between the two restores the block-level indentation.
 fn dump_space_ops(
     ops: &Ops,
-    prefix: &str,
+    prefix: &mut String,
     last: bool,
     stdout: &mut dyn WriteColor,
 ) -> std::io::Result<()> {
+    let base = prefix.len();
     // `operands` always follows `operators` within a space's op block, so
     // `operators` is never the last child and must render the mid-child
     // connector (`|-`), regardless of whether the block itself is the
@@ -115,17 +131,21 @@ fn dump_space_ops(
     // operand subtree (#700). Only `operands` inherits the block's
     // `last`.
     dump_ops_values("operators", &ops.operators, prefix, false, stdout)?;
+    prefix.truncate(base);
     dump_ops_values("operands", &ops.operands, prefix, last, stdout)
 }
 
+/// Render one named op list. Extends `prefix` in place for the list
+/// entries and leaves it extended; the caller truncates back (the space
+/// walk re-truncates on its next visit anyway).
 fn dump_ops_values(
     name: &str,
     ops: &[String],
-    prefix: &str,
+    prefix: &mut String,
     last: bool,
     stdout: &mut dyn WriteColor,
 ) -> std::io::Result<()> {
-    let (pref_child, pref) = if last { ("   ", "`- ") } else { ("|  ", "|- ") };
+    let (pref_child, pref) = branch_glyphs(last);
 
     color(stdout, Color::Blue)?;
     write!(stdout, "{prefix}{pref}")?;
@@ -137,7 +157,7 @@ fn dump_ops_values(
         return Ok(());
     };
 
-    let prefix = format!("{prefix}{pref_child}");
+    prefix.push_str(pref_child);
     for op in rest {
         color(stdout, Color::Blue)?;
         write!(stdout, "{prefix}|- ")?;
@@ -184,8 +204,66 @@ mod tests {
 
     fn render(ops: &Ops) -> String {
         let mut sink = NoColor::new(Vec::new());
-        dump_space(ops, "", true, &mut sink).expect("dump to in-memory sink");
+        dump_space(ops, &mut sink).expect("dump to in-memory sink");
         String::from_utf8(sink.into_inner()).expect("utf-8 dump")
+    }
+
+    #[test]
+    fn sibling_space_after_a_nested_one_resumes_its_own_rail() {
+        // The walk keeps one shared indentation buffer that is extended
+        // on descent and truncated on the next visit (#1054). `after` is
+        // a top-level sibling that follows `outer`'s deeper subtree, so a
+        // truncation bug leaves it (and its op blocks) indented under
+        // `inner`'s rail instead of back at the unit's. Built by hand so
+        // the op lists are ordered `Vec`s — the parsed `Ops` iteration
+        // order is not stable run to run.
+        //
+        // The expected rails match what the pre-#1054 binary emits for
+        // the equivalent parsed tree (`function outer(){function
+        // inner(){}} function after(){}`).
+        // `Ops` has an iterative `Drop` (#1056), so struct-update syntax
+        // (`..leaf_ops(…)`) cannot move fields out of it; build each node
+        // whole.
+        let func = |name: &str, line: usize, operators: Vec<String>, spaces: Vec<Ops>| Ops {
+            name: Some(name.to_string()),
+            name_was_lossy: false,
+            start_line: line,
+            end_line: line,
+            kind: SpaceKind::Function,
+            spaces,
+            operators,
+            operands: vec![],
+        };
+        let space = Ops {
+            name: Some("u".to_string()),
+            name_was_lossy: false,
+            start_line: 1,
+            end_line: 4,
+            kind: SpaceKind::Unit,
+            spaces: vec![
+                func("outer", 1, vec![], vec![func("inner", 2, vec![], vec![])]),
+                func("after", 4, vec!["+".to_string()], vec![]),
+            ],
+            operators: vec![],
+            operands: vec![],
+        };
+
+        let expected = concat!(
+            "`- unit: u (@1)\n",
+            "   |- operators\n",
+            "   |- operands\n",
+            "   |- function: outer (@1)\n",
+            "   |  |- operators\n",
+            "   |  |- operands\n",
+            "   |  `- function: inner (@2)\n",
+            "   |     |- operators\n",
+            "   |     `- operands\n",
+            "   `- function: after (@4)\n",
+            "      |- operators\n",
+            "      |  `- +\n",
+            "      `- operands\n",
+        );
+        assert_eq!(render(&space), expected);
     }
 
     #[test]
@@ -240,8 +318,12 @@ mod tests {
                         .push(leaf_ops(vec!["+".to_string()], vec!["a".to_string()]));
                     cursor = cursor.spaces.last_mut().expect("just pushed");
                 }
-                let mut sink = NoColor::new(Vec::new());
-                let ok = dump_space(&root, "", true, &mut sink).is_ok();
+                // Discard the bytes rather than buffering them: every
+                // line of a depth-8000 chain carries ~3 x depth bytes of
+                // indentation, so a `Vec` sink held ~0.5 GB for a test
+                // that only asserts the walk completes.
+                let mut sink = NoColor::new(std::io::sink());
+                let ok = dump_space(&root, &mut sink).is_ok();
                 // `root` drops here without flattening: `Ops`'s `Drop` is
                 // iterative as of #1056, so teardown costs no stack depth
                 // and cannot mask the dump result.

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -31,3 +31,16 @@ pub use code_climate::write_code_climate;
 
 pub mod warning_line;
 pub use warning_line::{write_clang_warning, write_msvc_warning};
+
+/// The `(child, own)` ASCII prefix pair for one line of the `metrics` and
+/// `ops` text trees: what the node contributes to its children's
+/// indentation, and the connector on its own line. `` `-  `` closes a
+/// subtree, `|- ` continues it.
+///
+/// Shared by [`dump_metrics`] and [`dump_ops`], which render the same
+/// glyph vocabulary over two different trees, so the two mirrored walks
+/// cannot drift apart. The AST dump ([`dump`]) deliberately uses Unicode
+/// box-drawing glyphs instead and has its own connector type.
+pub(crate) const fn branch_glyphs(last: bool) -> (&'static str, &'static str) {
+    if last { ("   ", "`- ") } else { ("|  ", "|- ") }
+}


### PR DESCRIPTION
Fixes #1054

`bca dump` was quadratic in AST nesting depth. The issue is already
closed with the full write-up; this PR is the code.

## Root cause: two quadratic terms, not one

1. **The prefix, as the issue describes.** Every queued node carried an
   owned `String` copy of its ancestors' box-drawing prefix, rebuilt with
   `format!` per node and `clone()`d per child. A tree that is wide *and*
   deep holds O(depth²) resident bytes plus an O(depth) copy per node.

2. **`Node::parent`, which the issue does not mention.** `branch_glyphs`
   called `node.parent().is_none()` once per node for the flush-left
   check, and `tree_sitter` resolves `parent()` by descending from the
   root — the same shape #1052 and #1084 hit. This term dominates on the
   wide-and-deep fixture.

## What changed

The walk keeps **one shared prefix buffer**, extended on descent and
truncated at the start of the next visit; each stack frame carries a
`prefix_len` instead of a `String`. Truncating on visit rather than on
the way back up is what makes a bare length sufficient — prefixes only
grow as the walk descends, so the first `prefix_len` bytes are still
this node's prefix when it is popped.

The flush-left decision moved onto the stack as a `Connector` enum
(`Flush` / `Last` / `Inner`) derived when a node is *pushed*, so
`Node::parent` is called exactly once per walk — for the start node, the
only node that can lack a parent. (`bca find` starts at a matched node
that *does* have one; it renders as a last child, as before.)

The mirrored `dump_metrics` / `dump_ops` walks carried the same per-entry
owned prefix and got the same treatment. Their measured cost is unchanged
on the fixtures tried — a nested-closure chain keeps one stack entry alive
at a time, so the quadratic term needs a tree that is wide *and* deep —
but the O(depth) copy per rendered line is gone and the three walks no
longer differ in shape.

The last commit (`87da2b98`) is a follow-up cleanup landed after the issue
write-up: `push_children` now consumes the child iterator directly and
reverses the new stack tail in place, dropping the reused `Vec<Node>`
staging buffer so each node is copied once rather than twice.

## Measurements

Release binary, the issue's fixture `int main(){return ((((…1…))));}`:

| depth | before | after | peak RSS before | after |
|---|---|---|---|---|
| 1000 | 84 ms | 10 ms | 15.5 MB | 11.6 MB |
| 2000 | 284 ms | 10 ms | 25.4 MB | 12.0 MB |
| 4000 | 1,181 ms | 50 ms | 66.2 MB | 13.0 MB |

Wide-and-deep JavaScript fixture (1500 nested functions, two extra
siblings per level), where the `parent()` term bites hardest:

| command | before | after |
|---|---|---|
| `bca dump` | 4.00 s | 0.05 s |
| `bca metrics` | 1.33 s | 1.29 s |

## What this does *not* fix

The **emitted byte count**, which is what the issue's "~34,000x
amplification" headline measures. A depth-`d` tree drawing carries `d`
glyphs of indentation on every line, so output is inherently
O(nodes × depth); 546 MB at depth 8000 is what the format costs. Bounding
the output is a CLI resource-limit decision tracked in #1053 — `--depth`
is the existing lever. This PR removes the time and the *resident* memory
spent producing those bytes, not the bytes.

## Evidence

- **Byte-identity** over 300 files spanning `src/`,
  `tests/repositories/pdf.js`, `tests/repositories/DeepSpeech`, and
  `tests/repositories/serde`, against a binary built from `main`:
  `dump` 300/300 and `metrics` 300/300 byte-identical; `ops` 300/300 after
  normalising the positional connector and sorting, because `bca ops`
  output is **already nondeterministic run to run on `main`** — filed
  separately as #1091.
- **`make pre-commit` green end to end** (`MAKE_EXIT=0`) on the tip
  commit: cargo trio, doc warnings, udeps, the markdown/TOML/shell/
  Makefile/Actions lint families, man-page drift, both self-scan tiers,
  and the Python ruff/mypy/pyright/pytest/stubtest stages.
- Every `prefix.truncate` is covered by a perturbation-verified test.
- No snapshot churn and no submodule bump: the rendered text is unchanged,
  so a clean run leaves no `.snap.new`.

**Not covered by `make bench-scaling`.** Its probes measure the metric
walk, not the `dump` walk, so no probe exercises this path — the numbers
above are direct release-binary timings on the two fixtures, not harness
output.

## Spun out

- **#1091** — `bca ops` entry order is nondeterministic run to run on
  `main`, found while establishing byte-parity.
