### PR TITLE
perf(cognitive): read function depth off the ancestor chain

### DIFF
--- a/.bca-baseline.toml
+++ b/.bca-baseline.toml
@@ -765,7 +765,7 @@ path = "src/metrics/cognitive/ruby.rs"
 qualified = "RubyCode::compute"
 start_line = 29
 metric = "halstead.effort"
-value = 53271.17757518335
+value = 53802.68593577912
 
 [[entry]]
 path = "src/metrics/loc/c.rs"

--- a/.bca-baseline.toml
+++ b/.bca-baseline.toml
@@ -728,14 +728,14 @@ value = 16.0
 [[entry]]
 path = "src/metrics/cognitive.rs"
 qualified = "tcl_switch_decision_arms"
-start_line = 475
+start_line = 490
 metric = "nargs"
 value = 7.0
 
 [[entry]]
 path = "src/metrics/cognitive.rs"
 qualified = "tcl_switch_decision_arms"
-start_line = 475
+start_line = 490
 metric = "nexits"
 value = 6.0
 
@@ -765,7 +765,7 @@ path = "src/metrics/cognitive/ruby.rs"
 qualified = "RubyCode::compute"
 start_line = 29
 metric = "halstead.effort"
-value = 52423.215599473966
+value = 53271.17757518335
 
 [[entry]]
 path = "src/metrics/loc/c.rs"
@@ -861,7 +861,7 @@ value = 32.0
 [[entry]]
 path = "src/ops.rs"
 qualified = "ops_inner"
-start_line = 216
+start_line = 221
 metric = "halstead.effort"
 value = 58764.00971804493
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,23 +275,29 @@ for historical reference.
   grammars whose cognitive impl is a no-op, `preproc` and `ccomment`, now
   build no map at all rather than one entry per AST node.
 
-  `cognitive`'s second `Node::parent` site is gone with it:
+  `cognitive`'s remaining `Node::parent` sites are gone with it.
   `increment_function_depth` asked every function node whether a
   function encloses it by climbing with `node.parent()`, which kept the
