### PR TITLE
fix(output): make the dump walks linear and the ops listing deterministic

### DIFF
--- a/.bca-baseline.toml
+++ b/.bca-baseline.toml
@@ -861,9 +861,9 @@ value = 32.0
 [[entry]]
 path = "src/ops.rs"
 qualified = "ops_inner"
-start_line = 211
+start_line = 216
 metric = "halstead.effort"
-value = 56640.89870124066
+value = 58764.00971804493
 
 [[entry]]
 path = "src/output/checkstyle.rs"

--- a/.bca-baseline.toml
+++ b/.bca-baseline.toml
@@ -882,35 +882,35 @@ value = 60471.77938561803
 [[entry]]
 path = "src/output/dump_metrics.rs"
 qualified = "dump_metrics"
-start_line = 138
+start_line = 149
 metric = "nexits"
 value = 6.0
 
 [[entry]]
 path = "src/output/dump_metrics.rs"
 qualified = "dump_space"
-start_line = 95
+start_line = 105
 metric = "nexits"
 value = 9.0
 
 [[entry]]
 path = "src/output/dump_metrics.rs"
 qualified = "dump_value"
-start_line = 217
+start_line = 242
 metric = "nexits"
 value = 5.0
 
 [[entry]]
 path = "src/output/dump_ops.rs"
 qualified = "dump_ops_values"
-start_line = 121
+start_line = 141
 metric = "nexits"
 value = 12.0
 
 [[entry]]
 path = "src/output/dump_ops.rs"
 qualified = "dump_space"
-start_line = 66
+start_line = 76
 metric = "nexits"
 value = 9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,18 @@ for historical reference.
 
 ### Performance
 
