### PR TITLE
perf(metrics): retire the remaining Node::parent climbs (#1088)

### DIFF
--- a/.bca-baseline.toml
+++ b/.bca-baseline.toml
@@ -637,7 +637,7 @@ value = 54681.01625588078
 [[entry]]
 path = "src/getter/elixir.rs"
 qualified = "ElixirCode::get_op_type"
-start_line = 138
+start_line = 142
 metric = "halstead.effort"
 value = 48241.44928566978
 
@@ -845,25 +845,18 @@ metric = "nargs"
 value = 9.0
 
 [[entry]]
-path = "src/metrics/npm/php.rs"
-qualified = "PhpCode::compute"
-start_line = 12
-metric = "nargs"
-value = 7.0
-
-[[entry]]
 path = "src/node.rs"
 qualified = "Node<'a>"
 start_line = 75
 metric = "nom"
-value = 32.0
+value = 33.0
 
 [[entry]]
 path = "src/ops.rs"
 qualified = "ops_inner"
-start_line = 221
+start_line = 242
 metric = "halstead.effort"
-value = 58764.00971804493
+value = 73943.73373291224
 
 [[entry]]
 path = "src/output/checkstyle.rs"
@@ -938,9 +931,9 @@ value = 7.0
 [[entry]]
 path = "src/parser.rs"
 qualified = "Parser<T>::filters"
-start_line = 175
+start_line = 176
 metric = "halstead.effort"
-value = 50360.26160456827
+value = 53278.10526315789
 
 [[entry]]
 path = "src/spaces/ast.rs"
@@ -961,7 +954,7 @@ path = "src/spaces/compute.rs"
 qualified = "compute_per_node"
 start_line = 218
 metric = "halstead.effort"
-value = 58315.43211975729
+value = 58974.691740375616
 
 [[entry]]
 path = "src/spaces/compute.rs"
@@ -973,7 +966,7 @@ value = 7.0
 [[entry]]
 path = "src/spaces/compute.rs"
 qualified = "metrics_inner"
-start_line = 507
+start_line = 513
 metric = "halstead.effort"
 value = 124910.02765596088
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ for historical reference.
 - Benchmark harness for the metric walk, in the new workspace member
   `big-code-analysis-bench` (#1068). `cargo bench -p
   big-code-analysis-bench --bench scaling` (or `make bench-scaling`)
-  measures nine probes at three doubling nesting depths and fits
+  measures eleven probes at three doubling nesting depths and fits
   `time ~ depth^k`, failing when a probe's exponent leaves its declared
   complexity class; `--bench metric_walk` (`make bench-walk`) runs
   criterion benchmarks per metric over a deterministic, self-reporting
@@ -134,6 +134,40 @@ for historical reference.
 
 ### Performance
 
+- The ancestor chain now reaches the predicates #1084 left climbing, and
+  the `ops`, `bca function`, and suppression-marker walks maintain one of
+  their own (#1088). The JS-family `Checker::is_func` / `is_closure`
+  name-binding walk, Ruby's `Checker::is_closure` block-versus-lambda
+  test, Elixir's `Getter::get_func_space_name`, and the
+  suppression scan each resolved ancestors with `Node::parent`, which
+  `tree_sitter` answers by descending from the root. `Checker::is_func`,
+  `is_closure`, `Getter::get_func_name`, `get_func_space_name`, and
+  `NArgs::compute` gained an `Ancestors` parameter to carry it; all are
+  `pub(crate)`, so the published API is unchanged.
+- Elixir's `Npm` / `Npa::compute` no longer run the class-space
+  classifier at all (#1088). Both opened with
+  `is_func_space_with_code`, which cost a source-text keyword scan per
+  node and, for `def`-shaped calls, an ancestor walk asking whether the
+  call sat inside a `quote` template. That walk's answer was always
+  discarded: the `defmodule` keyword check immediately below admits
+  exactly the nodes the classifier would have, and rejects every node
+  the walk was consulted for. Deleting the call removes the work rather
+  than making it cheaper. Counts are unchanged, pinned by two new tests
+  over a `defmodule` nested inside a `quote`.
+- `Node::wraps_any` — reached from `is_child` and `has_sibling`, and so
+  from every language's checkers and getters — scans a node's children
+  with a cursor instead of chaining `next_sibling()` (#1088). The chain
+  #217 introduced was premised on a sibling step being `O(1)`; it is
+  not, because `ts_node_next_sibling` resolves the parent first, so the
+  scan cost `O(children × depth)`. This was the dominant term behind the
+  JS closure classifier: the new `nom/nested-arrow` probe fits
+  `time ~ depth^k` at **1.97** before and **1.03** after, and at depth
+  4000 `nom` over nested arrow functions drops from ~17.6 s to ~6.3 ms,
+  while its `nom/nested-declared-function` shape control — the same
+  nesting written with `function` declarations, which need no ancestor
+  walk — holds at 1.08 either side. Ordinary input benefits too: a
+  metric walk over the 384-file `pdf.js` corpus drops from ~443 ms to
+  ~370 ms. Metric values are unchanged for every language.
 - The `ops` walk builds the file-level vocabulary once instead of once
   per closing space. `finalize` rebuilt the innermost still-open space's
   operator and operand lists on every call — that is, every time the

--- a/big-code-analysis-bench/src/shapes.rs
+++ b/big-code-analysis-bench/src/shapes.rs
@@ -134,6 +134,53 @@ pub fn nested_fns(depth: usize) -> String {
     )
 }
 
+/// JavaScript: `function f() { function f() { … 1; … } }`.
+///
+/// The linear control for [`nested_arrows`]: one function per nesting
+/// level and one `FuncSpace` per level, as there, but *declared* rather
+/// than written as an expression. `function_declaration` is a distinct
+/// grammar production, so `Checker::is_func` answers it from the node's
+/// own kind and never starts the ancestor walk. What is left is the
+/// space-nesting bookkeeping the two shapes share.
+///
+/// Named for the distinction that matters — declared vs expression —
+/// rather than for the language, so it does not read as a variant of
+/// [`nested_fns`], which is the Rust shape.
+#[must_use]
+pub fn nested_declared_functions(depth: usize) -> String {
+    format!(
+        "{}1;{}\n",
+        "function f() { ".repeat(depth),
+        "} ".repeat(depth)
+    )
+}
+
+/// JavaScript: `const f = a => { a => { … 1 … } };`.
+///
+/// The JS grammars have no production for "named function": `const f =
+/// () => …` and `g(() => …)` are the same `arrow_function` node, and
+/// `Checker::is_func` tells them apart by walking upward until it meets
+/// either a name binding or a frame that proves positional use. Here
+/// the enclosing `statement_block` stops the walk after two steps —
+/// which is the point. Two steps was still `O(depth)`, because
+/// `Node::parent` descends from the root, and the `PropertyIdentifier`
+/// adjacency check the predicate ends with scanned siblings the same
+/// way; both are why a shape with one arrow per level was quadratic
+/// before #1088 despite every walk being O(1) steps long.
+///
+/// Every level is an arrow function, so `nom` reads `depth`: the
+/// outermost is bound to `f` and counts as a function, the rest are
+/// closures. [`nested_declared_functions`] is the same nesting without
+/// the walk.
+#[must_use]
+pub fn nested_arrows(depth: usize) -> String {
+    format!(
+        "const f = {}1{};\n",
+        "a => { ".repeat(depth),
+        " }".repeat(depth)
+    )
+}
+
 /// One depth-scaling probe: a shape, the metric selection that
 /// exercises the hot path under test, and the complexity class the
 /// walk is expected to stay within.
@@ -340,6 +387,36 @@ pub const PROBES: &[Probe] = &[
                     languages, counting the four the JS-family macro \
                     expands to. `nom/nested-fn` is the same shape without \
                     the cognitive walk.",
+    },
+    Probe {
+        name: "nom/nested-declared-function",
+        lang: LANG::Javascript,
+        metrics: &[Metric::Nom],
+        render: nested_declared_functions,
+        reading: |m| m.nom.total(),
+        depths: LINEAR_DEPTHS,
+        max_exponent: LINEAR_BOUND,
+        rationale: "Shape control for `nom/nested-arrow`: one function and \
+                    one `FuncSpace` per level as there, but declared with \
+                    `function`, which `Checker::is_func` answers from the \
+                    node's own kind without an ancestor walk.",
+    },
+    Probe {
+        name: "nom/nested-arrow",
+        lang: LANG::Javascript,
+        metrics: &[Metric::Nom],
+        render: nested_arrows,
+        reading: |m| m.nom.total(),
+        depths: LINEAR_DEPTHS,
+        max_exponent: LINEAR_BOUND,
+        rationale: "#1088: the JS-family `Checker::is_func` / `is_closure` \
+                    decide whether an `arrow_function` is bound to a name by \
+                    walking upward. The enclosing `statement_block` stops \
+                    that walk after two steps, but `Node::parent` is \
+                    `O(depth)` per step, so the shape was quadratic; the \
+                    steps now index the walker's ancestor chain. \
+                    `nom/nested-declared-function` is the same nesting \
+                    without the walk.",
     },
 ];
 

--- a/docs/development/benchmarking.md
+++ b/docs/development/benchmarking.md
@@ -107,14 +107,16 @@ Read it as follows.
 | `nom/nested-quote` | Elixir | `elixir_is_inside_quote_block` | linear |
 | `nom/nested-fn` | Rust | `FuncSpace` nesting; metric control for the row below | linear |
 | `cognitive/nested-fn` | Rust | `increment_function_depth` (#1062) | linear |
+| `nom/nested-declared-function` | JavaScript | shape control for the row below | linear |
+| `nom/nested-arrow` | JavaScript | JS-family `is_func` / `is_closure` (#1088) | linear |
 
-Three of these were quadratic when the harness landed, and they shared
+Four of these were quadratic when the harness landed, and they shared
 one cause: `tree_sitter` stores no parent pointer, so `Node::parent`
 resolves by descending from the root and is itself `O(depth)`. Any
 predicate in the walk that asked a node for its parent was therefore
 `O(depth)` per node and `O(depth^2)` over a deeply nested file, however
-few steps it took. [#1084][parent-walk] fixed all three by having the
-metric walk carry the ancestor chain down with it (`Ancestors` in
+few steps it took. [#1084][parent-walk] fixed three of them by having
+the metric walk carry the ancestor chain down with it (`Ancestors` in
 `src/node.rs`), so a predicate reads an ancestor as a slice index. Their
 bounds moved to the linear bound in that same change, which is what now
 catches a relapse. `cognitive/nested-fn` is the fourth of the same
@@ -123,23 +125,44 @@ the same way in [#1062][cognitive-parent], which is also where that
 probe comes from — it fitted 2.04 against the climb and 1.21 against the
 chain.
 
-The remaining `Node::parent` climbs were left alone and are tracked in
-[#1088][remaining-climbs]. Those are more than a handful and no probe
+`nom/nested-arrow` is the fifth, added by [#1088][remaining-climbs] with
+the fix it guards. It cost the same family a second lesson: threading
+the chain into the JS-family predicates was *not enough* to make it
+linear. The walk they run is two steps long on that shape, and the
+remaining `O(depth)` term was hiding in `Node::wraps_any`, which scanned
+a node's children with `child(0)` + `next_sibling()`. A sibling step
+resolves its parent, so that scan was `O(children × depth)` — the same
+defect one level down, in a helper whose doc comment asserted it was
+`O(1)` per step. Moving the scan onto a cursor took the probe from 17.6 s
+to 6.3 ms at depth 4000 (`k` 1.97 to 1.03), and a walk over the 384-file `pdf.js` corpus
+from ~443 ms to ~370 ms. The lesson generalises: a chain-fed predicate
+is only as linear as the primitives it calls.
+
+The remaining `Node::parent` climbs are tracked in
+[#1096][halstead-climbs]. Those are more than a handful and no probe
 covers them. The list below is illustrative, not exhaustive — `rg
 '\.parent\(\)' src/` is the authority:
 
-- the five call sites that pass `Ancestors::unknown()`
-  (`js_ancestor_walk` in `src/checker.rs`, `suppression_markers`,
-  Elixir's `get_func_space_name`, and Elixir's `Npa` / `Npm`);
 - the per-node `node.parent()` calls in the Halstead `get_op_type`
   getters
-  (`src/getter/{python,rust,javascript,typescript,tsx,mozjs,cpp,mozcpp,bash,irules}.rs`)
-  and in `src/metrics/abc/{mozcpp,perl}.rs`;
+  (`src/getter/{python,rust,cpp,mozcpp,bash,irules}.rs`)
+  and in `src/metrics/abc/`;
 - per-node parent checks in several `loc` arms
   (`src/metrics/loc/{python,lua,kotlin,perl,tcl,irules,elixir}.rs`),
   in `src/metrics/npa/` and `src/metrics/npm/`, in
-  `src/metrics/cyclomatic/elixir.rs`, and in
-  `src/checker/{rust,ruby}.rs`.
+  `src/metrics/cyclomatic/elixir.rs`, and in `src/checker/rust.rs`
+  (`is_useful_comment`, which takes no chain). `Npm::compute` /
+  `Npa::compute` take no ancestor chain either, so this group needs the
+  parameter threaded first. Ruby's `Checker::is_closure` was in this
+  list until #1088 gave `is_closure` a chain — it is the one non-JS
+  predicate of that pair that reads an ancestor, so it now reads it
+  from the chain like the JS family does.
+
+The `Ancestors::unknown()` call sites that remain are deliberate rather
+than deferred: the two synthetic-`Unit`-root pushes hand it a node that
+*is* the root, `parser.rs`'s `--filter function` predicate is applied
+outside any walk, and the `Npm` arms that test a node's children cannot
+extend a borrowed slice by one element without allocating.
 
 Treat the linear bounds above as covering the walk's ancestor *chain*
 threading, not every `O(depth)` lookup in the crate.
@@ -147,8 +170,9 @@ threading, not every `O(depth)` lookup in the crate.
 [parent-walk]: https://github.com/dekobon/big-code-analysis/issues/1084
 [cognitive-parent]: https://github.com/dekobon/big-code-analysis/issues/1062
 [remaining-climbs]: https://github.com/dekobon/big-code-analysis/issues/1088
+[halstead-climbs]: https://github.com/dekobon/big-code-analysis/issues/1096
 
-The four control probes are what make the other readings mean
+The five control probes are what make the other readings mean
 something.
 
 - `nom/nested-while` and `nom/nested-fn` are **metric** controls.
@@ -156,14 +180,15 @@ something.
   the cognitive-attributable cost of each `cognitive/…` row is its
   difference from the `nom/…` row on the same shape, not the
   `cognitive` reading alone.
-- `loc/nested-while` and `cognitive/nested-while` are **shape**
-  controls: each is the same nesting as the ancestor-walk probe it sits
-  next to, with the one node that triggers the walk removed. Before
-  [#1084][parent-walk] each fitted near 1.0 where its counterpart
-  fitted near 2.0, which is what attributed the quadratic cost to
-  that call rather than to nesting in general. Now that all nine fit
-  near 1.0, the pair is what would localise a relapse: a probe drifting
-  up while its control holds means the ancestor lookup, not the shape.
+- `loc/nested-while`, `cognitive/nested-while`, and
+  `nom/nested-declared-function` are **shape** controls: each is the same
+  nesting as the ancestor-walk probe it sits next to, with the one node
+  that triggers the walk removed. Before [#1084][parent-walk] each
+  fitted near 1.0 where its counterpart fitted near 2.0, which is what
+  attributed the quadratic cost to that call rather than to nesting in
+  general. Now that all eleven fit near 1.0, the pair is what would
+  localise a relapse: a probe drifting up while its control holds means
+  the ancestor lookup, not the shape.
 
 ### Adding a probe
 

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -39,6 +39,7 @@ static RE: OnceLock<Regex> = OnceLock::new();
 macro_rules! js_ancestor_walk {
     (
         $node:ident,
+        $ancestors:ident,
         [$($up:ident)|+],
         [$($stop:ident)|+],
         $extra:expr $(,)?
@@ -47,13 +48,22 @@ macro_rules! js_ancestor_walk {
         // the ancestor walk's `is_else_if` filter is bound directly to the
         // language's own `Checker` (no `ParserTrait` round-trip).
         //
-        // `Ancestors::unknown()`, so this walk is still `O(depth)` per
-        // step. `is_func` / `is_closure` are called from `Nargs`, `Npm`,
-        // `function`, and `ops` as well as the metric walk, and only the
-        // metric walk holds a chain to hand over; threading one through
-        // all of them is tracked separately (#1088).
+        // `$ancestors` is the chain the caller descended through, so each
+        // step is a slice index. The walk stops at the first frame that
+        // proves positional use — an enclosing block, `return`, `new`, or
+        // call — so on ordinary JS it takes one or two steps. That is
+        // what made the pre-#1088 cost surprising: `Node::parent` is
+        // `O(depth)` per step whatever the count, so even a two-step walk
+        // was quadratic over a deeply nested file, which is what the
+        // `nom/nested-arrow` probe measures.
+        //
+        // A chain of *expression*-bodied arrows (`a => b => c => …`) is
+        // the one shape no chain can flatten: no `$stop` kind intervenes,
+        // so the walk itself is `O(depth)` long. The chain takes it from
+        // `O(depth^2)` per node to `O(depth)`; it stays quadratic overall
+        // and would need a different rule, not a cheaper lookup, to fix.
         $node.count_specific_ancestors::<Self>(
-            Ancestors::unknown(),
+            $ancestors,
             |node| matches!(node.kind_id().into(), $($up)|+),
             |node| matches!(node.kind_id().into(), $($stop)|+),
         ) > 0
@@ -62,9 +72,10 @@ macro_rules! js_ancestor_walk {
 }
 
 macro_rules! check_if_func {
-    ($node: ident) => {
+    ($node: ident, $ancestors: ident) => {
         js_ancestor_walk!(
             $node,
+            $ancestors,
             [VariableDeclarator | AssignmentExpression | LabeledStatement | Pair],
             [StatementBlock | ReturnStatement | NewExpression | Arguments],
             $node.is_child(Identifier as u16),
@@ -73,33 +84,34 @@ macro_rules! check_if_func {
 }
 
 macro_rules! check_if_arrow_func {
-    ($node: ident) => {
+    ($node: ident, $ancestors: ident) => {
         js_ancestor_walk!(
             $node,
+            $ancestors,
             [VariableDeclarator | AssignmentExpression | LabeledStatement],
             [StatementBlock | ReturnStatement | NewExpression | CallExpression],
-            $node.has_sibling(PropertyIdentifier as u16),
+            $node.has_sibling($ancestors, PropertyIdentifier as u16),
         )
     };
 }
 
 macro_rules! is_js_func {
-    ($node: ident) => {
+    ($node: ident, $ancestors: ident) => {
         match $node.kind_id().into() {
             FunctionDeclaration | MethodDefinition => true,
-            FunctionExpression => check_if_func!($node),
-            ArrowFunction => check_if_arrow_func!($node),
+            FunctionExpression => check_if_func!($node, $ancestors),
+            ArrowFunction => check_if_arrow_func!($node, $ancestors),
             _ => false,
         }
     };
 }
 
 macro_rules! is_js_closure {
-    ($node: ident) => {
+    ($node: ident, $ancestors: ident) => {
         match $node.kind_id().into() {
             GeneratorFunction | GeneratorFunctionDeclaration => true,
-            FunctionExpression => !check_if_func!($node),
-            ArrowFunction => !check_if_arrow_func!($node),
+            FunctionExpression => !check_if_func!($node, $ancestors),
+            ArrowFunction => !check_if_arrow_func!($node, $ancestors),
             _ => false,
         }
     };
@@ -108,15 +120,15 @@ macro_rules! is_js_closure {
 macro_rules! is_js_func_and_closure_checker {
     ($language: ident) => {
         #[inline]
-        fn is_func(node: &Node) -> bool {
+        fn is_func<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>) -> bool {
             use $language::*;
-            is_js_func!(node)
+            is_js_func!(node, ancestors)
         }
 
         #[inline]
-        fn is_closure(node: &Node) -> bool {
+        fn is_closure<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>) -> bool {
             use $language::*;
-            is_js_closure!(node)
+            is_js_closure!(node, ancestors)
         }
     };
 }
@@ -243,12 +255,27 @@ pub(crate) trait Checker {
     fn is_func_space(_: &Node) -> bool {
         false
     }
+    /// Whether `node` is a *named* function definition.
+    ///
+    /// `ancestors` is the chain the caller descended through. The
+    /// JS-family grammars have no distinct production for a named
+    /// function: `const f = () => …` and `g(() => …)` share one
+    /// `arrow_function` node, and only what encloses it says which is
+    /// which. Those steps come off the chain, because `Node::parent`
+    /// costs `O(depth)` each however few of them a walk takes (#1088).
+    /// Every other grammar answers `is_func` from the node's own kind
+    /// and ignores the parameter.
     #[inline]
-    fn is_func(_: &Node) -> bool {
+    fn is_func<'a>(_: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         false
     }
+    /// Whether `node` is an anonymous function — the complement of
+    /// [`is_func`] on the grammars that express both. Takes `ancestors`
+    /// for the same reason, plus one of its own: Ruby's `{ … }` block is
+    /// a closure only when its parent is not the `Lambda` that already
+    /// counted it.
     #[inline]
-    fn is_closure(_: &Node) -> bool {
+    fn is_closure<'a>(_: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         false
     }
     #[inline]
@@ -322,8 +349,8 @@ pub(crate) trait Checker {
     /// Source-aware variant of [`is_func`]. Same rationale as
     /// [`is_func_space_with_code`] (#275).
     #[inline]
-    fn is_func_with_code<'a>(node: &Node<'a>, _code: &[u8], _ancestors: Ancestors<'a, '_>) -> bool {
-        Self::is_func(node)
+    fn is_func_with_code<'a>(node: &Node<'a>, _code: &[u8], ancestors: Ancestors<'a, '_>) -> bool {
+        Self::is_func(node, ancestors)
     }
 
     /// Combined predicate the walker uses to decide whether to promote
@@ -494,8 +521,10 @@ mod tests {
     use super::*;
     use crate::count::count;
     use crate::langs::{
-        BashParser, JavascriptParser, MozjsParser, PhpParser, TsxParser, TypescriptParser,
+        BashParser, JavascriptCode, JavascriptParser, MozjsParser, PhpParser, TsxParser,
+        TypescriptParser,
     };
+    use crate::test_support::for_each_node_with_chain;
     use std::path::PathBuf;
 
     fn parse(source: &str) -> BashParser {
@@ -1088,7 +1117,7 @@ mod tests {
             "python_is_lambda must accept the emitted Lambda node",
         );
         assert!(
-            PythonCode::is_closure(&lambda),
+            PythonCode::is_closure(&lambda, Ancestors::unknown()),
             "is_closure must agree with python_is_lambda on the same lambda node",
         );
 
@@ -1591,6 +1620,121 @@ mod tests {
             count_string_matches_for_kind(&parser, rune_id, GoCode::is_string),
             0,
             "Go rune_literal must not match is_string (a rune is a char, not a string)",
+        );
+    }
+
+    /// Asserts `is_func` / `is_closure` answer the same off a known
+    /// chain as off a `Node::parent` climb, for every node of `code`.
+    /// Returns the `(functions, closures)` the chain path counted, so a
+    /// caller can additionally pin what the predicates actually decided.
+    ///
+    /// Both predicates fold their ancestor lookups into one boolean, so
+    /// a wrong ancestor does not fail — it silently moves a function
+    /// into the closure column. The counters keep a fixture honest: both
+    /// answers have to occur, for both predicates, or the parity holds
+    /// only over nodes the predicates never classify.
+    fn assert_func_parity<L: crate::traits::LanguageInfo + Checker>(
+        label: &str,
+        code: &[u8],
+    ) -> (usize, usize) {
+        let mut funcs = 0;
+        let mut closures = 0;
+        let visited = for_each_node_with_chain::<L>(code, |node, chain| {
+            let known = Ancestors::known(chain);
+            let climbing = Ancestors::unknown();
+            assert_eq!(
+                L::is_func(node, known),
+                L::is_func(node, climbing),
+                "{label}: is_func disagrees on {} at row {}",
+                node.kind(),
+                node.start_row()
+            );
+            assert_eq!(
+                L::is_closure(node, known),
+                L::is_closure(node, climbing),
+                "{label}: is_closure disagrees on {} at row {}",
+                node.kind(),
+                node.start_row()
+            );
+            funcs += usize::from(L::is_func(node, known));
+            closures += usize::from(L::is_closure(node, known));
+        });
+        assert!(visited > 20, "{label}: fixture is too small to prove much");
+        assert!(
+            funcs > 0 && closures > 0,
+            "{label}: fixture must contain both a named function and a closure, \
+             else parity holds over nodes the walk never classifies: \
+             {funcs} functions, {closures} closures"
+        );
+        (funcs, closures)
+    }
+
+    /// The JS-family `is_func` / `is_closure` must classify a node the
+    /// same whether they read the walker's ancestor chain or climb with
+    /// `Node::parent` (#1088).
+    ///
+    /// These are the predicates with the longest ancestor lookup: an
+    /// upward walk, its `is_else_if` filter, and a `has_sibling`
+    /// adjacency check.
+    #[test]
+    fn js_func_and_closure_agree_between_known_and_climbing() {
+        // One of each shape the walk distinguishes: an arrow bound to a
+        // name, an arrow passed positionally, a `function` expression
+        // named by an object `pair`, and a nested arrow whose only
+        // enclosing frame is a `statement_block`.
+        //
+        // The returned object literal is load-bearing. It is the one
+        // shape here where the trailing `has_sibling` adjacency check
+        // decides the answer: the upward walk stops at the `return`
+        // having counted no binding, so whether the arrow is a *named*
+        // function rests entirely on the `property_identifier` beside
+        // it. Everywhere else a binding is found first and the adjacency
+        // check is never reached, which would leave a wrong parent
+        // lookup invisible.
+        let code = concat!(
+            "const f = a => { g(() => 1); a => 2; };\n",
+            "const o = { m: function () { return 1; } };\n",
+            "function h() { return { k: (a) => a + 1 }; }\n",
+            "function i() { return function () { return 2; }; }\n",
+        )
+        .as_bytes();
+        // `is_js_func_and_closure_checker!` expands separately against
+        // each grammar's own `kind_id` enum, so the four impls are four
+        // distinct variant lists rather than one shared body. Checking
+        // only JavaScript would leave a drifted id in any of the other
+        // three uncovered.
+        assert_func_parity::<crate::langs::JavascriptCode>("javascript", code);
+        assert_func_parity::<crate::langs::MozjsCode>("mozjs", code);
+        assert_func_parity::<crate::langs::TypescriptCode>("typescript", code);
+        assert_func_parity::<crate::langs::TsxCode>("tsx", code);
+    }
+
+    /// Ruby's `is_closure` is the one non-JS predicate that needs an
+    /// ancestor: a `{ … }` block is a closure unless its parent is the
+    /// `Lambda` that already counted it (#465), so it reads the chain
+    /// for the same reason the JS family does (#1088).
+    ///
+    /// The stabby lambda is the discriminating shape. Its body block is
+    /// the only node here whose answer depends on the parent lookup —
+    /// every other block's parent is a `Call`, which the arm accepts
+    /// whether the lookup is right or wrong.
+    #[test]
+    fn ruby_block_closure_agrees_between_known_and_climbing() {
+        let code = concat!(
+            "def m\n",
+            "  f = ->(z) { z + 1 }\n",
+            "  [1].each { |x| x }\n",
+            "  lambda { 2 }\n",
+            "end\n",
+        )
+        .as_bytes();
+        let (funcs, closures) = assert_func_parity::<crate::langs::RubyCode>("ruby", code);
+        assert_eq!(funcs, 1, "only `def m` is a named function");
+        assert_eq!(
+            closures, 3,
+            "the stabby lambda, the `each` block and the `lambda` block \
+             are three closures — the stabby lambda's own body block must \
+             not add a fourth, which is the answer the parent lookup decides"
         );
     }
 }

--- a/src/checker/bash.rs
+++ b/src/checker/bash.rs
@@ -15,7 +15,7 @@ impl Checker for BashCode {
         )
     }
 
-    fn is_func(node: &Node) -> bool {
+    fn is_func<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         node.kind_id() == Bash::FunctionDefinition
     }
 

--- a/src/checker/c.rs
+++ b/src/checker/c.rs
@@ -28,7 +28,7 @@ impl Checker for CCode {
     }
 
     // Keep in sync with `is_func_space` and the C getters (#285).
-    fn is_func(node: &Node) -> bool {
+    fn is_func<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         matches!(
             node.kind_id().into(),
             C::FunctionDefinition | C::FunctionDefinition2
@@ -36,7 +36,7 @@ impl Checker for CCode {
     }
 
     // C has no closures/lambdas.
-    fn is_closure(_node: &Node) -> bool {
+    fn is_closure<'a>(_node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         false
     }
 

--- a/src/checker/cpp.rs
+++ b/src/checker/cpp.rs
@@ -37,7 +37,7 @@ impl Checker for CppCode {
 
     // Issue #285 contract: keep this in sync with `is_func_space` and
     // the C++ getters — see comment above `is_func_space`.
-    fn is_func(node: &Node) -> bool {
+    fn is_func<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         matches!(
             node.kind_id().into(),
             Cpp::FunctionDefinition
@@ -47,7 +47,7 @@ impl Checker for CppCode {
         )
     }
 
-    fn is_closure(node: &Node) -> bool {
+    fn is_closure<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         node.kind_id() == Cpp::LambdaExpression
     }
 

--- a/src/checker/csharp.rs
+++ b/src/checker/csharp.rs
@@ -42,7 +42,7 @@ impl Checker for CsharpCode {
         )
     }
 
-    fn is_func(node: &Node) -> bool {
+    fn is_func<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         if matches!(
             node.kind_id().into(),
             Csharp::IndexerDeclaration | Csharp::PropertyDeclaration
@@ -61,7 +61,7 @@ impl Checker for CsharpCode {
         )
     }
 
-    fn is_closure(node: &Node) -> bool {
+    fn is_closure<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         matches!(
             node.kind_id().into(),
             Csharp::LambdaExpression | Csharp::AnonymousMethodExpression

--- a/src/checker/elixir.rs
+++ b/src/checker/elixir.rs
@@ -27,7 +27,7 @@ impl Checker for ElixirCode {
         )
     }
 
-    fn is_func(_: &Node) -> bool {
+    fn is_func<'a>(_: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         false
     }
 
@@ -92,7 +92,7 @@ impl Checker for ElixirCode {
         elixir_is_method_macro(kw) && !elixir_is_inside_quote_block(node, code, ancestors)
     }
 
-    fn is_closure(node: &Node) -> bool {
+    fn is_closure<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         node.kind_id() == Elixir::AnonymousFunction
     }
 

--- a/src/checker/go.rs
+++ b/src/checker/go.rs
@@ -15,14 +15,14 @@ impl Checker for GoCode {
         )
     }
 
-    fn is_func(node: &Node) -> bool {
+    fn is_func<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         matches!(
             node.kind_id().into(),
             Go::FunctionDeclaration | Go::MethodDeclaration
         )
     }
 
-    fn is_closure(node: &Node) -> bool {
+    fn is_closure<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         node.kind_id() == Go::FuncLiteral
     }
 

--- a/src/checker/groovy.rs
+++ b/src/checker/groovy.rs
@@ -33,14 +33,14 @@ impl Checker for GroovyCode {
         )
     }
 
-    fn is_func(node: &Node) -> bool {
+    fn is_func<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         matches!(
             node.kind_id().into(),
             Groovy::MethodDeclaration | Groovy::ConstructorDeclaration
         )
     }
 
-    fn is_closure(node: &Node) -> bool {
+    fn is_closure<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         matches!(node.kind_id().into(), Groovy::Closure)
     }
 

--- a/src/checker/irules.rs
+++ b/src/checker/irules.rs
@@ -37,7 +37,7 @@ impl Checker for IrulesCode {
 
     // Handlers count as functions (not closures): `nom.functions` on a
     // typical iRules file is then the handler count, the intuitive metric.
-    fn is_func(node: &Node) -> bool {
+    fn is_func<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         matches!(
             node.kind_id().into(),
             Irules::Procedure | Irules::WhenEvent | Irules::OnHandler | Irules::TrapHandler
@@ -45,7 +45,7 @@ impl Checker for IrulesCode {
     }
 
     // iRules has no anonymous lambda node (`apply` is an ordinary command).
-    fn is_closure(_: &Node) -> bool {
+    fn is_closure<'a>(_: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         false
     }
 

--- a/src/checker/java.rs
+++ b/src/checker/java.rs
@@ -39,11 +39,11 @@ impl Checker for JavaCode {
         )
     }
 
-    fn is_func(node: &Node) -> bool {
+    fn is_func<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         node.kind_id() == Java::MethodDeclaration || node.kind_id() == Java::ConstructorDeclaration
     }
 
-    fn is_closure(node: &Node) -> bool {
+    fn is_closure<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         node.kind_id() == Java::LambdaExpression
     }
 

--- a/src/checker/kotlin.rs
+++ b/src/checker/kotlin.rs
@@ -22,14 +22,14 @@ impl Checker for KotlinCode {
         )
     }
 
-    fn is_func(node: &Node) -> bool {
+    fn is_func<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         matches!(
             node.kind_id().into(),
             Kotlin::FunctionDeclaration | Kotlin::SecondaryConstructor
         )
     }
 
-    fn is_closure(node: &Node) -> bool {
+    fn is_closure<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         matches!(
             node.kind_id().into(),
             Kotlin::LambdaLiteral | Kotlin::AnonymousFunction

--- a/src/checker/lua.rs
+++ b/src/checker/lua.rs
@@ -19,14 +19,14 @@ impl Checker for LuaCode {
         )
     }
 
-    fn is_func(node: &Node) -> bool {
+    fn is_func<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         matches!(
             node.kind_id().into(),
             Lua::FunctionDeclaration | Lua::FunctionDeclaration2 | Lua::FunctionDeclaration3
         )
     }
 
-    fn is_closure(node: &Node) -> bool {
+    fn is_closure<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         node.kind_id() == Lua::FunctionDefinition
     }
 

--- a/src/checker/mozcpp.rs
+++ b/src/checker/mozcpp.rs
@@ -37,7 +37,7 @@ impl Checker for MozcppCode {
 
     // Issue #285 contract: keep this in sync with `is_func_space` and
     // the C++ getters — see comment above `is_func_space`.
-    fn is_func(node: &Node) -> bool {
+    fn is_func<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         matches!(
             node.kind_id().into(),
             Mozcpp::FunctionDefinition
@@ -47,7 +47,7 @@ impl Checker for MozcppCode {
         )
     }
 
-    fn is_closure(node: &Node) -> bool {
+    fn is_closure<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         node.kind_id() == Mozcpp::LambdaExpression
     }
 

--- a/src/checker/objc.rs
+++ b/src/checker/objc.rs
@@ -39,7 +39,7 @@ impl Checker for ObjcCode {
     // A `method_definition` is the `@implementation`-side method with a
     // body; the `@interface`-side `method_declaration` has no body and
     // is therefore not a function.
-    fn is_func(node: &Node) -> bool {
+    fn is_func<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         matches!(
             node.kind_id().into(),
             Objc::FunctionDefinition | Objc::FunctionDefinition2 | Objc::MethodDefinition
@@ -47,7 +47,7 @@ impl Checker for ObjcCode {
     }
 
     // ObjC blocks `^{ … }` are the language's closures.
-    fn is_closure(node: &Node) -> bool {
+    fn is_closure<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         node.kind_id() == Objc::BlockLiteral
     }
 

--- a/src/checker/perl.rs
+++ b/src/checker/perl.rs
@@ -18,14 +18,14 @@ impl Checker for PerlCode {
         )
     }
 
-    fn is_func(node: &Node) -> bool {
+    fn is_func<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         matches!(
             node.kind_id().into(),
             Perl::FunctionDefinition | Perl::FunctionDefinitionWithoutSub
         )
     }
 
-    fn is_closure(node: &Node) -> bool {
+    fn is_closure<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         node.kind_id() == Perl::AnonymousFunction
     }
 

--- a/src/checker/php.rs
+++ b/src/checker/php.rs
@@ -24,14 +24,14 @@ impl Checker for PhpCode {
         )
     }
 
-    fn is_func(node: &Node) -> bool {
+    fn is_func<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         matches!(
             node.kind_id().into(),
             Php::FunctionDefinition | Php::MethodDeclaration
         )
     }
 
-    fn is_closure(node: &Node) -> bool {
+    fn is_closure<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         matches!(
             node.kind_id().into(),
             Php::AnonymousFunction | Php::ArrowFunction

--- a/src/checker/python.rs
+++ b/src/checker/python.rs
@@ -26,11 +26,11 @@ impl Checker for PythonCode {
         )
     }
 
-    fn is_func(node: &Node) -> bool {
+    fn is_func<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         node.kind_id() == Python::FunctionDefinition
     }
 
-    fn is_closure(node: &Node) -> bool {
+    fn is_closure<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         // Route through the single lambda-alias chokepoint so closure
         // detection here and the cognitive lambda-scope walks accept the
         // exact same set: `Lambda` (196, the concrete production emitted

--- a/src/checker/ruby.rs
+++ b/src/checker/ruby.rs
@@ -23,11 +23,11 @@ impl Checker for RubyCode {
         )
     }
 
-    fn is_func(node: &Node) -> bool {
+    fn is_func<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         matches!(node.kind_id().into(), Ruby::Method | Ruby::SingletonMethod)
     }
 
-    fn is_closure(node: &Node) -> bool {
+    fn is_closure<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>) -> bool {
         match node.kind_id().into() {
             Ruby::Lambda => true,
             // A stabby lambda `->(z) { … }` parses as a `Lambda` node that
@@ -37,8 +37,14 @@ impl Checker for RubyCode {
             // forms `lambda { }` / `proc { }` parse as a `Call` carrying a
             // `Block`/`DoBlock` argument (parent is not a `Lambda`), so they
             // still count exactly once.
-            Ruby::Block | Ruby::DoBlock => node
-                .parent()
+            //
+            // The parent comes off the caller's chain: `is_closure` runs
+            // per node from `Nom` / `NArgs`, and `Node::parent` costs
+            // `O(depth)` because `tree_sitter` resolves it by descending
+            // from the root (#1088). Ruby is the one non-JS grammar whose
+            // closure test is not answerable from the node's own kind.
+            Ruby::Block | Ruby::DoBlock => ancestors
+                .parent(node)
                 .is_none_or(|parent| parent.kind_id() != Ruby::Lambda),
             _ => false,
         }

--- a/src/checker/rust.rs
+++ b/src/checker/rust.rs
@@ -30,11 +30,11 @@ impl Checker for RustCode {
         )
     }
 
-    fn is_func(node: &Node) -> bool {
+    fn is_func<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         node.kind_id() == Rust::FunctionItem
     }
 
-    fn is_closure(node: &Node) -> bool {
+    fn is_closure<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         node.kind_id() == Rust::ClosureExpression
     }
 

--- a/src/checker/tcl.rs
+++ b/src/checker/tcl.rs
@@ -12,12 +12,12 @@ impl Checker for TclCode {
         matches!(node.kind_id().into(), Tcl::SourceFile | Tcl::Procedure)
     }
 
-    fn is_func(node: &Node) -> bool {
+    fn is_func<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         node.kind_id() == Tcl::Procedure
     }
 
     // Tcl closures (`apply`) are ordinary commands; the grammar has no distinct closure node.
-    fn is_closure(_: &Node) -> bool {
+    fn is_closure<'a>(_: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         false
     }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -55,12 +55,12 @@ pub(crate) fn function<T: ParserTrait>(parser: &T) -> Vec<FunctionSpan> {
     let root = parser.root();
     let code = parser.code();
     let mut spans = Vec::new();
-    root.act_on_node(&mut |n| {
-        if T::Checker::is_func(n) {
+    root.act_on_node(&mut |n, ancestors| {
+        if T::Checker::is_func(n, ancestors) {
             let start_line = n.start_row() + 1;
             let end_line = n.end_row() + 1;
             spans.push(FunctionSpan {
-                name: T::Getter::get_func_name(n, code).map(str::to_string),
+                name: T::Getter::get_func_name(n, code, ancestors).map(str::to_string),
                 start_line,
                 end_line,
             });

--- a/src/function_tests.rs
+++ b/src/function_tests.rs
@@ -182,3 +182,34 @@ fn dump_span_ansi_layout_error_branch() {
         &["   `- ", "error: ", "from line ", "7", " to line ", "8.\n"],
     );
 }
+
+/// The span walk must find every named function and name the ones whose
+/// name lives on an ancestor rather than on the node.
+///
+/// `outer` and `keyed` are `function_expression`s with no `name` field:
+/// the JS getter recovers both from the enclosing `variable_declarator`
+/// / `pair`, which #1088 moved onto the walk's ancestor chain. This is
+/// also the only lib-level exercise of that chain — `act_on_node`
+/// constructs it through `Ancestors::checked`, so a bookkeeping slip
+/// trips the debug assertion here rather than only in the web crate's
+/// endpoint tests.
+#[test]
+fn js_function_spans_name_expressions_from_their_binding() {
+    use crate::langs::JavascriptParser;
+    use crate::traits::ParserTrait;
+
+    let source = concat!(
+        "var outer = function () { return 1; };\n",
+        "var o = { keyed: function () { return 2; } };\n",
+        "function plain() { return 3; }\n",
+    );
+    let parser = JavascriptParser::new(source.as_bytes().to_vec(), &PathBuf::from("t.js"), None);
+    let spans = function(&parser);
+    let names: Vec<Option<&str>> = spans.iter().map(|s| s.name.as_deref()).collect();
+    assert_eq!(
+        names,
+        vec![Some("outer"), Some("keyed"), Some("plain")],
+        "each named function must be found, in source order, with the \
+         name its binding gives it"
+    );
+}

--- a/src/getter.rs
+++ b/src/getter.rs
@@ -182,11 +182,25 @@ macro_rules! impl_js_family_get_op_type {
 /// are not.
 #[doc(hidden)]
 pub(crate) trait Getter {
-    fn get_func_name<'a>(node: &Node, code: &'a [u8]) -> Option<&'a str> {
-        Self::get_func_space_name(node, code)
+    fn get_func_name<'a, 'tree>(
+        node: &Node<'tree>,
+        code: &'a [u8],
+        ancestors: Ancestors<'tree, '_>,
+    ) -> Option<&'a str> {
+        Self::get_func_space_name(node, code, ancestors)
     }
 
-    fn get_func_space_name<'a>(node: &Node, code: &'a [u8]) -> Option<&'a str> {
+    /// Names the space `node` opens.
+    ///
+    /// `ancestors` is the chain the caller descended through. Elixir
+    /// needs it: its `def` / `defmodule` heads are ordinary `Call`
+    /// nodes, and one inside a `quote` template names no space at all,
+    /// which is a question about what encloses the call (#1088).
+    fn get_func_space_name<'a, 'tree>(
+        node: &Node<'tree>,
+        code: &'a [u8],
+        _ancestors: Ancestors<'tree, '_>,
+    ) -> Option<&'a str> {
         // we're in a function or in a class
         if let Some(name) = node.child_by_field_name("name") {
             node_text(code, &name)
@@ -343,5 +357,88 @@ mod node_text_tests {
         let root = parser.root();
         assert_eq!(root.end_byte(), src.len());
         assert_eq!(node_text(parser.code(), &root), None);
+    }
+}
+
+#[cfg(test)]
+mod ancestor_tests {
+    use super::Getter;
+    use crate::node::{Ancestors, Node};
+    use crate::test_support::for_each_node_with_chain;
+    use crate::traits::LanguageInfo;
+
+    /// `get_func_space_name` must name a space the same whether it reads
+    /// the walker's ancestor chain or climbs with `Node::parent`.
+    ///
+    /// Two grammars consult an ancestor here, for different reasons:
+    /// the JS family names an anonymous `function` / arrow from the
+    /// `pair` or `variable_declarator` holding it, and Elixir skips
+    /// naming a `def` that sits inside a `quote` template. #1088 moved
+    /// both onto the chain.
+    fn assert_name_parity<L: LanguageInfo + Getter>(
+        label: &str,
+        code: &[u8],
+        expect_named: &[&str],
+    ) {
+        let mut seen: Vec<&str> = Vec::new();
+        let visited = for_each_node_with_chain::<L>(code, |node: &Node<'_>, chain| {
+            let known = L::get_func_space_name(node, code, Ancestors::known(chain));
+            let climbing = L::get_func_space_name(node, code, Ancestors::unknown());
+            assert_eq!(
+                known,
+                climbing,
+                "{label}: name of {} at row {} disagrees",
+                node.kind(),
+                node.start_row()
+            );
+            if let Some(name) = known
+                && expect_named.contains(&name)
+                && !seen.contains(&name)
+            {
+                seen.push(name);
+            }
+        });
+        assert!(visited > 20, "{label}: fixture is too small to prove much");
+        for name in expect_named {
+            assert!(
+                seen.contains(name),
+                "{label}: no node resolved to {name:?}, so the fixture no longer \
+                 exercises the ancestor-derived naming it was added for"
+            );
+        }
+    }
+
+    #[test]
+    fn func_space_name_agrees_between_known_and_climbing() {
+        // `outer` and `keyed` are only reachable through the parent:
+        // the function expressions themselves carry no `name` field.
+        //
+        // All four JS-family grammars are exercised, not just
+        // JavaScript: their `get_func_space_name` impls are separate
+        // copies of the same body against four distinct `kind_id`
+        // enums, so a `Pair` / `VariableDeclarator` id that drifted in
+        // one grammar would be invisible here if only one were checked.
+        let js_source =
+            b"var outer = function () { return 1; };\nvar o = { keyed: function () { return 2; } };\n";
+        assert_name_parity::<crate::langs::JavascriptCode>(
+            "javascript",
+            js_source,
+            &["outer", "keyed"],
+        );
+        assert_name_parity::<crate::langs::MozjsCode>("mozjs", js_source, &["outer", "keyed"]);
+        assert_name_parity::<crate::langs::TypescriptCode>(
+            "typescript",
+            js_source,
+            &["outer", "keyed"],
+        );
+        assert_name_parity::<crate::langs::TsxCode>("tsx", js_source, &["outer", "keyed"]);
+        // `multi` is named from its `Call` head; the `def a` inside the
+        // `quote` template is not a definition, so it falls through to
+        // the field-less default.
+        assert_name_parity::<crate::langs::ElixirCode>(
+            "elixir",
+            b"defmodule Foo do\n  defmacro multi do\n    quote do\n      def a, do: 1\n    end\n  end\nend\n",
+            &["Foo", "multi"],
+        );
     }
 }

--- a/src/getter/c.rs
+++ b/src/getter/c.rs
@@ -4,7 +4,11 @@
 use super::*;
 
 impl Getter for CCode {
-    fn get_func_space_name<'a>(node: &Node, code: &'a [u8]) -> Option<&'a str> {
+    fn get_func_space_name<'a, 'tree>(
+        node: &Node<'tree>,
+        code: &'a [u8],
+        _ancestors: Ancestors<'tree, '_>,
+    ) -> Option<&'a str> {
         // Issue #285 contract: every `C::FunctionDefinition*` alias must
         // be enumerated here AND in `get_space_kind` below AND in
         // `is_func` / `is_func_space` (see `src/checker.rs`). C has no

--- a/src/getter/cpp.rs
+++ b/src/getter/cpp.rs
@@ -4,7 +4,11 @@
 use super::*;
 
 impl Getter for CppCode {
-    fn get_func_space_name<'a>(node: &Node, code: &'a [u8]) -> Option<&'a str> {
+    fn get_func_space_name<'a, 'tree>(
+        node: &Node<'tree>,
+        code: &'a [u8],
+        _ancestors: Ancestors<'tree, '_>,
+    ) -> Option<&'a str> {
         // Issue #285 contract: every `Cpp::FunctionDefinition*` alias
         // must be enumerated here AND in `get_space_kind` below AND
         // in `is_func` / `is_func_space` (see `src/checker.rs`).

--- a/src/getter/elixir.rs
+++ b/src/getter/elixir.rs
@@ -96,7 +96,11 @@ impl Getter for ElixirCode {
     // Falls back to the trait default behaviour (`<anonymous>` for
     // nodes without a `name` field) when the Call is not one we
     // recognise.
-    fn get_func_space_name<'a>(node: &Node, code: &'a [u8]) -> Option<&'a str> {
+    fn get_func_space_name<'a, 'tree>(
+        node: &Node<'tree>,
+        code: &'a [u8],
+        ancestors: Ancestors<'tree, '_>,
+    ) -> Option<&'a str> {
         use Elixir as E;
 
         use crate::metrics::cognitive::{
@@ -107,17 +111,17 @@ impl Getter for ElixirCode {
         // additionally require the Call NOT to be inside a `quote`
         // template, matching the func-space promotion rule (#310).
         //
-        // `Ancestors::unknown()` — `get_func_space_name` runs once per
-        // *promoted* space, and a quoted `def` is never promoted, so
-        // the climbing lookup is off the per-node path that #1084 was
-        // about. Giving it a chain would mean widening the whole
-        // `Getter::get_func_space_name` surface (23 impls) for a call
-        // that fires a handful of times per file (#1088).
+        // The quote-block lookup reads the caller's chain rather than
+        // climbing with `Node::parent` (#1088). This fires once per
+        // *promoted* space rather than per node, so the win is smaller
+        // than at the walk's per-node sites — but `bca function` and the
+        // suppression scan reach it through `get_func_name` on every
+        // function node, where the climb was `O(depth)` apiece.
         if node.kind_id() == E::Call as u16
             && let Some(kw) = elixir_call_keyword(node, code)
             && (elixir_is_class_macro(kw)
                 || (elixir_is_method_macro(kw)
-                    && !elixir_is_inside_quote_block(node, code, Ancestors::unknown())))
+                    && !elixir_is_inside_quote_block(node, code, ancestors)))
         {
             let target_id = node.child_by_field_name("target").map(|t| t.id());
             if let Some(name) = node

--- a/src/getter/javascript.rs
+++ b/src/getter/javascript.rs
@@ -20,13 +20,17 @@ impl Getter for JavascriptCode {
         }
     }
 
-    fn get_func_space_name<'a>(node: &Node, code: &'a [u8]) -> Option<&'a str> {
+    fn get_func_space_name<'a, 'tree>(
+        node: &Node<'tree>,
+        code: &'a [u8],
+        ancestors: Ancestors<'tree, '_>,
+    ) -> Option<&'a str> {
         if let Some(name) = node.child_by_field_name("name") {
             node_text(code, &name)
         } else {
             // We can be in a pair: foo: function() {}
             // Or in a variable declaration: var aFun = function() {}
-            if let Some(parent) = node.parent() {
+            if let Some(parent) = ancestors.parent(node) {
                 match parent.kind_id().into() {
                     Javascript::Pair => {
                         if let Some(name) = parent.child_by_field_name("key") {

--- a/src/getter/mozcpp.rs
+++ b/src/getter/mozcpp.rs
@@ -4,7 +4,11 @@
 use super::*;
 
 impl Getter for MozcppCode {
-    fn get_func_space_name<'a>(node: &Node, code: &'a [u8]) -> Option<&'a str> {
+    fn get_func_space_name<'a, 'tree>(
+        node: &Node<'tree>,
+        code: &'a [u8],
+        _ancestors: Ancestors<'tree, '_>,
+    ) -> Option<&'a str> {
         // Issue #285 contract: every `Mozcpp::FunctionDefinition*` alias
         // must be enumerated here AND in `get_space_kind` below AND
         // in `is_func` / `is_func_space` (see `src/checker.rs`).

--- a/src/getter/mozjs.rs
+++ b/src/getter/mozjs.rs
@@ -20,13 +20,17 @@ impl Getter for MozjsCode {
         }
     }
 
-    fn get_func_space_name<'a>(node: &Node, code: &'a [u8]) -> Option<&'a str> {
+    fn get_func_space_name<'a, 'tree>(
+        node: &Node<'tree>,
+        code: &'a [u8],
+        ancestors: Ancestors<'tree, '_>,
+    ) -> Option<&'a str> {
         if let Some(name) = node.child_by_field_name("name") {
             node_text(code, &name)
         } else {
             // We can be in a pair: foo: function() {}
             // Or in a variable declaration: var aFun = function() {}
-            if let Some(parent) = node.parent() {
+            if let Some(parent) = ancestors.parent(node) {
                 match parent.kind_id().into() {
                     Mozjs::Pair => {
                         if let Some(name) = parent.child_by_field_name("key") {

--- a/src/getter/objc.rs
+++ b/src/getter/objc.rs
@@ -4,7 +4,11 @@
 use super::*;
 
 impl Getter for ObjcCode {
-    fn get_func_space_name<'a>(node: &Node, code: &'a [u8]) -> Option<&'a str> {
+    fn get_func_space_name<'a, 'tree>(
+        node: &Node<'tree>,
+        code: &'a [u8],
+        _ancestors: Ancestors<'tree, '_>,
+    ) -> Option<&'a str> {
         // Issue #285 contract: every `Objc::FunctionDefinition*` alias
         // must be enumerated here AND in `get_space_kind` below AND in
         // `is_func` / `is_func_space` (see `src/checker.rs`). Free

--- a/src/getter/rust.rs
+++ b/src/getter/rust.rs
@@ -4,7 +4,11 @@
 use super::*;
 
 impl Getter for RustCode {
-    fn get_func_space_name<'a>(node: &Node, code: &'a [u8]) -> Option<&'a str> {
+    fn get_func_space_name<'a, 'tree>(
+        node: &Node<'tree>,
+        code: &'a [u8],
+        _ancestors: Ancestors<'tree, '_>,
+    ) -> Option<&'a str> {
         // we're in a function or in a class or an impl
         // for an impl: we've  'impl ... type {...'
         if let Some(name) = node

--- a/src/getter/tsx.rs
+++ b/src/getter/tsx.rs
@@ -21,13 +21,17 @@ impl Getter for TsxCode {
         }
     }
 
-    fn get_func_space_name<'a>(node: &Node, code: &'a [u8]) -> Option<&'a str> {
+    fn get_func_space_name<'a, 'tree>(
+        node: &Node<'tree>,
+        code: &'a [u8],
+        ancestors: Ancestors<'tree, '_>,
+    ) -> Option<&'a str> {
         if let Some(name) = node.child_by_field_name("name") {
             node_text(code, &name)
         } else {
             // We can be in a pair: foo: function() {}
             // Or in a variable declaration: var aFun = function() {}
-            if let Some(parent) = node.parent() {
+            if let Some(parent) = ancestors.parent(node) {
                 match parent.kind_id().into() {
                     Tsx::Pair => {
                         if let Some(name) = parent.child_by_field_name("key") {

--- a/src/getter/typescript.rs
+++ b/src/getter/typescript.rs
@@ -21,13 +21,17 @@ impl Getter for TypescriptCode {
         }
     }
 
-    fn get_func_space_name<'a>(node: &Node, code: &'a [u8]) -> Option<&'a str> {
+    fn get_func_space_name<'a, 'tree>(
+        node: &Node<'tree>,
+        code: &'a [u8],
+        ancestors: Ancestors<'tree, '_>,
+    ) -> Option<&'a str> {
         if let Some(name) = node.child_by_field_name("name") {
             node_text(code, &name)
         } else {
             // We can be in a pair: foo: function() {}
             // Or in a variable declaration: var aFun = function() {}
-            if let Some(parent) = node.parent() {
+            if let Some(parent) = ancestors.parent(node) {
                 match parent.kind_id().into() {
                     Typescript::Pair => {
                         if let Some(name) = parent.child_by_field_name("key") {

--- a/src/metrics/nargs.rs
+++ b/src/metrics/nargs.rs
@@ -235,21 +235,21 @@ where
 {
     /// Walk `node` and update `stats` with this metric for the language
     /// implementing the trait.
-    fn compute(node: &Node, stats: &mut Stats) {
-        if Self::is_func(node) {
+    fn compute<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>, stats: &mut Stats) {
+        if Self::is_func(node, ancestors) {
             compute_args::<Self>(node, &mut stats.fn_nargs);
             return;
         }
 
-        if Self::is_closure(node) {
+        if Self::is_closure(node, ancestors) {
             compute_args::<Self>(node, &mut stats.closure_nargs);
         }
     }
 }
 
 impl NArgs for CppCode {
-    fn compute(node: &Node, stats: &mut Stats) {
-        if Self::is_func(node) {
+    fn compute<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>, stats: &mut Stats) {
+        if Self::is_func(node, ancestors) {
             if let Some(declarator) = node.child_by_field_name("declarator") {
                 let new_node = declarator;
                 compute_args::<Self>(&new_node, &mut stats.fn_nargs);
@@ -257,7 +257,7 @@ impl NArgs for CppCode {
             return;
         }
 
-        if Self::is_closure(node)
+        if Self::is_closure(node, ancestors)
             && let Some(declarator) = node.child_by_field_name("declarator")
         {
             let new_node = declarator;
@@ -267,8 +267,8 @@ impl NArgs for CppCode {
 }
 
 impl NArgs for CCode {
-    fn compute(node: &Node, stats: &mut Stats) {
-        if Self::is_func(node) {
+    fn compute<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>, stats: &mut Stats) {
+        if Self::is_func(node, ancestors) {
             if let Some(declarator) = node.child_by_field_name("declarator") {
                 let new_node = declarator;
                 compute_args::<Self>(&new_node, &mut stats.fn_nargs);
@@ -276,7 +276,7 @@ impl NArgs for CCode {
             return;
         }
 
-        if Self::is_closure(node)
+        if Self::is_closure(node, ancestors)
             && let Some(declarator) = node.child_by_field_name("declarator")
         {
             let new_node = declarator;
@@ -286,8 +286,8 @@ impl NArgs for CCode {
 }
 
 impl NArgs for MozcppCode {
-    fn compute(node: &Node, stats: &mut Stats) {
-        if Self::is_func(node) {
+    fn compute<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>, stats: &mut Stats) {
+        if Self::is_func(node, ancestors) {
             if let Some(declarator) = node.child_by_field_name("declarator") {
                 let new_node = declarator;
                 compute_args::<Self>(&new_node, &mut stats.fn_nargs);
@@ -295,7 +295,7 @@ impl NArgs for MozcppCode {
             return;
         }
 
-        if Self::is_closure(node)
+        if Self::is_closure(node, ancestors)
             && let Some(declarator) = node.child_by_field_name("declarator")
         {
             let new_node = declarator;
@@ -314,7 +314,7 @@ impl NArgs for MozcppCode {
 //   * a block `^(int x){ … }` holds its params in a `parameter_list`
 //     child rather than under a `parameters` field.
 impl NArgs for ObjcCode {
-    fn compute(node: &Node, stats: &mut Stats) {
+    fn compute<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>, stats: &mut Stats) {
         match node.kind_id().into() {
             Objc::FunctionDefinition | Objc::FunctionDefinition2 => {
                 if let Some(declarator) = node.child_by_field_name("declarator") {
@@ -376,13 +376,13 @@ fn compute_go_args(node: &Node, nargs: &mut usize) {
 }
 
 impl NArgs for GoCode {
-    fn compute(node: &Node, stats: &mut Stats) {
-        if Self::is_func(node) {
+    fn compute<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>, stats: &mut Stats) {
+        if Self::is_func(node, ancestors) {
             compute_go_args(node, &mut stats.fn_nargs);
             return;
         }
 
-        if Self::is_closure(node) {
+        if Self::is_closure(node, ancestors) {
             compute_go_args(node, &mut stats.closure_nargs);
         }
     }
@@ -418,13 +418,13 @@ fn compute_kotlin_lambda_args(node: &Node, nargs: &mut usize) {
 }
 
 impl NArgs for KotlinCode {
-    fn compute(node: &Node, stats: &mut Stats) {
-        if Self::is_func(node) {
+    fn compute<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>, stats: &mut Stats) {
+        if Self::is_func(node, ancestors) {
             compute_kotlin_func_args(node, &mut stats.fn_nargs);
             return;
         }
 
-        if Self::is_closure(node) {
+        if Self::is_closure(node, ancestors) {
             if node.kind_id() == Kotlin::LambdaLiteral {
                 compute_kotlin_lambda_args(node, &mut stats.closure_nargs);
             } else {
@@ -445,10 +445,10 @@ fn compute_lua_args(node: &Node, nargs: &mut usize) {
 }
 
 impl NArgs for LuaCode {
-    fn compute(node: &Node, stats: &mut Stats) {
-        if Self::is_func(node) {
+    fn compute<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>, stats: &mut Stats) {
+        if Self::is_func(node, ancestors) {
             compute_lua_args(node, &mut stats.fn_nargs);
-        } else if Self::is_closure(node) {
+        } else if Self::is_closure(node, ancestors) {
             compute_lua_args(node, &mut stats.closure_nargs);
         }
     }
@@ -465,8 +465,8 @@ fn compute_tcl_args(node: &Node, nargs: &mut usize) {
 }
 
 impl NArgs for TclCode {
-    fn compute(node: &Node, stats: &mut Stats) {
-        if Self::is_func(node) {
+    fn compute<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>, stats: &mut Stats) {
+        if Self::is_func(node, ancestors) {
             compute_tcl_args(node, &mut stats.fn_nargs);
         }
     }
@@ -488,8 +488,8 @@ fn compute_irules_args(node: &Node, nargs: &mut usize) {
 }
 
 impl NArgs for IrulesCode {
-    fn compute(node: &Node, stats: &mut Stats) {
-        if Self::is_func(node) {
+    fn compute<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>, stats: &mut Stats) {
+        if Self::is_func(node, ancestors) {
             compute_irules_args(node, &mut stats.fn_nargs);
         }
     }
@@ -519,15 +519,15 @@ implement_metric_trait!(
 // for a `parameters` field) misses them. Match the closure_parameters
 // child directly and count its `closure_parameter` grand-children.
 impl NArgs for GroovyCode {
-    fn compute(node: &Node, stats: &mut Stats) {
+    fn compute<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>, stats: &mut Stats) {
         use crate::languages::language_groovy::Groovy;
 
-        if Self::is_func(node) {
+        if Self::is_func(node, ancestors) {
             compute_args::<Self>(node, &mut stats.fn_nargs);
             return;
         }
 
-        if Self::is_closure(node)
+        if Self::is_closure(node, ancestors)
             && let Some(params) = node.first_child(|id| id == Groovy::ClosureParameters)
         {
             params.act_on_child(&mut |n| {

--- a/src/metrics/nom.rs
+++ b/src/metrics/nom.rs
@@ -242,7 +242,7 @@ where
             stats.functions += 1;
             return;
         }
-        if Self::is_closure(node) {
+        if Self::is_closure(node, ancestors) {
             stats.closures += 1;
         }
     }

--- a/src/metrics/npa.rs
+++ b/src/metrics/npa.rs
@@ -3672,6 +3672,29 @@ mod tests {
         );
     }
 
+    /// The `Npa` half of the #1088 simplification: a `defmodule` inside
+    /// a `quote` template still opens a class, so its `defstruct` fields
+    /// are still counted.
+    ///
+    /// Same reasoning as `npm::tests::
+    /// elixir_npm_counts_a_quoted_defmodule_as_a_class` — the
+    /// `is_func_space_with_code` gate that used to precede the
+    /// `defmodule` keyword check could not change the outcome, because
+    /// `elixir_is_class_macro` is exactly `defmodule`.
+    #[test]
+    fn elixir_npa_counts_a_quoted_defmodule_as_a_class() {
+        check_metrics::<ElixirParser>(
+            "defmodule Outer do\n  defstruct [:x]\n  defmacro gen do\n    quote do\n      defmodule Inner do\n        defstruct [:a, :b]\n      end\n    end\n  end\nend\n",
+            "outer.ex",
+            |metric| {
+                // `Outer` contributes `x`; the quoted `Inner` contributes
+                // `a` and `b`. Elixir struct fields are all public.
+                assert_eq!(metric.npa.class_na_sum(), 3);
+                assert_eq!(metric.npa.class_npa_sum(), 3);
+            },
+        );
+    }
+
     // ----- Objective-C -----
 
     #[test]

--- a/src/metrics/npa/elixir.rs
+++ b/src/metrics/npa/elixir.rs
@@ -26,15 +26,15 @@ impl Npa for ElixirCode {
     fn compute<'a>(node: &Node<'a>, code: &'a [u8], stats: &mut Stats) {
         use crate::metrics::cognitive::{elixir_call_keyword, elixir_do_block_call_children};
 
-        // `Ancestors::unknown()`: `Npm`/`Npa::compute` take no
-        // ancestor chain, so this pays `Node::parent`'s `O(depth)`
-        // per step for a quoted `def`. Widening the two traits' 20-odd
-        // impls is tracked as #1088.
-        if !stats.is_disabled() || !Self::is_func_space_with_code(node, code, Ancestors::unknown())
-        {
-            return;
-        }
-        if !matches!(elixir_call_keyword(node, code), Some("defmodule")) {
+        // `is_func_space_with_code` is not consulted: it is implied.
+        // `elixir_is_class_macro` is exactly `kw == "defmodule"`, so it
+        // answers `true` for every node this check lets through, and for
+        // the `def`-shaped calls where it would have consulted the
+        // ancestor chain — the `quote`-template lookup — this check
+        // rejects the node anyway. Calling it cost a source-text keyword
+        // scan per node plus, before #1088, an `O(depth)` climb, and its
+        // answer was discarded either way (#1088).
+        if !stats.is_disabled() || !matches!(elixir_call_keyword(node, code), Some("defmodule")) {
             return;
         }
 

--- a/src/metrics/npm.rs
+++ b/src/metrics/npm.rs
@@ -215,6 +215,20 @@ impl Stats {
     }
 }
 
+/// The direct children of `node` that `C` classifies as functions.
+///
+/// The class-body arms below all ask the same question — "which of this
+/// body's children are methods?" — and share one reason for answering it
+/// with [`Ancestors::unknown`]: a chain is a borrowed slice, so it cannot
+/// be extended by `node` without allocating one per body. Nothing is lost,
+/// because every grammar that reaches this helper (Java, Groovy, Kotlin,
+/// PHP) decides `is_func` from the node's own kind and never asks for an
+/// ancestor (#1088).
+fn direct_child_funcs<'a, C: Checker>(node: &Node<'a>) -> impl Iterator<Item = Node<'a>> {
+    node.children()
+        .filter(|child| C::is_func(child, Ancestors::unknown()))
+}
+
 #[doc(hidden)]
 /// Per-language counting of public methods.
 pub(crate) trait Npm
@@ -259,7 +273,7 @@ macro_rules! impl_npm_java_like {
 
                 match node.kind_id().into() {
                     ClassBody | EnumBodyDeclarations => {
-                        for method in node.children().filter(|n| Self::is_func(n)) {
+                        for method in direct_child_funcs::<Self>(node) {
                             stats.class_nm += 1;
                             // The first child node contains the list of method modifiers.
                             // Source: https://docs.oracle.com/javase/tutorial/reflect/member/methodModifiers.html
@@ -272,7 +286,7 @@ macro_rules! impl_npm_java_like {
                         }
                     }
                     InterfaceBody => {
-                        stats.interface_nm += node.children().filter(|n| Self::is_func(n)).count();
+                        stats.interface_nm += direct_child_funcs::<Self>(node).count();
                         stats.interface_npm = stats.interface_nm;
                     }
                     AnnotationTypeBody => {
@@ -3123,6 +3137,37 @@ class C {
                 // Only `defmacro multi` is a method (and public).
                 assert_eq!(metric.npm.class_nm_sum(), 1);
                 assert_eq!(metric.npm.class_npm_sum(), 1);
+            },
+        );
+    }
+
+    /// A `defmodule` inside a `quote` template still opens a class and
+    /// still has its methods counted.
+    ///
+    /// This pins the equivalence the #1088 simplification rests on.
+    /// `Npm::compute` used to gate on `is_func_space_with_code` before
+    /// checking for the `defmodule` keyword, which cost a source-text
+    /// scan per node and — for `def`-shaped calls — an ancestor walk
+    /// asking whether the call sat inside a `quote`. That walk's answer
+    /// was always discarded: `elixir_is_class_macro` is exactly
+    /// `defmodule`, so the keyword check that follows admits precisely
+    /// the nodes the gate would have, and rejects every node the walk
+    /// was consulted for.
+    ///
+    /// The quoted `defmodule Inner` is the shape where a *different*
+    /// reading of "is this a class space?" would show up: if the
+    /// quote-template rule were ever extended to class macros, these
+    /// counts would move.
+    #[test]
+    fn elixir_npm_counts_a_quoted_defmodule_as_a_class() {
+        check_metrics::<ElixirParser>(
+            "defmodule Outer do\n  defmacro gen do\n    quote do\n      defmodule Inner do\n        def a, do: 1\n        defp b, do: 2\n      end\n    end\n  end\nend\n",
+            "outer.ex",
+            |metric| {
+                // `Outer` contributes `defmacro gen`; the quoted `Inner`
+                // contributes `def a` (public) and `defp b` (private).
+                assert_eq!(metric.npm.class_nm_sum(), 3);
+                assert_eq!(metric.npm.class_npm_sum(), 2);
             },
         );
     }

--- a/src/metrics/npm/elixir.rs
+++ b/src/metrics/npm/elixir.rs
@@ -20,17 +20,18 @@ impl Npm for ElixirCode {
     fn compute<'a>(node: &Node<'a>, code: &'a [u8], stats: &mut Stats) {
         use crate::metrics::cognitive::{elixir_call_keyword, elixir_do_block_call_children};
 
-        // `Ancestors::unknown()`: `Npm`/`Npa::compute` take no
-        // ancestor chain, so this pays `Node::parent`'s `O(depth)`
-        // per step for a quoted `def`. Widening the two traits' 20-odd
-        // impls is tracked as #1088.
-        if !stats.is_disabled() || !Self::is_func_space_with_code(node, code, Ancestors::unknown())
-        {
-            return;
-        }
         // The space-opening node for a `defmodule` Call is the node
         // itself, so this triggers exactly once per Class.
-        if !matches!(elixir_call_keyword(node, code), Some("defmodule")) {
+        //
+        // `is_func_space_with_code` is not consulted: it is implied.
+        // `elixir_is_class_macro` is exactly `kw == "defmodule"`, so it
+        // answers `true` for every node this check lets through, and for
+        // the `def`-shaped calls where it would have consulted the
+        // ancestor chain — the `quote`-template lookup — this check
+        // rejects the node anyway. Calling it cost a source-text keyword
+        // scan per node plus, before #1088, an `O(depth)` climb, and its
+        // answer was discarded either way (#1088).
+        if !stats.is_disabled() || !matches!(elixir_call_keyword(node, code), Some("defmodule")) {
             return;
         }
 

--- a/src/metrics/npm/groovy.rs
+++ b/src/metrics/npm/groovy.rs
@@ -28,7 +28,7 @@ impl Npm for GroovyCode {
             ClassBody | EnumBody => {
                 let is_interface_like = groovy_body_is_interface_like(node);
 
-                for method in node.children().filter(|n| Self::is_func(n)) {
+                for method in direct_child_funcs::<Self>(node) {
                     if is_interface_like {
                         stats.interface_nm += 1;
                         stats.interface_npm += 1;

--- a/src/metrics/npm/kotlin.rs
+++ b/src/metrics/npm/kotlin.rs
@@ -45,7 +45,7 @@ impl Npm for KotlinCode {
         // `declaration` rule layers, so function declarations and
         // secondary constructors appear as direct children of
         // `class_body`. `Self::is_func` recognises both kinds.
-        for func in node.children().filter(|c| Self::is_func(c)) {
+        for func in direct_child_funcs::<Self>(node) {
             if is_interface {
                 stats.interface_nm += 1;
                 stats.interface_npm += 1;

--- a/src/metrics/npm/php.rs
+++ b/src/metrics/npm/php.rs
@@ -23,7 +23,7 @@ impl Npm for PhpCode {
                 };
                 match parent_kind {
                     ClassDeclaration | TraitDeclaration | AnonymousClass => {
-                        for method in node.children().filter(|c| Self::is_func(c)) {
+                        for method in direct_child_funcs::<Self>(node) {
                             stats.class_nm += 1;
                             if super::npa::php_is_explicit_public(&method) {
                                 stats.class_npm += 1;
@@ -32,7 +32,7 @@ impl Npm for PhpCode {
                     }
                     // Interface methods are implicitly public.
                     InterfaceDeclaration => {
-                        let count = node.children().filter(|c| Self::is_func(c)).count();
+                        let count = direct_child_funcs::<Self>(node).count();
                         stats.interface_nm += count;
                         stats.interface_npm = stats.interface_nm;
                     }
@@ -41,7 +41,7 @@ impl Npm for PhpCode {
             }
             // PHP 8.1 enums can declare regular and static methods.
             EnumDeclarationList => {
-                for method in node.children().filter(|c| Self::is_func(c)) {
+                for method in direct_child_funcs::<Self>(node) {
                     stats.class_nm += 1;
                     if super::npa::php_is_explicit_public(&method) {
                         stats.class_npm += 1;

--- a/src/node.rs
+++ b/src/node.rs
@@ -166,12 +166,16 @@ impl<'a> Node<'a> {
     /// closure-classification hot path (`check_if_arrow_func!`); see
     /// #521.
     ///
+    /// `ancestors` supplies the parent, because [`Node::parent`] costs
+    /// `O(depth)` — `tree_sitter` stores no parent pointer and resolves
+    /// one by descending from the root (#1088).
+    ///
     /// [`wraps_any`]: Self::wraps_any
     #[inline]
-    pub(crate) fn has_sibling(&self, id: u16) -> bool {
-        self.0
-            .parent()
-            .is_some_and(|parent| Node(parent).is_child(id))
+    pub(crate) fn has_sibling(&self, ancestors: Ancestors<'a, '_>, id: u16) -> bool {
+        ancestors
+            .parent(self)
+            .is_some_and(|parent| parent.is_child(id))
     }
 
     pub(crate) fn previous_sibling(&self) -> Option<Node<'a>> {
@@ -205,9 +209,11 @@ impl<'a> Node<'a> {
     /// caller of this method `O(depth)` per node, which is the same
     /// defect #1084 removed from the predicates that ask for an
     /// ancestor outright. The cursor iterator is `O(children)` after one
-    /// allocation, and measured faster on real input as well as on a
-    /// pathological one: a metric walk over the 384-file `pdf.js`
-    /// corpus dropped from ~443 ms to ~370 ms (#1088).
+    /// allocation, and measured faster on real input as well as on the
+    /// pathological one: the `nom/nested-arrow` probe went from
+    /// quadratic (17.6 s at depth 4000) to linear (6.3 ms), and a walk
+    /// over the 384-file `pdf.js` corpus dropped from ~443 ms to
+    /// ~370 ms (#1088).
     ///
     /// [`is_child`]: Self::is_child
     #[inline]
@@ -648,15 +654,32 @@ impl<'a> Search<'a> for Node<'a> {
         None
     }
 
-    fn act_on_node(&self, action: &mut dyn FnMut(&Node<'a>)) {
+    fn act_on_node(&self, action: &mut dyn FnMut(&Node<'a>, Ancestors<'a, '_>)) {
         let mut cursor = self.cursor();
         let mut stack = Vec::new();
         let mut children = Vec::new();
+        // Ancestor chain of the node being visited, root first. Kept by
+        // the same truncate/push rule as the metric walk, so a predicate
+        // the action applies can read an ancestor as a slice index
+        // rather than through the `O(depth)` `Node::parent` (#1088).
+        //
+        // Seeded with this subtree root's own ancestry rather than left
+        // empty: `Ancestors` reads an empty chain as "this node is the
+        // tree root", so on a subtree an empty seed would report no
+        // parent for `*self` — silently costing e.g. the JS getters the
+        // binding a `function_expression` takes its name from. One
+        // climb, and none at all for the tree root this is called on
+        // today.
+        let mut chain: Vec<Node<'a>> = std::iter::successors(self.parent(), Node::parent).collect();
+        chain.reverse();
+        let depth = chain.len();
 
-        stack.push(*self);
+        stack.push((*self, depth));
 
-        while let Some(node) = stack.pop() {
-            action(&node);
+        while let Some((node, depth)) = stack.pop() {
+            chain.truncate(depth);
+            action(&node, Ancestors::checked(&chain, &node));
+            chain.push(node);
             cursor.reset(&node);
             if cursor.goto_first_child() {
                 loop {
@@ -666,7 +689,7 @@ impl<'a> Search<'a> for Node<'a> {
                     }
                 }
                 for child in children.drain(..).rev() {
-                    stack.push(child);
+                    stack.push((child, depth + 1));
                 }
             }
         }
@@ -687,6 +710,7 @@ impl<'a> Search<'a> for Node<'a> {
 mod tests {
     use super::*;
     use crate::langs::MozjsCode;
+    use crate::test_support::for_each_node_with_chain;
 
     /// The `child(0)` + `next_sibling()` chain [`Node::wraps_any`] used
     /// between #217 and #1088, kept here as the reference the cursor
@@ -738,15 +762,18 @@ mod tests {
         let absent_id = u16::MAX;
 
         let mut stack = vec![ts_tree.root_node()];
+        let mut matched = 0;
         while let Some(n) = stack.pop() {
             let wrapped = Node(n);
             for &id in kinds.iter().chain(std::iter::once(&absent_id)) {
+                let found = wrapped.has_sibling(Ancestors::unknown(), id);
                 assert_eq!(
-                    wrapped.has_sibling(id),
+                    found,
                     sibling_chain_has_sibling(n, id),
                     "has_sibling diverged from the retired sibling chain at node kind {} for id {id}",
                     n.kind(),
                 );
+                matched += usize::from(found);
             }
             let mut child = n.child(0);
             while let Some(c) = child {
@@ -754,13 +781,21 @@ mod tests {
                 child = c.next_sibling();
             }
         }
+        // The comment above claims the collected kinds cover the
+        // present-sibling case; this enforces it. Both sides answering
+        // `false` everywhere would agree without either scan ever
+        // running to a match.
+        assert!(
+            matched > 0,
+            "every answer was `false`, so the sibling scan was never exercised"
+        );
 
         // No-parent node (root) always reports no sibling.
         let root = Node(ts_tree.root_node());
-        assert!(!root.has_sibling(absent_id));
+        assert!(!root.has_sibling(Ancestors::unknown(), absent_id));
         for &id in &kinds {
             assert!(
-                !root.has_sibling(id),
+                !root.has_sibling(Ancestors::unknown(), id),
                 "root node has no parent → no sibling"
             );
         }
@@ -1012,40 +1047,6 @@ mod tests {
         );
     }
 
-    /// Visits `code`'s tree in pre-order, maintaining the ancestor chain
-    /// exactly as `spaces::compute::metrics_inner` does, and hands each
-    /// node to `check` together with that chain.
-    ///
-    /// Keeping the bookkeeping identical to the walker's is the point:
-    /// a test that built the chain some other way would prove
-    /// [`Ancestors`] self-consistent without proving the walker feeds it
-    /// the right slice.
-    fn for_each_node_with_chain<L: LanguageInfo>(
-        code: &[u8],
-        mut check: impl FnMut(&Node<'_>, &[Node<'_>]),
-    ) -> usize {
-        let tree = Tree::new::<L>(code);
-        let root = tree.get_root();
-        assert!(
-            !root.has_error(),
-            "fixture must parse cleanly, else the walk covers error recovery"
-        );
-
-        let mut chain: Vec<Node<'_>> = Vec::new();
-        let mut stack = vec![(root, 0_usize)];
-        let mut visited = 0;
-        while let Some((node, depth)) = stack.pop() {
-            chain.truncate(depth);
-            check(&node, &chain);
-            visited += 1;
-            chain.push(node);
-            let first = stack.len();
-            stack.extend(node.children().map(|child| (child, depth + 1)));
-            stack[first..].reverse();
-        }
-        visited
-    }
-
     /// Ancestor ids yielded by `ancestors`, nearest first.
     fn ancestor_ids(ancestors: Ancestors<'_, '_>, node: &Node<'_>) -> Vec<usize> {
         ancestors.iter(node).map(|(a, _)| a.id()).collect()
@@ -1161,6 +1162,105 @@ mod tests {
             b"def f(x)\n  case x\n  when 1 then 1\n  else 2\n  end\n  def g\n    if x\n    end\n  end\nend\n",
             &["method"],
         );
+
+        // The shape #1088 added as a consumer: the JS-family
+        // `Checker::is_func` / `is_closure` walk upward from an
+        // `arrow_function` / `function_expression` looking for the
+        // binding that names it, and end on `Ancestors::previous_sibling`
+        // through `has_sibling`. None of the fixtures above contains
+        // either node.
+        assert_parity::<crate::langs::JavascriptCode>(
+            "javascript",
+            b"const f = a => { a => { g(() => 1); }; };\nconst o = { m: function () { return 1; } };\n",
+            &["arrow_function"],
+        );
+    }
+
+    /// [`Node::has_sibling`] must answer the same whether its parent
+    /// comes off a known chain or from `Node::parent`.
+    ///
+    /// The parent lookup is the only thing #1088 changed here, and it is
+    /// the half a caller cannot see: `check_if_arrow_func!` folds the
+    /// answer into a disjunction, so a wrong parent would silently
+    /// reclassify an arrow function rather than fail. Checked for every
+    /// node against every kind the fixture contains, plus one that never
+    /// occurs so the absent-sibling answer is covered too.
+    #[test]
+    fn has_sibling_agrees_between_known_and_climbing() {
+        // Object-literal methods and an arrow bound to a property are
+        // the shapes whose `PropertyIdentifier` sibling the JS closure
+        // check asks about.
+        let code = b"const o = { m: (a) => a + 1, n: function () {} };\nconst p = a => a;\n";
+        let mut kinds = std::collections::BTreeSet::new();
+        for_each_node_with_chain::<crate::langs::JavascriptCode>(code, |node, _| {
+            kinds.insert(node.kind_id());
+        });
+        // An id no node in the fixture carries, so the `false` answer is
+        // exercised as well as the `true` one.
+        let absent = u16::MAX;
+        let mut agreed_true = 0;
+        let visited =
+            for_each_node_with_chain::<crate::langs::JavascriptCode>(code, |node, chain| {
+                for &id in kinds.iter().chain(std::iter::once(&absent)) {
+                    let known = node.has_sibling(Ancestors::known(chain), id);
+                    let climbing = node.has_sibling(Ancestors::unknown(), id);
+                    assert_eq!(
+                        known,
+                        climbing,
+                        "has_sibling({id}) on {} disagrees between chain and climb",
+                        node.kind()
+                    );
+                    agreed_true += usize::from(known);
+                }
+            });
+        assert!(visited > 20, "fixture is too small to prove much");
+        assert!(
+            agreed_true > 0,
+            "every answer was `false`, so the sibling scan never ran to a match"
+        );
+    }
+
+    /// [`Search::act_on_node`] must hand each node its true ancestry
+    /// even when the walk starts below the tree root.
+    ///
+    /// The seed is what decides this. [`Ancestors`] reads an empty chain
+    /// as "this node is the root", so seeding empty — which is correct
+    /// for the one caller that exists today, `bca function`, whose walk
+    /// starts at the root — would report no parent for the subtree root
+    /// and shift every answer beneath it. For the JS getters that means
+    /// losing the `variable_declarator` a `function_expression` takes
+    /// its name from, so the space would silently be named
+    /// `<anonymous>`.
+    ///
+    /// No caller passes a subtree yet, so nothing else would catch this;
+    /// the fixture below is the guard, and it fails against an empty
+    /// seed both here and through `Ancestors::checked`'s debug
+    /// assertion.
+    #[test]
+    fn act_on_node_hands_a_subtree_its_real_ancestry() {
+        let code = b"var outer = function () { return 1; };\n";
+        let tree = Tree::new::<MozjsCode>(code);
+        let root = tree.get_root();
+        let subtree = root
+            .preorder()
+            .find(|n| n.kind() == "variable_declarator")
+            .expect("fixture has a variable_declarator");
+        assert!(
+            subtree.parent().is_some(),
+            "the walk must start below the root, else the seed is vacuous"
+        );
+
+        let mut visited = 0;
+        subtree.act_on_node(&mut |node, ancestors| {
+            assert_eq!(
+                ancestors.parent(node).map(|p| p.id()),
+                node.parent().map(|p| p.id()),
+                "parent of {} disagrees with the tree",
+                node.kind()
+            );
+            visited += 1;
+        });
+        assert!(visited > 3, "subtree is too small to prove much");
     }
 
     /// `previous_sibling` must not answer "no previous sibling" when the

--- a/src/node.rs
+++ b/src/node.rs
@@ -162,12 +162,9 @@ impl<'a> Node<'a> {
     /// Returns `true` if this node's parent has any direct child with
     /// the given grammar `kind_id` (the parent's children include this
     /// node itself, so a self-match counts). Delegates to [`wraps_any`]
-    /// on the parent so the scan reuses the allocation-free `child(0)` +
-    /// `next_sibling()` walk rather than `children(&mut parent.walk())`,
-    /// which heap-allocates a `TreeCursor` per call. This sits on the
-    /// JS/TS arrow-function closure-classification hot path
-    /// (`check_if_arrow_func!`), the same path #217 optimized for
-    /// `wraps_any` / `is_child` but missed here. See #521.
+    /// on the parent. This sits on the JS/TS arrow-function
+    /// closure-classification hot path (`check_if_arrow_func!`); see
+    /// #521.
     ///
     /// [`wraps_any`]: Self::wraps_any
     #[inline]
@@ -182,13 +179,8 @@ impl<'a> Node<'a> {
     }
 
     /// Returns `true` if any direct child has the given grammar
-    /// `kind_id`. Walks via `child(0)` + `next_sibling()` instead of
-    /// `children(&mut self.0.walk())` so the implementation avoids
-    /// the per-call `TreeCursor` heap allocation that the iterator
-    /// form requires. Each `next_sibling()` is O(1) (tree-sitter
-    /// stores siblings as a linked list), so total cost is O(n)
-    /// without cursor overhead. See #217 for the motivating perf
-    /// finding from the JS/TS template-literal hot path.
+    /// `kind_id`. See #217 for the motivating perf finding from the
+    /// JS/TS template-literal hot path.
     #[inline]
     pub(crate) fn is_child(&self, id: u16) -> bool {
         self.wraps_any(&[id])
@@ -196,23 +188,31 @@ impl<'a> Node<'a> {
 
     /// Returns `true` if any direct child matches one of the given
     /// grammar `kind_id`s. The single-id [`is_child`] delegates here, so
-    /// both share one allocation-free sibling walk (the `#[inline]` makes
-    /// the single-element `contains` collapse to an equality check — the
-    /// #217 hot-path optimization is preserved). Generalizing the check to
-    /// a set lets the shared string-interpolation operand skip declare its
-    /// rule once (issue #420).
+    /// both share one child scan (the `#[inline]` makes the
+    /// single-element `contains` collapse to an equality check).
+    /// Generalizing the check to a set lets the shared
+    /// string-interpolation operand skip declare its rule once (issue
+    /// #420).
+    ///
+    /// # Why a cursor rather than `child(0)` + `next_sibling()`
+    ///
+    /// #217 replaced the cursor walk with a `next_sibling()` chain to
+    /// dodge the `TreeCursor` heap allocation, on the premise that a
+    /// sibling step is `O(1)`. It is not: `ts_node_next_sibling`
+    /// resolves the parent first, and `tree_sitter` stores no parent
+    /// pointer — it descends from the root — so each step cost
+    /// `O(depth)` and the scan `O(children × depth)`. That made every
+    /// caller of this method `O(depth)` per node, which is the same
+    /// defect #1084 removed from the predicates that ask for an
+    /// ancestor outright. The cursor iterator is `O(children)` after one
+    /// allocation, and measured faster on real input as well as on a
+    /// pathological one: a metric walk over the 384-file `pdf.js`
+    /// corpus dropped from ~443 ms to ~370 ms (#1088).
     ///
     /// [`is_child`]: Self::is_child
     #[inline]
     pub(crate) fn wraps_any(&self, ids: &[u16]) -> bool {
-        let mut cur = self.0.child(0);
-        while let Some(c) = cur {
-            if ids.contains(&c.kind_id()) {
-                return true;
-            }
-            cur = c.next_sibling();
-        }
-        false
+        self.children().any(|c| ids.contains(&c.kind_id()))
     }
 
     pub(crate) fn child_count(&self) -> usize {
@@ -688,22 +688,32 @@ mod tests {
     use super::*;
     use crate::langs::MozjsCode;
 
-    /// The cursor-free [`Node::has_sibling`] (issue #521) must yield the
-    /// exact same result as the original `parent.children(&mut
-    /// parent.walk()).any(...)` form for every node and every kind in a
-    /// real tree: same child set (named + anonymous), same order, same
-    /// short-circuit. Comparing against the literal old logic node-by-node
-    /// proves equivalence without hardcoding grammar `kind_id`s.
-    fn old_has_sibling(node: OtherNode, id: u16) -> bool {
+    /// The `child(0)` + `next_sibling()` chain [`Node::wraps_any`] used
+    /// between #217 and #1088, kept here as the reference the cursor
+    /// walk that replaced it is checked against.
+    ///
+    /// The swap was made for cost, not for behaviour: a sibling step
+    /// resolves its parent, and `tree_sitter` resolves a parent by
+    /// descending from the root, so the chain was `O(children × depth)`
+    /// where the cursor is `O(children)`. Nothing about the *set* of
+    /// children was supposed to change, and this is what says so —
+    /// node-by-node over a real tree, same order and same short-circuit,
+    /// without hardcoding grammar `kind_id`s.
+    fn sibling_chain_has_sibling(node: OtherNode, id: u16) -> bool {
         node.parent().is_some_and(|parent| {
-            parent
-                .children(&mut parent.walk())
-                .any(|child| child.kind_id() == id)
+            let mut cur = parent.child(0);
+            while let Some(c) = cur {
+                if c.kind_id() == id {
+                    return true;
+                }
+                cur = c.next_sibling();
+            }
+            false
         })
     }
 
     #[test]
-    fn has_sibling_matches_cursor_iterator_form() {
+    fn has_sibling_matches_the_retired_sibling_chain() {
         // Arrow functions exercise the `check_if_arrow_func!` call site
         // that motivated #521 (PropertyIdentifier siblings on the JS/TS
         // closure-classification hot path).
@@ -733,8 +743,8 @@ mod tests {
             for &id in kinds.iter().chain(std::iter::once(&absent_id)) {
                 assert_eq!(
                     wrapped.has_sibling(id),
-                    old_has_sibling(n, id),
-                    "has_sibling diverged from cursor-iterator form at node kind {} for id {id}",
+                    sibling_chain_has_sibling(n, id),
+                    "has_sibling diverged from the retired sibling chain at node kind {} for id {id}",
                     n.kind(),
                 );
             }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -347,7 +347,6 @@ pub(crate) fn ops_inner<T: ParserTrait>(
 )]
 mod tests {
     use super::Ops;
-    use crate::node::Ancestors;
     use crate::{Ast, LANG, Source};
 
     #[inline]
@@ -880,6 +879,7 @@ mod tests {
     #[test]
     fn unit_space_name_is_none_not_anonymous() {
         use crate::getter::Getter;
+        use crate::node::Ancestors;
         use crate::traits::ParserTrait;
         use crate::{RustCode, RustParser, SpaceKind};
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -71,7 +71,12 @@ impl Ops {
         crate::wire::Ops::from(self)
     }
 
-    fn new<T: Getter>(node: &Node, code: &[u8], kind: SpaceKind) -> Self {
+    fn new<'a, T: Getter>(
+        node: &Node<'a>,
+        code: &[u8],
+        ancestors: Ancestors<'a, '_>,
+        kind: SpaceKind,
+    ) -> Self {
         let (start_position, end_position) = match kind {
             SpaceKind::Unit => {
                 if node.child_count() == 0 {
@@ -90,7 +95,7 @@ impl Ops {
         // default getter returns. Other kinds keep the AST-derived name.
         // Mirrors the `SpaceKind::Unit` handling in `FuncSpace::new`.
         let name = (kind != SpaceKind::Unit)
-            .then(|| T::get_func_space_name(node, code).map(str::to_owned))
+            .then(|| T::get_func_space_name(node, code, ancestors).map(str::to_owned))
             .flatten();
         Self {
             name,
@@ -130,7 +135,7 @@ fn push_synthetic_unit_root<T: ParserTrait>(
     // no ancestors to hand over either way.
     if T::Getter::get_space_kind_with_code(node, code, Ancestors::unknown()) != SpaceKind::Unit {
         state_stack.push(State {
-            ops: Ops::new::<T::Getter>(node, code, SpaceKind::Unit),
+            ops: Ops::new::<T::Getter>(node, code, Ancestors::unknown(), SpaceKind::Unit),
             halstead_maps: HalsteadMaps::new(),
         });
     }
@@ -213,6 +218,22 @@ fn finalize<T: ParserTrait>(state_stack: &mut Vec<State>, diff_level: usize) {
     }
 }
 
+/// Context the ops walk carries down the tree alongside each node.
+///
+/// A named pair rather than a `(usize, usize)`: the two counts advance
+/// on different events and swapping them is silent — `level` only moves
+/// at space boundaries while `depth` counts every AST step. Mirrors
+/// [`crate::spaces::compute`]'s `Walk`, minus the comment flag this walk
+/// has no use for.
+#[derive(Clone, Copy)]
+struct Walk {
+    /// Nesting level, used to close op-spaces on the way back up.
+    level: usize,
+    /// AST depth — the number of ancestors this node has, so the root
+    /// sits at `0`. Indexes the ancestor chain the walk maintains.
+    depth: usize,
+}
+
 /// Explicit-name core of the operator/operand walk backing the
 /// [`crate::Ast::ops`] `Source`-based seam. The top-level [`Ops::name`]
 /// is whatever the caller passes in `name`; `name_was_lossy` is left at
@@ -227,6 +248,10 @@ pub(crate) fn ops_inner<T: ParserTrait>(
     let mut cursor = node.cursor();
     let mut stack = Vec::new();
     let mut children = Vec::new();
+    // Ancestor chain of the node currently being visited, root first,
+    // maintained by the same truncate/push rule as
+    // `spaces::compute::metrics_inner` (#1084).
+    let mut chain: Vec<Node<'_>> = Vec::new();
     let mut state_stack: Vec<State> = Vec::new();
     let mut last_level = 0;
 
@@ -237,21 +262,24 @@ pub(crate) fn ops_inner<T: ParserTrait>(
     // succeeds (issue #789).
     push_synthetic_unit_root::<T>(&mut state_stack, &node, code);
 
-    stack.push((node, 0));
+    stack.push((node, Walk { level: 0, depth: 0 }));
 
-    while let Some((node, level)) = stack.pop() {
+    while let Some((node, Walk { level, depth })) = stack.pop() {
+        chain.truncate(depth);
+
         if level < last_level {
             finalize::<T>(&mut state_stack, last_level - level);
             last_level = level;
         }
 
         let kind = T::Getter::get_space_kind(&node);
+        let ancestors = Ancestors::checked(&chain, &node);
 
-        let func_space = T::Checker::is_func(&node) || T::Checker::is_func_space(&node);
+        let func_space = T::Checker::is_func(&node, ancestors) || T::Checker::is_func_space(&node);
 
         let new_level = if func_space {
             let state = State {
-                ops: Ops::new::<T::Getter>(&node, code, kind),
+                ops: Ops::new::<T::Getter>(&node, code, ancestors, kind),
                 halstead_maps: HalsteadMaps::new(),
             };
             state_stack.push(state);
@@ -265,6 +293,8 @@ pub(crate) fn ops_inner<T: ParserTrait>(
             T::Halstead::compute(&node, code, &mut state.halstead_maps);
         }
 
+        chain.push(node);
+
         // Shared with `metrics_inner` (issue #969): `push_children` is
         // State-independent — it only moves the cursor over child nodes —
         // so unlike the local `finalize` / `push_synthetic_unit_root`
@@ -273,7 +303,16 @@ pub(crate) fn ops_inner<T: ParserTrait>(
         // it encapsulates is load-bearing for suppression attribution.
         // The returned child slice is only useful to `metrics_inner`,
         // which seeds their cognitive nesting; `ops` just walks them.
-        push_children(&mut cursor, &node, new_level, &mut children, &mut stack);
+        push_children(
+            &mut cursor,
+            &node,
+            Walk {
+                level: new_level,
+                depth: depth + 1,
+            },
+            &mut children,
+            &mut stack,
+        );
     }
 
     finalize::<T>(&mut state_stack, usize::MAX);
@@ -308,6 +347,7 @@ pub(crate) fn ops_inner<T: ParserTrait>(
 )]
 mod tests {
     use super::Ops;
+    use crate::node::Ancestors;
     use crate::{Ast, LANG, Source};
 
     #[inline]
@@ -850,7 +890,7 @@ mod tests {
         // field, so the default getter would invent `<anonymous>`.
         assert_eq!(SpaceKind::Unit, RustCode::get_space_kind(&root));
 
-        let ops = super::Ops::new::<RustCode>(&root, code, SpaceKind::Unit);
+        let ops = super::Ops::new::<RustCode>(&root, code, Ancestors::unknown(), SpaceKind::Unit);
         assert_eq!(
             ops.name, None,
             "Unit space must preserve name = None, not invent <anonymous>"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -19,6 +19,7 @@ use crate::loc::Loc;
 use crate::mi::Mi;
 use crate::nargs::NArgs;
 use crate::nexits::Exit;
+use crate::node::Ancestors;
 use crate::nom::Nom;
 use crate::npa::Npa;
 use crate::npm::Npm;
@@ -182,7 +183,14 @@ impl<
                 "comment" => res.push(Box::new(T::is_comment)),
                 "error" => res.push(Box::new(T::is_error)),
                 "string" => res.push(Box::new(T::is_string)),
-                "function" => res.push(Box::new(T::is_func)),
+                // `Ancestors::unknown()`: a `--filter` predicate is applied
+                // to nodes the dump walk reaches without a chain. Only the
+                // JS-family `is_func` consults one, and it answers the same
+                // either way — a climb costs `O(depth)` rather than `O(1)`
+                // per matched function expression (#1088).
+                "function" => res.push(Box::new(|node: &Node| {
+                    T::is_func(node, Ancestors::unknown())
+                })),
                 _ => {
                     if let Ok(n) = f.parse::<u16>() {
                         // A numeric `-t`/`--type` value matches by raw

--- a/src/spaces.rs
+++ b/src/spaces.rs
@@ -266,7 +266,13 @@ impl FuncSpace {
         crate::wire::FuncSpace::from(self)
     }
 
-    fn new<T: Getter>(node: &Node, code: &[u8], kind: SpaceKind, selected: MetricSet) -> Self {
+    fn new<'a, T: Getter>(
+        node: &Node<'a>,
+        code: &[u8],
+        ancestors: Ancestors<'a, '_>,
+        kind: SpaceKind,
+        selected: MetricSet,
+    ) -> Self {
         let (start_position, end_position) = match kind {
             SpaceKind::Unit => {
                 if node.child_count() == 0 {
@@ -283,7 +289,7 @@ impl FuncSpace {
         // it here is wasted work. Other kinds keep the AST-derived name.
         let name = (kind != SpaceKind::Unit)
             .then(|| {
-                T::get_func_space_name(node, code)
+                T::get_func_space_name(node, code, ancestors)
                     .map(|name| name.split_whitespace().collect::<Vec<_>>().join(" "))
             })
             .flatten();

--- a/src/spaces/compute.rs
+++ b/src/spaces/compute.rs
@@ -260,7 +260,7 @@ fn compute_per_node<'a, T: ParserTrait>(
         T::Tokens::compute(node, &mut last.metrics.tokens, in_comment);
     }
     if selected.contains(Metric::Nargs) {
-        T::NArgs::compute(node, &mut last.metrics.nargs);
+        T::NArgs::compute(node, ancestors, &mut last.metrics.nargs);
     }
     if selected.contains(Metric::Nexits) {
         T::Exit::compute(node, code, &mut last.metrics.nexits);
@@ -293,7 +293,13 @@ fn push_synthetic_unit_root<T: ParserTrait>(
     // `Ancestors::unknown()`: `node` is the tree root here, so it has no
     // ancestors to hand over either way.
     if T::Getter::get_space_kind_with_code(node, code, Ancestors::unknown()) != SpaceKind::Unit {
-        let mut synthetic = FuncSpace::new::<T::Getter>(node, code, SpaceKind::Unit, selected);
+        let mut synthetic = FuncSpace::new::<T::Getter>(
+            node,
+            code,
+            Ancestors::unknown(),
+            SpaceKind::Unit,
+            selected,
+        );
         let (end_row, end_column) = node.end_position();
         synthetic
             .metrics
@@ -325,7 +331,7 @@ fn open_func_space<'a, T: ParserTrait>(
 ) -> usize {
     let kind = T::Getter::get_space_kind_with_code(node, code, ancestors);
     state_stack.push(State {
-        space: FuncSpace::new::<T::Getter>(node, code, kind, selected),
+        space: FuncSpace::new::<T::Getter>(node, code, ancestors, kind, selected),
         halstead_maps: HalsteadMaps::new(),
     });
     level + 1

--- a/src/spaces_tests.rs
+++ b/src/spaces_tests.rs
@@ -1,4 +1,5 @@
 use crate::MetricsOptions;
+use crate::node::Ancestors;
 use crate::spaces::metrics_inner;
 use crate::test_support::check_func_space;
 use crate::{CppParser, ParserTrait, SpaceKind};
@@ -68,7 +69,7 @@ fn cpp_function_definition_is_classified_as_function() {
         .expect("parse must produce a function_definition node");
 
     assert!(
-        CppCode::is_func(&fn_node),
+        CppCode::is_func(&fn_node, Ancestors::unknown()),
         "is_func must return true for a function_definition"
     );
     assert!(
@@ -81,7 +82,7 @@ fn cpp_function_definition_is_classified_as_function() {
         "get_space_kind must classify function_definition as Function"
     );
     assert_eq!(
-        CppCode::get_func_space_name(&fn_node, source.as_bytes()),
+        CppCode::get_func_space_name(&fn_node, source.as_bytes(), Ancestors::unknown()),
         Some("the_func"),
         "get_func_space_name must extract the declarator identifier"
     );

--- a/src/suppression.rs
+++ b/src/suppression.rs
@@ -571,48 +571,78 @@ pub struct SuppressionMarker {
 pub(crate) fn suppression_markers<T: ParserTrait>(parser: &T) -> Vec<SuppressionMarker> {
     let code = parser.code();
     let mut markers = Vec::new();
+    // Ancestor chain of the node currently being visited, root first.
+    // Maintained by the same truncate/push rule as
+    // `spaces::compute::metrics_inner`: this walk is pre-order, so every
+    // ancestor has already been visited and appended, and truncating to
+    // the node's depth drops the sibling subtree just finished (#1084).
+    let mut chain: Vec<Node<'_>> = Vec::new();
     // Explicit-stack DFS (not recursion) so a pathologically deep AST
     // cannot overflow the call stack. Each frame carries the nearest
     // enclosing function name, borrowed from `code`, so child nodes
-    // inherit it without re-deriving.
-    let mut stack: Vec<(Node<'_>, Option<&str>)> = vec![(parser.root(), None)];
-    while let Some((node, enclosing)) = stack.pop() {
-        if T::Checker::is_comment(&node)
-            && let Some(text) = node.utf8_text(code)
-            && let Ok(Some(suppression)) = parse_marker(text)
-        {
-            // File-scoped markers are whole-file by definition, so the
-            // enclosing function is irrelevant; report `None` to avoid a
-            // misleading "inside fn X" attribution.
-            let function = match suppression.kind {
-                SuppressionKind::Function => enclosing.map(str::to_owned),
-                SuppressionKind::File => None,
-            };
-            markers.push(SuppressionMarker {
-                line: node.start_row() + 1,
-                target: suppression.kind.into(),
-                scope: suppression.scope,
-                dialect: suppression.source.into(),
-                function,
-            });
+    // inherit it without re-deriving, plus the node's depth, which
+    // indexes `chain`.
+    let mut stack: Vec<(Node<'_>, Option<&str>, usize)> = vec![(parser.root(), None, 0)];
+    while let Some((node, enclosing, depth)) = stack.pop() {
+        chain.truncate(depth);
+
+        if let Some(marker) = marker_at::<T>(&node, code, enclosing) {
+            markers.push(marker);
         }
         // `is_func_with_code` rather than `is_func`: C/C++ identify
         // functions only via the code-aware predicate, and the default
-        // impl delegates to `is_func` for every other language.
-        // `Ancestors::unknown()`: this marker scan is its own walk and
-        // keeps no ancestor chain. Only Elixir's override climbs, and it
-        // does so once per `def`-shaped `Call`, not per node (#1088).
-        let child_enclosing = if T::Checker::is_func_with_code(&node, code, Ancestors::unknown()) {
-            T::Getter::get_func_name(&node, code).or(enclosing)
+        // impl delegates to `is_func` for every other language. The
+        // predicates that consult an ancestor — Elixir's `quote`
+        // template check, the JS-family name-binding walk — read it off
+        // `chain` rather than climbing with `Node::parent` (#1088).
+        let ancestors = Ancestors::checked(&chain, &node);
+        let child_enclosing = if T::Checker::is_func_with_code(&node, code, ancestors) {
+            T::Getter::get_func_name(&node, code, ancestors).or(enclosing)
         } else {
             enclosing
         };
+        chain.push(node);
         for child in node.children() {
-            stack.push((child, child_enclosing));
+            stack.push((child, child_enclosing, depth + 1));
         }
     }
     markers.sort_by_key(|m| m.line);
     markers
+}
+
+/// The suppression marker `node` carries, if it is a comment holding a
+/// well-formed one.
+///
+/// `enclosing` names the syntactically nearest enclosing function.
+/// File-scoped markers are whole-file by definition, so the enclosing
+/// function is irrelevant to them and reported as `None` rather than as
+/// a misleading "inside fn X".
+///
+/// A malformed native marker yields `None`: the audit is a read-only
+/// listing of what *is* a marker, and the threshold walk is the surface
+/// that already warns on malformed bodies.
+fn marker_at<T: ParserTrait>(
+    node: &Node<'_>,
+    code: &[u8],
+    enclosing: Option<&str>,
+) -> Option<SuppressionMarker> {
+    if !T::Checker::is_comment(node) {
+        return None;
+    }
+    let Ok(Some(suppression)) = parse_marker(node.utf8_text(code)?) else {
+        return None;
+    };
+    let function = match suppression.kind {
+        SuppressionKind::Function => enclosing.map(str::to_owned),
+        SuppressionKind::File => None,
+    };
+    Some(SuppressionMarker {
+        line: node.start_row() + 1,
+        target: suppression.kind.into(),
+        scope: suppression.scope,
+        dialect: suppression.source.into(),
+        function,
+    })
 }
 
 #[cfg(test)]

--- a/src/suppression.rs
+++ b/src/suppression.rs
@@ -1155,4 +1155,45 @@ mod tests {
         assert!(rust_markers("").is_empty());
         assert!(rust_markers("fn f() {}\n").is_empty());
     }
+
+    /// A comment the parser rejects contributes nothing to the audit,
+    /// and does not stop the walk from collecting the valid markers
+    /// around it.
+    ///
+    /// Two rejections reach [`marker_at`] and both must be silent here.
+    /// `parse_marker` answers `Ok(None)` for an ordinary comment that
+    /// simply is not a marker, and `Err` for one that *looks* like a
+    /// marker but is malformed — an unknown metric name voids the whole
+    /// list (see `native_mixed_valid_and_unknown_metric_voids_whole_marker`).
+    /// The audit is a read-only listing of what *is* a marker; the
+    /// threshold walk is the surface that warns on malformed bodies, so
+    /// dropping them without a diagnostic is the contract, not an
+    /// oversight.
+    ///
+    /// Without this, every comment the collector's tests feed it parses
+    /// successfully, and the reject arm is never taken.
+    #[test]
+    fn collector_skips_comments_that_are_not_valid_markers() {
+        let src = "// an ordinary comment\n\
+                   fn f() {\n\
+                   \x20   // bca: suppress(cyclomatic, no_such_metric)\n\
+                   \x20   // bca: suppress garbage\n\
+                   \x20   // bca: suppress(cognitive)\n\
+                   }\n";
+        let markers = rust_markers(src);
+        assert_eq!(
+            markers.len(),
+            1,
+            "only the well-formed marker is collected, got {markers:?}"
+        );
+        assert_eq!(markers[0].line, 5);
+        assert_eq!(markers[0].function.as_deref(), Some("f"));
+
+        // And a file of nothing but rejected comments yields nothing at
+        // all, rather than a marker with a defaulted scope.
+        assert!(
+            rust_markers("// bca: disable\n// not a marker at all\n").is_empty(),
+            "a rejected marker must not be collected with a fallback scope"
+        );
+    }
 }

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -10,7 +10,9 @@
 
 use std::path::PathBuf;
 
+use crate::node::{Node, Tree};
 use crate::spaces::metrics_inner;
+use crate::traits::LanguageInfo;
 use crate::{
     CodeMetrics, FuncSpace, LANG, MetricsOptions, ParserTrait, Source, SpaceKind, analyze,
 };
@@ -105,4 +107,38 @@ pub(crate) fn child_space<'a>(func_space: &'a FuncSpace, name: &str) -> &'a Func
         .iter()
         .find(|s| s.name.as_deref() == Some(name))
         .unwrap_or_else(|| panic!("expected a child FuncSpace named {name:?}"))
+}
+
+/// Visits `code`'s tree in pre-order, maintaining the ancestor chain
+/// exactly as `spaces::compute::metrics_inner` does, and hands each
+/// node to `check` together with that chain.
+///
+/// Keeping the bookkeeping identical to the walker's is the point: a
+/// test that built the chain some other way would prove
+/// [`crate::node::Ancestors`] self-consistent without proving the
+/// walker feeds it the right slice.
+pub(crate) fn for_each_node_with_chain<L: LanguageInfo>(
+    code: &[u8],
+    mut check: impl FnMut(&Node<'_>, &[Node<'_>]),
+) -> usize {
+    let tree = Tree::new::<L>(code);
+    let root = tree.get_root();
+    assert!(
+        !root.has_error(),
+        "fixture must parse cleanly, else the walk covers error recovery"
+    );
+
+    let mut chain: Vec<Node<'_>> = Vec::new();
+    let mut stack = vec![(root, 0_usize)];
+    let mut visited = 0;
+    while let Some((node, depth)) = stack.pop() {
+        chain.truncate(depth);
+        check(&node, &chain);
+        visited += 1;
+        chain.push(node);
+        let first = stack.len();
+        stack.extend(node.children().map(|child| (child, depth + 1)));
+        stack[first..].reverse();
+    }
+    visited
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -21,6 +21,7 @@ use crate::loc::Loc;
 use crate::mi::Mi;
 use crate::nargs::NArgs;
 use crate::nexits::Exit;
+use crate::node::Ancestors;
 use crate::node::Node;
 use crate::nom::Nom;
 use crate::npa::Npa;
@@ -74,7 +75,10 @@ pub(crate) trait ParserTrait {
 
 pub(crate) trait Search<'a> {
     fn first_occurrence(&self, pred: fn(u16) -> bool) -> Option<Node<'a>>;
-    fn act_on_node(&self, action: &mut dyn FnMut(&Node<'a>));
+    /// Visits every node of the subtree in source order, handing the
+    /// action each node's ancestor chain alongside it so a predicate it
+    /// applies stays off `Node::parent` (#1088).
+    fn act_on_node(&self, action: &mut dyn FnMut(&Node<'a>, Ancestors<'a, '_>));
     fn first_child(&self, pred: fn(u16) -> bool) -> Option<Node<'a>>;
     fn act_on_child(&self, action: &mut dyn FnMut(&Node<'a>));
 }


### PR DESCRIPTION
Closes #1088.

Retires the four `Node::parent` climbs #1084 deferred — and one cause
the issue did not name, which turned out to be the one that mattered.

## What changed

**`perf(node): scan a node's children with a cursor`** — `Node::wraps_any`,
reached from `is_child` and `has_sibling` and so from most languages'
checkers and getters, walked a node's children with `child(0)` +
`next_sibling()`. #217 chose that form over the cursor iterator to avoid
a `TreeCursor` allocation, on the stated premise that a sibling step is
`O(1)`. It is not: `ts_node_next_sibling` resolves the parent first, and
`tree_sitter` stores no parent pointer — it descends from the root. The
scan was `O(children × depth)`, making every caller `O(depth)` per node.

**`perf(metrics): thread the chain through the last climbs`** — three of
the four listed sites take an `Ancestors` parameter (JS-family
`is_func` / `is_closure` and the JS space-name getters, Elixir's
`get_func_space_name`, the suppression scan), plus Ruby's `is_closure`,
which the first pass missed. `ops_inner`, `act_on_node`, and
`suppression_markers` maintain chains of their own. All widened items
are `pub(crate)`; **the published API is unchanged**.

The fourth site wanted deleting, not threading. Elixir's `Npm` / `Npa`
`compute` opened with `is_func_space_with_code`, whose answer the
`defmodule` keyword check immediately below always discarded —
`elixir_is_class_macro` is exactly `defmodule`, so the classifier
admits precisely what that check admits, and every node whose
classification consulted the `quote`-template ancestor walk is rejected
by it regardless. Removing the call removes the work rather than making
it cheaper, and leaves both signatures untouched.

## Measurements

The issue's "worth measuring first" instinct is what caught the real
cause: threading the chain into the JS predicates left the probe at
`k = 1.97`. The walk is two steps long on that shape, so it should have
flattened — the remaining `O(depth)` was one level down, in
`wraps_any`. **A chain-fed predicate is only as linear as the
primitives it calls.**

| Probe | before | after |
|---|---|---|
| `nom/nested-arrow` (JS, one arrow per level) | `k = 1.97`, 17.6 s @ depth 4000 | `k = 1.03`, 6.3 ms |
| `nom/nested-declared-function` (shape control) | `k = 1.08` | `k = 1.08` |

Ordinary input benefits too: a metric walk over the 384-file `pdf.js`
corpus drops from ~443 ms to ~370 ms.

The probe deliberately uses *block*-bodied arrows, where the walk stops
in two steps. A chain of **expression**-bodied arrows
(`a => b => c => …`) is the one shape no chain can flatten — no stop
kind intervenes, so the walk itself is `O(depth)` long. Documented at
the macro rather than silently left.

## Metric values

Unchanged for every language. Full workspace suite green with no
`.snap.new` under the `big-code-analysis-output` submodule, so no
submodule bump is needed.

## Tests

Chain-vs-climb parity for every newly threaded consumer, each **verified
by perturbation** to fail against a wrong ancestor read: `is_func` /
`is_closure` across all four JS grammars plus Ruby, `get_func_space_name`
across all four JS grammars plus Elixir, `has_sibling`, a JS fixture
added to the existing `a_known_chain_answers_exactly_what_climbing_answers`,
the `bca function` span walk, and `act_on_node` on a subtree.
`wraps_any`'s equivalence test keeps its node-by-node comparison with the
reference flipped — the retired sibling chain is now the reference, so
what it pins is that the swap did not change the set of children
enumerated.

Two `Npm` / `Npa` parity tests written during the first pass were
**vacuous** and were replaced: they asserted that a known chain and a
climb agree, over a fixture where the ancestor answer never reached the
output — which is the redundancy described above, showing up as a test
that could not fail. The replacements pin counts over a `defmodule`
nested inside a `quote`.

## Follow-up

#1096 tracks the remaining per-node `node.parent()` calls (Halstead
`get_op_type` getters, `src/metrics/abc/`, the `loc` / `npm` / `npa` /
`cyclomatic` bodies). `docs/development/benchmarking.md` is updated to
point there, and the `Ancestors::unknown()` call sites that remain are
deliberate and documented at each.

## Validation

`make pre-commit` green, including the self-scan gate at both tiers.
`.bca-baseline.toml` net *shrank* — removing the redundant Elixir
classifier and reverting the unused `Npm` / `Npa` parameter took several
functions back below their recorded values.