-  metric `O(depth²)` on nested definitions across the 19 languages that
-  call it. It now reads the ancestor chain the walker hands down (the #1084
+  metric `O(depth²)` on nested definitions across its 19 call sites (22
+  languages, counting the four the JS-family macro expands to). It now
+  reads the ancestor chain the walker hands down (the #1084
   mechanism, deferred out of that change), and a new
   `cognitive/nested-fn` depth-scaling probe covers it: `time ~ depth^k`
   fits 2.04 against the climb and 1.21 against the chain, and at depth
-  4000 the walk drops from ~150 ms to ~16 ms. Cognitive values are
-  unchanged — the arithmetic is pinned at depth 1000 by
-  `cognitive_function_depth_is_inherited_at_depth`.
+  4000 the walk drops from ~150 ms to ~16 ms. The two remaining
+  per-node climbs inside the metric — Kotlin's `when`-default check and
+  Ruby's `case`-default check, one per `else` node — read the same
+  chain now. Cognitive values are unchanged; the arithmetic is pinned at
+  depth 1000 by `cognitive_function_depth_is_inherited_at_depth` and
+  across languages by
+  `function_depth_surcharge_holds_across_languages`.
 
-  The `Node::parent` climbs that remain are outside `cognitive` and
-  outside the probed walks — five `Ancestors::unknown()` call sites plus
-  the Halstead `get_op_type` getters — and are tracked in #1088.
-  Operators analysing untrusted input should still bound request
-  concurrency and input size.
+  `Node::parent` climbs remain elsewhere in the crate — the five
+  `Ancestors::unknown()` call sites, the Halstead `get_op_type`
+  getters, and per-node lookups in several `loc`, `npa` / `npm`, and
+  `checker` arms — all outside `cognitive` and outside the probed
+  walks, and tracked in #1088. Operators analysing untrusted input
+  should still bound request concurrency and input size.
 
 - Deeply nested source no longer costs quadratic time in the `tokens`
   metric (#1052). `Tokens` decided whether a leaf sat inside a comment by
@@ -372,18 +378,19 @@ for historical reference.
   of deeply nested source could pin a core for minutes against the
   unauthenticated `bca-web` endpoints, whose parse deadline frees the
   client but cannot cancel the blocking task. Two of the quadratic paths
-  are gone — the `tokens` ancestor walk (#1052) and both of `cognitive`'s
-  parent lookups (#1062) — as are the three `Node::parent` predicates the
-  benchmark harness measured as quadratic (#1084); see those entries
-  under **Fixed**. Every walk the depth-scaling gate probes now fits an
-  exponent near 1.0.
+  are gone — the `tokens` ancestor walk (#1052) and every one of
+  `cognitive`'s parent lookups (#1062) — as are the three `Node::parent`
+  predicates the benchmark harness measured as quadratic (#1084); see
+  those entries under **Fixed**. Every walk the depth-scaling gate
+  probes now fits an exponent near 1.0.
 
-  **This is not closed.** The climbs listed in #1088 are unprobed and
-  still resolve a parent by descending from the root: the JS/TS
-  `is_func` / `is_closure` walk, Elixir's `Npa` / `Npm` /
-  `get_func_space_name` / suppression-marker lookups, and the Halstead
-  `get_op_type` getters. Operators analysing untrusted input must still
-  bound request concurrency and input size.
+  **This is not closed.** The climbs tracked in #1088 are unprobed and
+  still resolve a parent by descending from the root, among them the
+  JS/TS `is_func` / `is_closure` walk, Elixir's `Npa` / `Npm` /
+  `get_func_space_name` / suppression-marker lookups, the Halstead
+  `get_op_type` getters, and per-node `Node::parent` calls in several
+  `loc` and `checker` arms. Operators analysing untrusted input must
+  still bound request concurrency and input size.
 - Cleared the two RUSTSEC advisories behind the OpenSSF Scorecard
   Vulnerabilities alert: `anyhow` `1.0.102` → `1.0.103` (unsound
   `Error::downcast_mut()`, RUSTSEC-2026-0190) and `memmap2` `0.9.10`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ for historical reference.
 - Benchmark harness for the metric walk, in the new workspace member
   `big-code-analysis-bench` (#1068). `cargo bench -p
   big-code-analysis-bench --bench scaling` (or `make bench-scaling`)
-  measures eight probes at three doubling nesting depths and fits
+  measures nine probes at three doubling nesting depths and fits
   `time ~ depth^k`, failing when a probe's exponent leaves its declared
   complexity class; `--bench metric_walk` (`make bench-walk`) runs
   criterion benchmarks per metric over a deterministic, self-reporting
@@ -275,21 +275,23 @@ for historical reference.
   grammars whose cognitive impl is a no-op, `preproc` and `ccomment`, now
   build no map at all rather than one entry per AST node.
 
-  **Deeply nested code is still superlinear in general** — this fixes one
-  of several `Node::parent` call sites, and *not* the one users hit most.
-  `Checker::is_else_if` calls `parent()` (or `previous_sibling()`, which
-  is implemented via `parent()`) for every `if`, across 13 languages, so
-  nested and `else if`-chained conditionals remain quadratic: a 4000-deep
-  C `if` chain takes ~3.3 s at depth 8000 where the equivalent `while`
-  chain takes 44 ms. Also outstanding: `Node::count_specific_ancestors`
-  (used by `loc` for C-family, Java, C#, Go, Groovy, Objective-C, and
-  twice per node by Python's boolean-operator handling),
-  `cognitive::increment_function_depth` (4000 nested Rust `fn`s, 55 KB →
-  ~1.9 s), and Elixir's `is_inside_quote_block`, which runs for every
-  node behind no metric selection and so cannot be deselected (4000
-  nested `quote` blocks, 52 KB → ~2.7 s). All tracked in #1062, which
-  stays open; a shared parent lookup owned by the walker would retire
-  them together.
+  `cognitive`'s second `Node::parent` site is gone with it:
+  `increment_function_depth` asked every function node whether a
+  function encloses it by climbing the ancestor chain, which kept the
+  metric `O(depth²)` on nested definitions across the 19 languages that
+  call it. It now reads the chain the walker hands down (the #1084
+  mechanism, deferred out of that change), and a new
+  `cognitive/nested-fn` depth-scaling probe covers it: `time ~ depth^k`
+  fits 2.04 against the climb and 1.21 against the chain, and at depth
+  4000 the walk drops from ~150 ms to ~16 ms. Cognitive values are
+  unchanged — the arithmetic is pinned at depth 1000 by
+  `cognitive_function_depth_is_inherited_at_depth`.
+
+  The `Node::parent` climbs that remain are outside `cognitive` and
+  outside the probed walks — five `Ancestors::unknown()` call sites plus
+  the Halstead `get_op_type` getters — and are tracked in #1088.
+  Operators analysing untrusted input should still bound request
+  concurrency and input size.
 
 - Deeply nested source no longer costs quadratic time in the `tokens`
   metric (#1052). `Tokens` decided whether a leaf sat inside a comment by
@@ -370,15 +372,18 @@ for historical reference.
   of deeply nested source could pin a core for minutes against the
   unauthenticated `bca-web` endpoints, whose parse deadline frees the
   client but cannot cancel the blocking task. Two of the quadratic paths
-  are gone — the `tokens` ancestor walk (#1052) and the `cognitive`
-  nesting lookup (#1062); see those entries under **Fixed**.
+  are gone — the `tokens` ancestor walk (#1052) and both of `cognitive`'s
+  parent lookups (#1062) — as are the three `Node::parent` predicates the
+  benchmark harness measured as quadratic (#1084); see those entries
+  under **Fixed**. Every walk the depth-scaling gate probes now fits an
+  exponent near 1.0.
 
-  **This is not closed.** `Checker::is_else_if` still calls
-  `Node::parent` per `if` across 13 languages, so deeply nested or
-  `else if`-chained conditionals — ordinary generated and state-machine
-  code, not just adversarial input — remain quadratic, along with three
-  further ancestor walks. All tracked in #1062. Operators analysing
-  untrusted input must still bound request concurrency and input size.
+  **This is not closed.** The climbs listed in #1088 are unprobed and
+  still resolve a parent by descending from the root: the JS/TS
+  `is_func` / `is_closure` walk, Elixir's `Npa` / `Npm` /
+  `get_func_space_name` / suppression-marker lookups, and the Halstead
+  `get_op_type` getters. Operators analysing untrusted input must still
+  bound request concurrency and input size.
 - Cleared the two RUSTSEC advisories behind the OpenSSF Scorecard
   Vulnerabilities alert: `anyhow` `1.0.102` → `1.0.103` (unsound
   `Error::downcast_mut()`, RUSTSEC-2026-0190) and `memmap2` `0.9.10`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,9 +277,9 @@ for historical reference.
 
   `cognitive`'s second `Node::parent` site is gone with it:
   `increment_function_depth` asked every function node whether a
-  function encloses it by climbing the ancestor chain, which kept the
+  function encloses it by climbing with `node.parent()`, which kept the
   metric `O(depth²)` on nested definitions across the 19 languages that
-  call it. It now reads the chain the walker hands down (the #1084
+  call it. It now reads the ancestor chain the walker hands down (the #1084
   mechanism, deferred out of that change), and a new
   `cognitive/nested-fn` depth-scaling probe covers it: `time ~ depth^k`
   fits 2.04 against the climb and 1.21 against the chain, and at depth

--- a/big-code-analysis-bench/src/shapes.rs
+++ b/big-code-analysis-bench/src/shapes.rs
@@ -197,10 +197,11 @@ const LINEAR_BOUND: f64 = 1.5;
 /// One entry per hot path identified during the #1052 / #1062 / #1084
 /// work, plus the controls that make those readings interpretable:
 ///
-/// - a *metric* control, `nom/nested-while`. `Cognitive` declares
-///   `Nom` as a dependency, so the cognitive-attributable cost is the
-///   difference between the two `nested-while` rows, not `cognitive`
-///   alone.
+/// - two *metric* controls, `nom/nested-while` and `nom/nested-fn`.
+///   `Cognitive` declares `Nom` as a dependency, so the
+///   cognitive-attributable cost of a `cognitive/…` row is its
+///   difference from the `nom/…` row on the same shape, not the
+///   `cognitive` reading alone.
 /// - two *shape* controls, `cognitive/nested-while` and
 ///   `loc/nested-while`. Each is the same nesting as the ancestor-walk
 ///   probe below it with the one node that triggers the walk removed.
@@ -335,9 +336,10 @@ pub const PROBES: &[Probe] = &[
                     node whether a function encloses it. The answer now \
                     comes off the walker's ancestor chain and is found two \
                     steps up; climbing with `Node::parent` instead cost \
-                    `O(depth)` per step across the 19 languages that call \
-                    it. `nom/nested-fn` is the same shape without the \
-                    cognitive walk.",
+                    `O(depth)` per step across the 19 call sites — 22 \
+                    languages, counting the four the JS-family macro \
+                    expands to. `nom/nested-fn` is the same shape without \
+                    the cognitive walk.",
     },
 ];
 

--- a/big-code-analysis-bench/src/shapes.rs
+++ b/big-code-analysis-bench/src/shapes.rs
@@ -110,17 +110,26 @@ pub fn nested_quotes(depth: usize) -> String {
     )
 }
 
-/// Rust: `fn f() { fn f() { … let x = 1; … } }`.
+/// Rust: `fn f() { if a {} fn f() { … let x = 1; … } }`.
 ///
-/// Each level opens a `FuncSpace`, so this drives `increment_function
-/// _depth`, the space-nesting bookkeeping, and the recursive
-/// `FuncSpace` tree that #1056 had to bound. Inner `fn f` shadows are
-/// legal — each sits in its own block scope.
+/// Each level opens a `FuncSpace`, so this drives the space-nesting
+/// bookkeeping and the recursive `FuncSpace` tree that #1056 had to
+/// bound. Inner `fn f` shadows are legal — each sits in its own block
+/// scope.
+///
+/// The `if` is what makes the shape readable by `cognitive`. A chain of
+/// bare functions carries no cognitive weight at all, so the metric
+/// would score zero at every depth; with one `if` per level the reading
+/// is `n(n+1)/2`, because `increment_function_depth` gives the function
+/// at level *k* a function-nesting depth of *k* and every `if` is
+/// penalised by the depth of the function holding it. That makes the
+/// value column sensitive to the function-depth walk this probe times
+/// (#1062), not only to the walk's cost.
 #[must_use]
 pub fn nested_fns(depth: usize) -> String {
     format!(
         "{}let x = 1;{}\n",
-        "fn f() { ".repeat(depth),
+        "fn f() { if a {} ".repeat(depth),
         "} ".repeat(depth)
     )
 }
@@ -308,9 +317,27 @@ pub const PROBES: &[Probe] = &[
         reading: |m| m.nom.total(),
         depths: LINEAR_DEPTHS,
         max_exponent: LINEAR_BOUND,
-        rationale: "One `FuncSpace` per level: `increment_function_depth`, \
-                    the space-nesting bookkeeping, and the recursive \
-                    `FuncSpace` tree #1056 had to bound.",
+        rationale: "One `FuncSpace` per level: the space-nesting \
+                    bookkeeping and the recursive `FuncSpace` tree #1056 \
+                    had to bound. Also the metric control for \
+                    `cognitive/nested-fn` below, which selects `Cognitive` \
+                    on the same shape and so pays this row's cost too.",
+    },
+    Probe {
+        name: "cognitive/nested-fn",
+        lang: LANG::Rust,
+        metrics: &[Metric::Cognitive],
+        render: nested_fns,
+        reading: |m| m.cognitive.cognitive_sum(),
+        depths: LINEAR_DEPTHS,
+        max_exponent: LINEAR_BOUND,
+        rationale: "#1062: `increment_function_depth` asks every function \
+                    node whether a function encloses it. The answer now \
+                    comes off the walker's ancestor chain and is found two \
+                    steps up; climbing with `Node::parent` instead cost \
+                    `O(depth)` per step across the 19 languages that call \
+                    it. `nom/nested-fn` is the same shape without the \
+                    cognitive walk.",
     },
 ];
 

--- a/docs/development/benchmarking.md
+++ b/docs/development/benchmarking.md
@@ -125,14 +125,24 @@ chain.
 
 The remaining `Node::parent` climbs were left alone and are tracked in
 [#1088][remaining-climbs]. Those are more than a handful and no probe
-covers them — the five call sites that pass `Ancestors::unknown()`
-(`js_ancestor_walk` in `src/checker.rs`, `suppression_markers`,
-Elixir's `get_func_space_name`, and Elixir's `Npa` / `Npm`) and the
-per-node `node.parent()` calls in the Halstead `get_op_type` getters
-(`src/getter/{python,rust,javascript,typescript,tsx,mozjs,cpp,mozcpp,bash,irules}.rs`)
-and in `src/metrics/abc/{mozcpp,perl}.rs`. Treat the linear bounds
-above as covering the walk's ancestor *chain* threading, not every
-`O(depth)` lookup in the crate.
+covers them. The list below is illustrative, not exhaustive — `rg
+'\.parent\(\)' src/` is the authority:
+
+- the five call sites that pass `Ancestors::unknown()`
+  (`js_ancestor_walk` in `src/checker.rs`, `suppression_markers`,
+  Elixir's `get_func_space_name`, and Elixir's `Npa` / `Npm`);
+- the per-node `node.parent()` calls in the Halstead `get_op_type`
+  getters
+  (`src/getter/{python,rust,javascript,typescript,tsx,mozjs,cpp,mozcpp,bash,irules}.rs`)
+  and in `src/metrics/abc/{mozcpp,perl}.rs`;
+- per-node parent checks in several `loc` arms
+  (`src/metrics/loc/{python,lua,kotlin,perl,tcl,irules,elixir}.rs`),
+  in `src/metrics/npa/` and `src/metrics/npm/`, in
+  `src/metrics/cyclomatic/elixir.rs`, and in
+  `src/checker/{rust,ruby}.rs`.
+
+Treat the linear bounds above as covering the walk's ancestor *chain*
+threading, not every `O(depth)` lookup in the crate.
 
 [parent-walk]: https://github.com/dekobon/big-code-analysis/issues/1084
 [cognitive-parent]: https://github.com/dekobon/big-code-analysis/issues/1062

--- a/docs/development/benchmarking.md
+++ b/docs/development/benchmarking.md
@@ -105,7 +105,8 @@ Read it as follows.
 | `loc/nested-while` | C | shape control for the row below | linear |
 | `loc/nested-declaration` | C | `Node::count_specific_ancestors` | linear |
 | `nom/nested-quote` | Elixir | `elixir_is_inside_quote_block` | linear |
-| `nom/nested-fn` | Rust | `increment_function_depth`, `FuncSpace` nesting | linear |
+| `nom/nested-fn` | Rust | `FuncSpace` nesting; metric control for the row below | linear |
+| `cognitive/nested-fn` | Rust | `increment_function_depth` (#1062) | linear |
 
 Three of these were quadratic when the harness landed, and they shared
 one cause: `tree_sitter` stores no parent pointer, so `Node::parent`
@@ -116,13 +117,17 @@ few steps it took. [#1084][parent-walk] fixed all three by having the
 metric walk carry the ancestor chain down with it (`Ancestors` in
 `src/node.rs`), so a predicate reads an ancestor as a slice index. Their
 bounds moved to the linear bound in that same change, which is what now
-catches a relapse. The fix stopped at the three probed paths: the
-`Node::parent` climbs outside them were left alone and are tracked in
+catches a relapse. `cognitive/nested-fn` is the fourth of the same
+family: `increment_function_depth` was deferred out of #1084 and fixed
+the same way in [#1062][cognitive-parent], which is also where that
+probe comes from — it fitted 2.04 against the climb and 1.21 against the
+chain.
+
+The remaining `Node::parent` climbs were left alone and are tracked in
 [#1088][remaining-climbs]. Those are more than a handful and no probe
-covers them — the five call sites that now pass `Ancestors::unknown()`
+covers them — the five call sites that pass `Ancestors::unknown()`
 (`js_ancestor_walk` in `src/checker.rs`, `suppression_markers`,
-Elixir's `get_func_space_name`, and Elixir's `Npa` / `Npm`),
-`increment_function_depth` in `src/metrics/cognitive.rs`, and the
+Elixir's `get_func_space_name`, and Elixir's `Npa` / `Npm`) and the
 per-node `node.parent()` calls in the Halstead `get_op_type` getters
 (`src/getter/{python,rust,javascript,typescript,tsx,mozjs,cpp,mozcpp,bash,irules}.rs`)
 and in `src/metrics/abc/{mozcpp,perl}.rs`. Treat the linear bounds
@@ -130,23 +135,25 @@ above as covering the walk's ancestor *chain* threading, not every
 `O(depth)` lookup in the crate.
 
 [parent-walk]: https://github.com/dekobon/big-code-analysis/issues/1084
+[cognitive-parent]: https://github.com/dekobon/big-code-analysis/issues/1062
 [remaining-climbs]: https://github.com/dekobon/big-code-analysis/issues/1088
 
-The three control probes are what make the other readings mean
+The four control probes are what make the other readings mean
 something.
 
-- `nom/nested-while` is a **metric** control. `Cognitive` declares
-  `Nom` as a dependency in `src/metric_set.rs`, so the
-  cognitive-attributable cost is the difference between the two rows,
-  not `cognitive` alone.
+- `nom/nested-while` and `nom/nested-fn` are **metric** controls.
+  `Cognitive` declares `Nom` as a dependency in `src/metric_set.rs`, so
+  the cognitive-attributable cost of each `cognitive/…` row is its
+  difference from the `nom/…` row on the same shape, not the
+  `cognitive` reading alone.
 - `loc/nested-while` and `cognitive/nested-while` are **shape**
   controls: each is the same nesting as the ancestor-walk probe it sits
   next to, with the one node that triggers the walk removed. Before
   [#1084][parent-walk] each fitted near 1.0 where its counterpart
   fitted near 2.0, which is what attributed the quadratic cost to
-  that call rather than to nesting in general. Now that all eight fit near 1.0, the pair
-  is what would localise a relapse: a probe drifting up while its
-  control holds means the ancestor lookup, not the shape.
+  that call rather than to nesting in general. Now that all nine fit
+  near 1.0, the pair is what would localise a relapse: a probe drifting
+  up while its control holds means the ancestor lookup, not the shape.
 
 ### Adding a probe
 

--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -9784,9 +9784,16 @@ end",
                 .is_ok_and(|ast| !ast.as_tree_sitter().root_node().has_error())
         }
 
-        // C and Objective-C: a GNU nested function definition.
+        // C: a GNU nested function definition.
         const C_FLAT: &str = "void f(int a) { if (a) { } }\n";
         const C_NESTED: &str = "void f(int a) { void g(int b) { if (b) { } } }\n";
+        // Objective-C reuses C's `function_definition` stop but adds
+        // `method_definition`, which only a real `@implementation`
+        // reaches — running the C source here would duplicate the row
+        // above and leave that extra stop untested.
+        const OBJC_FLAT: &str = "@implementation A\n- (void)m:(int)a { if (a) { } }\n@end\n";
+        const OBJC_NESTED: &str =
+            "@implementation A\n- (void)m:(int)a { void g(int b) { if (b) { } } }\n@end\n";
         // C++ has no nested function definitions; a method on a local
         // struct is the nesting the grammar does admit (see
         // `cpp_nested_function_resets_nesting_and_adds_depth`).
@@ -9808,7 +9815,7 @@ end",
         let mut wrong = Vec::new();
         for (lang, flat, nested) in [
             (LANG::C, C_FLAT, C_NESTED),
-            (LANG::Objc, C_FLAT, C_NESTED),
+            (LANG::Objc, OBJC_FLAT, OBJC_NESTED),
             (LANG::Mozcpp, CPP_FLAT, CPP_NESTED),
             (LANG::Javascript, JS_FLAT, JS_NESTED),
             (LANG::Mozjs, JS_FLAT, JS_NESTED),
@@ -9819,16 +9826,16 @@ end",
             (LANG::Bash, BASH_FLAT, BASH_NESTED),
             (LANG::Irules, TCL_FLAT, TCL_NESTED),
         ] {
-            // Collected rather than asserted per row: a bare
-            // `assert_eq!` stops at the first language, and when this
-            // walk breaks it breaks for all of them at once — the list
-            // of which languages moved is the diagnostic.
             for (label, source) in [("flat", flat), ("nested", nested)] {
                 assert!(
                     parses_cleanly(lang, source),
                     "{lang:?}: the {label} source must parse without an ERROR node:\n{source}",
                 );
             }
+            // Costs are collected rather than asserted per row: a bare
+            // `assert_eq!` stops at the first language, and when this
+            // walk breaks it breaks for all of them at once — the list
+            // of which languages moved is the diagnostic.
             let (flat_cost, nested_cost) = (cognitive_of(lang, flat), cognitive_of(lang, nested));
             if (flat_cost, nested_cost) != (1, 2) {
                 wrong.push(format!(

--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -9812,8 +9812,7 @@ end",
         const TCL_NESTED: &str =
             "proc outer {x} {\nproc inner {y} {\nif {$y > 0} {\nputs positive\n}\n}\n}\n";
 
-        let mut wrong = Vec::new();
-        for (lang, flat, nested) in [
+        let rows = [
             (LANG::C, C_FLAT, C_NESTED),
             (LANG::Objc, OBJC_FLAT, OBJC_NESTED),
             (LANG::Mozcpp, CPP_FLAT, CPP_NESTED),
@@ -9825,29 +9824,32 @@ end",
             (LANG::Lua, LUA_FLAT, LUA_NESTED),
             (LANG::Bash, BASH_FLAT, BASH_NESTED),
             (LANG::Irules, TCL_FLAT, TCL_NESTED),
-        ] {
-            for (label, source) in [("flat", flat), ("nested", nested)] {
-                assert!(
-                    parses_cleanly(lang, source),
-                    "{lang:?}: the {label} source must parse without an ERROR node:\n{source}",
-                );
-            }
-            // Costs are collected rather than asserted per row: a bare
-            // `assert_eq!` stops at the first language, and when this
-            // walk breaks it breaks for all of them at once — the list
-            // of which languages moved is the diagnostic.
-            let (flat_cost, nested_cost) = (cognitive_of(lang, flat), cognitive_of(lang, nested));
-            if (flat_cost, nested_cost) != (1, 2) {
-                wrong.push(format!(
-                    "{lang:?}: expected 1 then 2, got {flat_cost} then {nested_cost}"
-                ));
-            }
-        }
-        assert!(
-            wrong.is_empty(),
-            "an `if` must cost 1 in a top-level function and 2 one \
-             function deeper:\n{}",
-            wrong.join("\n"),
+        ];
+
+        // Whole vectors rather than a per-row `assert_eq!`: when this
+        // shared walk breaks it breaks for every language at once, and
+        // comparing the columns shows all of them instead of stopping
+        // at the first. Hand-rolling that diagnostic with a `wrong`
+        // accumulator would work too, but its `push` arm is a branch no
+        // passing run ever takes — dead weight that reads as a coverage
+        // hole and never gets exercised.
+        let measured: Vec<(LANG, u64, u64)> = rows
+            .iter()
+            .map(|&(lang, flat, nested)| {
+                for (label, source) in [("flat", flat), ("nested", nested)] {
+                    assert!(
+                        parses_cleanly(lang, source),
+                        "{lang:?}: the {label} source must parse without an ERROR node:\n{source}",
+                    );
+                }
+                (lang, cognitive_of(lang, flat), cognitive_of(lang, nested))
+            })
+            .collect();
+        let expected: Vec<(LANG, u64, u64)> = rows.iter().map(|&(lang, ..)| (lang, 1, 2)).collect();
+
+        assert_eq!(
+            measured, expected,
+            "an `if` must cost 1 in a top-level function and 2 one function deeper",
         );
     }
 }

--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -9771,6 +9771,19 @@ end",
                 .cognitive_sum()
         }
 
+        // Every row must parse cleanly. Several of these snippets lean
+        // on a grammar's less-travelled corners — GNU nested functions
+        // in C, a `function` statement inside another in Lua, a `proc`
+        // inside a `proc` in iRules — and a grammar bump that stopped
+        // accepting one would leave that row measuring `tree_sitter`'s
+        // error recovery while still reporting 1 and 2. Verified: with
+        // trailing garbage appended to the C source, the costs below
+        // are unmoved and the test stays green without this check.
+        fn parses_cleanly(lang: LANG, source: &str) -> bool {
+            crate::Ast::parse(crate::Source::new(lang, source.as_bytes()))
+                .is_ok_and(|ast| !ast.as_tree_sitter().root_node().has_error())
+        }
+
         // C and Objective-C: a GNU nested function definition.
         const C_FLAT: &str = "void f(int a) { if (a) { } }\n";
         const C_NESTED: &str = "void f(int a) { void g(int b) { if (b) { } } }\n";
@@ -9810,10 +9823,16 @@ end",
             // `assert_eq!` stops at the first language, and when this
             // walk breaks it breaks for all of them at once — the list
             // of which languages moved is the diagnostic.
-            let (flat, nested) = (cognitive_of(lang, flat), cognitive_of(lang, nested));
-            if (flat, nested) != (1, 2) {
+            for (label, source) in [("flat", flat), ("nested", nested)] {
+                assert!(
+                    parses_cleanly(lang, source),
+                    "{lang:?}: the {label} source must parse without an ERROR node:\n{source}",
+                );
+            }
+            let (flat_cost, nested_cost) = (cognitive_of(lang, flat), cognitive_of(lang, nested));
+            if (flat_cost, nested_cost) != (1, 2) {
                 wrong.push(format!(
-                    "{lang:?}: expected 1 then 2, got {flat} then {nested}"
+                    "{lang:?}: expected 1 then 2, got {flat_cost} then {nested_cost}"
                 ));
             }
         }

--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -280,14 +280,29 @@ fn get_nesting_from_map(node: &Node, nesting_map: &NestingMap) -> Nesting {
     nesting_map.get(&node.id()).copied().unwrap_or_default()
 }
 
-fn increment_function_depth<T: PartialEq + From<u16>>(depth: &mut usize, node: &Node, stops: &[T]) {
-    let mut child = *node;
-    while let Some(parent) = child.parent() {
-        if stops.contains(&T::from(parent.kind_id())) {
-            *depth += 1;
-            break;
-        }
-        child = parent;
+/// Adds one to `depth` when `node` is lexically nested inside another
+/// function, where `stops` lists the grammar kinds that count as a
+/// function for this language.
+///
+/// The scan reads the walker's ancestor chain. Climbing with
+/// [`Node::parent`] instead costs `O(depth)` per step — tree-sitter
+/// stores no parent pointer — which made `Cognitive` `O(depth²)` on
+/// nested function definitions (#1062, deferred out of #1084). A nested
+/// function's enclosing function is a couple of levels up, so the scan
+/// stops immediately there; a function with *no* enclosing function
+/// scans its whole chain, but each step is a slice index rather than a
+/// descent from the root.
+fn increment_function_depth<'a, T: PartialEq + From<u16>>(
+    depth: &mut usize,
+    node: &Node<'a>,
+    ancestors: Ancestors<'a, '_>,
+    stops: &[T],
+) {
+    if ancestors
+        .iter(node)
+        .any(|(ancestor, _)| stops.contains(&T::from(ancestor.kind_id())))
+    {
+        *depth += 1;
     }
 }
 
@@ -380,7 +395,7 @@ macro_rules! js_cognitive {
                     nesting = 0;
                     lambda = 0;
                     // Increase depth function nesting if needed
-                    increment_function_depth(&mut depth, node, &[FunctionDeclaration]);
+                    increment_function_depth(&mut depth, node, ancestors, &[FunctionDeclaration]);
                 }
                 ArrowFunction => {
                     lambda += 1;
@@ -9641,10 +9656,12 @@ end",
     /// measurement at three depths, which belongs in a bench target
     /// and not in the unit suite.
     ///
-    /// Uses `while`, deliberately, **not** `if`: `Checker::is_else_if`
-    /// calls `node.parent()` for every `if_statement`, so nested `if`s
-    /// are still quadratic for reasons this fix does not touch. The
-    /// harness measures that shape too, under a quadratic bound.
+    /// Uses `while`, deliberately, **not** `if`: when this test was
+    /// written `Checker::is_else_if` still called `node.parent()` for
+    /// every `if_statement`, so nested `if`s were quadratic for reasons
+    /// that fix did not touch. #1084 moved that predicate onto the
+    /// walker's ancestor chain, and the harness now measures the `if`
+    /// shape under the same linear bound as this one.
     #[test]
     fn cognitive_nesting_is_inherited_at_depth() {
         // Restricted to `Cognitive` — which pulls in `Nom` as a declared
@@ -9673,5 +9690,138 @@ end",
 
         assert_eq!(cognitive_of(&nested_whiles(3)), expected(3), "1 + 2 + 3");
         assert_eq!(cognitive_of(&nested_whiles(2_000)), expected(2_000));
+    }
+
+    /// Function-nesting depth is still counted correctly thousands of
+    /// levels deep (#1062).
+    ///
+    /// `increment_function_depth` asks whether any ancestor of a
+    /// function node is itself a function. It used to climb with
+    /// `node.parent()`, which is `O(depth)` per step, so `Cognitive`
+    /// stayed `O(depth²)` on nested definitions after the nesting-map
+    /// half of #1062 was fixed. The scan now walks the ancestor chain
+    /// the walker hands down.
+    ///
+    /// Both versions answer identically, so what this pins is the
+    /// arithmetic at depth; the *cost* is pinned by the
+    /// `cognitive/nested-fn` probe in the benchmark harness
+    /// (`cargo bench -p big-code-analysis-bench --bench scaling`),
+    /// which asserts the complexity class.
+    #[test]
+    fn cognitive_function_depth_is_inherited_at_depth() {
+        fn cognitive_of(source: &str) -> u64 {
+            crate::test_support::metrics_verbatim(
+                crate::LANG::Rust,
+                source.as_bytes(),
+                crate::MetricsOptions::default().with_only(&[crate::Metric::Cognitive]),
+            )
+            .cognitive
+            .cognitive_sum()
+        }
+
+        // The function at level k has k enclosing functions, so its
+        // `if` costs k + 1 and the file totals 1 + 2 + … + n. The `if`
+        // is what makes the depth observable: a chain of bare functions
+        // scores zero however the depth is computed.
+        let nested_fns = |n: usize| -> String {
+            format!(
+                "{}let x = 1;{}\n",
+                "fn f() { if a {} ".repeat(n),
+                "} ".repeat(n)
+            )
+        };
+        let expected = |n: u64| n * (n + 1) / 2;
+
+        assert_eq!(cognitive_of(&nested_fns(3)), expected(3), "1 + 2 + 3");
+        // Half the depth of `cognitive_nesting_is_inherited_at_depth`:
+        // each level here also opens a `FuncSpace`, and the debug-build
+        // `Ancestors::checked` assertion re-derives every parent with
+        // `Node::parent`, so the unoptimised walk is quadratic even
+        // though the release one is not.
+        assert_eq!(cognitive_of(&nested_fns(1_000)), expected(1_000));
+    }
+
+    /// A function nested inside another makes its `if` cost one more
+    /// than the same `if` at the top level, in every language that can
+    /// express the nesting (#1062).
+    ///
+    /// That surcharge has exactly one source: `increment_function_depth`,
+    /// which asks whether any ancestor of a function node is itself a
+    /// function. #1062 moved the scan off `Node::parent` — `O(depth)` per
+    /// step, and so quadratic over a deeply nested file — and onto the
+    /// ancestor chain the walker hands down. The flat source in each row
+    /// is the control: the same `if` with nothing enclosing its function,
+    /// which must stay at 1, so the pair measures the surcharge and not
+    /// the body.
+    ///
+    /// These are the languages whose function-depth arm had no test of
+    /// its own; C++, C#, Groovy, Java, Kotlin, Perl, PHP, Python, Rust
+    /// and Tcl are covered by dedicated tests elsewhere in this module.
+    /// Go is deliberately absent: its stop set is `function_declaration`
+    /// / `method_declaration` and the grammar allows neither inside a
+    /// function body, so the surcharge is unreachable there — a nested
+    /// Go function is a `func_literal`, which takes the `lambda` path.
+    #[test]
+    fn function_depth_surcharge_holds_across_languages() {
+        use crate::test_support::metrics_verbatim;
+
+        fn cognitive_of(lang: LANG, source: &str) -> u64 {
+            metrics_verbatim(lang, source.as_bytes(), MetricsOptions::default())
+                .cognitive
+                .cognitive_sum()
+        }
+
+        // C and Objective-C: a GNU nested function definition.
+        const C_FLAT: &str = "void f(int a) { if (a) { } }\n";
+        const C_NESTED: &str = "void f(int a) { void g(int b) { if (b) { } } }\n";
+        // C++ has no nested function definitions; a method on a local
+        // struct is the nesting the grammar does admit (see
+        // `cpp_nested_function_resets_nesting_and_adds_depth`).
+        const CPP_FLAT: &str = "struct S { void f(bool a) { if (a) { } } };\n";
+        const CPP_NESTED: &str =
+            "struct S { void f(bool a) { struct I { void g(bool b) { if (b) { } } }; } };\n";
+        const JS_FLAT: &str = "function f(a) { if (a) { } }\n";
+        const JS_NESTED: &str = "function f(a) { function g(b) { if (b) { } } }\n";
+        const RUBY_FLAT: &str = "def f\nif a\nend\nend\n";
+        const RUBY_NESTED: &str = "def f\ndef g\nif a\nend\nend\nend\n";
+        const LUA_FLAT: &str = "function f() if a then end end\n";
+        const LUA_NESTED: &str = "function f() function g() if a then end end end\n";
+        const BASH_FLAT: &str = "f() {\nif [ -n \"$a\" ]; then :; fi\n}\n";
+        const BASH_NESTED: &str = "f() {\ng() {\nif [ -n \"$a\" ]; then :; fi\n}\n}\n";
+        const TCL_FLAT: &str = "proc outer {x} {\nif {$x > 0} {\nputs positive\n}\n}\n";
+        const TCL_NESTED: &str =
+            "proc outer {x} {\nproc inner {y} {\nif {$y > 0} {\nputs positive\n}\n}\n}\n";
+
+        let mut wrong = Vec::new();
+        for (lang, flat, nested) in [
+            (LANG::C, C_FLAT, C_NESTED),
+            (LANG::Objc, C_FLAT, C_NESTED),
+            (LANG::Mozcpp, CPP_FLAT, CPP_NESTED),
+            (LANG::Javascript, JS_FLAT, JS_NESTED),
+            (LANG::Mozjs, JS_FLAT, JS_NESTED),
+            (LANG::Typescript, JS_FLAT, JS_NESTED),
+            (LANG::Tsx, JS_FLAT, JS_NESTED),
+            (LANG::Ruby, RUBY_FLAT, RUBY_NESTED),
+            (LANG::Lua, LUA_FLAT, LUA_NESTED),
+            (LANG::Bash, BASH_FLAT, BASH_NESTED),
+            (LANG::Irules, TCL_FLAT, TCL_NESTED),
+        ] {
+            // Collected rather than asserted per row: a bare
+            // `assert_eq!` stops at the first language, and when this
+            // walk breaks it breaks for all of them at once — the list
+            // of which languages moved is the diagnostic.
+            let (flat, nested) = (cognitive_of(lang, flat), cognitive_of(lang, nested));
+            if (flat, nested) != (1, 2) {
+                wrong.push(format!(
+                    "{lang:?}: expected 1 then 2, got {flat} then {nested}"
+                ));
+            }
+        }
+        assert!(
+            wrong.is_empty(),
+            "an `if` must cost 1 in a top-level function and 2 one \
+             function deeper:\n{}",
+            wrong.join("\n"),
+        );
     }
 }

--- a/src/metrics/cognitive/bash.rs
+++ b/src/metrics/cognitive/bash.rs
@@ -17,7 +17,7 @@ impl Cognitive for BashCode {
     fn compute<'a>(
         node: &Node<'a>,
         _code: &'a [u8],
-        _ancestors: Ancestors<'a, '_>,
+        ancestors: Ancestors<'a, '_>,
         stats: &mut Stats,
         nesting_map: &mut NestingMap,
     ) {
@@ -52,7 +52,7 @@ impl Cognitive for BashCode {
             }
             FunctionDefinition => {
                 nesting = 0;
-                increment_function_depth(&mut depth, node, &[FunctionDefinition]);
+                increment_function_depth(&mut depth, node, ancestors, &[FunctionDefinition]);
             }
             _ => {}
         }

--- a/src/metrics/cognitive/c.rs
+++ b/src/metrics/cognitive/c.rs
@@ -60,6 +60,7 @@ impl Cognitive for CCode {
                 increment_function_depth(
                     &mut depth,
                     node,
+                    ancestors,
                     &[FunctionDefinition, FunctionDefinition2],
                 );
             }

--- a/src/metrics/cognitive/cpp.rs
+++ b/src/metrics/cognitive/cpp.rs
@@ -65,6 +65,7 @@ impl Cognitive for CppCode {
                 increment_function_depth(
                     &mut depth,
                     node,
+                    ancestors,
                     &[
                         FunctionDefinition,
                         FunctionDefinition2,

--- a/src/metrics/cognitive/csharp.rs
+++ b/src/metrics/cognitive/csharp.rs
@@ -100,6 +100,7 @@ impl Cognitive for CsharpCode {
                 increment_function_depth(
                     &mut depth,
                     node,
+                    ancestors,
                     &[
                         MethodDeclaration,
                         ConstructorDeclaration,

--- a/src/metrics/cognitive/go.rs
+++ b/src/metrics/cognitive/go.rs
@@ -53,6 +53,7 @@ impl Cognitive for GoCode {
                 increment_function_depth(
                     &mut depth,
                     node,
+                    ancestors,
                     &[G::FunctionDeclaration, G::MethodDeclaration],
                 );
             }

--- a/src/metrics/cognitive/groovy.rs
+++ b/src/metrics/cognitive/groovy.rs
@@ -89,6 +89,7 @@ impl Cognitive for GroovyCode {
                 increment_function_depth(
                     &mut depth,
                     node,
+                    ancestors,
                     &[MethodDeclaration, ConstructorDeclaration],
                 );
             }

--- a/src/metrics/cognitive/irules.rs
+++ b/src/metrics/cognitive/irules.rs
@@ -72,6 +72,7 @@ impl Cognitive for IrulesCode {
                 increment_function_depth(
                     &mut depth,
                     node,
+                    ancestors,
                     &[Procedure, WhenEvent, OnHandler, TrapHandler],
                 );
             }

--- a/src/metrics/cognitive/java.rs
+++ b/src/metrics/cognitive/java.rs
@@ -72,6 +72,7 @@ impl Cognitive for JavaCode {
                 increment_function_depth(
                     &mut depth,
                     node,
+                    ancestors,
                     &[MethodDeclaration, ConstructorDeclaration],
                 );
             }

--- a/src/metrics/cognitive/kotlin.rs
+++ b/src/metrics/cognitive/kotlin.rs
@@ -85,6 +85,7 @@ impl Cognitive for KotlinCode {
                 increment_function_depth(
                     &mut depth,
                     node,
+                    ancestors,
                     &[FunctionDeclaration, SecondaryConstructor],
                 );
             }

--- a/src/metrics/cognitive/kotlin.rs
+++ b/src/metrics/cognitive/kotlin.rs
@@ -59,7 +59,14 @@ impl Cognitive for KotlinCode {
                 // Per the SonarSource spec, `else ->` inside a `when`
                 // expression is the default arm of a switch-like construct
                 // and should be +0, not +1.
-                let in_when = node.parent().is_some_and(|p| p.kind_id() == WhenEntry);
+                //
+                // Read off the walker's chain rather than `Node::parent`,
+                // which is `O(depth)` — one climb per `else` keeps the
+                // metric quadratic on a deeply nested `if`/`else` chain,
+                // the shape #1062 exists to make linear.
+                let in_when = ancestors
+                    .parent(node)
+                    .is_some_and(|p| p.kind_id() == WhenEntry);
                 if !in_when {
                     increment_by_one(stats);
                 }

--- a/src/metrics/cognitive/lua.rs
+++ b/src/metrics/cognitive/lua.rs
@@ -61,6 +61,7 @@ impl Cognitive for LuaCode {
                 increment_function_depth(
                     &mut depth,
                     node,
+                    ancestors,
                     &[
                         FunctionDeclaration,
                         FunctionDeclaration2,

--- a/src/metrics/cognitive/mozcpp.rs
+++ b/src/metrics/cognitive/mozcpp.rs
@@ -65,6 +65,7 @@ impl Cognitive for MozcppCode {
                 increment_function_depth(
                     &mut depth,
                     node,
+                    ancestors,
                     &[
                         FunctionDefinition,
                         FunctionDefinition2,

--- a/src/metrics/cognitive/objc.rs
+++ b/src/metrics/cognitive/objc.rs
@@ -67,6 +67,7 @@ impl Cognitive for ObjcCode {
                 increment_function_depth(
                     &mut depth,
                     node,
+                    ancestors,
                     &[FunctionDefinition, FunctionDefinition2, MethodDefinition],
                 );
             }

--- a/src/metrics/cognitive/perl.rs
+++ b/src/metrics/cognitive/perl.rs
@@ -39,7 +39,7 @@ impl Cognitive for PerlCode {
     fn compute<'a>(
         node: &Node<'a>,
         _code: &'a [u8],
-        _ancestors: Ancestors<'a, '_>,
+        ancestors: Ancestors<'a, '_>,
         stats: &mut Stats,
         nesting_map: &mut NestingMap,
     ) {
@@ -103,6 +103,7 @@ impl Cognitive for PerlCode {
                 increment_function_depth(
                     &mut depth,
                     node,
+                    ancestors,
                     &[P::FunctionDefinition, P::FunctionDefinitionWithoutSub],
                 );
             }

--- a/src/metrics/cognitive/php.rs
+++ b/src/metrics/cognitive/php.rs
@@ -101,6 +101,7 @@ impl Cognitive for PhpCode {
                 increment_function_depth(
                     &mut depth,
                     node,
+                    ancestors,
                     &[FunctionDefinition, MethodDeclaration],
                 );
             }

--- a/src/metrics/cognitive/python.rs
+++ b/src/metrics/cognitive/python.rs
@@ -203,7 +203,7 @@ impl Cognitive for PythonCode {
             }
             FunctionDefinition => {
                 // Increase depth function nesting if needed
-                increment_function_depth(&mut depth, node, &[FunctionDefinition]);
+                increment_function_depth(&mut depth, node, ancestors, &[FunctionDefinition]);
             }
             _ => {}
         }

--- a/src/metrics/cognitive/ruby.rs
+++ b/src/metrics/cognitive/ruby.rs
@@ -102,8 +102,13 @@ impl Cognitive for RubyCode {
                 // `if`/`elsif` alternative and the `begin/rescue` no-exception
                 // branch — extends the parent branch at +1. Mirrors Kotlin's
                 // single `Else` arm gated on `WhenEntry`.
-                let is_case_default = node
-                    .parent()
+                //
+                // Read off the walker's chain rather than `Node::parent`,
+                // which is `O(depth)` — one climb per `else` keeps the
+                // metric quadratic on a deeply nested `if`/`else` chain,
+                // the shape #1062 exists to make linear.
+                let is_case_default = ancestors
+                    .parent(node)
                     .is_some_and(|p| matches!(p.kind_id().into(), R::Case | R::CaseMatch));
                 if !is_case_default {
                     increment_branch_extension(stats);

--- a/src/metrics/cognitive/ruby.rs
+++ b/src/metrics/cognitive/ruby.rs
@@ -130,7 +130,12 @@ impl Cognitive for RubyCode {
             }
             R::Method | R::SingletonMethod => {
                 nesting = 0;
-                increment_function_depth(&mut depth, node, &[R::Method, R::SingletonMethod]);
+                increment_function_depth(
+                    &mut depth,
+                    node,
+                    ancestors,
+                    &[R::Method, R::SingletonMethod],
+                );
             }
             // Blocks, do-blocks and lambdas are the closure/lambda forms.
             R::Block | R::DoBlock | R::Lambda => {

--- a/src/metrics/cognitive/rust.rs
+++ b/src/metrics/cognitive/rust.rs
@@ -60,7 +60,7 @@ impl Cognitive for RustCode {
             FunctionItem => {
                 nesting = 0;
                 // Increase depth function nesting if needed
-                increment_function_depth(&mut depth, node, &[FunctionItem]);
+                increment_function_depth(&mut depth, node, ancestors, &[FunctionItem]);
             }
             ClosureExpression => {
                 lambda += 1;

--- a/src/metrics/cognitive/tcl.rs
+++ b/src/metrics/cognitive/tcl.rs
@@ -63,7 +63,7 @@ impl Cognitive for TclCode {
             }
             Procedure => {
                 nesting = 0;
-                increment_function_depth(&mut depth, node, &[Procedure]);
+                increment_function_depth(&mut depth, node, ancestors, &[Procedure]);
             }
             _ => {}
         }

--- a/src/metrics/tokens.rs
+++ b/src/metrics/tokens.rs
@@ -424,9 +424,12 @@ mod tests {
 
     /// Total token count for `source`, analysed byte-for-byte.
     ///
-    /// Restricted to `Tokens`: with every metric enabled, `cognitive`'s
-    /// own superlinear nesting lookup (#1062) dominates the deep-nesting
-    /// case below and would misattribute a regression.
+    /// Restricted to `Tokens` so the deep-nesting case below measures
+    /// this metric and not the rest of the walk. When it was written,
+    /// `cognitive`'s own parent lookups (#1062) dominated that case and
+    /// would have misattributed a regression; they are linear now, but
+    /// isolating the metric under test is still what makes the reading
+    /// mean something.
     fn tokens_of(source: &str) -> u64 {
         metrics_verbatim(
             crate::LANG::Rust,

--- a/src/node.rs
+++ b/src/node.rs
@@ -1053,8 +1053,19 @@ mod tests {
     /// grandparent shape), and Elixir (`quote` templates).
     #[test]
     fn a_known_chain_answers_exactly_what_climbing_answers() {
-        fn assert_parity<L: LanguageInfo>(label: &str, code: &[u8]) {
+        /// `must_nest` names kinds that have to appear *inside another
+        /// node of the same kind* in the fixture. `visited > 20` alone
+        /// does not keep a fixture honest: a grammar bump that flattened
+        /// the nesting a row was added for would leave a large,
+        /// clean-parsing tree that no longer exercises the shape, and
+        /// the parity assertions would keep passing over it.
+        fn assert_parity<L: LanguageInfo>(label: &str, code: &[u8], must_nest: &[&str]) {
+            let mut nested_seen = vec![false; must_nest.len()];
             let visited = for_each_node_with_chain::<L>(code, |node, chain| {
+                for (slot, kind) in nested_seen.iter_mut().zip(must_nest) {
+                    *slot |= node.kind() == *kind
+                        && chain.iter().any(|ancestor| ancestor.kind() == *kind);
+                }
                 let known = Ancestors::known(chain);
                 let climbing = Ancestors::unknown();
                 assert_eq!(
@@ -1088,23 +1099,57 @@ mod tests {
                 }
             });
             assert!(visited > 20, "{label}: fixture is too small to prove much");
+            for (found, kind) in nested_seen.iter().zip(must_nest) {
+                assert!(
+                    found,
+                    "{label}: no `{kind}` sits inside another `{kind}`, so the \
+                     fixture no longer exercises the nesting it was added for"
+                );
+            }
         }
 
         assert_parity::<crate::langs::CCode>(
             "c",
             b"int main() { if (a) { int x; } else if (b) { for (int i = 0; i < 2; i++) x; } }",
+            &[],
         );
         assert_parity::<crate::langs::JavaCode>(
             "java",
             b"class A { void m() { if (a) {} else if (b) {} else {} for (int i = 0; i < 2; i++) {} } }",
+            &[],
         );
         assert_parity::<crate::langs::PythonCode>(
             "python",
             b"def f(a, b):\n    if a:\n        pass\n    else:\n        if b:\n            pass\n    return a and b or a\n",
+            &[],
         );
         assert_parity::<crate::langs::ElixirCode>(
             "elixir",
             b"defmodule M do\n  def g do\n    :ok\n  end\n  quote do\n    def f do\n      :ok\n    end\n  end\nend\n",
+            &["call"],
+        );
+
+        // The shapes #1062 added as consumers, which the four fixtures
+        // above do not contain: a function nested inside a function
+        // (every language's `increment_function_depth` arm walks the
+        // chain looking for one) and the two default-arm checks that
+        // now read `Ancestors::parent` — Kotlin's `else ->` inside a
+        // `when` and Ruby's `else` inside a `case`. Parity over the
+        // machinery is not parity over the shape a caller asks about.
+        assert_parity::<crate::langs::RustCode>(
+            "rust",
+            b"fn f(a: bool) { if a { } else if a { } fn g(b: bool) { if b { } } }\n",
+            &["function_item"],
+        );
+        assert_parity::<crate::langs::KotlinCode>(
+            "kotlin",
+            b"fun f(x: Int) {\n    when (x) {\n        1 -> {}\n        else -> {}\n    }\n    fun g() {\n        if (x > 0) {}\n    }\n}\n",
+            &["function_declaration"],
+        );
+        assert_parity::<crate::langs::RubyCode>(
+            "ruby",
+            b"def f(x)\n  case x\n  when 1 then 1\n  else 2\n  end\n  def g\n    if x\n    end\n  end\nend\n",
+            &["method"],
         );
     }
 


### PR DESCRIPTION
## Summary

Closes the last of #1062's four `Node::parent` sites.
`increment_function_depth` asked every function node whether a function
encloses it by climbing with `Node::parent`, which `tree_sitter`
resolves by descending from the root. That is `O(depth)` per step, so
`Cognitive` stayed `O(depth²)` on nested function definitions
everywhere it is called.

The scan now reads the ancestor chain the walker hands down (`Ancestors`,
from #1084), so a step is a slice index. It was deferred out of #1084 to
bound that change's blast radius; all 19 call sites (22 languages,
counting the four the JS-family macro expands to) already had an
`ancestors` value in scope, so this is one helper signature plus one
argument per call — no per-language logic moves.

Code review then turned up two more per-node climbs inside the same
metric that the issue never listed: Kotlin's `when`-default check and
Ruby's `case`-default check each called `node.parent()` once per `else`
node, so a deeply nested `if`/`else` chain stayed quadratic in the very
metric this PR makes linear on nested definitions. Both read the same
chain now, and `cognitive` has no `Node::parent` call left in
production.

The `in_function`-flag mechanism sketched on the issue was not needed,
and neither was the per-language proof it would have required that each
match arm's kind set equals its `stops` set.

## Measured

`cargo bench -p big-code-analysis-bench --bench scaling`, new
`cognitive/nested-fn` probe (Rust, `Metric::Cognitive`, depths
1000 / 2000 / 4000), fitted `time ~ depth^k`:

| build | k | verdict |
|---|---|---|
| `Node::parent` climb (pre-fix body, new probe) | **2.04** | OVER BOUND |
| ancestor chain | **1.21** | ok (bound 1.50) |

At depth 4000 the walk drops from ~150 ms to ~16 ms. No other probe
moved; `nom/nested-fn` on the same shape fits 1.13 and is the metric
control.

The probe is new because `nom/nested-fn` never reached this function —
it selects `Metric::Nom`. Its shape gains one `if` per level so
`cognitive` scores `n(n+1)/2` on it, which moves if function depth stops
being counted, so the value column guards the walk as well as the
timing.

## Correctness

Cognitive values are unchanged in every language. Two tests pin that:

- `cognitive_function_depth_is_inherited_at_depth` — the closed form
  `n(n+1)/2` at depth 1000 for nested Rust `fn`s.
- `function_depth_surcharge_holds_across_languages` — an `if` costs 1 in
  a top-level function and 2 one function deeper, for C, Objective-C,
  Mozcpp, JavaScript, MozJS, TypeScript, TSX, Ruby, Lua, Bash and
  iRules. Those were the languages whose function-depth arm had no test
  of its own; C++, C#, Groovy, Java, Kotlin, Perl, PHP, Python, Rust and
  Tcl already had one. Go is deliberately absent — its stop set is
  `function_declaration` / `method_declaration`, neither of which the
  grammar admits inside a function body, so the surcharge is unreachable
  there and a nested Go function takes the `lambda` path.

Both verified by perturbation: with `*depth += 1` turned into
`*depth += 0`, the cross-language test reports all 11 rows and the
whole-suite run fails exactly 10 tests out of 3,110 — precise rather
than coarse.

The second commit is a test-audit fix: the surcharge table asserted only
the two costs, so a row whose snippet stopped parsing would keep
reporting 1 and 2 off an error-recovery tree (verified — appending
garbage to the C source left the test green). Each row now rejects an
ERROR-node parse first, which matters for the rows leaning on GNU nested
functions, Lua's nested `function` statement and an iRules `proc` inside
a `proc`.

## Baseline

`RubyCode::compute`'s `halstead.effort` crosses its recorded
`.bca-baseline.toml` value twice here — 52,423 → 53,271 on the added
argument, then → 53,802 on the `case`-default fix. Refreshed with
`make self-scan-write-baseline-headroom` in each of those commits, per
the baseline-refresh discipline in `AGENTS.md`; skipping it turns
`make self-scan` red on a clean checkout for everyone, not just the
author.

## Still open elsewhere

The `Node::parent` climbs that remain are all outside `cognitive` and
outside every probed walk: the JS/TS `is_func` / `is_closure` walk,
Elixir's `Npa` / `Npm` / `get_func_space_name` / suppression-marker
lookups, the Halstead `get_op_type` getters, and per-node lookups in
several `loc`, `npa` / `npm`, `cyclomatic` and `checker` arms. That
last group was missing from the inventories in the CHANGELOG and
`benchmarking.md`, which read as exhaustive; both now say otherwise.
All stay tracked in #1088, which has been updated to record that its
deferred `increment_function_depth` item is done.

## Validation

- `make pre-commit` green on the final tree.
- `cargo test --workspace --all-features`: 3,110 + 75 passing, 0 failed.
- Reviewed with the `review`, `rust-optimize`, `audit-tests` and
  `code-review` passes; every finding is folded into the four commits.
  The Kotlin / Ruby fix is covered by five existing tests, confirmed by
  perturbation (swapping in the grandparent fails exactly those five
  and nothing else).

Fixes #1062