+- The `ops` walk builds the file-level vocabulary once instead of once
+  per closing space. `finalize` rebuilt the innermost still-open space's
+  operator and operand lists on every call — that is, every time the
+  walk left a function — and every result but the last was immediately
+  overwritten, so a file with F function spaces rebuilt the root's whole
+  vocabulary F times. Only the root needs the trailing rebuild, and it
+  now happens once, in `ops_inner`, after the walk drains. On
+  `hlo_instruction.cc` (4 057 lines, ~180 spaces) `bca ops -O json`
+  drops from ~39 ms to ~27 ms per run — faster than before the #1091
+  sort was added, which the redundant rebuilds would otherwise have run
+  F times over. Output is byte-identical.
+
 - The metric walk carries its ancestor chain down the traversal instead
   of rediscovering it with `Node::parent`, which `tree_sitter` resolves
   by descending from the root (#1084). `Checker::is_else_if` (13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,20 @@ for historical reference.
 
 ### Fixed
 
+- `Ops::operators` and `Ops::operands` are now sorted in
+  byte-lexicographic order, so `bca ops` produces identical bytes for
+  identical input (#1091). Both vectors were collected from `HashMap`
+  keys, and `RandomState` reseeds per map instance, so the listings
+  were reordered on every run — and even between two parses within one
+  process. That made `bca ops` output impossible to diff between runs,
+  check into a repository, or use as a cache key, in the tree renderer
+  and in every serialized format alike. The fields were documented as
+  "arbitrary order", so pinning them down is additive for callers; no
+  metric value moves, since Halstead's `n1` / `n2` are set
+  cardinalities. Sorting costs `O(n log n)` per space over the space's
+  vocabulary and is paid only on the `ops` seam — the metric walk does
+  not run it.
+
 - The `dump` AST walk no longer rebuilds its indentation prefix per
   node, and no longer resolves a node's parent per node (#1054). Each
   queued node carried an owned copy of its ancestors' box-drawing

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -113,7 +113,11 @@ section.
     functions (`function`, `find`, `count`, `rm_comments`) are
     `pub(crate)`, not part of the public surface, and the
     parser-generic `operands_and_operators` function was removed in
-    favour of `Ast::ops`.
+    favour of `Ast::ops`. `Ops::operators` and `Ops::operands` are
+    sorted in byte-lexicographic order as of the `2.1` line; before
+    that they were documented as arbitrary and did in fact vary run
+    to run. The order is part of the contract now — callers may diff
+    or hash `ops` output — and will not change before `3.0`.
   - `NumJobs` in `src/concurrent_files.rs` (added in 1.x, #560): the
     shared `<N|auto>` worker-count selector for `ConcurrentRunner`,
     used by both the `bca` CLI and the `bca-web` server. A

--- a/big-code-analysis-book/src/recipes/exporting-data.md
+++ b/big-code-analysis-book/src/recipes/exporting-data.md
@@ -169,6 +169,10 @@ bca ops \
 
 Each output file mirrors the input path under `/tmp/ops/`.
 
+Both lists are sorted, so re-running `ops` over unchanged sources
+produces byte-identical output — safe to diff between runs, check into
+a repository, or use as a cache key.
+
 ## Strip comments from a tree
 
 `strip-comments` rewrites source so that downstream tools that don't

--- a/big-code-analysis-py/python/big_code_analysis/_native.pyi
+++ b/big-code-analysis-py/python/big_code_analysis/_native.pyi
@@ -271,7 +271,7 @@ class Ast:
         """Return each function's name and 1-based line range."""
 
     def ops(self) -> OpsDict:
-        """Return the Halstead operator/operand tree (deduplicated
+        """Return the Halstead operator/operand tree (sorted, deduplicated
         ``operators`` / ``operands`` per space).
         """
 

--- a/big-code-analysis-py/python/big_code_analysis/_types.py
+++ b/big-code-analysis-py/python/big_code_analysis/_types.py
@@ -590,8 +590,8 @@ class FunctionSpanDict(TypedDict):
 
 
 class OpsDict(TypedDict):
-    """A Halstead operator/operand tree node returned by `Ast.ops()`: the deduplicated `operators`
-    (n1) and `operands` (n2) for a space, with nested `spaces`.
+    """A Halstead operator/operand tree node returned by `Ast.ops()`: the sorted, deduplicated
+    `operators` (n1) and `operands` (n2) for a space, with nested `spaces`.
     """
 
     name: str | None

--- a/big-code-analysis-py/src/ast.rs
+++ b/big-code-analysis-py/src/ast.rs
@@ -247,7 +247,7 @@ impl PyAst {
     }
 
     /// Return the Halstead operator/operand tree for the file (an `OpsDict`),
-    /// the deduplicated operators (`n1`) and operands (`n2`) per space.
+    /// the sorted, deduplicated operators (`n1`) and operands (`n2`) per space.
     fn ops<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let ops = py
             .detach(|| self.inner.ops())

--- a/big-code-analysis-py/src/types_codegen.rs
+++ b/big-code-analysis-py/src/types_codegen.rs
@@ -704,8 +704,8 @@ const SPECS: &[DictSpec] = &[
     DictSpec {
         class: "OpsDict",
         doc: "A Halstead operator/operand tree node returned by \
-              `Ast.ops()`: the deduplicated `operators` (n1) and `operands` \
-              (n2) for a space, with nested `spaces`.",
+              `Ast.ops()`: the sorted, deduplicated `operators` (n1) and \
+              `operands` (n2) for a space, with nested `spaces`.",
         fields: &[
             req("name", OptStr),
             opt("name_was_lossy", Bool),

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -155,9 +155,14 @@ fn compute_operators_and_operands<T: ParserTrait>(state: &mut State) {
         .operators
         .keys()
         .map(|k| T::Getter::get_operator_id_as_str(*k).to_owned())
-        .chain(maps.primitive_operators.keys().map(|k| bytes_to_string(k)))
+        .chain(
+            maps.primitive_operators
+                .keys()
+                .copied()
+                .map(bytes_to_string),
+        )
         .collect();
-    let mut operands: Vec<String> = maps.operands.keys().map(|k| bytes_to_string(k)).collect();
+    let mut operands: Vec<String> = maps.operands.keys().copied().map(bytes_to_string).collect();
 
     // `HashMap`'s hasher is randomly seeded per instance, so key order
     // differs between two runs — and even between two parses in one
@@ -928,7 +933,15 @@ mod tests {
     /// Assert that every space in the tree carries sorted vocabularies,
     /// and return how many spaces were checked so a caller can prove the
     /// walk actually descended.
+    ///
+    /// The length floor is what keeps this from going quietly vacuous:
+    /// `is_sorted` is trivially true for an empty or single-entry
+    /// vector, so without it a fixture that stopped producing real
+    /// vocabularies would keep passing while covering nothing.
     fn assert_sorted_spaces(ops: &Ops, lang: LANG) -> usize {
+        /// Smallest vocabulary in which an ordering is observable.
+        const MIN_OBSERVABLE: usize = 2;
+
         let mut stack = vec![ops];
         let mut visited = 0;
 
@@ -939,8 +952,9 @@ mod tests {
                 ("operands", &space.operands),
             ] {
                 assert!(
-                    values.is_sorted(),
-                    "{lang:?} {field} of space {:?} (@{}) must be sorted: {values:?}",
+                    values.len() >= MIN_OBSERVABLE && values.is_sorted(),
+                    "{lang:?} {field} of space {:?} (@{}) must hold at least \
+                     {MIN_OBSERVABLE} entries and be sorted: {values:?}",
                     space.name,
                     space.start_line
                 );
@@ -953,19 +967,32 @@ mod tests {
 
     /// Every space's vocabularies come back sorted, in every language.
     ///
-    /// The sources are chosen to exercise both operator maps: the
-    /// token-id-keyed one and the text-keyed `primitive_operators` map
-    /// that C++ / Java primitive types land in — sorting the union is
-    /// what interleaves the two (#1091).
+    /// The operator vocabulary is the union of two maps — one keyed by
+    /// token id, one keyed by text, which is where primitive types such
+    /// as C++ `int` land — and sorting is what interleaves them rather
+    /// than leaving the second concatenated onto the first (#1091). The
+    /// `spans_both_maps` pair per case names one entry from each map, so
+    /// a fixture that stopped exercising the text-keyed map fails here
+    /// instead of silently narrowing the test's reach.
     #[test]
     fn ops_vocabularies_are_sorted_1091() {
-        let cases: &[(LANG, &str, &str)] = &[
+        /// `(language, file name, source, (text-keyed operator,
+        /// token-id-keyed operator that must sort after it))`.
+        type Case = (
+            LANG,
+            &'static str,
+            &'static str,
+            (&'static str, &'static str),
+        );
+
+        let cases: &[Case] = &[
             #[cfg(feature = "rust")]
             (
                 LANG::Rust,
                 "rust.rs",
                 "fn zeta(quux: u32) -> u32 { let mid = quux + 1; \
                  let alpha = |beta: u32| beta * mid; alpha(mid) - quux }\n",
+                ("u32", "|"),
             ),
             #[cfg(feature = "cpp")]
             (
@@ -973,6 +1000,7 @@ mod tests {
                 "cpp.cpp",
                 "int zeta(int quux) { double mid = quux + 1; \
                  char alpha = 'z'; return quux - mid + alpha; }\n",
+                ("int", "return"),
             ),
             #[cfg(feature = "java")]
             (
@@ -980,6 +1008,7 @@ mod tests {
                 "Java.java",
                 "class Zeta { int quux(int mid) { long alpha = mid + 1; \
                  boolean beta = alpha > 2; return beta ? mid : 0; } }\n",
+                ("long", "return"),
             ),
             #[cfg(feature = "python")]
             (
@@ -987,6 +1016,10 @@ mod tests {
                 "python.py",
                 "def zeta(quux):\n    mid = quux + 1\n    \
                  def alpha(beta):\n        return beta * mid\n    return alpha(mid) - quux\n",
+                // Python has no primitive-type operators; both entries
+                // come from the token-id map, so this pair only pins the
+                // ordering, not the interleaving.
+                ("def", "return"),
             ),
             #[cfg(feature = "typescript")]
             (
@@ -994,10 +1027,11 @@ mod tests {
                 "ts.ts",
                 "function zeta(quux: number): number { const mid: number = quux + 1; \
                  const alpha = (beta: number) => beta * mid; return alpha(mid) - quux; }\n",
+                ("number", "return"),
             ),
         ];
 
-        for (lang, file, source) in cases {
+        for (lang, file, source, (from_text_map, sorts_after)) in cases {
             let ops = Ast::parse(
                 Source::new(*lang, source.as_bytes()).with_name(Some((*file).to_owned())),
             )
@@ -1005,10 +1039,23 @@ mod tests {
             .ops()
             .expect("ops walk must yield a top-level Ops");
 
+            let position = |needle: &str| {
+                ops.operators
+                    .iter()
+                    .position(|op| op == needle)
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "{lang:?} operators must contain {needle:?}: {:?}",
+                            ops.operators
+                        )
+                    })
+            };
             assert!(
-                !ops.operators.is_empty() && !ops.operands.is_empty(),
-                "{lang:?} sample must produce a non-trivial vocabulary"
+                position(from_text_map) < position(sorts_after),
+                "{lang:?} must order {from_text_map:?} before {sorts_after:?}: {:?}",
+                ops.operators
             );
+
             assert!(
                 assert_sorted_spaces(&ops, *lang) > 1,
                 "{lang:?} sample must nest at least one sub-space"

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -47,13 +47,13 @@ pub struct Ops {
     pub spaces: Vec<Ops>,
     /// The **distinct** operands of a space — the deduplicated Halstead
     /// operand vocabulary (`n2`), one entry per unique operand, not every
-    /// occurrence. Backed by the keys of a `HashMap`, so entries are
-    /// unique and returned in arbitrary order.
+    /// occurrence. Sorted in byte-lexicographic order, so the same input
+    /// always yields the same sequence (#1091).
     pub operands: Vec<String>,
     /// The **distinct** operators of a space — the deduplicated Halstead
     /// operator vocabulary (`n1`), one entry per unique operator, not
-    /// every occurrence. Backed by the keys of a `HashMap`, so entries
-    /// are unique and returned in arbitrary order.
+    /// every occurrence. Sorted in byte-lexicographic order, so the same
+    /// input always yields the same sequence (#1091).
     pub operators: Vec<String>,
 }
 
@@ -146,28 +146,36 @@ fn bytes_to_string(b: &[u8]) -> String {
 }
 
 fn compute_operators_and_operands<T: ParserTrait>(state: &mut State) {
-    state.ops.operators = state
-        .halstead_maps
+    let maps = &state.halstead_maps;
+
+    // Primitive-type operators live in a second map (keyed by text rather
+    // than by token id), so the operator vocabulary is the concatenation
+    // of both key sets.
+    let mut operators: Vec<String> = maps
         .operators
         .keys()
         .map(|k| T::Getter::get_operator_id_as_str(*k).to_owned())
+        .chain(maps.primitive_operators.keys().map(|k| bytes_to_string(k)))
         .collect();
+    let mut operands: Vec<String> = maps.operands.keys().map(|k| bytes_to_string(k)).collect();
 
-    // Add primitive-type operators (stored by text in HalsteadMaps)
-    state.ops.operators.extend(
-        state
-            .halstead_maps
-            .primitive_operators
-            .keys()
-            .map(|k| bytes_to_string(k)),
-    );
+    // `HashMap`'s hasher is randomly seeded per instance, so key order
+    // differs between two runs — and even between two parses in one
+    // process. Without a canonical order the same input renders and
+    // serializes differently every time, which makes `bca ops` output
+    // undiffable and unusable as a cache key (#1091).
+    //
+    // Byte-lexicographic, not first-appearance, order: `finalize` merges
+    // a child space's maps into its parent, so an insertion-ordered map
+    // would give the parent "what it saw directly, then whatever each
+    // child contributed" — a walk artifact that shifts when nesting
+    // changes. Sorting is also stable across platforms and hasher
+    // versions, which insertion order via a different map type is not.
+    operators.sort_unstable();
+    operands.sort_unstable();
 
-    state.ops.operands = state
-        .halstead_maps
-        .operands
-        .keys()
-        .map(|k| bytes_to_string(k))
-        .collect();
+    state.ops.operators = operators;
+    state.ops.operands = operands;
 }
 
 fn finalize<T: ParserTrait>(state_stack: &mut Vec<State>, diff_level: usize) {
@@ -294,6 +302,7 @@ pub(crate) fn ops_inner<T: ParserTrait>(
     clippy::too_many_lines
 )]
 mod tests {
+    use super::Ops;
     use crate::{Ast, LANG, Source};
 
     #[inline]
@@ -311,19 +320,18 @@ mod tests {
             .ops()
             .expect("ops walk must yield a top-level Ops");
 
-        let mut operators_str: Vec<&str> = ops.operators.iter().map(AsRef::as_ref).collect();
-        let mut operands_str: Vec<&str> = ops.operands.iter().map(AsRef::as_ref).collect();
+        let operators_str: Vec<&str> = ops.operators.iter().map(AsRef::as_ref).collect();
+        let operands_str: Vec<&str> = ops.operands.iter().map(AsRef::as_ref).collect();
 
-        // Sorting out operators because they are returned in arbitrary order
-        operators_str.sort_unstable();
+        // Only the *expectations* are sorted here: `Ops` is documented to
+        // come back byte-lexicographically ordered (#1091), so comparing
+        // against a sorted expectation without re-sorting the actual value
+        // makes every `check_ops` caller an ordering regression test for
+        // its language.
         correct_operators.sort_unstable();
-
         assert_eq!(&operators_str[..], correct_operators);
 
-        // Sorting out operands because they are returned in arbitrary order
-        operands_str.sort_unstable();
         correct_operands.sort_unstable();
-
         assert_eq!(&operands_str[..], correct_operands);
     }
 
@@ -915,5 +923,139 @@ mod tests {
             unique_operands.len(),
             "Ops::operands must be the distinct operand vocabulary (n2)"
         );
+    }
+
+    /// Assert that every space in the tree carries sorted vocabularies,
+    /// and return how many spaces were checked so a caller can prove the
+    /// walk actually descended.
+    fn assert_sorted_spaces(ops: &Ops, lang: LANG) -> usize {
+        let mut stack = vec![ops];
+        let mut visited = 0;
+
+        while let Some(space) = stack.pop() {
+            visited += 1;
+            for (field, values) in [
+                ("operators", &space.operators),
+                ("operands", &space.operands),
+            ] {
+                assert!(
+                    values.is_sorted(),
+                    "{lang:?} {field} of space {:?} (@{}) must be sorted: {values:?}",
+                    space.name,
+                    space.start_line
+                );
+            }
+            stack.extend(space.spaces.iter());
+        }
+
+        visited
+    }
+
+    /// Every space's vocabularies come back sorted, in every language.
+    ///
+    /// The sources are chosen to exercise both operator maps: the
+    /// token-id-keyed one and the text-keyed `primitive_operators` map
+    /// that C++ / Java primitive types land in — sorting the union is
+    /// what interleaves the two (#1091).
+    #[test]
+    fn ops_vocabularies_are_sorted_1091() {
+        let cases: &[(LANG, &str, &str)] = &[
+            #[cfg(feature = "rust")]
+            (
+                LANG::Rust,
+                "rust.rs",
+                "fn zeta(quux: u32) -> u32 { let mid = quux + 1; \
+                 let alpha = |beta: u32| beta * mid; alpha(mid) - quux }\n",
+            ),
+            #[cfg(feature = "cpp")]
+            (
+                LANG::Cpp,
+                "cpp.cpp",
+                "int zeta(int quux) { double mid = quux + 1; \
+                 char alpha = 'z'; return quux - mid + alpha; }\n",
+            ),
+            #[cfg(feature = "java")]
+            (
+                LANG::Java,
+                "Java.java",
+                "class Zeta { int quux(int mid) { long alpha = mid + 1; \
+                 boolean beta = alpha > 2; return beta ? mid : 0; } }\n",
+            ),
+            #[cfg(feature = "python")]
+            (
+                LANG::Python,
+                "python.py",
+                "def zeta(quux):\n    mid = quux + 1\n    \
+                 def alpha(beta):\n        return beta * mid\n    return alpha(mid) - quux\n",
+            ),
+            #[cfg(feature = "typescript")]
+            (
+                LANG::Typescript,
+                "ts.ts",
+                "function zeta(quux: number): number { const mid: number = quux + 1; \
+                 const alpha = (beta: number) => beta * mid; return alpha(mid) - quux; }\n",
+            ),
+        ];
+
+        for (lang, file, source) in cases {
+            let ops = Ast::parse(
+                Source::new(*lang, source.as_bytes()).with_name(Some((*file).to_owned())),
+            )
+            .expect("language feature enabled")
+            .ops()
+            .expect("ops walk must yield a top-level Ops");
+
+            assert!(
+                !ops.operators.is_empty() && !ops.operands.is_empty(),
+                "{lang:?} sample must produce a non-trivial vocabulary"
+            );
+            assert!(
+                assert_sorted_spaces(&ops, *lang) > 1,
+                "{lang:?} sample must nest at least one sub-space"
+            );
+        }
+    }
+
+    /// Two parses of the same bytes in one process must agree exactly.
+    ///
+    /// `RandomState` bumps its thread-local seed per instance, so the
+    /// pre-fix code could — and did — order two `HashMap`s built from
+    /// identical keys differently within a single run. This is the
+    /// in-process form of the cross-run churn in #1091.
+    #[test]
+    #[cfg(feature = "rust")]
+    fn ops_are_stable_across_repeated_parses_1091() {
+        use std::fmt::Write as _;
+
+        // Enough distinct operands, in enough distinct spaces, that
+        // agreement by coincidence is not a plausible explanation for a
+        // pass.
+        let mut src = String::new();
+        for i in 0..40 {
+            writeln!(src, "fn name{i}(arg{i}: u32) -> u32 {{ arg{i} + {i} }}")
+                .expect("writing to a String cannot fail");
+        }
+
+        let parse = || {
+            Ast::parse(Source::new(LANG::Rust, src.as_bytes()).with_name(Some("foo.rs".to_owned())))
+                .expect("rust feature enabled")
+                .ops()
+                .expect("ops walk must yield a top-level Ops")
+        };
+
+        let (first, second) = (parse(), parse());
+        assert!(
+            first.operands.len() >= 40 && first.spaces.len() >= 40,
+            "sample must have a wide vocabulary across many spaces, got {} operands \
+             in {} spaces",
+            first.operands.len(),
+            first.spaces.len()
+        );
+        // `Ops` has no `PartialEq`, and the nested spaces are the half a
+        // top-level vector comparison would miss, so compare the whole
+        // serialized tree.
+        let render =
+            |ops: &Ops| serde_json::to_string(&ops.to_wire()).expect("wire Ops serializes to JSON");
+        assert_eq!(render(&first), render(&second));
     }
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -178,13 +178,17 @@ fn compute_operators_and_operands<T: ParserTrait>(state: &mut State) {
     state.ops.operands = operands;
 }
 
+/// Close up to `diff_level` open spaces, folding each into its parent.
+///
+/// Only the states this pops get their vocabularies computed. The
+/// bottom state is never popped here, so the root's vocabulary is built
+/// once by [`ops_inner`] after the final drain — computing it on every
+/// call would rebuild (and, since #1091, re-sort) the whole file's
+/// vocabulary once per level-drop in the walk, and every result but the
+/// last would be overwritten.
 fn finalize<T: ParserTrait>(state_stack: &mut Vec<State>, diff_level: usize) {
-    if state_stack.is_empty() {
-        return;
-    }
-
     for _ in 0..diff_level {
-        if state_stack.len() == 1 {
+        if state_stack.len() < 2 {
             break;
         }
         let mut state = state_stack
@@ -201,13 +205,6 @@ fn finalize<T: ParserTrait>(state_stack: &mut Vec<State>, diff_level: usize) {
         // Merge child's Halstead maps into parent and record child space.
         last_state.halstead_maps.merge(&state.halstead_maps);
         last_state.ops.spaces.push(state.ops);
-    }
-
-    // Compute ops for the remaining parent from its fully-merged
-    // HalsteadMaps. This runs once instead of per-iteration, and
-    // produces the deduplicated union of all operators/operands.
-    if let Some(last_state) = state_stack.last_mut() {
-        compute_operators_and_operands::<T>(last_state);
     }
 }
 
@@ -286,6 +283,9 @@ pub(crate) fn ops_inner<T: ParserTrait>(
     // variant rather than a bare `None`. See `MetricsError::EmptyRoot`
     // for the matching variant doc.
     let mut state = state_stack.pop().ok_or(MetricsError::EmptyRoot)?;
+    // The root is the one state `finalize` never pops, so its vocabulary
+    // is built here — once, from the fully-merged maps.
+    compute_operators_and_operands::<T>(&mut state);
     state.ops.name = name;
     Ok(state.ops)
 }

--- a/src/output/dump.rs
+++ b/src/output/dump.rs
@@ -112,13 +112,13 @@ struct DumpState<'a> {
 /// connector glyph it renders with, and the remaining depth budget.
 ///
 /// The prefix is stored as a *length* rather than an owned `String`
-/// (#1054). Prefixes only grow by appending as the walk descends, so the
-/// first `prefix_len` bytes of the shared buffer are exactly this node's
-/// prefix for as long as the frame is queued: nothing visited between the
-/// push and the pop can rewrite them (every other queued frame sits at
-/// this level or deeper, so it truncates to `prefix_len` or beyond). One
-/// owned prefix per frame made a depth-`d` chain cost O(d²) resident
-/// bytes plus an O(d) copy per node.
+/// (#1054). Prefixes only grow by appending as the walk descends, so
+/// `prefix_len` is non-decreasing from the bottom of the stack to the
+/// top: every frame popped before this one truncates to `prefix_len` or
+/// beyond, so the first `prefix_len` bytes of the shared buffer stay
+/// exactly this node's prefix until it is popped. One owned prefix per
+/// frame made a depth-`d` chain cost O(d²) resident bytes plus an O(d)
+/// copy per node.
 struct Frame<'a> {
     node: Node<'a>,
     prefix_len: usize,

--- a/src/output/dump.rs
+++ b/src/output/dump.rs
@@ -354,6 +354,7 @@ mod tests {
 
     use termcolor::NoColor;
 
+    use crate::output::test_support::assert_io_error_propagates_at_every_write;
     use crate::{CppParser, ParserTrait};
 
     use super::*;
@@ -656,5 +657,40 @@ mod tests {
 
         // depth = 0: nothing renders at all.
         assert!(render(code, &root, 0).is_empty(), "depth=0 renders nothing");
+    }
+
+    /// Every write position in the AST walk surfaces an I/O error, and
+    /// the walk stops there.
+    ///
+    /// `dump_node` documents that it propagates any `std::io::Error` the
+    /// writer produces — `bca dump | head` closes the pipe mid-stream —
+    /// but every existing test writes into an infallible `Vec`, leaving
+    /// the failure half of each `?` in `dump_tree_helper`, `paint`,
+    /// `write_node_line`, `write_node_header`, `write_node_location`, and
+    /// `write_node_snippet` unexercised.
+    ///
+    /// The fixture is deliberately the smallest tree that still nests:
+    /// the sweep re-runs the whole dump once per write position, so cost
+    /// is quadratic in the node count.
+    #[test]
+    fn every_write_position_propagates_an_io_error() {
+        let code = b"int a = 42;\n";
+        let parser = CppParser::new(code.to_vec(), &PathBuf::from("t.c"), None);
+        let root = parser.root();
+        let (line_start, line_end) = (None, None);
+
+        // 40: the eight nodes of this tree cost several operations each
+        // (connector, header, location, snippet). A floor well under the
+        // real count catches a fixture that collapsed to a leaf without
+        // churning on an exact number.
+        assert_io_error_propagates_at_every_write(40, |sink| {
+            let mut state = DumpState {
+                code,
+                line_start: &line_start,
+                line_end: &line_end,
+                stdout: sink,
+            };
+            dump_tree_helper(&mut state, &root, -1)
+        });
     }
 }

--- a/src/output/dump_ops.rs
+++ b/src/output/dump_ops.rs
@@ -215,8 +215,8 @@ mod tests {
         // a top-level sibling that follows `outer`'s deeper subtree, so a
         // truncation bug leaves it (and its op blocks) indented under
         // `inner`'s rail instead of back at the unit's. Built by hand so
-        // the op lists are ordered `Vec`s — the parsed `Ops` iteration
-        // order is not stable run to run.
+        // the tree shape and the op lists are exactly what the expected
+        // rails below spell out, independent of any grammar's parse.
         //
         // The expected rails match what the pre-#1054 binary emits for
         // the equivalent parsed tree (`function outer(){function

--- a/src/output/dump_ops.rs
+++ b/src/output/dump_ops.rs
@@ -187,6 +187,7 @@ fn dump_ops_values(
 mod tests {
     use super::*;
     use crate::spaces::SpaceKind;
+    use std::io::{ErrorKind, Write as _};
     use termcolor::NoColor;
 
     fn leaf_ops(operators: Vec<String>, operands: Vec<String>) -> Ops {
@@ -206,6 +207,64 @@ mod tests {
         let mut sink = NoColor::new(Vec::new());
         dump_space(ops, &mut sink).expect("dump to in-memory sink");
         String::from_utf8(sink.into_inner()).expect("utf-8 dump")
+    }
+
+    /// A [`WriteColor`] that succeeds for `budget` operations and then
+    /// fails every later one with [`ErrorKind::BrokenPipe`].
+    ///
+    /// Both `write` and `set_color` are counted. The walk reaches its
+    /// writer two ways — `write!` / `writeln!`, and [`color`] /
+    /// [`intense_color`], which are `set_color` calls — so counting only
+    /// one of them would leave half the `?` sites unreachable.
+    ///
+    /// `attempts` keeps counting past the failure, which is what lets a
+    /// caller tell "the walk stopped at the first error" from "the walk
+    /// swallowed it and kept writing".
+    struct FailAfter {
+        budget: usize,
+        attempts: usize,
+    }
+
+    impl FailAfter {
+        fn new(budget: usize) -> Self {
+            Self {
+                budget,
+                attempts: 0,
+            }
+        }
+
+        fn step(&mut self) -> std::io::Result<()> {
+            self.attempts += 1;
+            if self.attempts > self.budget {
+                return Err(std::io::Error::new(ErrorKind::BrokenPipe, "sink closed"));
+            }
+            Ok(())
+        }
+    }
+
+    impl std::io::Write for FailAfter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.step()?;
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            self.step()
+        }
+    }
+
+    impl WriteColor for FailAfter {
+        fn supports_color(&self) -> bool {
+            true
+        }
+
+        fn set_color(&mut self, _spec: &termcolor::ColorSpec) -> std::io::Result<()> {
+            self.step()
+        }
+
+        fn reset(&mut self) -> std::io::Result<()> {
+            self.step()
+        }
     }
 
     #[test]
@@ -344,5 +403,83 @@ mod tests {
             handle.join().expect("dump thread must not overflow"),
             "deep space nesting must dump successfully"
         );
+    }
+
+    /// Every write position in the walk surfaces an I/O error, and the
+    /// walk stops there.
+    ///
+    /// `dump_ops` documents that it propagates any `std::io::Error` the
+    /// writer produces — `bca ops | head` closes the pipe mid-stream, so
+    /// this is a real path, not a hypothetical. Sweeping the failure
+    /// across every operation the dump performs is what makes the test
+    /// discriminating: a single `let _ = write!(..)` anywhere in
+    /// `dump_space` / `dump_space_ops` / `dump_ops_values` leaves exactly
+    /// one budget in the sweep returning `Ok`, and a swallow that let the
+    /// walk continue shows up as extra attempts after the failure.
+    #[test]
+    fn every_write_position_propagates_an_io_error() {
+        // Two levels, and both op blocks populated at both levels, so the
+        // sweep reaches the nested-space descent, both block headers, and
+        // the per-entry lines with both connector glyphs.
+        let space = Ops {
+            name: Some("u".to_string()),
+            name_was_lossy: false,
+            start_line: 1,
+            end_line: 2,
+            kind: SpaceKind::Unit,
+            spaces: vec![Ops {
+                name: Some("inner".to_string()),
+                name_was_lossy: false,
+                start_line: 2,
+                end_line: 2,
+                kind: SpaceKind::Function,
+                spaces: vec![],
+                operators: vec!["*".to_string()],
+                operands: vec!["b".to_string()],
+            }],
+            operators: vec!["+".to_string(), "-".to_string()],
+            operands: vec!["a".to_string()],
+        };
+
+        // `flush` and `reset` are counted like any other fallible
+        // operation even though this walk happens to use neither today,
+        // so the sweep keeps its reach if one is ever added. Pinning that
+        // here also keeps the harness from silently becoming a writer
+        // that cannot fail in two of its five entry points.
+        let mut harness = FailAfter::new(1);
+        assert!(harness.supports_color());
+        harness
+            .flush()
+            .expect("the first operation is within budget");
+        assert_eq!(
+            harness.reset().map_err(|e| e.kind()),
+            Err(ErrorKind::BrokenPipe),
+            "reset past the budget must fail like any other operation"
+        );
+
+        let mut unlimited = FailAfter::new(usize::MAX);
+        dump_space(&space, &mut unlimited).expect("an unlimited sink must not fail");
+        let total = unlimited.attempts;
+        assert!(
+            total > 20,
+            "fixture must exercise many write positions, got {total}"
+        );
+
+        for budget in 0..total {
+            let mut sink = FailAfter::new(budget);
+            let Err(err) = dump_space(&space, &mut sink) else {
+                panic!("failing operation #{budget} of {total} must surface as an error");
+            };
+            assert_eq!(
+                err.kind(),
+                ErrorKind::BrokenPipe,
+                "operation #{budget} must propagate the writer's own error kind"
+            );
+            assert_eq!(
+                sink.attempts,
+                budget + 1,
+                "the walk must stop at operation #{budget}, not keep writing past it"
+            );
+        }
     }
 }

--- a/src/output/dump_ops.rs
+++ b/src/output/dump_ops.rs
@@ -186,8 +186,8 @@ fn dump_ops_values(
 )]
 mod tests {
     use super::*;
+    use crate::output::test_support::assert_io_error_propagates_at_every_write;
     use crate::spaces::SpaceKind;
-    use std::io::{ErrorKind, Write as _};
     use termcolor::NoColor;
 
     fn leaf_ops(operators: Vec<String>, operands: Vec<String>) -> Ops {
@@ -207,64 +207,6 @@ mod tests {
         let mut sink = NoColor::new(Vec::new());
         dump_space(ops, &mut sink).expect("dump to in-memory sink");
         String::from_utf8(sink.into_inner()).expect("utf-8 dump")
-    }
-
-    /// A [`WriteColor`] that succeeds for `budget` operations and then
-    /// fails every later one with [`ErrorKind::BrokenPipe`].
-    ///
-    /// Both `write` and `set_color` are counted. The walk reaches its
-    /// writer two ways — `write!` / `writeln!`, and [`color`] /
-    /// [`intense_color`], which are `set_color` calls — so counting only
-    /// one of them would leave half the `?` sites unreachable.
-    ///
-    /// `attempts` keeps counting past the failure, which is what lets a
-    /// caller tell "the walk stopped at the first error" from "the walk
-    /// swallowed it and kept writing".
-    struct FailAfter {
-        budget: usize,
-        attempts: usize,
-    }
-
-    impl FailAfter {
-        fn new(budget: usize) -> Self {
-            Self {
-                budget,
-                attempts: 0,
-            }
-        }
-
-        fn step(&mut self) -> std::io::Result<()> {
-            self.attempts += 1;
-            if self.attempts > self.budget {
-                return Err(std::io::Error::new(ErrorKind::BrokenPipe, "sink closed"));
-            }
-            Ok(())
-        }
-    }
-
-    impl std::io::Write for FailAfter {
-        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-            self.step()?;
-            Ok(buf.len())
-        }
-
-        fn flush(&mut self) -> std::io::Result<()> {
-            self.step()
-        }
-    }
-
-    impl WriteColor for FailAfter {
-        fn supports_color(&self) -> bool {
-            true
-        }
-
-        fn set_color(&mut self, _spec: &termcolor::ColorSpec) -> std::io::Result<()> {
-            self.step()
-        }
-
-        fn reset(&mut self) -> std::io::Result<()> {
-            self.step()
-        }
     }
 
     #[test]
@@ -441,45 +383,9 @@ mod tests {
             operands: vec!["a".to_string()],
         };
 
-        // `flush` and `reset` are counted like any other fallible
-        // operation even though this walk happens to use neither today,
-        // so the sweep keeps its reach if one is ever added. Pinning that
-        // here also keeps the harness from silently becoming a writer
-        // that cannot fail in two of its five entry points.
-        let mut harness = FailAfter::new(1);
-        assert!(harness.supports_color());
-        harness
-            .flush()
-            .expect("the first operation is within budget");
-        assert_eq!(
-            harness.reset().map_err(|e| e.kind()),
-            Err(ErrorKind::BrokenPipe),
-            "reset past the budget must fail like any other operation"
-        );
-
-        let mut unlimited = FailAfter::new(usize::MAX);
-        dump_space(&space, &mut unlimited).expect("an unlimited sink must not fail");
-        let total = unlimited.attempts;
-        assert!(
-            total > 20,
-            "fixture must exercise many write positions, got {total}"
-        );
-
-        for budget in 0..total {
-            let mut sink = FailAfter::new(budget);
-            let Err(err) = dump_space(&space, &mut sink) else {
-                panic!("failing operation #{budget} of {total} must surface as an error");
-            };
-            assert_eq!(
-                err.kind(),
-                ErrorKind::BrokenPipe,
-                "operation #{budget} must propagate the writer's own error kind"
-            );
-            assert_eq!(
-                sink.attempts,
-                budget + 1,
-                "the walk must stop at operation #{budget}, not keep writing past it"
-            );
-        }
+        // 30: the fixture's two levels, two op blocks each, and three op
+        // entries come to 37 operations; a floor well under that catches
+        // a fixture that collapsed without churning on exact counts.
+        assert_io_error_propagates_at_every_write(30, |sink| dump_space(&space, sink));
     }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+pub(crate) mod test_support;
+
 pub(crate) mod color;
 pub use color::ColorMode;
 

--- a/src/output/test_support.rs
+++ b/src/output/test_support.rs
@@ -1,0 +1,153 @@
+//! Shared test scaffolding for the text-output walks.
+//!
+//! The `dump`, `dump_metrics`, and `dump_ops` walks all render through a
+//! [`WriteColor`] and propagate its errors with `?`. Every one of those
+//! `?`s is a branch no test takes while the sink is an infallible
+//! `Vec<u8>`, so the failure half of each write is unexercised — which
+//! matters, because `bca dump | head` and `bca ops | head` close the
+//! pipe mid-stream.
+
+use std::io::{ErrorKind, Write};
+
+use termcolor::{ColorSpec, WriteColor};
+
+/// A [`WriteColor`] that succeeds for `budget` operations and then fails
+/// every later one with [`ErrorKind::BrokenPipe`].
+///
+/// Both `write` and `set_color` are counted. A walk reaches its writer
+/// two ways — `write!` / `writeln!`, and the `color` / `intense_color`
+/// helpers, which are `set_color` calls — so counting only one of them
+/// would leave half the `?` sites unreachable.
+pub(crate) struct FailAfter {
+    budget: usize,
+    attempts: usize,
+}
+
+impl FailAfter {
+    /// A sink that permits `budget` operations before it starts failing.
+    /// `usize::MAX` never fails, which is how a caller measures how many
+    /// operations a full render performs.
+    pub(crate) fn new(budget: usize) -> Self {
+        Self {
+            budget,
+            attempts: 0,
+        }
+    }
+
+    /// How many operations were *attempted*, including those refused
+    /// after the budget ran out.
+    ///
+    /// Counting past the failure is what lets a caller tell "the walk
+    /// stopped at the first error" from "the walk swallowed it and kept
+    /// writing".
+    pub(crate) fn attempts(&self) -> usize {
+        self.attempts
+    }
+
+    fn step(&mut self) -> std::io::Result<()> {
+        self.attempts += 1;
+        if self.attempts > self.budget {
+            return Err(std::io::Error::new(ErrorKind::BrokenPipe, "sink closed"));
+        }
+        Ok(())
+    }
+}
+
+impl Write for FailAfter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.step()?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.step()
+    }
+}
+
+impl WriteColor for FailAfter {
+    fn supports_color(&self) -> bool {
+        true
+    }
+
+    fn set_color(&mut self, _spec: &ColorSpec) -> std::io::Result<()> {
+        self.step()
+    }
+
+    fn reset(&mut self) -> std::io::Result<()> {
+        self.step()
+    }
+}
+
+/// Assert that `render` surfaces an I/O error raised at *any* single
+/// write position, and stops the walk there.
+///
+/// Sweeping the failure across every operation is what makes this
+/// discriminating: one `let _ = write!(..)` anywhere in the walk leaves
+/// exactly one budget in the sweep returning `Ok`, and a swallow that
+/// let the walk continue shows up as attempts beyond the failing one.
+///
+/// `min_operations` guards the fixture rather than the code under test —
+/// a fixture that shrank to a couple of writes would still pass every
+/// assertion below while covering almost nothing.
+pub(crate) fn assert_io_error_propagates_at_every_write(
+    min_operations: usize,
+    mut render: impl FnMut(&mut FailAfter) -> std::io::Result<()>,
+) {
+    let mut unlimited = FailAfter::new(usize::MAX);
+    render(&mut unlimited).expect("a sink that never fails must not produce an error");
+    let total = unlimited.attempts();
+    assert!(
+        total >= min_operations,
+        "fixture must exercise at least {min_operations} write positions, got {total}"
+    );
+
+    for budget in 0..total {
+        let mut sink = FailAfter::new(budget);
+        let Err(err) = render(&mut sink) else {
+            panic!("failing operation #{budget} of {total} must surface as an error");
+        };
+        assert_eq!(
+            err.kind(),
+            ErrorKind::BrokenPipe,
+            "operation #{budget} must propagate the writer's own error kind"
+        );
+        assert_eq!(
+            sink.attempts(),
+            budget + 1,
+            "the walk must stop at operation #{budget}, not keep writing past it"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The harness counts every fallible `WriteColor` operation,
+    /// including the two no current walk uses.
+    ///
+    /// Pinned here so the sweep keeps its reach if a walk ever starts
+    /// flushing or resetting, and so the harness cannot quietly become a
+    /// writer that is incapable of failing in two of its entry points.
+    #[test]
+    fn every_fallible_operation_counts_against_the_budget() {
+        let mut sink = FailAfter::new(3);
+        assert!(sink.supports_color());
+
+        sink.write_all(b"first").expect("within budget");
+        sink.flush().expect("within budget");
+        sink.set_color(&ColorSpec::new()).expect("within budget");
+        assert_eq!(sink.attempts(), 3);
+
+        assert_eq!(
+            sink.reset().map_err(|e| e.kind()),
+            Err(ErrorKind::BrokenPipe),
+            "the fourth operation is past the budget"
+        );
+        assert_eq!(
+            sink.attempts(),
+            4,
+            "a refused operation still counts as an attempt"
+        );
+    }
+}


### PR DESCRIPTION
Two output-path defects found while working on the `dump` walk, plus the
performance and test follow-through each one exposed.

## #1054 — quadratic prefix growth in the `dump` walks

Every queued node carried an owned copy of its ancestors' box-drawing
prefix, a string that grows ~3 bytes per nesting level, so a wide-and-deep
tree held O(depth²) resident bytes and copied O(depth) per node.
Separately, the flush-left check called `tree_sitter::Node::parent` — which
resolves by descending from the root — once per node.

All three walks (`dump`, `dump_metrics`, `dump_ops`) now share one prefix
buffer that is extended on descent and truncated on the next visit, and
carry each node's connector glyph on the work stack so only the node the
walk starts from needs a parent lookup. The child staging buffer went away
with it.

## #1091 — nondeterministic operator/operand order

`Ops::operators` and `Ops::operands` were collected from `HashMap` keys.
`RandomState` reseeds per map instance, so the listings were reordered on
every run — and even between two parses in one process. `bca ops` output
could not be diffed between runs, checked into a repository, or used as a
cache key, in the tree renderer and in every serialized format alike.

Both vectors are now sorted byte-lexicographically:

```
$ bca ops --no-config --color never src/int_hash.rs | md5sum
5b995d882efa09ed58c27668ee569e48  -
5b995d882efa09ed58c27668ee569e48  -
5b995d882efa09ed58c27668ee569e48  -
```

### Why sorting rather than an ordered map

`indexmap` (already in the dependency graph transitively) and `ordermap`
were both evaluated and rejected — for reasons about this code, not the
crates:

- The maps that would have to change are `HalsteadMaps`, which every
  `metrics` run populates for every node. The ordering only matters on the
  `ops` seam, a separate command. That taxes the hot path for a property
  nothing on it observes.
- Insertion order is not canonical here anyway: `finalize` merges a child
  space's maps into its parent, so parent order would be "what it saw
  directly, then whatever each child contributed" — a walk artifact that
  shifts when nesting changes, not source order. Byte-lexicographic order
  is also stable across platforms, rustc versions, and hashbrown bumps.

A fixed-seed hasher was rejected outright: deterministic per build, but the
order still churns on any capacity change or hasher-version bump.

Full analysis in
https://github.com/dekobon/big-code-analysis/issues/1091#issuecomment-5094904436.

## Performance

Removing the redundant rebuild the sort exposed left `ops` **net faster
than before the issue**. `finalize` rebuilt the innermost still-open
space's vocabulary on every call — every time the walk left a function —
and every result but the last was overwritten, so a file with F function
spaces rebuilt the root's whole vocabulary F times. Only the root needs
that; it now happens once, in `ops_inner`.

`hlo_instruction.cc` (4 057 lines, ~180 spaces), `bca ops -O json`,
20 runs each, interleaved:

| build | ms/run |
|---|---|
| pre-#1091 | 36.9 / 40.9 |
| sorted + single rebuild | 25.3 / 28.8 |

Output byte-identical between the two.

## Behaviour change

`Ops::operators` / `Ops::operands` were documented as "arbitrary order", so
tightening to "sorted" is additive for callers, but it does change observed
output. Recorded in `CHANGELOG.md` under Unreleased and in `STABILITY.md`,
which now states the order is contractual from the `2.1` line and will not
change before `3.0`. No metric value moves — Halstead's `n1` / `n2` are set
cardinalities.

## Tests

- `ops_vocabularies_are_sorted_1091` walks every space of Rust, C++, Java,
  Python, and TypeScript samples, requiring each vocabulary to be sorted
  and to hold at least two entries so `is_sorted` cannot pass vacuously.
  Each case also pins one entry from the token-id-keyed operator map
  against one from the text-keyed `primitive_operators` map, proving the
  union is sorted as a whole rather than concatenated.
- `ops_are_stable_across_repeated_parses_1091` — two parses of the same
  40-space source in one process must serialize identically. This failed
  before the fix.
- `check_ops` no longer re-sorts the value under test, which turns all ~20
  existing per-language callers into ordering regression tests.
- Verified by reverting the two `sort_unstable` calls: 20 of 27 `ops` tests
  fail, including both new ones.

## Review

`review`, `audit-tests`, `rust-optimize`, and `/code-review --fix` were all
run. Findings resolved in-branch: the redundant per-space rebuild above,
two vacuous-assertion gaps in the new tests, a stale `_native.pyi`
docstring that still promised only "deduplicated", a refutable invariant in
`Frame`'s doc (the prefix-length scheme rests on `prefix_len` being
non-decreasing bottom-to-top, not on "every other frame sits deeper"), and
a test comment that this branch's own sort commit made false.

One pre-existing inconsistency was found and deliberately left: `dump_tree_helper`'s
early-out still trusts `child_count() == 0` while `push_children` now
derives last-child from the child the cursor actually walks last. These
agree on well-formed trees; reconciling them belongs in its own issue.

`make pre-commit` green.

Fixes #1054
Fixes #1091
