### PR TITLE
refactor(repo): move helper scripts into utils/

### DIFF
--- a/.claude/skills/add-lang/SKILL.md
+++ b/.claude/skills/add-lang/SKILL.md
@@ -966,7 +966,7 @@ cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace --all-features
 RUSTFLAGS="-D warnings" cargo clippy --manifest-path enums/Cargo.toml \
   --all-targets --locked -- -D warnings
-./check-snapshot-anchors.py
+./utils/check-snapshot-anchors.py
 ```
 
 If `pre-commit` is installed, also run `pre-commit run --all-files`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,13 +515,13 @@ jobs:
       # explicitly so a regression in `make lint` cannot silently disable
       # this check.
       - name: snapshot anchors (explicit)
-        run: python3 check-snapshot-anchors.py
+        run: python3 utils/check-snapshot-anchors.py
       # Defensive twin to the snapshot-anchors gate above: `make lint`
       # already invokes check-versions, but pinning it here guarantees
       # the lockstep version invariant is enforced even if a future
       # refactor drops it from the aggregate recipe.
       - name: check-versions (explicit)
-        run: python3 check-versions.py
+        run: python3 utils/check-versions.py
       # Defensive twin for the man-page packaging gate (#446): a bca
       # subcommand man page that drops out of the hand-maintained
       # deb/rpm asset lists ships an artifact without its page (the
@@ -529,7 +529,7 @@ jobs:
       # it here guarantees enforcement even if a future refactor drops
       # it from the aggregate recipe.
       - name: check-manpage-assets (explicit)
-        run: python3 check-manpage-assets.py
+        run: python3 utils/check-manpage-assets.py
       # Defensive twin for the grammar-marker-sync gate (#400): bumping
       # the notification-only marker in tree-sitter-{mozjs,mozcpp}/
       # Cargo.toml without re-running the matching generate-*.sh
@@ -539,12 +539,12 @@ jobs:
       # in the `make lint` aggregate cannot silently disable this
       # check.
       - name: grammar-marker-sync (explicit)
-        run: python3 check-grammar-marker-sync.py
+        run: python3 utils/check-grammar-marker-sync.py
       # Run the gate's own unittests as their own explicit step
       # so a refactor that breaks the script can't disable the
       # gate without surfacing the regression in CI.
       - name: grammar-marker-sync self-tests (explicit)
-        run: python3 -m unittest -q check-grammar-marker-sync-test.py
+        run: python3 -m unittest -q utils/check-grammar-marker-sync-test.py
       # Defensive twin for the enums-codegen-drift gate (#405):
       # running any grammar regen previously regenerated
       # `src/c_langs_macros/*.rs` to a pre-optimization form
@@ -552,12 +552,12 @@ jobs:
       # checked-in files; running it explicitly here guards
       # against `make lint` ever dropping it from the aggregate.
       - name: enums-codegen-drift (explicit)
-        run: bash check-enums-codegen-drift.sh
+        run: bash utils/check-enums-codegen-drift.sh
       # Run the gate's own unittests as their own explicit step
       # so a refactor that breaks the script can't disable the
       # gate without surfacing the regression in CI.
       - name: enums-codegen-drift self-tests (explicit)
-        run: python3 -m unittest -q check-enums-codegen-drift-test.py
+        run: python3 -m unittest -q utils/check-enums-codegen-drift-test.py
       # Defensive: the prior `make lint` step already runs enums-check
       # as part of its aggregate. Repeating it here protects against a
       # regression to that aggregate (e.g., enums-check accidentally

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
       # ccomment leaf at the workspace-pinned version (probing one
       # leaf is enough because every owned crate in this repo shares
       # one version per the Lockstep version policy in RELEASING.md,
-      # enforced by ./check-versions.py in `make pre-commit`).
+      # enforced by ./utils/check-versions.py in `make pre-commit`).
       # Once that leaf is on crates.io the bootstrap has happened and
       # the parent dry-run becomes a hard gate again.
       - name: Dry-run cargo publish for big-code-analysis

--- a/.grammar-marker-baseline.toml
+++ b/.grammar-marker-baseline.toml
@@ -15,7 +15,7 @@
 # After re-running `./generate-grammars/generate-{mozjs,mozcpp}.sh`
 # and committing the regenerated sources, refresh the entry below
 # in the same commit. Easiest path:
-#     ./check-grammar-marker-sync.py --update
+#     ./utils/check-grammar-marker-sync.py --update
 # That command updates `marker` and `version` in place,
 # preserving the per-section audit notes that follow each
 # section's body.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,8 +76,8 @@ repos:
       - id: snapshot-anchors
         name: snapshot-anchors
         language: system
-        files: '^(src/metrics/.*\.rs|\.snapshot-anchor-baseline\.txt|check-snapshot-anchors\.py)$'
-        entry: python3 check-snapshot-anchors.py
+        files: '^(src/metrics/.*\.rs|\.snapshot-anchor-baseline\.txt|utils/check-snapshot-anchors\.py)$'
+        entry: python3 utils/check-snapshot-anchors.py
         pass_filenames: false
 
       # Block grammar-marker bumps in tree-sitter-{mozjs,mozcpp}
@@ -92,8 +92,8 @@ repos:
       - id: grammar-marker-sync
         name: grammar-marker-sync
         language: system
-        files: '^(tree-sitter-(mozjs|mozcpp)/Cargo\.toml|\.grammar-marker-baseline\.toml|check-grammar-marker-sync\.py)$'
-        entry: python3 check-grammar-marker-sync.py
+        files: '^(tree-sitter-(mozjs|mozcpp)/Cargo\.toml|\.grammar-marker-baseline\.toml|utils/check-grammar-marker-sync\.py)$'
+        entry: python3 utils/check-grammar-marker-sync.py
         pass_filenames: false
 
       # Self-tests for the grammar-marker-sync gate itself. Runs
@@ -104,8 +104,8 @@ repos:
       - id: grammar-marker-sync-test
         name: grammar-marker-sync-test
         language: system
-        files: '^check-grammar-marker-sync(-test)?\.py$'
-        entry: python3 -m unittest -q check-grammar-marker-sync-test.py
+        files: '^utils/check-grammar-marker-sync(-test)?\.py$'
+        entry: python3 -m unittest -q utils/check-grammar-marker-sync-test.py
         pass_filenames: false
 
       # Self-tests for the lockstep-version gate. Runs on edits to the
@@ -114,8 +114,8 @@ repos:
       - id: check-versions-test
         name: check-versions-test
         language: system
-        files: '^check-versions(-test)?\.py$'
-        entry: python3 -m unittest -q check-versions-test.py
+        files: '^utils/check-versions(-test)?\.py$'
+        entry: python3 -m unittest -q utils/check-versions-test.py
         pass_filenames: false
 
       # Sync-test for check-grammar-crate.py's EXTENSIONS table against
@@ -124,8 +124,8 @@ repos:
       - id: check-grammar-crate-test
         name: check-grammar-crate-test
         language: system
-        files: '^(check-grammar-crate(-test)?\.py|src/langs\.rs)$'
-        entry: python3 -m unittest -q check-grammar-crate-test.py
+        files: '^(utils/check-grammar-crate(-test)?\.py|src/langs\.rs)$'
+        entry: python3 -m unittest -q utils/check-grammar-crate-test.py
         pass_filenames: false
 
       # Block enums codegen drift (#405). Runs the codegen into a
@@ -141,8 +141,8 @@ repos:
       - id: enums-codegen-drift
         name: enums-codegen-drift
         language: system
-        files: '^(enums/(src|templates|data)/.+|enums/Cargo\.toml|src/c_langs_macros/[^/]+\.rs|src/languages/language_[^/]+\.rs|check-enums-codegen-drift\.sh)$'
-        entry: bash check-enums-codegen-drift.sh
+        files: '^(enums/(src|templates|data)/.+|enums/Cargo\.toml|src/c_langs_macros/[^/]+\.rs|src/languages/language_[^/]+\.rs|utils/check-enums-codegen-drift\.sh)$'
+        entry: bash utils/check-enums-codegen-drift.sh
         pass_filenames: false
 
       # Self-tests for the enums-codegen-drift gate. Runs on edits
@@ -153,8 +153,8 @@ repos:
       - id: enums-codegen-drift-test
         name: enums-codegen-drift-test
         language: system
-        files: '^check-enums-codegen-drift(-test\.py|\.sh)$'
-        entry: python3 -m unittest -q check-enums-codegen-drift-test.py
+        files: '^utils/check-enums-codegen-drift(-test\.py|\.sh)$'
+        entry: python3 -m unittest -q utils/check-enums-codegen-drift-test.py
         pass_filenames: false
 
       # Catch clap-vs-man-page drift before push. The
@@ -189,8 +189,8 @@ repos:
       - id: check-versions
         name: check-versions
         language: system
-        files: '(Cargo\.toml|/Cargo\.toml|/bindings/rust/README\.md|^README\.md|^STABILITY\.md|big-code-analysis-book/src/library/(quick-start|cargo-features|stability)\.md|big-code-analysis-book/src/recipes/ci\.md|check-versions\.py)$'
-        entry: python3 check-versions.py
+        files: '(Cargo\.toml|/Cargo\.toml|/bindings/rust/README\.md|^README\.md|^STABILITY\.md|big-code-analysis-book/src/library/(quick-start|cargo-features|stability)\.md|big-code-analysis-book/src/recipes/ci\.md|utils/check-versions\.py)$'
+        entry: python3 utils/check-versions.py
         pass_filenames: false
 
       # Man-page packaging gate — every man/bca*.1 page (the top-level
@@ -201,8 +201,8 @@ repos:
       - id: check-manpage-assets
         name: check-manpage-assets
         language: system
-        files: '^(man/bca.*\.1|big-code-analysis-cli/Cargo\.toml|big-code-analysis-web/Cargo\.toml|check-manpage-assets\.py)$'
-        entry: python3 check-manpage-assets.py
+        files: '^(man/bca.*\.1|big-code-analysis-cli/Cargo\.toml|big-code-analysis-web/Cargo\.toml|utils/check-manpage-assets\.py)$'
+        entry: python3 utils/check-manpage-assets.py
         pass_filenames: false
 
       # The `enums/` crate is workspace-excluded, so the workspace

--- a/.snapshot-anchor-baseline.txt
+++ b/.snapshot-anchor-baseline.txt
@@ -1,19 +1,19 @@
 # Bare insta::assert_json_snapshot! call counts per metric file.
 # Maintained by check-snapshot-anchors.py; see AGENTS.md.
 # Lower-or-equal current counts pass; any increase fails CI.
-# Regenerate with: ./check-snapshot-anchors.py --update
+# Regenerate with: ./utils/check-snapshot-anchors.py --update
 
 src/metrics/abc.rs 27
 src/metrics/cognitive.rs 0
 src/metrics/cyclomatic.rs 1
-src/metrics/exit.rs 0
 src/metrics/halstead.rs 3
 src/metrics/loc.rs 0
 src/metrics/mi.rs 0
 src/metrics/mod.rs 0
 src/metrics/nargs.rs 0
+src/metrics/nexits.rs 0
 src/metrics/nom.rs 0
-src/metrics/npa.rs 13
+src/metrics/npa.rs 12
 src/metrics/npm.rs 23
 src/metrics/tokens.rs 0
 src/metrics/wmc.rs 13

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -186,7 +186,7 @@ tasks:
               git clone --quiet ${repository}
               cd big-code-analysis
               git -c advice.detachedHead=false checkout ${head_rev}
-              ./check-grammars-crates.sh tree-sitter-mozcpp
+              ./utils/check-grammars-crates.sh tree-sitter-mozcpp
           cache:
             big-code-analysis-mozilla-central-repository: /cache
           artifacts:
@@ -220,7 +220,7 @@ tasks:
               git clone --quiet ${repository}
               cd big-code-analysis
               git -c advice.detachedHead=false checkout ${head_rev}
-              ./check-grammars-crates.sh tree-sitter-mozjs
+              ./utils/check-grammars-crates.sh tree-sitter-mozjs
           cache:
             big-code-analysis-mozilla-central-repository: /cache
           artifacts:
@@ -254,7 +254,7 @@ tasks:
               git clone --quiet ${repository}
               cd big-code-analysis
               git -c advice.detachedHead=false checkout ${head_rev}
-              ./check-grammars-crates.sh tree-sitter-rust
+              ./utils/check-grammars-crates.sh tree-sitter-rust
           cache:
             big-code-analysis-mozilla-central-repository: /cache
           artifacts:
@@ -288,7 +288,7 @@ tasks:
               git clone --quiet ${repository}
               cd big-code-analysis
               git -c advice.detachedHead=false checkout ${head_rev}
-              ./check-grammars-crates.sh tree-sitter-java
+              ./utils/check-grammars-crates.sh tree-sitter-java
           cache:
             big-code-analysis-mozilla-central-repository: /cache
           artifacts:
@@ -322,7 +322,7 @@ tasks:
               git clone --quiet ${repository}
               cd big-code-analysis
               git -c advice.detachedHead=false checkout ${head_rev}
-              ./check-grammars-crates.sh tree-sitter-kotlin
+              ./utils/check-grammars-crates.sh tree-sitter-kotlin
           cache:
             big-code-analysis-mozilla-central-repository: /cache
           artifacts:
@@ -356,7 +356,7 @@ tasks:
               git clone --quiet ${repository}
               cd big-code-analysis
               git -c advice.detachedHead=false checkout ${head_rev}
-              ./check-grammars-crates.sh tree-sitter-python
+              ./utils/check-grammars-crates.sh tree-sitter-python
           cache:
             big-code-analysis-mozilla-central-repository: /cache
           artifacts:
@@ -390,7 +390,7 @@ tasks:
               git clone --quiet ${repository}
               cd big-code-analysis
               git -c advice.detachedHead=false checkout ${head_rev}
-              ./check-grammars-crates.sh tree-sitter-typescript
+              ./utils/check-grammars-crates.sh tree-sitter-typescript
           cache:
             big-code-analysis-mozilla-central-repository: /cache
           artifacts:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,9 +57,17 @@ and `cargo run -p big-code-analysis-web --`.
 - `big-code-analysis-book/` — mdBook documentation source.
 - `enums/` — separate workspace member (excluded from the root workspace)
   that generates language enum tables.
-- Helper scripts: `check-grammar-crate.py`, `check-grammars-crates.sh`,
-  `recreate-grammars.sh`, `generate-grammars/`. (The grammar-bump diff
-  step now uses the native `bca diff`; the former
+- `utils/` — repo-maintenance helper scripts, including the gates run
+  by `make pre-commit` / `make ci`: `check-versions.py`,
+  `check-snapshot-anchors.py`, `check-manpage-assets.py`,
+  `check-grammar-marker-sync.py`, `check-enums-codegen-drift.sh`,
+  `check-grammar-crate.py`, `check-grammars-crates.sh`,
+  `verify-name-only-churn.py`, and each gate's `*-test.py` self-tests.
+  Each resolves the repository root from its own location
+  (`Path(__file__).resolve().parents[1]`) rather than the cwd, so it
+  runs correctly from anywhere; callers invoke them as `utils/<name>`.
+- Other helper scripts: `recreate-grammars.sh`, `generate-grammars/`.
+  (The grammar-bump diff step now uses the native `bca diff`; the former
   `split-minimal-tests.py` + external `json-minimal-tests` chain was
   retired in #487.)
 
@@ -329,12 +337,12 @@ This policy is enforced automatically. `make snapshot-anchors` (run
 as part of `make pre-commit` and `make ci`, the
 `.pre-commit-config.yaml` hooks, and the `lint` job in
 `.github/workflows/ci.yml`) invokes
-`./check-snapshot-anchors.py`, which scans every
+`./utils/check-snapshot-anchors.py`, which scans every
 `insta::assert_json_snapshot!(metric.…)` call under `src/metrics/`
 and counts the unanchored ones per file. The current per-file
 counts are checked in at `.snapshot-anchor-baseline.txt`; CI fails
 on any *increase*. Decreases are silent and may be locked in with
-`./check-snapshot-anchors.py --update`, which regenerates the
+`./utils/check-snapshot-anchors.py --update`, which regenerates the
 baseline from the working tree.
 
 **Integration snapshots live in the `big-code-analysis-output`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,25 @@ for historical reference.
   a reachable remote process abort open until `3.0`. The mechanical fix
   at each call site is a `.clone()` or a borrow; 13 sites inside this
   repository needed it.
+- Repository layout, no shipped-library change: the twelve helper
+  scripts that used to sit in the repository root moved into `utils/`,
+  joining `check-tools.sh` and `deploy-book-to-gh-pages.sh`. This
+  covers every gate run by `make pre-commit` / `make ci`
+  (`check-versions.py`, `check-snapshot-anchors.py`,
+  `check-manpage-assets.py`, `check-grammar-marker-sync.py`,
+  `check-enums-codegen-drift.sh`, `check-grammar-crate.py`), the
+  scripts coupled to them (`check-grammars-crates.sh` and each gate's
+  `*-test.py` self-tests), and `verify-name-only-churn.py`. Each script
+  now resolves the repository root as `parents[1]` of its own location
+  rather than `parent`, so it still runs correctly from any cwd, and
+  the two self-tests that stage a copy of their gate into a tempdir
+  stage it under `<tmpdir>/utils/` so the tempdir keeps standing in for
+  the repository root. Callers were updated in lockstep: the
+  `Makefile`, `.pre-commit-config.yaml` (both the `entry:` commands and
+  the `^`-anchored `files:` triggers), `.github/workflows/ci.yml`, and
+  `.taskcluster.yml` now invoke them as `utils/<name>`. Contributors
+  invoking a gate by hand need the new prefix, e.g.
+  `./utils/check-snapshot-anchors.py --update`.
 - Internal, no behaviour change: the crate's shared `#[cfg(test)]`
   helpers moved out of `src/tools.rs` into a new test-only
   `src/test_support.rs`, retiring that file's `loc.sloc` baseline entry

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ gate. In one parallel pass it runs, among other stages:
   (`rumdl`, `taplo`, `shellcheck`, `shfmt`, `checkmake`,
   `actionlint`).
 - The man-page drift gate and the `bca` self-scan threshold gates.
-- `./check-snapshot-anchors.py` (see "Snapshot anchors" below).
+- `./utils/check-snapshot-anchors.py` (see "Snapshot anchors" below).
 - The Python lint / type-check / test stages (see below), skipped
   per stage when a tool is absent.
 
@@ -153,7 +153,7 @@ Each new snapshot assertion must carry one of:
   re-deriving the metric from scratch.
 
 The policy is enforced automatically by
-`./check-snapshot-anchors.py`, which `make pre-commit`, `make ci`,
+`./utils/check-snapshot-anchors.py`, which `make pre-commit`, `make ci`,
 the pre-commit hooks, and the `lint` job in
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml) all invoke.
 The per-file baseline of pre-existing unanchored snapshots lives in

--- a/Makefile
+++ b/Makefile
@@ -283,7 +283,7 @@ actionlint:
 
 snapshot-anchors:
 	@echo "Checking insta snapshot anchors..."
-	@python3 $(BASE_DIR)check-snapshot-anchors.py
+	@python3 $(BASE_DIR)utils/check-snapshot-anchors.py
 
 # Grammar-marker-sync gate. Blocks the failure mode from #400:
 # bumping the notification-only `tree-sitter-{javascript,cpp}`
@@ -292,7 +292,7 @@ snapshot-anchors:
 # Static lint — no network, no cargo, runs in milliseconds.
 grammar-marker-sync:
 	@echo "Checking grammar-marker sync against baseline..."
-	@python3 $(BASE_DIR)check-grammar-marker-sync.py
+	@python3 $(BASE_DIR)utils/check-grammar-marker-sync.py
 
 # Enums-codegen drift gate. Closes #405: running any
 # `recreate-grammars.sh` invocation silently regenerated
@@ -301,7 +301,7 @@ grammar-marker-sync:
 # and diffs against the checked-in files; drift fails.
 enums-codegen-drift:
 	@echo "Checking enums codegen drift..."
-	@bash $(BASE_DIR)check-enums-codegen-drift.sh
+	@bash $(BASE_DIR)utils/check-enums-codegen-drift.sh
 
 # Self-tests for the enums-codegen-drift gate. Kept separate from
 # the gate target so the gate stays a one-line invariant check
@@ -309,7 +309,7 @@ enums-codegen-drift:
 # get their own clean parallel-arm output in the pre-commit/CI DAG.
 enums-codegen-drift-test:
 	@echo "Running enums-codegen-drift self-tests..."
-	@(cd $(BASE_DIR) && python3 -m unittest -q check-enums-codegen-drift-test.py)
+	@(cd $(BASE_DIR) && python3 -m unittest -q utils/check-enums-codegen-drift-test.py)
 
 # Self-tests for the grammar-marker-sync gate. Kept separate from
 # the gate target so the gate stays a one-line invariant check
@@ -318,7 +318,7 @@ enums-codegen-drift-test:
 # the pre-commit/CI DAG.
 grammar-marker-sync-test:
 	@echo "Running grammar-marker-sync self-tests..."
-	@(cd $(BASE_DIR) && python3 -m unittest -q check-grammar-marker-sync-test.py)
+	@(cd $(BASE_DIR) && python3 -m unittest -q utils/check-grammar-marker-sync-test.py)
 
 # Regenerate the man pages under `man/` from the live clap schema.
 # Auto-fix flavour: `cargo xtask` rewrites every `.1` file so a
@@ -349,7 +349,7 @@ manpages-check:
 # `RELEASING.md` "Lockstep version policy" and `check-versions.py`.
 check-versions:
 	@echo "Checking lockstep version invariant..."
-	@python3 $(BASE_DIR)check-versions.py
+	@python3 $(BASE_DIR)utils/check-versions.py
 
 # Self-tests for the lockstep-version gate. Kept separate from the
 # gate target (matching the grammar-marker-sync-test pattern) so the
@@ -357,7 +357,7 @@ check-versions:
 # their own clean parallel-arm output in the pre-commit/CI DAG.
 check-versions-test:
 	@echo "Running check-versions self-tests..."
-	@(cd $(BASE_DIR) && python3 -m unittest -q check-versions-test.py)
+	@(cd $(BASE_DIR) && python3 -m unittest -q utils/check-versions-test.py)
 
 # Man-page packaging gate. Blocks the failure mode from #444:
 # a bca subcommand man page that drops out of the hand-maintained
@@ -365,7 +365,7 @@ check-versions-test:
 # lint — no network, no cargo, runs in milliseconds. See #446.
 check-manpage-assets:
 	@echo "Checking man-page packaging asset lists..."
-	@python3 $(BASE_DIR)check-manpage-assets.py
+	@python3 $(BASE_DIR)utils/check-manpage-assets.py
 
 # Sync gate for check-grammar-crate.py's EXTENSIONS table. Re-derives
 # the grammar -> extension mapping from src/langs.rs `mk_langs!` and
@@ -374,7 +374,7 @@ check-manpage-assets:
 # other helper-script self-tests.
 check-grammar-crate-test:
 	@echo "Running check-grammar-crate self-tests..."
-	@(cd $(BASE_DIR) && python3 -m unittest -q check-grammar-crate-test.py)
+	@(cd $(BASE_DIR) && python3 -m unittest -q utils/check-grammar-crate-test.py)
 
 # The `enums/` crate is listed in `[workspace].exclude` (it ships a
 # non-published codegen binary used only by `recreate-grammars.sh`), so

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -212,7 +212,7 @@ drift. A version bump touches:
 9. A new `## [<new>]` section in `CHANGELOG.md` (the unreleased
    block is collapsed into it at release time).
 
-Run `./check-versions.py` (also wired into `make pre-commit` and
+Run `./utils/check-versions.py` (also wired into `make pre-commit` and
 the `lint` job in `.github/workflows/ci.yml`) after editing to
 catch any item the human eye missed.
 
@@ -527,7 +527,7 @@ diverge: after the post-tag bump, `Cargo.toml` reads ahead of every
 documentation example, and that is correct. When in doubt, apply the
 reader test: if someone copies this line today, does it resolve?
 
-`./check-versions.py` (`make check-versions`, wired into
+`./utils/check-versions.py` (`make check-versions`, wired into
 `make pre-commit` and the CI lint job) enforces the two automatable
 categories: dependency-example pins must equal the latest released
 `## [X.Y.Z]` section of `CHANGELOG.md`, and the `recipes/ci.md`

--- a/big-code-analysis-book/src/recipes/exporting-data.md
+++ b/big-code-analysis-book/src/recipes/exporting-data.md
@@ -119,7 +119,7 @@ unless the opt-in `--exit-code` flag is passed, which exits 2 when
 the filtered diff is non-empty.
 It replaces the former `json-minimal-tests` + `split-minimal-tests.py`
 chain used to validate that a grammar bump did not regress metrics; the
-`check-grammar-crate.py` helper now calls `bca diff` internally.
+`utils/check-grammar-crate.py` helper now calls `bca diff` internally.
 
 ## Pull a single metric across an entire tree
 

--- a/docs/development/output_name_normalization_design.md
+++ b/docs/development/output_name_normalization_design.md
@@ -125,7 +125,7 @@ pub struct WalkFile {
   arm, so the emitted document name, baseline key, diff key, and
   exclude-match target all used the one canonical `name`.
 - The four anchoring helpers and `with_cwd` were deleted.
-- A reusable safety tool, `verify-name-only-churn.py`, was written to
+- A reusable safety tool, `utils/verify-name-only-churn.py`, was written to
   prove the bulk snapshot regen was value-preserving (it is kept; it is
   generally useful and is the one artifact of this attempt worth
   retaining on the main branch).
@@ -314,7 +314,7 @@ the three configurations the gate's uniformity hid:
   CWD read`).
 - The correct, retained consumer-side fixes for #497 Bug A/B are on the
   main work branch as `f0b83a7d`.
-- `verify-name-only-churn.py` (kept): proves a bulk snapshot regen is
+- `utils/verify-name-only-churn.py` (kept): proves a bulk snapshot regen is
   name-only/value-preserving; reusable for whichever round-two option
   touches emitted paths.
 - Related: STABILITY.md (the `2.0` deferral list), issues

--- a/tests/README.md
+++ b/tests/README.md
@@ -207,7 +207,7 @@ Every `insta::assert_json_snapshot!` call must be **anchored** — see
 `AGENTS.md` "snapshot-anchor policy". Either inline the expected block,
 add a positive `assert_eq!` on an integer accessor immediately above,
 or include a `// expected: …` derivation comment. `make pre-commit`
-runs `./check-snapshot-anchors.py` against
+runs `./utils/check-snapshot-anchors.py` against
 `.snapshot-anchor-baseline.txt` and fails on any increase.
 
 ### A new synthetic fixture (Pattern B)

--- a/utils/check-enums-codegen-drift-test.py
+++ b/utils/check-enums-codegen-drift-test.py
@@ -12,7 +12,7 @@ The shared cargo target cache (`enums/target/`) is warmed once
 in `setUpClass`, so per-test invocations hit a hot build.
 
 Run with:
-    python3 -m unittest -q check-enums-codegen-drift-test.py
+    python3 -m unittest -q utils/check-enums-codegen-drift-test.py
 """
 
 from __future__ import annotations
@@ -25,8 +25,21 @@ import sys
 import tempfile
 import unittest
 
-REPO_ROOT = pathlib.Path(__file__).resolve().parent
-SCRIPT_SRC = REPO_ROOT / "check-enums-codegen-drift.sh"
+# The gate under test is a sibling in `utils/`; every path it reads
+# or writes is anchored at the repository root one level above.
+UTILS_DIR = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = UTILS_DIR.parent
+SCRIPT_SRC = UTILS_DIR / "check-enums-codegen-drift.sh"
+
+
+def _staged(tmpdir: pathlib.Path) -> pathlib.Path:
+    """Where the staged copy of the drift script must live.
+
+    The script derives its `$ROOT` as the *parent* of its own
+    directory, so the copy has to sit in `tmpdir/utils/` for
+    `tmpdir` itself to stand in for the repository root.
+    """
+    return tmpdir / "utils" / SCRIPT_SRC.name
 
 
 def _run(
@@ -34,7 +47,7 @@ def _run(
 ) -> subprocess.CompletedProcess[str]:
     """Run the drift script from `tmpdir` (its $ROOT)."""
     return subprocess.run(
-        ["bash", str(tmpdir / SCRIPT_SRC.name), *args],
+        ["bash", str(_staged(tmpdir)), *args],
         capture_output=True,
         text=True,
         check=False,
@@ -86,12 +99,13 @@ class DriftGateTest(unittest.TestCase):
                 REPO_ROOT / "src" / sub,
                 self.tmpdir / "src" / sub,
             )
-        # Copy the script itself so `$BASH_SOURCE` and
-        # `dirname "$BASH_SOURCE"` resolve to the tempdir.
-        # (`git rev-parse --show-toplevel` fails here — not a
-        # git tree — and the script falls back to BASH_SOURCE
-        # dirname, which is exactly what we want.)
-        shutil.copy(SCRIPT_SRC, self.tmpdir / SCRIPT_SRC.name)
+        # Copy the script itself so `dirname "$BASH_SOURCE"/..`
+        # resolves to the tempdir. (`git rev-parse
+        # --show-toplevel` fails here — not a git tree — and the
+        # script falls back to BASH_SOURCE dirname, which is
+        # exactly what we want.)
+        _staged(self.tmpdir).parent.mkdir()
+        shutil.copy(SCRIPT_SRC, _staged(self.tmpdir))
 
     def tearDown(self) -> None:
         # Symlink under self.tmpdir is removed by rmtree without
@@ -229,7 +243,7 @@ class DriftGateTest(unittest.TestCase):
         env = os.environ.copy()
         env["PATH"] = f"{stub_dir}{os.pathsep}{env['PATH']}"
         return subprocess.run(
-            ["bash", str(self.tmpdir / SCRIPT_SRC.name)],
+            ["bash", str(_staged(self.tmpdir))],
             capture_output=True,
             text=True,
             check=False,
@@ -307,7 +321,7 @@ class DriftGateTest(unittest.TestCase):
         env = os.environ.copy()
         env["PATH"] = f"{stub_dir}{os.pathsep}{env['PATH']}"
         result = subprocess.run(
-            ["bash", str(self.tmpdir / SCRIPT_SRC.name)],
+            ["bash", str(_staged(self.tmpdir))],
             capture_output=True,
             text=True,
             check=False,

--- a/utils/check-enums-codegen-drift.sh
+++ b/utils/check-enums-codegen-drift.sh
@@ -21,15 +21,15 @@ set -euo pipefail
 # string and reporting drift on a non-existent path.
 shopt -s nullglob
 
-# `ROOT` is the directory containing the script (which is also
-# the directory containing `enums/`, `src/`, etc.). Using
-# `BASH_SOURCE` dirname rather than `git rev-parse
-# --show-toplevel` keeps the gate hermetic: it doesn't matter
-# what the caller's cwd is (e.g., a different git repo or
-# `/tmp` in test fixtures), the script always operates on its
-# own sibling directories. This also works under release
+# `ROOT` is the repository root: the parent of `utils/`, where
+# this script lives, and so the directory containing `enums/`,
+# `src/`, etc. Using `BASH_SOURCE` dirname rather than `git
+# rev-parse --show-toplevel` keeps the gate hermetic: it doesn't
+# matter what the caller's cwd is (e.g., a different git repo or
+# `/tmp` in test fixtures), the script always operates on the
+# tree it was invoked from. This also works under release
 # tarballs / packaging-script invocations that have no `.git`.
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # Use a script-local variable name (NOT `TMPDIR`) so the caller's
 # `$TMPDIR` env var is preserved for cargo / rustfmt / etc. The

--- a/utils/check-grammar-crate-test.py
+++ b/utils/check-grammar-crate-test.py
@@ -9,7 +9,7 @@ anti-drift guard for #869: the old table had gone stale across the
 key, phantom globs), so a grammar bump tested the wrong file set.
 
 Run with:
-    python3 -m unittest -q check-grammar-crate-test.py
+    python3 -m unittest -q utils/check-grammar-crate-test.py
 """
 
 from __future__ import annotations
@@ -19,8 +19,11 @@ import pathlib
 import re
 import unittest
 
-REPO_ROOT = pathlib.Path(__file__).resolve().parent
-SCRIPT_SRC = REPO_ROOT / "check-grammar-crate.py"
+# The gate under test is a sibling in `utils/`; every path it reads
+# or writes is anchored at the repository root one level above.
+UTILS_DIR = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = UTILS_DIR.parent
+SCRIPT_SRC = UTILS_DIR / "check-grammar-crate.py"
 LANGS_RS = REPO_ROOT / "src" / "langs.rs"
 
 # The tree-sitter function token in `mk_langs!` maps 1:1 to the grammar

--- a/utils/check-grammar-crate.py
+++ b/utils/check-grammar-crate.py
@@ -9,17 +9,17 @@ chosen repository, before and after a tree-sitter-grammar update.
 
 To compute metrics:
 
-./check-grammar-crate.py compute-metrics -u REPO_URL -p LOCAL_DIR -g TREE_SITTER_GRAMMAR
+./utils/check-grammar-crate.py compute-metrics -u REPO_URL -p LOCAL_DIR -g TREE_SITTER_GRAMMAR
 
 NOTE: The compute-metrics subcommand MUST be run on a clean master branch!
 
 To compute metrics on a continuous integration system:
 
-./check-grammar-crate.py compute-ci-metrics -p LOCAL_DIR -g TREE_SITTER_GRAMMAR
+./utils/check-grammar-crate.py compute-ci-metrics -p LOCAL_DIR -g TREE_SITTER_GRAMMAR
 
 To compare metrics and retrieve per-metric differences:
 
-./check-grammar-crate.py compare-metrics -g TREE_SITTER_GRAMMAR [-t MIN_CHANGE]
+./utils/check-grammar-crate.py compare-metrics -g TREE_SITTER_GRAMMAR [-t MIN_CHANGE]
 
 This buckets the per-file metric deltas by metric using the native
 `bca diff` (issue #487), printing a summary to stdout and saving a

--- a/utils/check-grammar-marker-sync-test.py
+++ b/utils/check-grammar-marker-sync-test.py
@@ -2,16 +2,17 @@
 """Tests for check-grammar-marker-sync.py.
 
 Each test stages a synthetic mini-repo in a tempdir (the script
-plus the two vendored Cargo.toml stubs plus an optional baseline)
-and runs the script as a subprocess. Subprocess invocation is the
-most representative shape — the script's behaviour is keyed off
-`pathlib.Path(__file__).resolve().parent`, so co-locating with
-the fixture is enough to redirect every path.
+under `utils/` plus the two vendored Cargo.toml stubs plus an
+optional baseline) and runs the script as a subprocess.
+Subprocess invocation is the most representative shape — the
+script's behaviour is keyed off
+`pathlib.Path(__file__).resolve().parents[1]`, so staging the
+copy one level below the fixture root redirects every path.
 
 Run with:
-    python3 -m unittest -q check-grammar-marker-sync-test.py
+    python3 -m unittest -q utils/check-grammar-marker-sync-test.py
 Or:
-    python3 check-grammar-marker-sync-test.py
+    python3 utils/check-grammar-marker-sync-test.py
 """
 
 from __future__ import annotations
@@ -23,8 +24,11 @@ import sys
 import tempfile
 import unittest
 
-REPO_ROOT = pathlib.Path(__file__).resolve().parent
-SCRIPT_SRC = REPO_ROOT / "check-grammar-marker-sync.py"
+# The gate under test is a sibling in `utils/`. Its own paths are
+# anchored at the repository root one level above, which is why the
+# fixtures below stage a copy into `<tmpdir>/utils/`.
+UTILS_DIR = pathlib.Path(__file__).resolve().parent
+SCRIPT_SRC = UTILS_DIR / "check-grammar-marker-sync.py"
 
 
 _MOZJS_BARE = (
@@ -59,7 +63,11 @@ def _make_fixture(
     omit the marker line entirely. Returns the path to the
     staged script.
     """
-    script_path = tmpdir / SCRIPT_SRC.name
+    # The script derives `REPO_ROOT` as the *parent* of its own
+    # directory, so the staged copy has to sit in `tmpdir/utils/`
+    # for `tmpdir` itself to stand in for the repository root.
+    script_path = tmpdir / "utils" / SCRIPT_SRC.name
+    script_path.parent.mkdir()
     shutil.copy(SCRIPT_SRC, script_path)
 
     mozjs_dir = tmpdir / "tree-sitter-mozjs"

--- a/utils/check-grammar-marker-sync.py
+++ b/utils/check-grammar-marker-sync.py
@@ -18,7 +18,7 @@ entry in `.grammar-marker-baseline.toml`. Any divergence fails.
 
 Regenerate the baseline after a verified regen with:
 
-    ./check-grammar-marker-sync.py --update
+    ./utils/check-grammar-marker-sync.py --update
 
 `--update` rewrites both the `marker` and `version` values of
 existing sections in place, preserving per-section audit
@@ -60,7 +60,9 @@ except ImportError:
         sys.exit(2)
 
 
-REPO_ROOT = pathlib.Path(__file__).resolve().parent
+# `parents[1]`, not `parent`: these gates live in `utils/` but every
+# path they read or write is anchored at the repository root.
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 BASELINE_PATH = REPO_ROOT / ".grammar-marker-baseline.toml"
 
 # `--update` produced invalid TOML for a tree that load_baseline
@@ -685,7 +687,7 @@ def main() -> int:
             "    commit the regenerated `src/parser.c` (+ scanner.c /\n"
             "    grammar.json / node-types.json) in the same PR, then\n"
             "    refresh the baseline:\n"
-            "        ./check-grammar-marker-sync.py --update\n"
+            "        ./utils/check-grammar-marker-sync.py --update\n"
             "  - The sources were regenerated but the baseline was not\n"
             "    refreshed. Run the --update command above.\n"
             "\nSee AGENTS.md and #400 for context.\n"

--- a/utils/check-grammars-crates.sh
+++ b/utils/check-grammars-crates.sh
@@ -53,7 +53,7 @@ fi
 pushd /cache/gecko-dev && git pull origin master && popd
 
 # Compute metrics
-./check-grammar-crate.py compute-ci-metrics -p /cache/gecko-dev -g "$TREE_SITTER_CRATE"
+./utils/check-grammar-crate.py compute-ci-metrics -p /cache/gecko-dev -g "$TREE_SITTER_CRATE"
 
 # Count files in metrics directories
 OLD=$(find "/tmp/$TREE_SITTER_CRATE-old" -mindepth 1 -maxdepth 1 | wc -l)
@@ -80,7 +80,7 @@ fi
 # minimal-test files per metric, a different axis that bca diff's
 # per-metric bucketing makes unnecessary).
 MIN_CHANGE=0
-./check-grammar-crate.py compare-metrics -g "$TREE_SITTER_CRATE" -t "$MIN_CHANGE"
+./utils/check-grammar-crate.py compare-metrics -g "$TREE_SITTER_CRATE" -t "$MIN_CHANGE"
 
 # Create artifact to be uploaded (if there is any diff output)
 COMPARE=/tmp/$TREE_SITTER_CRATE-compare

--- a/utils/check-manpage-assets.py
+++ b/utils/check-manpage-assets.py
@@ -35,7 +35,9 @@ import pathlib
 import sys
 import tomllib
 
-REPO_ROOT = pathlib.Path(__file__).resolve().parent
+# `parents[1]`, not `parent`: these gates live in `utils/` but every
+# path they read or write is anchored at the repository root.
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 MAN_DIR = REPO_ROOT / "man"
 CLI_MANIFEST = REPO_ROOT / "big-code-analysis-cli" / "Cargo.toml"
 WEB_MANIFEST = REPO_ROOT / "big-code-analysis-web" / "Cargo.toml"

--- a/utils/check-snapshot-anchors.py
+++ b/utils/check-snapshot-anchors.py
@@ -29,7 +29,9 @@ import re
 import sys
 from collections import OrderedDict
 
-REPO_ROOT = pathlib.Path(__file__).resolve().parent
+# `parents[1]`, not `parent`: these gates live in `utils/` but every
+# path they read or write is anchored at the repository root.
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 METRICS_DIR = REPO_ROOT / "src" / "metrics"
 DEFAULT_BASELINE = REPO_ROOT / ".snapshot-anchor-baseline.txt"
 
@@ -271,7 +273,7 @@ def write_baseline(path: pathlib.Path, counts: dict[str, int]) -> None:
         "# Bare insta::assert_json_snapshot! call counts per metric file.",
         "# Maintained by check-snapshot-anchors.py; see AGENTS.md.",
         "# Lower-or-equal current counts pass; any increase fails CI.",
-        "# Regenerate with: ./check-snapshot-anchors.py --update",
+        "# Regenerate with: ./utils/check-snapshot-anchors.py --update",
         "",
     ]
     for rel, count in counts.items():
@@ -406,7 +408,7 @@ def main() -> int:
             "  - // expected: <derivation> comment (within 5 non-blank lines)\n"
             "See AGENTS.md \"Validation gates\". If the increase is intentional\n"
             "(e.g. new tests already anchored differently), regenerate the\n"
-            "baseline with: ./check-snapshot-anchors.py --update\n"
+            "baseline with: ./utils/check-snapshot-anchors.py --update\n"
         )
         return 1
 

--- a/utils/check-versions-test.py
+++ b/utils/check-versions-test.py
@@ -13,7 +13,7 @@ Two kinds of test live here:
   asserts a clean tree reports lockstep.
 
 Run with:
-    python3 -m unittest -q check-versions-test.py
+    python3 -m unittest -q utils/check-versions-test.py
 """
 
 from __future__ import annotations
@@ -24,8 +24,11 @@ import subprocess
 import sys
 import unittest
 
-REPO_ROOT = pathlib.Path(__file__).resolve().parent
-SCRIPT_SRC = REPO_ROOT / "check-versions.py"
+# The gate under test is a sibling in `utils/`; every path it reads
+# or writes is anchored at the repository root one level above.
+UTILS_DIR = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = UTILS_DIR.parent
+SCRIPT_SRC = UTILS_DIR / "check-versions.py"
 
 
 def _load_module():  # type: ignore[no-untyped-def]

--- a/utils/check-versions.py
+++ b/utils/check-versions.py
@@ -29,7 +29,9 @@ import pathlib
 import re
 import sys
 
-REPO_ROOT = pathlib.Path(__file__).resolve().parent
+# `parents[1]`, not `parent`: these gates live in `utils/` but every
+# path they read or write is anchored at the repository root.
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 
 # Owned crates that carry an own `[package].version` line (i.e. do
 # not inherit via `version.workspace = true`). Each must match the

--- a/utils/verify-name-only-churn.py
+++ b/utils/verify-name-only-churn.py
@@ -28,8 +28,8 @@ value-sets — is unreachable by a relabeling refactor that never touches
 metric computation.
 
 Usage:
-    ./verify-name-only-churn.py [ROOT ...]      # default roots: . and the submodule
-    ./verify-name-only-churn.py --self-test     # prove the verifier itself
+    ./utils/verify-name-only-churn.py [ROOT ...]      # default roots: . and the submodule
+    ./utils/verify-name-only-churn.py --self-test     # prove the verifier itself
 Exit status: 0 if every changed snapshot is name-only; 1 otherwise.
 """
 


### PR DESCRIPTION
## What

Moves the twelve helper scripts that sat loose in the repository
root into `utils/`, where `check-tools.sh` and
`deploy-book-to-gh-pages.sh` already lived. The root now lists
project structure rather than maintenance tooling.

| Moved to `utils/` | Purpose |
|---|---|
| `check-versions.py` + `-test.py` | Lockstep version invariant across owned crates and doc pins |
| `check-snapshot-anchors.py` | Blocks new bare `insta::assert_json_snapshot!` in `src/metrics/` |
| `check-manpage-assets.py` | Every `man/bca*.1` present in the deb+rpm asset lists |
| `check-grammar-marker-sync.py` + `-test.py` | mozjs/mozcpp marker vs bundled `parser.c` (#400) |
| `check-grammar-crate.py` + `-test.py` + `check-grammars-crates.sh` | Grammar-bump metric diff; the test guards `EXTENSIONS` against `src/langs.rs` |
| `check-enums-codegen-drift.sh` + `-test.py` | enums codegen drift (#405) |
| `verify-name-only-churn.py` | Proves a bulk snapshot regen is path-only churn |

`recreate-grammars.sh` stays at the root — nothing moved is coupled
to it. The two shell scripts move rather than splitting each from
the test that exercises it (`check-enums-codegen-drift.sh`) and the
script it calls (`check-grammars-crates.sh`).

## The parts that are not a rename

Three things a plain `git mv` plus a path rewrite would have broken
silently:

- **Repo-root anchoring.** Every script derived its paths from
  `Path(__file__).resolve().parent`, which was the repository root
  only by accident of where the file sat. That becomes `parents[1]`,
  so each still resolves the root from its own location and runs
  correctly from any cwd.
- **The two self-tests that stage a copy of their gate into a
  tempdir** (`check-grammar-marker-sync-test.py`,
  `check-enums-codegen-drift-test.py`) relied on the same
  coincidence: the copy sat *at* the fixture root. Under `parents[1]`
  that resolves to the tempdir's parent, so the copy now stages under
  `<tmpdir>/utils/`. Both suites failed loudly at the intermediate
  step, which is how this surfaced.
- **`.pre-commit-config.yaml` `files:` regexes**, not just the
  `entry:` commands. Several are `^`-anchored, so a hook such as
  `grammar-marker-sync-test` would have silently stopped firing on
  edits to its own script.

## Callers updated

`Makefile`, `.pre-commit-config.yaml`, `.github/workflows/ci.yml`,
`.github/workflows/release.yml`, `.taskcluster.yml`, and
`check-grammars-crates.sh`'s own call sites. Prose in `AGENTS.md`,
`CONTRIBUTING.md`, `RELEASING.md`, `tests/README.md`,
`docs/development/output_name_normalization_design.md`, the book's
`recipes/exporting-data.md`, and `.claude/skills/add-lang/SKILL.md`.
The `--update` hints the gates print to users carry the new prefix
too, as does the header written into
`.grammar-marker-baseline.toml`. `CHANGELOG.md` history is left
alone.

## Reviewer note on `.snapshot-anchor-baseline.txt`

Regenerated because its header embeds the script path. The regen
also corrects two rows that were stale before this change, which is
the one non-rename content change in the diff:

- a phantom `src/metrics/exit.rs` entry left behind by the rename to
  `nexits.rs` (count 0 either way);
- `src/metrics/npa.rs` ratcheting 13 → 12, after an anchor landed
  without a baseline refresh.

Both are corrections toward the live measurement. Say the word if
you would rather the move commit be a pure path change and these
land separately.

## Validation

`make pre-commit` green end-to-end, plus a targeted lint re-run for
the few edits that landed after that run started. Each gate and each
self-test was also run individually from the new location.

`ja.po` is untouched per the translation policy — the changed
`exporting-data.md` paragraph falls back to English on `/ja/` until
the next `make book-po-update`.
