### PR TITLE
perf(metrics): retire the per-node Node::parent calls in the metric bodies

### DIFF
--- a/.bca-baseline.toml
+++ b/.bca-baseline.toml
@@ -98,14 +98,14 @@ value = 7.0
 [[entry]]
 path = "big-code-analysis-cli/src/commands/check.rs"
 qualified = "emit_check_results"
-start_line = 560
+start_line = 564
 metric = "nargs"
 value = 8.0
 
 [[entry]]
 path = "big-code-analysis-cli/src/commands/check.rs"
 qualified = "filter_by_baseline"
-start_line = 371
+start_line = 375
 metric = "nargs"
 value = 8.0
 
@@ -632,35 +632,56 @@ path = "src/getter/bash.rs"
 qualified = "BashCode::get_op_type"
 start_line = 31
 metric = "halstead.effort"
-value = 54681.01625588078
+value = 64170.027458982564
 
 [[entry]]
 path = "src/getter/elixir.rs"
 qualified = "ElixirCode::get_op_type"
 start_line = 142
 metric = "halstead.effort"
-value = 48241.44928566978
+value = 56464.822908007496
+
+[[entry]]
+path = "src/getter/irules.rs"
+qualified = "IrulesCode::get_op_type"
+start_line = 19
+metric = "halstead.effort"
+value = 53163.06867422894
 
 [[entry]]
 path = "src/getter/perl.rs"
 qualified = "PerlCode::get_op_type"
 start_line = 17
 metric = "halstead.effort"
-value = 65994.57830587434
+value = 76538.42828561828
 
 [[entry]]
 path = "src/getter/php.rs"
 qualified = "PhpCode::get_op_type"
 start_line = 31
 metric = "halstead.effort"
-value = 48279.902911067526
+value = 54691.60133906107
+
+[[entry]]
+path = "src/getter/python.rs"
+qualified = "PythonCode::get_op_type"
+start_line = 16
+metric = "halstead.effort"
+value = 48346.66496041094
 
 [[entry]]
 path = "src/getter/ruby.rs"
 qualified = "RubyCode::get_op_type"
 start_line = 21
 metric = "halstead.effort"
-value = 72634.96827369716
+value = 84039.86210807812
+
+[[entry]]
+path = "src/macros/mod.rs"
+qualified = "<file>"
+start_line = 1
+metric = "loc.sloc"
+value = 768.0
 
 [[entry]]
 path = "src/metrics/abc/c.rs"
@@ -672,21 +693,28 @@ value = 15.0
 [[entry]]
 path = "src/metrics/abc/cpp.rs"
 qualified = "CppCode::compute"
-start_line = 105
+start_line = 104
 metric = "cyclomatic"
 value = 15.0
 
 [[entry]]
 path = "src/metrics/abc/go.rs"
 qualified = "GoCode::compute"
-start_line = 95
+start_line = 94
 metric = "cyclomatic"
 value = 15.0
 
 [[entry]]
+path = "src/metrics/abc/go.rs"
+qualified = "GoCode::compute"
+start_line = 94
+metric = "halstead.effort"
+value = 50933.14135135399
+
+[[entry]]
 path = "src/metrics/abc/kotlin.rs"
 qualified = "KotlinCode::compute"
-start_line = 154
+start_line = 156
 metric = "cyclomatic"
 value = 16.0
 
@@ -707,21 +735,28 @@ value = 16.0
 [[entry]]
 path = "src/metrics/abc/perl.rs"
 qualified = "PerlCode::compute"
-start_line = 200
+start_line = 199
 metric = "halstead.effort"
-value = 67862.8313802447
+value = 71163.29612014526
 
 [[entry]]
 path = "src/metrics/abc/perl.rs"
 qualified = "perl_inspect_container"
 start_line = 55
 metric = "halstead.effort"
-value = 53345.08959628053
+value = 48499.6860937902
+
+[[entry]]
+path = "src/metrics/abc/php.rs"
+qualified = "php_count_unary_conditions"
+start_line = 95
+metric = "cognitive"
+value = 25.0
 
 [[entry]]
 path = "src/metrics/abc/rust.rs"
 qualified = "RustCode::compute"
-start_line = 128
+start_line = 127
 metric = "cyclomatic"
 value = 16.0
 
@@ -807,26 +842,47 @@ path = "src/metrics/loc/perl.rs"
 qualified = "PerlCode::compute"
 start_line = 17
 metric = "halstead.effort"
-value = 53115.849304792464
+value = 54303.845454620816
+
+[[entry]]
+path = "src/metrics/loc/shared.rs"
+qualified = "add_multiline_string_ploc"
+start_line = 136
+metric = "nargs"
+value = 7.0
+
+[[entry]]
+path = "src/metrics/npa/csharp.rs"
+qualified = "CsharpCode::compute"
+start_line = 12
+metric = "nargs"
+value = 7.0
+
+[[entry]]
+path = "src/metrics/npa/go.rs"
+qualified = "GoCode::compute"
+start_line = 42
+metric = "nargs"
+value = 7.0
 
 [[entry]]
 path = "src/metrics/npa/php.rs"
 qualified = "PhpCode::compute"
 start_line = 12
 metric = "halstead.effort"
-value = 49615.191188139346
+value = 52227.844233305164
 
 [[entry]]
 path = "src/metrics/npa/php.rs"
 qualified = "PhpCode::compute"
 start_line = 12
 metric = "nargs"
-value = 9.0
+value = 10.0
 
 [[entry]]
 path = "src/metrics/npa/python.rs"
 qualified = "python_self_attr_name_bytes"
-start_line = 297
+start_line = 302
 metric = "nexits"
 value = 6.0
 
@@ -835,28 +891,28 @@ path = "src/metrics/npm/go.rs"
 qualified = "GoCode::compute"
 start_line = 12
 metric = "halstead.effort"
-value = 64139.86021318563
+value = 65898.2477704053
 
 [[entry]]
 path = "src/metrics/npm/go.rs"
 qualified = "GoCode::compute"
 start_line = 12
 metric = "nargs"
-value = 9.0
+value = 10.0
 
 [[entry]]
 path = "src/node.rs"
 qualified = "Node<'a>"
 start_line = 75
 metric = "nom"
-value = 33.0
+value = 34.0
 
 [[entry]]
 path = "src/ops.rs"
 qualified = "ops_inner"
 start_line = 242
 metric = "halstead.effort"
-value = 73943.73373291224
+value = 74781.76504632097
 
 [[entry]]
 path = "src/output/checkstyle.rs"
@@ -954,7 +1010,7 @@ path = "src/spaces/compute.rs"
 qualified = "compute_per_node"
 start_line = 218
 metric = "halstead.effort"
-value = 58974.691740375616
+value = 62326.31232911353
 
 [[entry]]
 path = "src/spaces/compute.rs"
@@ -966,7 +1022,7 @@ value = 7.0
 [[entry]]
 path = "src/spaces/compute.rs"
 qualified = "metrics_inner"
-start_line = 513
+start_line = 514
 metric = "halstead.effort"
 value = 124910.02765596088
 
@@ -980,7 +1036,7 @@ value = 8.0
 [[entry]]
 path = "src/tools.rs"
 qualified = "read_file_with_eol"
-start_line = 140
+start_line = 141
 metric = "nexits"
 value = 7.0
 

--- a/.bca-baseline.toml
+++ b/.bca-baseline.toml
@@ -744,14 +744,7 @@ path = "src/metrics/abc/perl.rs"
 qualified = "perl_inspect_container"
 start_line = 55
 metric = "halstead.effort"
-value = 48499.6860937902
-
-[[entry]]
-path = "src/metrics/abc/php.rs"
-qualified = "php_count_unary_conditions"
-start_line = 95
-metric = "cognitive"
-value = 25.0
+value = 49178.00338181524
 
 [[entry]]
 path = "src/metrics/abc/rust.rs"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ for historical reference.
 - Benchmark harness for the metric walk, in the new workspace member
   `big-code-analysis-bench` (#1068). `cargo bench -p
   big-code-analysis-bench --bench scaling` (or `make bench-scaling`)
-  measures sixteen probes at three doubling nesting depths and fits
+  measures eighteen probes at three doubling nesting depths and fits
   `time ~ depth^k`, failing when a probe's exponent leaves its declared
   complexity class; `--bench metric_walk` (`make bench-walk`) runs
   criterion benchmarks per metric over a deterministic, self-reporting
@@ -143,14 +143,18 @@ for historical reference.
   parent from the caller that descended from it; and the
   comment-removal walk behind `bca remove-comments` maintains a chain of
   its own. All are `pub(crate)`, so the published API is unchanged, and
-  metric values are unchanged for every language. Three new probes and
-  two new controls guard the classes: `halstead/nested-not` fits
-  `time ~ depth^k` at **1.99** before and **0.99** after,
-  `abc/nested-if` at **2.00** and **1.14**, and `loc/nested-quote` at
-  **2.00** and **1.03**. At depth 4000 those three drop from ~478 ms to
-  ~0.57 ms, from ~808 ms to ~3.3 ms, and from ~9.6 s to ~9.2 ms; their
-  `halstead/nested-paren` and `abc/nested-block` shape controls hold at
-  0.97-1.18 either side. Per #1088's lesson, the primitives were checked
+  metric values are unchanged for every language. Python's `Cyclomatic`
+  `else` arm went the same way: it climbed two links through
+  `Node::parent_grandparent_match`, which no search for `.parent()`
+  finds at the call site. Four new probes and three new controls guard
+  the classes: `halstead/nested-not` fits `time ~ depth^k` at **1.99**
+  before and **0.99** after, `abc/nested-if` at **2.00** and **1.14**,
+  `cyclomatic/nested-ternary` at **2.06** and **1.27**, and
+  `loc/nested-quote` at **2.00** and **1.03**. At depth 4000 those four
+  drop from ~478 ms to ~0.57 ms, from ~808 ms to ~3.3 ms, from ~1.13 s
+  to ~3.4 ms, and from ~9.6 s to ~9.2 ms; their `halstead/nested-paren`,
+  `abc/nested-block`, and `cyclomatic/nested-and` shape controls hold at
+  0.97-1.31 either side. Per #1088's lesson, the primitives were checked
   too: the ABC walkers' `Node::previous_sibling` carried the same
   `O(depth)` (`ts_node__prev_sibling` opens with `ts_node_parent`) and
   now scans the known parent's children instead, through the new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ for historical reference.
 - Benchmark harness for the metric walk, in the new workspace member
   `big-code-analysis-bench` (#1068). `cargo bench -p
   big-code-analysis-bench --bench scaling` (or `make bench-scaling`)
-  measures eleven probes at three doubling nesting depths and fits
+  measures sixteen probes at three doubling nesting depths and fits
   `time ~ depth^k`, failing when a probe's exponent leaves its declared
   complexity class; `--bench metric_walk` (`make bench-walk`) runs
   criterion benchmarks per metric over a deterministic, self-reporting
@@ -134,6 +134,27 @@ for historical reference.
 
 ### Performance
 
+- The ancestor chain now reaches the per-language metric bodies, retiring
+  the last per-node `Node::parent` calls in the walk (#1096).
+  `Getter::get_op_type` (and its `_with_code` variant), `Abc::compute`,
+  `Npm::compute`, `Npa::compute`, `Cyclomatic::compute` /
+  `compute_with_options`, and `Checker::is_useful_comment` gained an
+  `Ancestors` parameter; the ABC condition walkers take the slot's
+  parent from the caller that descended from it; and the
+  comment-removal walk behind `bca remove-comments` maintains a chain of
+  its own. All are `pub(crate)`, so the published API is unchanged, and
+  metric values are unchanged for every language. Three new probes and
+  two new controls guard the classes: `halstead/nested-not` fits
+  `time ~ depth^k` at **1.99** before and **0.99** after,
+  `abc/nested-if` at **2.00** and **1.14**, and `loc/nested-quote` at
+  **2.00** and **1.03**. At depth 4000 those three drop from ~478 ms to
+  ~0.57 ms, from ~808 ms to ~3.3 ms, and from ~9.6 s to ~9.2 ms; their
+  `halstead/nested-paren` and `abc/nested-block` shape controls hold at
+  0.97-1.18 either side. Per #1088's lesson, the primitives were checked
+  too: the ABC walkers' `Node::previous_sibling` carried the same
+  `O(depth)` (`ts_node__prev_sibling` opens with `ts_node_parent`) and
+  now scans the known parent's children instead, through the new
+  `Node::previous_sibling_under`.
 - The ancestor chain now reaches the predicates #1084 left climbing, and
   the `ops`, `bca function`, and suppression-marker walks maintain one of
   their own (#1088). The JS-family `Checker::is_func` / `is_closure`

--- a/big-code-analysis-bench/src/shapes.rs
+++ b/big-code-analysis-bench/src/shapes.rs
@@ -66,6 +66,37 @@ pub fn nested_ifs(depth: usize) -> String {
     )
 }
 
+/// Rust: `fn f(x: bool) -> bool { !!!…x }`.
+///
+/// One `!` per nesting level, and `Getter::get_op_type`'s `BANG` arm
+/// asks each one whether its parent is an `inner_doc_comment_marker`
+/// (`//!`). That parent now comes off the walker's ancestor chain;
+/// calling `Node::parent` instead is `O(depth)` each, which made
+/// `Halstead` quadratic in nesting depth for the six grammars whose
+/// operator classification consults a parent (#1096).
+/// [`nested_parens`] is the same nesting through an arm that does not.
+#[must_use]
+pub fn nested_nots(depth: usize) -> String {
+    format!("fn f(x: bool) -> bool {{ {}x }}\n", "!".repeat(depth))
+}
+
+/// C: `int main(){ int x; { x = 1; { x = 1; … } } }`.
+///
+/// The linear control for [`nested_ifs`] under `Abc`: one
+/// `assignment_expression` per nesting level, which the metric counts
+/// from the node's own kind. No `if` / `while` head means no condition
+/// slot, so the C-family container walker — the one that reads the
+/// slot's parent to decide whether it sits in boolean context — is
+/// never entered.
+#[must_use]
+pub fn nested_blocks(depth: usize) -> String {
+    format!(
+        "int main(){{ int x; {}x = 1;{} }}\n",
+        "{ x = 1; ".repeat(depth),
+        "} ".repeat(depth)
+    )
+}
+
 /// C: `int main(){ while (a) { int x; … } }`.
 ///
 /// One `declaration` per nesting level. `loc`'s C-family arm resolves
@@ -342,6 +373,78 @@ pub const PROBES: &[Probe] = &[
                     walker's ancestor chain instead of calling \
                     `Node::parent`. `loc/nested-while` is the same \
                     nesting without a declaration.",
+    },
+    Probe {
+        name: "halstead/nested-paren",
+        lang: LANG::Rust,
+        metrics: &[Metric::Halstead],
+        render: nested_parens,
+        reading: |m| m.halstead.length(),
+        depths: LINEAR_DEPTHS,
+        max_exponent: LINEAR_BOUND,
+        rationale: "Shape control for `halstead/nested-not`: the same \
+                    nesting through `get_op_type` arms that classify a \
+                    token from its own kind, with no parent read.",
+    },
+    Probe {
+        name: "halstead/nested-not",
+        lang: LANG::Rust,
+        metrics: &[Metric::Halstead],
+        render: nested_nots,
+        reading: |m| m.halstead.length(),
+        depths: LINEAR_DEPTHS,
+        max_exponent: LINEAR_BOUND,
+        rationale: "#1096: `Getter::get_op_type` asks every `!` token \
+                    whether its parent is an inner-doc-comment marker. \
+                    The answer now indexes the walker's ancestor chain; \
+                    `Node::parent` was `O(depth)` per token across the \
+                    six grammars whose operator classification reads a \
+                    parent. `halstead/nested-paren` is the same nesting \
+                    without the read.",
+    },
+    Probe {
+        name: "abc/nested-block",
+        lang: LANG::C,
+        metrics: &[Metric::Abc],
+        render: nested_blocks,
+        reading: |m| m.abc.assignments_sum(),
+        depths: LINEAR_DEPTHS,
+        max_exponent: LINEAR_BOUND,
+        rationale: "Shape control for `abc/nested-if`: the same nesting \
+                    with no condition slot, so the C-family container \
+                    walker is never entered.",
+    },
+    Probe {
+        name: "abc/nested-if",
+        lang: LANG::C,
+        metrics: &[Metric::Abc],
+        render: nested_ifs,
+        reading: |m| m.abc.conditions_sum(),
+        depths: LINEAR_DEPTHS,
+        max_exponent: LINEAR_BOUND,
+        rationale: "#1096: every `if (…)` head routes its condition \
+                    through the C-family container walker, which seeds \
+                    its boolean-context flag from the slot's parent. \
+                    That parent is now passed in by the caller that \
+                    descended from it; resolving it with `Node::parent` \
+                    was `O(depth)` per `if` across all twenty `Abc` \
+                    impls. `abc/nested-block` is the same nesting \
+                    without a condition slot.",
+    },
+    Probe {
+        name: "loc/nested-quote",
+        lang: LANG::Elixir,
+        metrics: &[Metric::Loc],
+        render: nested_quotes,
+        reading: |m| m.loc.lloc(),
+        depths: LINEAR_DEPTHS,
+        max_exponent: LINEAR_BOUND,
+        rationale: "#1096: Elixir's `loc` catch-all arm asks every named \
+                    node whether its parent is a statement container, so \
+                    unlike the other group-3 arms it fires per node \
+                    rather than per construct. The parent now comes off \
+                    the walker's ancestor chain. `nom/nested-quote` is \
+                    the same shape under a metric that does not ask.",
     },
     Probe {
         name: "nom/nested-quote",

--- a/big-code-analysis-bench/src/shapes.rs
+++ b/big-code-analysis-bench/src/shapes.rs
@@ -34,6 +34,39 @@ pub fn nested_parens(depth: usize) -> String {
     )
 }
 
+/// Python: `x = (a and (a and (… a …)))`.
+///
+/// The linear control for [`nested_ternaries`]: one `and` operator per
+/// nesting level, which `Cyclomatic` counts from the token's own kind.
+/// Python's block syntax cannot nest statements without indenting them,
+/// which would make the input grow quadratically; parenthesised
+/// expressions are the only Python shape that nests at constant bytes
+/// per level.
+#[must_use]
+pub fn nested_ands(depth: usize) -> String {
+    format!("x = {}a{}\n", "(a and ".repeat(depth), ")".repeat(depth))
+}
+
+/// Python: `x = (1 if a else (1 if a else … 1 …))`.
+///
+/// One `else` token per nesting level. Python's `Cyclomatic` asks each
+/// one whether it opens a `for` / `while` / `try` else-clause — a
+/// two-link parent/grandparent test that short-circuits on the first
+/// link here, because a conditional expression's `else` has no
+/// `else_clause` parent. That one link was still `O(depth)` while it
+/// went through `Node::parent`, which is what made the shape quadratic
+/// before #1096; it now indexes the walker's ancestor chain.
+/// [`nested_ands`] is the same nesting through an arm that never looks
+/// up.
+#[must_use]
+pub fn nested_ternaries(depth: usize) -> String {
+    format!(
+        "x = {}1{}\n",
+        "(1 if a else ".repeat(depth),
+        ")".repeat(depth)
+    )
+}
+
 /// C: `int main(){ while (a) { … 1; … } }`.
 ///
 /// The linear control for [`nested_ifs`]: structurally identical, but
@@ -430,6 +463,32 @@ pub const PROBES: &[Probe] = &[
                     was `O(depth)` per `if` across all twenty `Abc` \
                     impls. `abc/nested-block` is the same nesting \
                     without a condition slot.",
+    },
+    Probe {
+        name: "cyclomatic/nested-and",
+        lang: LANG::Python,
+        metrics: &[Metric::Cyclomatic],
+        render: nested_ands,
+        reading: |m| m.cyclomatic.cyclomatic_sum(),
+        depths: LINEAR_DEPTHS,
+        max_exponent: LINEAR_BOUND,
+        rationale: "Shape control for `cyclomatic/nested-ternary`: the \
+                    same nesting through an arm that counts the token \
+                    from its own kind and never looks up.",
+    },
+    Probe {
+        name: "cyclomatic/nested-ternary",
+        lang: LANG::Python,
+        metrics: &[Metric::Cyclomatic],
+        render: nested_ternaries,
+        reading: |m| m.cyclomatic.cyclomatic_sum(),
+        depths: LINEAR_DEPTHS,
+        max_exponent: LINEAR_BOUND,
+        rationale: "#1096: Python's `Cyclomatic` asks every `else` token \
+                    whether it opens a loop or `try` else-clause, through \
+                    `Node::parent_grandparent_match`. Both links now index \
+                    the walker's ancestor chain. `cyclomatic/nested-and` \
+                    is the same nesting without the lookup.",
     },
     Probe {
         name: "loc/nested-quote",

--- a/docs/development/benchmarking.md
+++ b/docs/development/benchmarking.md
@@ -113,6 +113,8 @@ Read it as follows.
 | `halstead/nested-not` | Rust | `Getter::get_op_type`'s parent read (#1096) | linear |
 | `abc/nested-block` | C | shape control for the row below | linear |
 | `abc/nested-if` | C | the C-family ABC container walker (#1096) | linear |
+| `cyclomatic/nested-and` | Python | shape control for the row below | linear |
+| `cyclomatic/nested-ternary` | Python | `Node::parent_grandparent_match` (#1096) | linear |
 | `loc/nested-quote` | Elixir | `loc`'s Elixir catch-all arm (#1096) | linear |
 
 Four of these were quadratic when the harness landed, and they shared
@@ -150,11 +152,15 @@ bodies: the Halstead `get_op_type` getters, every `Abc` impl, and the
 `Halstead::compute`, `Abc::compute`, `Npm::compute`, `Npa::compute`,
 `Cyclomatic::compute`, and `Checker::is_useful_comment` gained an
 `Ancestors` parameter there, and the comment-removal walk grew a chain
-of its own. All three probes fitted 1.99-2.00 before and 0.99-1.14
-after; at depth 4000 `halstead/nested-not` dropped from ~478 ms to
-~0.57 ms, `abc/nested-if` from ~808 ms to ~3.3 ms, and
+of its own. A fourth call the issue had not listed turned up
+during review — Python's `Cyclomatic` `else` arm, reached through
+`Node::parent_grandparent_match`, which no `rg '\.parent\(\)'` sweep
+finds at the call site. All four probes fitted 1.99-2.06 before and
+0.99-1.27 after; at depth 4000 `halstead/nested-not` dropped from
+~478 ms to ~0.57 ms, `abc/nested-if` from ~808 ms to ~3.3 ms,
+`cyclomatic/nested-ternary` from ~1.13 s to ~3.4 ms, and
 `loc/nested-quote` from ~9.6 s to ~9.2 ms. Their controls held at
-0.97-1.18 either side.
+0.97-1.31 either side.
 
 That change also confirmed #1088's lesson a second time from the other
 direction. The ABC condition walkers reach a slot's parent to decide
@@ -179,7 +185,7 @@ threading, not every `O(depth)` lookup in the crate.
 [remaining-climbs]: https://github.com/dekobon/big-code-analysis/issues/1088
 [halstead-climbs]: https://github.com/dekobon/big-code-analysis/issues/1096
 
-The seven control probes are what make the other readings mean
+The eight control probes are what make the other readings mean
 something.
 
 - `nom/nested-while` and `nom/nested-fn` are **metric** controls.
@@ -188,13 +194,14 @@ something.
   difference from the `nom/…` row on the same shape, not the
   `cognitive` reading alone.
 - `loc/nested-while`, `cognitive/nested-while`,
-  `nom/nested-declared-function`, `halstead/nested-paren`, and
-  `abc/nested-block` are **shape** controls: each is the same nesting as
+  `nom/nested-declared-function`, `halstead/nested-paren`,
+  `abc/nested-block`, and `cyclomatic/nested-and` are **shape**
+  controls: each is the same nesting as
   the ancestor-walk probe it sits next to, with the one node that
   triggers the walk removed. Before [#1084][parent-walk] each fitted
   near 1.0 where its counterpart fitted near 2.0, which is what
   attributed the quadratic cost to that call rather than to nesting in
-  general. Now that all sixteen fit near 1.0, the pair is what would
+  general. Now that all eighteen fit near 1.0, the pair is what would
   localise a relapse: a probe drifting up while its control holds means
   the ancestor lookup, not the shape.
 

--- a/docs/development/benchmarking.md
+++ b/docs/development/benchmarking.md
@@ -109,6 +109,11 @@ Read it as follows.
 | `cognitive/nested-fn` | Rust | `increment_function_depth` (#1062) | linear |
 | `nom/nested-declared-function` | JavaScript | shape control for the row below | linear |
 | `nom/nested-arrow` | JavaScript | JS-family `is_func` / `is_closure` (#1088) | linear |
+| `halstead/nested-paren` | Rust | shape control for the row below | linear |
+| `halstead/nested-not` | Rust | `Getter::get_op_type`'s parent read (#1096) | linear |
+| `abc/nested-block` | C | shape control for the row below | linear |
+| `abc/nested-if` | C | the C-family ABC container walker (#1096) | linear |
+| `loc/nested-quote` | Elixir | `loc`'s Elixir catch-all arm (#1096) | linear |
 
 Four of these were quadratic when the harness landed, and they shared
 one cause: `tree_sitter` stores no parent pointer, so `Node::parent`
@@ -138,25 +143,27 @@ to 6.3 ms at depth 4000 (`k` 1.97 to 1.03), and a walk over the 384-file `pdf.js
 from ~443 ms to ~370 ms. The lesson generalises: a chain-fed predicate
 is only as linear as the primitives it calls.
 
-The remaining `Node::parent` climbs are tracked in
-[#1096][halstead-climbs]. Those are more than a handful and no probe
-covers them. The list below is illustrative, not exhaustive — `rg
-'\.parent\(\)' src/` is the authority:
+The last three probes come from [#1096][halstead-climbs], which
+retired the remaining `Node::parent` calls in the per-language metric
+bodies: the Halstead `get_op_type` getters, every `Abc` impl, and the
+`loc` / `npm` / `npa` / `cyclomatic` / `is_useful_comment` arms.
+`Halstead::compute`, `Abc::compute`, `Npm::compute`, `Npa::compute`,
+`Cyclomatic::compute`, and `Checker::is_useful_comment` gained an
+`Ancestors` parameter there, and the comment-removal walk grew a chain
+of its own. All three probes fitted 1.99-2.00 before and 0.99-1.14
+after; at depth 4000 `halstead/nested-not` dropped from ~478 ms to
+~0.57 ms, `abc/nested-if` from ~808 ms to ~3.3 ms, and
+`loc/nested-quote` from ~9.6 s to ~9.2 ms. Their controls held at
+0.97-1.18 either side.
 
-- the per-node `node.parent()` calls in the Halstead `get_op_type`
-  getters
-  (`src/getter/{python,rust,cpp,mozcpp,bash,irules}.rs`)
-  and in `src/metrics/abc/`;
-- per-node parent checks in several `loc` arms
-  (`src/metrics/loc/{python,lua,kotlin,perl,tcl,irules,elixir}.rs`),
-  in `src/metrics/npa/` and `src/metrics/npm/`, in
-  `src/metrics/cyclomatic/elixir.rs`, and in `src/checker/rust.rs`
-  (`is_useful_comment`, which takes no chain). `Npm::compute` /
-  `Npa::compute` take no ancestor chain either, so this group needs the
-  parameter threaded first. Ruby's `Checker::is_closure` was in this
-  list until #1088 gave `is_closure` a chain — it is the one non-JS
-  predicate of that pair that reads an ancestor, so it now reads it
-  from the chain like the JS family does.
+That change also confirmed #1088's lesson a second time from the other
+direction. The ABC condition walkers reach a slot's parent to decide
+whether it sits in boolean context, and the same walkers ask
+`Node::previous_sibling` whether a ternary's `?` / `:` precedes the
+operand — and `ts_node__prev_sibling` opens with `ts_node_parent`, so
+it carries the same `O(depth)`. Passing the parent in and scanning its
+children (`Node::previous_sibling_under`) was needed for the fix to
+hold on a ternary shape, not only on the shapes the probes render.
 
 The `Ancestors::unknown()` call sites that remain are deliberate rather
 than deferred: the two synthetic-`Unit`-root pushes hand it a node that
@@ -172,7 +179,7 @@ threading, not every `O(depth)` lookup in the crate.
 [remaining-climbs]: https://github.com/dekobon/big-code-analysis/issues/1088
 [halstead-climbs]: https://github.com/dekobon/big-code-analysis/issues/1096
 
-The five control probes are what make the other readings mean
+The seven control probes are what make the other readings mean
 something.
 
 - `nom/nested-while` and `nom/nested-fn` are **metric** controls.
@@ -180,15 +187,22 @@ something.
   the cognitive-attributable cost of each `cognitive/…` row is its
   difference from the `nom/…` row on the same shape, not the
   `cognitive` reading alone.
-- `loc/nested-while`, `cognitive/nested-while`, and
-  `nom/nested-declared-function` are **shape** controls: each is the same
-  nesting as the ancestor-walk probe it sits next to, with the one node
-  that triggers the walk removed. Before [#1084][parent-walk] each
-  fitted near 1.0 where its counterpart fitted near 2.0, which is what
+- `loc/nested-while`, `cognitive/nested-while`,
+  `nom/nested-declared-function`, `halstead/nested-paren`, and
+  `abc/nested-block` are **shape** controls: each is the same nesting as
+  the ancestor-walk probe it sits next to, with the one node that
+  triggers the walk removed. Before [#1084][parent-walk] each fitted
+  near 1.0 where its counterpart fitted near 2.0, which is what
   attributed the quadratic cost to that call rather than to nesting in
-  general. Now that all eleven fit near 1.0, the pair is what would
+  general. Now that all sixteen fit near 1.0, the pair is what would
   localise a relapse: a probe drifting up while its control holds means
   the ancestor lookup, not the shape.
+
+  `loc/nested-quote` is the one #1096 probe with no shape control of its
+  own: its Elixir arm fires for every named node, so there is no version
+  of the shape with the trigger removed. `nom/nested-quote` — the same
+  source under a metric that does not ask for a parent — is the metric
+  control that stands in for one.
 
 ### Adding a probe
 

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -247,8 +247,14 @@ pub(crate) trait Checker {
     fn is_comment(_: &Node) -> bool {
         false
     }
+    /// Whether this comment must survive `strip_comments`.
+    ///
+    /// `ancestors` is the chain the comment-removal walk descended
+    /// through. Rust's impl reads the parent to keep a comment that is
+    /// a macro token; reaching it with [`Node::parent`] costs
+    /// `O(depth)` per comment (#1096).
     #[inline]
-    fn is_useful_comment(_: &Node, _: &[u8]) -> bool {
+    fn is_useful_comment<'a>(_: &Node<'a>, _: &[u8], _: Ancestors<'a, '_>) -> bool {
         false
     }
     #[inline]

--- a/src/checker/c.rs
+++ b/src/checker/c.rs
@@ -8,7 +8,7 @@ impl Checker for CCode {
         node.kind_id() == C::Comment
     }
 
-    fn is_useful_comment(node: &Node, code: &[u8]) -> bool {
+    fn is_useful_comment<'a>(node: &Node<'a>, code: &[u8], _ancestors: Ancestors<'a, '_>) -> bool {
         get_aho_corasick_match(&code[node.start_byte()..node.end_byte()])
     }
 

--- a/src/checker/ccomment.rs
+++ b/src/checker/ccomment.rs
@@ -8,7 +8,7 @@ impl Checker for CcommentCode {
         node.kind_id() == Ccomment::Comment
     }
 
-    fn is_useful_comment(node: &Node, code: &[u8]) -> bool {
+    fn is_useful_comment<'a>(node: &Node<'a>, code: &[u8], _ancestors: Ancestors<'a, '_>) -> bool {
         get_aho_corasick_match(&code[node.start_byte()..node.end_byte()])
     }
 

--- a/src/checker/cpp.rs
+++ b/src/checker/cpp.rs
@@ -8,7 +8,7 @@ impl Checker for CppCode {
         node.kind_id() == Cpp::Comment
     }
 
-    fn is_useful_comment(node: &Node, code: &[u8]) -> bool {
+    fn is_useful_comment<'a>(node: &Node<'a>, code: &[u8], _ancestors: Ancestors<'a, '_>) -> bool {
         get_aho_corasick_match(&code[node.start_byte()..node.end_byte()])
     }
 

--- a/src/checker/mozcpp.rs
+++ b/src/checker/mozcpp.rs
@@ -8,7 +8,7 @@ impl Checker for MozcppCode {
         node.kind_id() == Mozcpp::Comment
     }
 
-    fn is_useful_comment(node: &Node, code: &[u8]) -> bool {
+    fn is_useful_comment<'a>(node: &Node<'a>, code: &[u8], _ancestors: Ancestors<'a, '_>) -> bool {
         get_aho_corasick_match(&code[node.start_byte()..node.end_byte()])
     }
 

--- a/src/checker/objc.rs
+++ b/src/checker/objc.rs
@@ -8,7 +8,7 @@ impl Checker for ObjcCode {
         node.kind_id() == Objc::Comment
     }
 
-    fn is_useful_comment(node: &Node, code: &[u8]) -> bool {
+    fn is_useful_comment<'a>(node: &Node<'a>, code: &[u8], _ancestors: Ancestors<'a, '_>) -> bool {
         get_aho_corasick_match(&code[node.start_byte()..node.end_byte()])
     }
 

--- a/src/checker/python.rs
+++ b/src/checker/python.rs
@@ -8,7 +8,7 @@ impl Checker for PythonCode {
         node.kind_id() == Python::Comment
     }
 
-    fn is_useful_comment(node: &Node, code: &[u8]) -> bool {
+    fn is_useful_comment<'a>(node: &Node<'a>, code: &[u8], _ancestors: Ancestors<'a, '_>) -> bool {
         // comment containing coding info are useful
         node.start_row() <= 1
             && RE

--- a/src/checker/rust.rs
+++ b/src/checker/rust.rs
@@ -8,8 +8,8 @@ impl Checker for RustCode {
         node.kind_id() == Rust::LineComment || node.kind_id() == Rust::BlockComment
     }
 
-    fn is_useful_comment(node: &Node, code: &[u8]) -> bool {
-        if let Some(parent) = node.parent()
+    fn is_useful_comment<'a>(node: &Node<'a>, code: &[u8], ancestors: Ancestors<'a, '_>) -> bool {
+        if let Some(parent) = ancestors.parent(node)
             && parent.kind_id() == Rust::TokenTree
         {
             // A comment could be a macro token

--- a/src/comment_rm.rs
+++ b/src/comment_rm.rs
@@ -7,6 +7,7 @@
 #![allow(clippy::enum_glob_use, clippy::if_not_else, clippy::wildcard_imports)]
 
 use crate::checker::Checker;
+use crate::node::{Ancestors, Node};
 use crate::traits::ParserTrait;
 
 /// Size of the fast-path newline buffers. A removed multi-line comment span
@@ -88,18 +89,29 @@ pub(crate) fn rm_comments<T: ParserTrait>(parser: &T) -> Option<Vec<u8>> {
     let mut stack = Vec::new();
     let mut cursor = node.cursor();
     let mut spans = Vec::new();
+    // Ancestor chain of the node currently being visited, root first,
+    // maintained by the same truncate/push rule as
+    // `spaces::compute::metrics_inner` (#1096). Rust's
+    // `is_useful_comment` reads the parent off it; `Node::parent` would
+    // cost `O(depth)` per comment.
+    let mut chain: Vec<Node<'_>> = Vec::new();
 
-    stack.push(node);
+    stack.push((node, 0));
 
-    while let Some(node) = stack.pop() {
-        if T::Checker::is_comment(&node) && !T::Checker::is_useful_comment(&node, parser.code()) {
+    while let Some((node, depth)) = stack.pop() {
+        chain.truncate(depth);
+        let ancestors = Ancestors::checked(&chain, &node);
+        if T::Checker::is_comment(&node)
+            && !T::Checker::is_useful_comment(&node, parser.code(), ancestors)
+        {
             let lines = node.end_row() - node.start_row();
             spans.push((node.start_byte(), node.end_byte(), lines));
         } else {
             cursor.reset(&node);
             if cursor.goto_first_child() {
+                chain.push(node);
                 loop {
-                    stack.push(cursor.node());
+                    stack.push((cursor.node(), depth + 1));
                     if !cursor.goto_next_sibling() {
                         break;
                     }
@@ -158,7 +170,7 @@ fn remove_from_code(code: &[u8], mut spans: Vec<(usize, usize, usize)>) -> Vec<u
 mod tests {
     use std::path::PathBuf;
 
-    use crate::{CcommentParser, ParserTrait};
+    use crate::{CcommentParser, ParserTrait, RustParser};
 
     use super::rm_comments;
 
@@ -242,6 +254,33 @@ mod tests {
             lf_count(&no_comments),
             lf_count(crlf_source),
             "comment removal must preserve the CRLF line count, not drop lines"
+        );
+    }
+
+    /// Rust's `Checker::is_useful_comment` keeps a comment that is a
+    /// macro token — one whose parent is a `token_tree` — because
+    /// deleting it would change what the macro expands. It reads that
+    /// parent off the ancestor chain `rm_comments` maintains rather
+    /// than calling `Node::parent` (#1096), so this pins that the chain
+    /// really reaches the comment: a chain that went stale would report
+    /// the wrong parent and strip the token.
+    #[test]
+    fn rust_keeps_a_macro_token_comment_and_strips_an_ordinary_one() {
+        let path = PathBuf::from("foo.rs");
+        let source =
+            "macro_rules! m {\n    () => {};\n}\nfn f() {\n    m!(/* keep */);\n}\n// strip\n";
+        let parser = RustParser::new(source.as_bytes().to_vec(), &path, None);
+
+        let stripped = rm_comments(&parser).expect("the `// strip` comment is removable");
+        let stripped = String::from_utf8(stripped).expect("stripping preserves UTF-8");
+
+        assert!(
+            stripped.contains("/* keep */"),
+            "a comment inside a macro token tree must survive: {stripped:?}"
+        );
+        assert!(
+            !stripped.contains("// strip"),
+            "an ordinary comment must still be stripped: {stripped:?}"
         );
     }
 }

--- a/src/comment_rm.rs
+++ b/src/comment_rm.rs
@@ -170,9 +170,22 @@ fn remove_from_code(code: &[u8], mut spans: Vec<(usize, usize, usize)>) -> Vec<u
 mod tests {
     use std::path::PathBuf;
 
-    use crate::{CcommentParser, ParserTrait, RustParser};
+    use crate::{
+        CParser, CcommentParser, CppParser, MozcppParser, ObjcParser, ParserTrait, RustParser,
+    };
 
     use super::rm_comments;
+
+    /// Strips `src` as language `T` and returns the result as text.
+    ///
+    /// Panics when nothing was removed, which every caller below relies
+    /// on: each fixture carries at least one strippable comment, so a
+    /// `None` means the walk stopped finding comments at all.
+    fn strip<T: ParserTrait>(src: &str, path: &str) -> String {
+        let parser = T::new(src.as_bytes().to_vec(), &PathBuf::from(path), None);
+        let stripped = rm_comments(&parser).expect("every fixture has a removable comment");
+        String::from_utf8(stripped).expect("stripping preserves UTF-8")
+    }
 
     const SOURCE_CODE: &str = "/* Remove this code block */\n\
                                int a = 42; // Remove this comment\n\
@@ -282,5 +295,44 @@ mod tests {
             !stripped.contains("// strip"),
             "an ordinary comment must still be stripped: {stripped:?}"
         );
+    }
+
+    /// The C-family `Checker::is_useful_comment` impls (C, C++, Mozilla
+    /// C++, Objective-C, and the comment-only `Ccomment` grammar) all
+    /// delegate to one Aho-Corasick automaton whose single needle is
+    /// `<div rustbindgen` — the marker `rust-bindgen` reads out of a
+    /// doc comment, so stripping it would change generated bindings.
+    /// Only `Ccomment` had a test; the other four impls were reached by
+    /// no test at all, which is how #1096 could add a parameter to all
+    /// five signatures with four of them uncovered.
+    ///
+    /// Each case pairs the marker comment with an ordinary one so a
+    /// `is_useful_comment` that answered `true` unconditionally — the
+    /// other way to make the first assertion pass — fails the second.
+    #[test]
+    fn the_c_family_keeps_a_rustbindgen_comment_and_strips_an_ordinary_one() {
+        // `/** <div rustbindgen ... */` is the shape bindgen documents;
+        // the needle is a plain substring match, so the surrounding
+        // syntax only has to parse as a comment in each grammar.
+        const SRC: &str = "/** <div rustbindgen opaque></div> */\nint a = 1;\n/* drop me */\n";
+
+        let cases = [
+            ("c", strip::<CParser>(SRC, "keep.c")),
+            ("cpp", strip::<CppParser>(SRC, "keep.cpp")),
+            ("mozcpp", strip::<MozcppParser>(SRC, "keep.cpp")),
+            ("objc", strip::<ObjcParser>(SRC, "keep.m")),
+            ("ccomment", strip::<CcommentParser>(SRC, "keep.c")),
+        ];
+
+        for (lang, stripped) in &cases {
+            assert!(
+                stripped.contains("<div rustbindgen"),
+                "{lang}: the bindgen marker comment must survive: {stripped:?}"
+            );
+            assert!(
+                !stripped.contains("drop me"),
+                "{lang}: an ordinary comment must still be stripped: {stripped:?}"
+            );
+        }
     }
 }

--- a/src/getter.rs
+++ b/src/getter.rs
@@ -102,7 +102,7 @@ macro_rules! impl_js_family_get_op_type {
         operand_extras: [$($operand_extra:ident),* $(,)?]
         $(, predefined_void: $predefined_type:ident)? $(,)?
     ) => {
-        fn get_op_type(node: &Node) -> HalsteadType {
+        fn get_op_type<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> HalsteadType {
             use $lang::*;
 
             // TS/TSX only: a `void` return / parameter type is parsed as a
@@ -232,7 +232,16 @@ pub(crate) trait Getter {
         Self::get_space_kind(node)
     }
 
-    fn get_op_type(_node: &Node) -> HalsteadType {
+    /// Classifies `node` as a Halstead operator, operand, or neither.
+    ///
+    /// `ancestors` is the chain the walker descended through. Six
+    /// impls read a parent from it to disambiguate a token whose role
+    /// depends on what encloses it — Python's `not` inside `not in`,
+    /// Rust's `||` inside a binary expression, the C++ namespace
+    /// identifier, Bash's `$name`, and iRules' `$var`. Reaching those
+    /// parents with [`Node::parent`] instead costs `O(depth)` per node
+    /// (#1096).
+    fn get_op_type<'a>(_node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> HalsteadType {
         HalsteadType::Unknown
     }
 
@@ -244,9 +253,15 @@ pub(crate) trait Getter {
     /// tokens with no structured interpolation node — the distinction
     /// between an interpolated `$name` and a literal `$5` is only
     /// visible in the source bytes (#454).
+    ///
+    /// [`get_op_type`]: Self::get_op_type
     #[inline]
-    fn get_op_type_with_code(node: &Node, _code: &[u8]) -> HalsteadType {
-        Self::get_op_type(node)
+    fn get_op_type_with_code<'a>(
+        node: &Node<'a>,
+        _code: &[u8],
+        ancestors: Ancestors<'a, '_>,
+    ) -> HalsteadType {
+        Self::get_op_type(node, ancestors)
     }
 
     /// Returns the source-byte slice used to key a Halstead *operand*.

--- a/src/getter.rs
+++ b/src/getter.rs
@@ -236,11 +236,12 @@ pub(crate) trait Getter {
     ///
     /// `ancestors` is the chain the walker descended through. Six
     /// impls read a parent from it to disambiguate a token whose role
-    /// depends on what encloses it — Python's `not` inside `not in`,
-    /// Rust's `||` inside a binary expression, the C++ namespace
-    /// identifier, Bash's `$name`, and iRules' `$var`. Reaching those
-    /// parents with [`Node::parent`] instead costs `O(depth)` per node
-    /// (#1096).
+    /// depends on what encloses it: Python's `not` / `in` / `is` inside
+    /// the compound `not in` / `is not`, Rust's `||` and `!` inside a
+    /// binary expression rather than a doc-comment marker, the
+    /// namespace identifier in both C++ grammars, Bash's `$name`, and
+    /// iRules' `$var`. Reaching those parents with [`Node::parent`]
+    /// instead costs `O(depth)` per node (#1096).
     fn get_op_type<'a>(_node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> HalsteadType {
         HalsteadType::Unknown
     }
@@ -273,7 +274,11 @@ pub(crate) trait Getter {
     /// distinct `"a "` operand and break parity with the long `${a}`
     /// form (#454).
     #[inline]
-    fn get_operand_id<'a>(node: &Node, code: &'a [u8]) -> &'a [u8] {
+    fn get_operand_id<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        _ancestors: Ancestors<'a, '_>,
+    ) -> &'a [u8] {
         &code[node.start_byte()..node.end_byte()]
     }
 

--- a/src/getter/bash.rs
+++ b/src/getter/bash.rs
@@ -28,7 +28,7 @@ impl Getter for BashCode {
         }
     }
 
-    fn get_op_type(node: &Node) -> HalsteadType {
+    fn get_op_type<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>) -> HalsteadType {
         match node.kind_id().into() {
             // Control flow and declaration keywords
             Bash::If | Bash::Then | Bash::Fi | Bash::Elif | Bash::Else
@@ -111,8 +111,8 @@ impl Getter for BashCode {
             // `variable_substitution`.
             Bash::VariableName | Bash::VariableName2 | Bash::VariableName3
             | Bash::SpecialVariableName | Bash::SpecialVariableName2 => {
-                if node
-                    .parent()
+                if ancestors
+                    .parent(node)
                     .is_some_and(|p| p.kind_id() == Bash::SimpleExpansion as u16)
                 {
                     HalsteadType::Unknown

--- a/src/getter/c.rs
+++ b/src/getter/c.rs
@@ -56,7 +56,7 @@ impl Getter for CCode {
         }
     }
 
-    fn get_op_type(node: &Node) -> HalsteadType {
+    fn get_op_type<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> HalsteadType {
         use C::*;
 
         // C's operator alphabet is the C++ set minus the C++-only forms

--- a/src/getter/cpp.rs
+++ b/src/getter/cpp.rs
@@ -77,7 +77,7 @@ impl Getter for CppCode {
         }
     }
 
-    fn get_op_type(node: &Node) -> HalsteadType {
+    fn get_op_type<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>) -> HalsteadType {
         use Cpp::*;
 
         // `LPAREN2` here (and the `LBRACK2`/`LBRACK3` aliases in the
@@ -112,7 +112,7 @@ impl Getter for CppCode {
             | Signed | Unsigned | Long | Short => HalsteadType::Operator,
             Identifier | TypeIdentifier | FieldIdentifier | RawStringLiteral | StringLiteral
             | NumberLiteral | True | False | Null | DOTDOTDOT => HalsteadType::Operand,
-            NamespaceIdentifier => match node.parent() {
+            NamespaceIdentifier => match ancestors.parent(node) {
                 Some(parent) if matches!(parent.kind_id().into(), NamespaceDefinition) => {
                     HalsteadType::Operand
                 }

--- a/src/getter/csharp.rs
+++ b/src/getter/csharp.rs
@@ -45,7 +45,7 @@ impl Getter for CsharpCode {
         }
     }
 
-    fn get_op_type(node: &Node) -> HalsteadType {
+    fn get_op_type<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> HalsteadType {
         use Csharp::*;
 
         match node.kind_id().into() {

--- a/src/getter/elixir.rs
+++ b/src/getter/elixir.rs
@@ -139,7 +139,7 @@ impl Getter for ElixirCode {
         Some("<anonymous>")
     }
 
-    fn get_op_type(node: &Node) -> HalsteadType {
+    fn get_op_type<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> HalsteadType {
         use Elixir as E;
 
         match node.kind_id().into() {

--- a/src/getter/go.rs
+++ b/src/getter/go.rs
@@ -16,7 +16,7 @@ impl Getter for GoCode {
         }
     }
 
-    fn get_op_type(node: &Node) -> HalsteadType {
+    fn get_op_type<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> HalsteadType {
         use Go as G;
 
         match node.kind_id().into() {

--- a/src/getter/groovy.rs
+++ b/src/getter/groovy.rs
@@ -43,7 +43,7 @@ impl Getter for GroovyCode {
         }
     }
 
-    fn get_op_type(node: &Node) -> HalsteadType {
+    fn get_op_type<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> HalsteadType {
         use Groovy::*;
         // Mirrors `JavaCode`'s minimal classification — modifiers
         // (`Public`, `Static`, …), declaration keywords (`Class`,

--- a/src/getter/irules.rs
+++ b/src/getter/irules.rs
@@ -16,7 +16,7 @@ impl Getter for IrulesCode {
         }
     }
 
-    fn get_op_type(node: &Node) -> HalsteadType {
+    fn get_op_type<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>) -> HalsteadType {
         match node.kind_id().into() {
             // Anonymous keyword tokens (the `*2` aliases are the keyword
             // literals; the unsuffixed high-id variants are the statement
@@ -116,8 +116,8 @@ impl Getter for IrulesCode {
             // parent check, not a kind exclusion (`Id2` here is a different,
             // non-surfacing token).
             Irules::Id => {
-                if node
-                    .parent()
+                if ancestors
+                    .parent(node)
                     .is_some_and(|p| p.kind_id() == Irules::VariableSubstitution as u16)
                 {
                     HalsteadType::Unknown

--- a/src/getter/java.rs
+++ b/src/getter/java.rs
@@ -34,7 +34,7 @@ impl Getter for JavaCode {
         }
     }
 
-    fn get_op_type(node: &Node) -> HalsteadType {
+    fn get_op_type<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> HalsteadType {
         use Java::*;
         // Some guides that informed grammar choice for Halstead
         // keywords, operators, literals: https://docs.oracle.com/javase/specs/jls/se18/html/jls-3.html#jls-3.12

--- a/src/getter/kotlin.rs
+++ b/src/getter/kotlin.rs
@@ -52,7 +52,7 @@ fn kotlin_leading_identifier_len(text: &str) -> usize {
 /// identifier prefix is sufficient; the prefix is the recovered operand
 /// and the remainder is literal text. Only a token with no identifier
 /// prefix (`"price: $5"` → `"5"`) stays literal.
-fn kotlin_is_short_interp_name(node: &Node, code: &[u8]) -> bool {
+fn kotlin_is_short_interp_name(node: &Node, previous: Option<Node<'_>>, code: &[u8]) -> bool {
     use Kotlin::{StringContent, StringContent2, StringContent3};
 
     // The grammar emits three aliased `string_content` kind ids
@@ -67,7 +67,7 @@ fn kotlin_is_short_interp_name(node: &Node, code: &[u8]) -> bool {
     if !STRING_CONTENT_KINDS.contains(&node.kind_id()) {
         return false;
     }
-    let Some(prev) = node.previous_sibling() else {
+    let Some(prev) = previous else {
         return false;
     };
     if !STRING_CONTENT_KINDS.contains(&prev.kind_id()) || prev.utf8_text(code) != Some("$") {
@@ -110,8 +110,15 @@ fn kotlin_short_interp_operand_bytes<'a>(node: &Node, code: &'a [u8]) -> &'a [u8
 fn kotlin_string_has_interp(node: &Node, code: &[u8]) -> bool {
     use Kotlin::Interpolation;
 
+    // The scan already holds each child's predecessor, so the short-form
+    // test gets it for free rather than through the `O(depth)`
+    // `Node::previous_sibling` (#1096).
+    let mut previous = None;
     node.children().any(|child| {
-        child.kind_id() == Interpolation as u16 || kotlin_is_short_interp_name(&child, code)
+        let found = child.kind_id() == Interpolation as u16
+            || kotlin_is_short_interp_name(&child, previous, code);
+        previous = Some(child);
+        found
     })
 }
 
@@ -226,7 +233,7 @@ impl Getter for KotlinCode {
             // those are left as literal text rather than emitting a
             // partial-literal operand.
             StringContent | StringContent2 | StringContent3
-                if kotlin_is_short_interp_name(node, code) =>
+                if kotlin_is_short_interp_name(node, ancestors.previous_sibling(node), code) =>
             {
                 HalsteadType::Operand
             }
@@ -245,11 +252,15 @@ impl Getter for KotlinCode {
         }
     }
 
-    fn get_operand_id<'a>(node: &Node, code: &'a [u8]) -> &'a [u8] {
+    fn get_operand_id<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+    ) -> &'a [u8] {
         // Narrow a recovered short-interpolation name token to its
         // leading identifier prefix so `"$a $b"` keys operand `"a"`,
         // not `"a "`, matching the long `${a}` form (#454).
-        if kotlin_is_short_interp_name(node, code) {
+        if kotlin_is_short_interp_name(node, ancestors.previous_sibling(node), code) {
             kotlin_short_interp_operand_bytes(node, code)
         } else {
             &code[node.start_byte()..node.end_byte()]

--- a/src/getter/kotlin.rs
+++ b/src/getter/kotlin.rs
@@ -163,7 +163,7 @@ impl Getter for KotlinCode {
         }
     }
 
-    fn get_op_type(node: &Node) -> HalsteadType {
+    fn get_op_type<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> HalsteadType {
         use Kotlin::*;
 
         match node.kind_id().into() {
@@ -206,7 +206,11 @@ impl Getter for KotlinCode {
         }
     }
 
-    fn get_op_type_with_code(node: &Node, code: &[u8]) -> HalsteadType {
+    fn get_op_type_with_code<'a>(
+        node: &Node<'a>,
+        code: &[u8],
+        ancestors: Ancestors<'a, '_>,
+    ) -> HalsteadType {
         use Kotlin::*;
 
         match node.kind_id().into() {
@@ -237,7 +241,7 @@ impl Getter for KotlinCode {
                     HalsteadType::Operand
                 }
             }
-            _ => Self::get_op_type(node),
+            _ => Self::get_op_type(node, ancestors),
         }
     }
 

--- a/src/getter/lua.rs
+++ b/src/getter/lua.rs
@@ -15,7 +15,7 @@ impl Getter for LuaCode {
         }
     }
 
-    fn get_op_type(node: &Node) -> HalsteadType {
+    fn get_op_type<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> HalsteadType {
         match node.kind_id().into() {
             // Control-flow and declaration keywords
             Lua::If

--- a/src/getter/mozcpp.rs
+++ b/src/getter/mozcpp.rs
@@ -77,7 +77,7 @@ impl Getter for MozcppCode {
         }
     }
 
-    fn get_op_type(node: &Node) -> HalsteadType {
+    fn get_op_type<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>) -> HalsteadType {
         use Mozcpp::*;
 
         // `LPAREN2` is a defensive arm (collapsed to `LPAREN` before
@@ -104,7 +104,7 @@ impl Getter for MozcppCode {
             | Signed | Unsigned | Long | Short => HalsteadType::Operator,
             Identifier | TypeIdentifier | FieldIdentifier | RawStringLiteral | StringLiteral
             | NumberLiteral | True | False | Null | DOTDOTDOT => HalsteadType::Operand,
-            NamespaceIdentifier => match node.parent() {
+            NamespaceIdentifier => match ancestors.parent(node) {
                 Some(parent) if matches!(parent.kind_id().into(), NamespaceDefinition) => {
                     HalsteadType::Operand
                 }

--- a/src/getter/objc.rs
+++ b/src/getter/objc.rs
@@ -72,7 +72,7 @@ impl Getter for ObjcCode {
         }
     }
 
-    fn get_op_type(node: &Node) -> HalsteadType {
+    fn get_op_type<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> HalsteadType {
         use Objc::*;
 
         // ObjC is C plus message sends, blocks, and the `@`-directives.

--- a/src/getter/perl.rs
+++ b/src/getter/perl.rs
@@ -14,7 +14,7 @@ impl Getter for PerlCode {
         }
     }
 
-    fn get_op_type(node: &Node) -> HalsteadType {
+    fn get_op_type<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> HalsteadType {
         use Perl as P;
 
         match node.kind_id().into() {

--- a/src/getter/php.rs
+++ b/src/getter/php.rs
@@ -28,7 +28,7 @@ impl Getter for PhpCode {
         }
     }
 
-    fn get_op_type(node: &Node) -> HalsteadType {
+    fn get_op_type<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> HalsteadType {
         use Php::*;
         match node.kind_id().into() {
             // Operator: control-flow keywords

--- a/src/getter/python.rs
+++ b/src/getter/python.rs
@@ -13,7 +13,7 @@ impl Getter for PythonCode {
         }
     }
 
-    fn get_op_type(node: &Node) -> HalsteadType {
+    fn get_op_type<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>) -> HalsteadType {
         use Python::*;
 
         match node.kind_id().into() {
@@ -24,7 +24,7 @@ impl Getter for PythonCode {
             // compounds, the compound itself is classified as the single
             // operator below, so the leaf must yield Unknown — otherwise
             // `a not in b` would count `not` + `in` as two operators (#413).
-            Not | In | Is => match node.parent().map(|p| p.kind_id().into()) {
+            Not | In | Is => match ancestors.parent(node).map(|p| p.kind_id().into()) {
                 Some(Notin | Isnot) => HalsteadType::Unknown,
                 _ => HalsteadType::Operator,
             },
@@ -60,7 +60,8 @@ impl Getter for PythonCode {
             String => {
                 // Docstring / module-level string statement: an `ExpressionStatement`
                 // whose only child is the string. Skip those.
-                let Some(parent) = node.parent() else {
+                let mut climb = ancestors.iter(node);
+                let Some((parent, _)) = climb.next() else {
                     return HalsteadType::Unknown;
                 };
                 if parent.kind_id() == ExpressionStatement && parent.child_count() == 1 {
@@ -74,7 +75,7 @@ impl Getter for PythonCode {
                 // contribution depend on how many literals it was split into
                 // (#695). Suppress every fragment of such a docstring.
                 if parent.kind_id() == ConcatenatedString
-                    && parent.parent().is_some_and(|grandparent| {
+                    && climb.next().is_some_and(|(grandparent, _)| {
                         grandparent.kind_id() == ExpressionStatement
                             && grandparent.child_count() == 1
                     })

--- a/src/getter/ruby.rs
+++ b/src/getter/ruby.rs
@@ -18,7 +18,7 @@ impl Getter for RubyCode {
         }
     }
 
-    fn get_op_type(node: &Node) -> HalsteadType {
+    fn get_op_type<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> HalsteadType {
         use Ruby as R;
 
         match node.kind_id().into() {

--- a/src/getter/rust.rs
+++ b/src/getter/rust.rs
@@ -33,7 +33,7 @@ impl Getter for RustCode {
         }
     }
 
-    fn get_op_type(node: &Node) -> HalsteadType {
+    fn get_op_type<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>) -> HalsteadType {
         use Rust::*;
 
         match node.kind_id().into() {
@@ -42,14 +42,14 @@ impl Getter for RustCode {
             // are not recognized as `ClosureExpression` and their `||` node is identified as `PIPEPIPE` instead of `ClosureParameters`.
             //
             // Similarly, exclude `/` when it corresponds to the third slash in `///` (`OuterDocCommentMarker`)
-            PIPEPIPE | SLASH => match node.parent() {
+            PIPEPIPE | SLASH => match ancestors.parent(node) {
                 Some(parent) if matches!(parent.kind_id().into(), BinaryExpression) => {
                     HalsteadType::Operator
                 }
                 _ => HalsteadType::Unknown,
             },
             // Ensure `!` is counted as an operator unless it belongs to an `InnerDocCommentMarker` `//!`
-            BANG => match node.parent() {
+            BANG => match ancestors.parent(node) {
                 Some(parent) if !matches!(parent.kind_id().into(), InnerDocCommentMarker) => {
                     HalsteadType::Operator
                 }

--- a/src/getter/tcl.rs
+++ b/src/getter/tcl.rs
@@ -12,7 +12,7 @@ impl Getter for TclCode {
         }
     }
 
-    fn get_op_type(node: &Node) -> HalsteadType {
+    fn get_op_type<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> HalsteadType {
         match node.kind_id().into() {
             // Anonymous keyword tokens (control-flow and declaration keywords).
             Tcl::Proc

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -37,7 +37,7 @@ macro_rules! get_language {
 // impl.
 macro_rules! implement_metric_trait {
     (Abc, $($code:ident),+) => (
-        implement_metric_trait!(@code_taking Abc, $($code),+);
+        implement_metric_trait!(@code_and_chain_taking Abc, $($code),+);
     );
     (Cognitive, $($code:ident),+) => (
         $(
@@ -59,32 +59,48 @@ macro_rules! implement_metric_trait {
     (Halstead, $($code:ident),+) => (
         $(
            impl Halstead for $code {
-               fn compute<'a>(_node: &Node<'a>, _code: &'a [u8], _halstead_maps: &mut HalsteadMaps<'a>) {}
+               fn compute<'a>(
+                   _node: &Node<'a>,
+                   _code: &'a [u8],
+                   _ancestors: crate::Ancestors<'a, '_>,
+                   _halstead_maps: &mut HalsteadMaps<'a>,
+               ) {}
            }
         )+
     );
     // Internal helper: shared no-op body for traits whose `compute`
-    // signature is `<'a>(&Node<'a>, &'a [u8], &mut Stats)` (Exit,
-    // Cyclomatic). Public arms below delegate here so the body is
-    // written once.
-    (@code_taking $trait:ident, $($code:ident),+) => (
+    // signature is `<'a>(&Node<'a>, &'a [u8], Ancestors<'a, '_>,
+    // &mut Stats)` (Abc, Cyclomatic, Npa, Npm). Public arms below
+    // delegate here so the body is written once.
+    (@code_and_chain_taking $trait:ident, $($code:ident),+) => (
         $(
            impl $trait for $code {
+               fn compute<'a>(
+                   _node: &Node<'a>,
+                   _code: &'a [u8],
+                   _ancestors: crate::Ancestors<'a, '_>,
+                   _stats: &mut Stats,
+               ) {}
+           }
+        )+
+    );
+    // `Exit` is the one metric whose `compute` still takes no ancestor
+    // chain: no language's exit rule asks what encloses the node.
+    (Exit, $($code:ident),+) => (
+        $(
+           impl Exit for $code {
                fn compute<'a>(_node: &Node<'a>, _code: &'a [u8], _stats: &mut Stats) {}
            }
         )+
     );
-    (Exit, $($code:ident),+) => (
-        implement_metric_trait!(@code_taking Exit, $($code),+);
-    );
     (Cyclomatic, $($code:ident),+) => (
-        implement_metric_trait!(@code_taking Cyclomatic, $($code),+);
+        implement_metric_trait!(@code_and_chain_taking Cyclomatic, $($code),+);
     );
     (Npa, $($code:ident),+) => (
-        implement_metric_trait!(@code_taking Npa, $($code),+);
+        implement_metric_trait!(@code_and_chain_taking Npa, $($code),+);
     );
     (Npm, $($code:ident),+) => (
-        implement_metric_trait!(@code_taking Npm, $($code),+);
+        implement_metric_trait!(@code_and_chain_taking Npm, $($code),+);
     );
     (Loc, $($code:ident),+) => (
         $(

--- a/src/metrics/abc.rs
+++ b/src/metrics/abc.rs
@@ -1820,6 +1820,81 @@ mod tests {
         );
     }
 
+    /// `groovy_walk_for_statement` splits on whether child(3) is the
+    /// `;` of an empty condition slot. The existing `for` test uses
+    /// `i < 10`, which the `LT` token arm counts on its own — the
+    /// walker's own branch never contributes there, so it stayed
+    /// uncovered. A bare-identifier condition has no comparison token,
+    /// so the count can only come from the walker.
+    #[test]
+    fn groovy_for_with_bare_identifier_condition() {
+        check_metrics::<GroovyParser>(
+            "void f(boolean go) {
+                for (int i = 0; go; i++) {
+                    println(i)
+                }
+            }",
+            "foo.groovy",
+            |metric| {
+                // `go` is the whole condition and counts once.
+                assert_eq!(metric.abc.conditions_sum(), 1);
+                // `int i = 0` (EQ) + `i++` (PLUSPLUS) = 2, as in
+                // `groovy_for_with_variable_declaration`.
+                assert_eq!(metric.abc.assignments_sum(), 2);
+            },
+        );
+    }
+
+    /// The other half of `groovy_walk_for_statement`'s split. With an
+    /// initialiser present the children are
+    /// `for ( init ; cond ; update )`, so child(3) is the separating
+    /// `;` and the condition is read from child(4). Drop the
+    /// initialiser and everything shifts left: child(3) *is* the
+    /// condition, which is the branch the shape above never reaches.
+    #[test]
+    fn groovy_for_with_empty_initializer_reads_the_condition_at_child_three() {
+        check_metrics::<GroovyParser>(
+            "void f(boolean go) {
+                int i = 0
+                for (; go; i++) {
+                    println(i)
+                }
+            }",
+            "foo.groovy",
+            |metric| {
+                assert_eq!(metric.abc.conditions_sum(), 1);
+                // `int i = 0` (EQ) + `i++` (PLUSPLUS), as above — the
+                // initialiser just moved out of the loop header.
+                assert_eq!(metric.abc.assignments_sum(), 2);
+            },
+        );
+    }
+
+    /// C#'s `csharp_walk_for_statement` reads the loop condition off
+    /// the named `condition` field and routes a parenthesised or
+    /// `!`-prefixed one through `csharp_inspect_container`. Every other
+    /// C# `for` test uses a comparison (`i < n`), which the `LT` token
+    /// arm counts without entering the walker.
+    #[test]
+    fn csharp_for_with_negated_condition() {
+        check_metrics::<CsharpParser>(
+            "class A {
+                void M(bool done) {
+                    for (int i = 0; !done; i++) { System.Console.WriteLine(i); }
+                }
+            }",
+            "foo.cs",
+            |metric| {
+                // `!done` unwraps to the `done` terminal: one condition,
+                // and no comparison token to double-count it.
+                assert_eq!(metric.abc.conditions_sum(), 1);
+                // `int i = 0` + `i++`.
+                assert_eq!(metric.abc.assignments_sum(), 2);
+                assert_eq!(metric.abc.branches_sum(), 1);
+            },
+        );
+    }
+
     #[test]
     fn groovy_eq_arm_increments_when_no_declaration() {
         // Bare reassignment of an already-declared variable: the

--- a/src/metrics/abc.rs
+++ b/src/metrics/abc.rs
@@ -376,12 +376,14 @@ where
     /// / `Halstead` / `Exit` / `Cognitive` pattern keeps the signature
     /// uniform.
     ///
-    /// `ancestors` is the chain the walker descended through. Most
-    /// languages classify a token by what encloses it somewhere in
-    /// their condition rules — Rust's `<` is a comparison only under a
-    /// `binary_expression`, C's `*` a dereference only under a unary
-    /// one — and reaching that parent with [`Node::parent`] costs
-    /// `O(depth)` per node (#1096).
+    /// `ancestors` is the chain the walker descended through. Nearly
+    /// every language classifies some token by what encloses it: `<`
+    /// and `>` are comparisons only under a binary expression (a type
+    /// -argument list otherwise), and `&&` / `||` reach their operands
+    /// through the enclosing chain node. Reaching that parent with
+    /// [`Node::parent`] costs `O(depth)` per node (#1096). The
+    /// condition-slot walkers take *their* parent as an argument
+    /// instead, because the caller descended from it.
     fn compute<'a>(
         node: &Node<'a>,
         code: &'a [u8],

--- a/src/metrics/abc.rs
+++ b/src/metrics/abc.rs
@@ -375,7 +375,19 @@ where
     /// target lives only in the source text. Matching the `Cyclomatic`
     /// / `Halstead` / `Exit` / `Cognitive` pattern keeps the signature
     /// uniform.
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], stats: &mut Stats);
+    ///
+    /// `ancestors` is the chain the walker descended through. Most
+    /// languages classify a token by what encloses it somewhere in
+    /// their condition rules — Rust's `<` is a comparison only under a
+    /// `binary_expression`, C's `*` a dereference only under a unary
+    /// one — and reaching that parent with [`Node::parent`] costs
+    /// `O(depth)` per node (#1096).
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    );
 }
 
 // Shared Phase-2B helper (issue #403): walk every named child of an
@@ -384,14 +396,21 @@ where
 // classifier. Used for `return value1, value2, ...` arms where the
 // values live one level below the return statement under a list
 // wrapper. The classifier receives only named children so that
-// `,` / `;` / `(` / `)` tokens never reach it.
-pub(super) fn for_each_named_child(list: &Node, conditions: &mut f64, f: fn(&Node, &mut f64)) {
+// `,` / `;` / `(` / `)` tokens never reach it, plus `list` itself as
+// the child's parent — the container classifiers seed their
+// boolean-context flag from the parent kind, and reaching it with
+// `Node::parent` would cost `O(depth)` per node (#1096).
+pub(super) fn for_each_named_child(
+    list: &Node,
+    conditions: &mut f64,
+    f: fn(&Node, &Node, &mut f64),
+) {
     let mut cursor = list.cursor();
     if cursor.goto_first_child() {
         loop {
             let child = cursor.node();
             if child.is_named() {
-                f(&child, conditions);
+                f(&child, list, conditions);
             }
             if !cursor.goto_next_sibling() {
                 break;

--- a/src/metrics/abc/bash.rs
+++ b/src/metrics/abc/bash.rs
@@ -13,7 +13,12 @@ use super::{Abc, Stats};
 use crate::*;
 
 impl Abc for BashCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        _ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         match node.kind_id().into() {
             // Each `variable_assignment` is one assignment regardless of
             // operator (`=`, `+=`, `-=`, …) — counting the parent node

--- a/src/metrics/abc/c.rs
+++ b/src/metrics/abc/c.rs
@@ -14,7 +14,12 @@ use super::{Abc, Stats};
 use crate::*;
 
 impl Abc for CCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use C::*;
 
         match node.kind_id().into() {
@@ -67,7 +72,7 @@ impl Abc for CCode {
             // because the grammar emits the node under two
             // production-rule paths.
             LT | GT
-                if node.parent().is_some_and(|p| {
+                if ancestors.parent(node).is_some_and(|p| {
                     matches!(p.kind_id().into(), BinaryExpression | BinaryExpression2)
                 }) =>
             {
@@ -76,7 +81,7 @@ impl Abc for CCode {
             // Fitzpatrick Rule 9 (Figure 3): each operand of a
             // `&&` / `||` chain is one condition (issue #403).
             AMPAMP | PIPEPIPE => {
-                if let Some(parent) = node.parent() {
+                if let Some(parent) = ancestors.parent(node) {
                     cpp_count_unary_conditions(&parent, &mut stats.conditions);
                 }
             }
@@ -93,7 +98,7 @@ impl Abc for CCode {
             // value field is always at index 1.
             IfStatement | WhileStatement => {
                 if let Some(cond) = node.child_by_field_name("condition") {
-                    cpp_inspect_container(&cond, &mut stats.conditions);
+                    cpp_inspect_container(&cond, node, &mut stats.conditions);
                 }
             }
             ReturnStatement => {

--- a/src/metrics/abc/cpp.rs
+++ b/src/metrics/abc/cpp.rs
@@ -24,17 +24,16 @@ use crate::*;
 // rules) — all render to one base name, so a single string arm covers each
 // family: equivalent to the former `Cpp`-enum match for Cpp, and
 // grammar-agnostic for Mozcpp.
-pub(super) fn cpp_inspect_container(container_node: &Node, conditions: &mut f64) {
+pub(super) fn cpp_inspect_container(container_node: &Node, parent: &Node, conditions: &mut f64) {
     let mut node = *container_node;
     let mut node_kind = node.kind();
-    let Some(parent) = node.parent() else { return };
     let parent_kind = parent.kind();
     let mut has_boolean_content = matches!(
         parent_kind,
         "binary_expression" | "if_statement" | "while_statement" | "do_statement" | "for_statement"
     ) || (parent_kind == "conditional_expression"
         && node
-            .previous_sibling()
+            .previous_sibling_under(parent)
             .is_none_or(|prev| !matches!(prev.kind(), "?" | ":")));
 
     loop {
@@ -75,7 +74,7 @@ pub(super) fn cpp_inspect_container(container_node: &Node, conditions: &mut f64)
 // the paren wrapper provides the unwrap step.
 pub(super) fn cpp_inspect_child(node: &Node, idx: usize, conditions: &mut f64) {
     if let Some(child) = node.child(idx) {
-        cpp_inspect_container(&child, conditions);
+        cpp_inspect_container(&child, node, conditions);
     }
 }
 
@@ -91,7 +90,7 @@ pub(super) fn cpp_count_unary_conditions(list_node: &Node, conditions: &mut f64)
             if matches!(node_kind, cpp_bool_terminal_kinds!()) && list_kind == "binary_expression" {
                 *conditions += 1.;
             } else if node.is_named() {
-                cpp_inspect_container(&node, conditions);
+                cpp_inspect_container(&node, list_node, conditions);
             }
 
             if !cursor.goto_next_sibling() {
@@ -102,7 +101,12 @@ pub(super) fn cpp_count_unary_conditions(list_node: &Node, conditions: &mut f64)
 }
 
 impl Abc for CppCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Cpp::*;
 
         match node.kind_id().into() {
@@ -173,7 +177,7 @@ impl Abc for CppCode {
             // because the C++ grammar emits the same node under two
             // production-rule paths.
             LT | GT
-                if node.parent().is_some_and(|p| {
+                if ancestors.parent(node).is_some_and(|p| {
                     matches!(p.kind_id().into(), BinaryExpression | BinaryExpression2)
                 }) =>
             {
@@ -182,7 +186,7 @@ impl Abc for CppCode {
             // Fitzpatrick Rule 9 (C++ in Figure 3): each operand of a
             // `&&` / `||` chain is one condition (issue #403).
             AMPAMP | PIPEPIPE => {
-                if let Some(parent) = node.parent() {
+                if let Some(parent) = ancestors.parent(node) {
                     cpp_count_unary_conditions(&parent, &mut stats.conditions);
                 }
             }
@@ -201,7 +205,7 @@ impl Abc for CppCode {
             // attribute precedes it.
             IfStatement | WhileStatement => {
                 if let Some(cond) = node.child_by_field_name("condition") {
-                    cpp_inspect_container(&cond, &mut stats.conditions);
+                    cpp_inspect_container(&cond, node, &mut stats.conditions);
                 }
             }
             ReturnStatement => {
@@ -247,6 +251,16 @@ mod tests {
         )
     }
 
+    // `cpp_inspect_container` takes the container's parent explicitly
+    // rather than resolving it, because `Node::parent` costs `O(depth)`
+    // on the metric walk (#1096). These tests reach their container by
+    // search rather than by descent, so the authoritative lookup is what
+    // supplies it here.
+    fn parent_of<'a>(node: &Node<'a>) -> Node<'a> {
+        node.parent()
+            .expect("every fixture below places its container under a parent node")
+    }
+
     // First node in pre-order (document order) whose kind name is `kind`.
     fn first_of_kind<'a>(node: Node<'a>, kind: &str) -> Option<Node<'a>> {
         let mut stack = vec![node];
@@ -286,7 +300,7 @@ mod tests {
         let cond = first_of_kind(p.root(), "condition_clause")
             .expect("`if (...)` produces a condition_clause");
         let mut conditions = 0.;
-        cpp_inspect_container(&cond, &mut conditions);
+        cpp_inspect_container(&cond, &parent_of(&cond), &mut conditions);
         assert_eq!(conditions, 1.);
     }
 
@@ -298,7 +312,7 @@ mod tests {
         let cond = first_of_kind(p.root(), "condition_clause")
             .expect("`if (...)` produces a condition_clause");
         let mut conditions = 0.;
-        cpp_inspect_container(&cond, &mut conditions);
+        cpp_inspect_container(&cond, &parent_of(&cond), &mut conditions);
         assert_eq!(conditions, 1.);
     }
 
@@ -311,7 +325,7 @@ mod tests {
         let cond = first_of_kind(p.root(), "condition_clause")
             .expect("`if (...)` produces a condition_clause");
         let mut conditions = 0.;
-        cpp_inspect_container(&cond, &mut conditions);
+        cpp_inspect_container(&cond, &parent_of(&cond), &mut conditions);
         assert_eq!(conditions, 1.);
     }
 
@@ -325,7 +339,7 @@ mod tests {
         let paren = first_of_kind(p.root(), "parenthesized_expression")
             .expect("`(a)` parses to a parenthesized_expression");
         let mut conditions = 0.;
-        cpp_inspect_container(&paren, &mut conditions);
+        cpp_inspect_container(&paren, &parent_of(&paren), &mut conditions);
         assert_eq!(conditions, 0.);
     }
 }

--- a/src/metrics/abc/csharp.rs
+++ b/src/metrics/abc/csharp.rs
@@ -15,7 +15,7 @@ use crate::macros::{
 };
 use crate::*;
 
-fn csharp_inspect_container(container_node: &Node, conditions: &mut f64) {
+fn csharp_inspect_container(container_node: &Node, parent: &Node, conditions: &mut f64) {
     use Csharp::*;
 
     let mut node = *container_node;
@@ -24,11 +24,10 @@ fn csharp_inspect_container(container_node: &Node, conditions: &mut f64) {
     // Seed the boolean-context flag from the parent: known-boolean
     // contexts (loop / if / binary expression) imply the contained
     // expression evaluates as a condition.
-    let Some(parent) = node.parent() else { return };
     let mut has_boolean_content = match parent.kind_id().into() {
         BinaryExpression | IfStatement | WhileStatement | DoStatement | ForStatement => true,
         ConditionalExpression => node
-            .previous_sibling()
+            .previous_sibling_under(parent)
             .is_none_or(|prev| !matches!(prev.kind_id().into(), QMARK | COLON)),
         _ => false,
     };
@@ -95,7 +94,7 @@ fn csharp_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
             {
                 *conditions += 1.;
             } else {
-                csharp_inspect_container(&node, conditions);
+                csharp_inspect_container(&node, list_node, conditions);
             }
 
             if !cursor.goto_next_sibling() {
@@ -164,7 +163,11 @@ fn csharp_count_token_branch(node: &Node, stats: &mut Stats) -> bool {
     false
 }
 
-fn csharp_count_token_condition(node: &Node, stats: &mut Stats) -> bool {
+fn csharp_count_token_condition<'a>(
+    node: &Node<'a>,
+    ancestors: Ancestors<'a, '_>,
+    stats: &mut Stats,
+) -> bool {
     use Csharp::*;
     match node.kind_id().into() {
         // The statement `switch` counts its `Case` arms; the `default:`
@@ -193,7 +196,7 @@ fn csharp_count_token_condition(node: &Node, stats: &mut Stats) -> bool {
         // delimiters of unsafe function-pointer types
         // (`delegate*<int, int>`).
         GT | LT => {
-            if let Some(parent) = node.parent()
+            if let Some(parent) = ancestors.parent(node)
                 && !matches!(
                     parent.kind_id().into(),
                     TypeArgumentList | TypeParameterList | FunctionPointerType
@@ -207,12 +210,16 @@ fn csharp_count_token_condition(node: &Node, stats: &mut Stats) -> bool {
     true
 }
 
-fn csharp_walk_for_conditions(node: &Node, stats: &mut Stats) {
+fn csharp_walk_for_conditions<'a>(
+    node: &Node<'a>,
+    ancestors: Ancestors<'a, '_>,
+    stats: &mut Stats,
+) {
     use Csharp::*;
     let conds = &mut stats.conditions;
     match node.kind_id().into() {
         AMPAMP | PIPEPIPE => {
-            if let Some(parent) = node.parent() {
+            if let Some(parent) = ancestors.parent(node) {
                 csharp_count_unary_conditions(&parent, conds);
             }
         }
@@ -226,7 +233,7 @@ fn csharp_walk_for_conditions(node: &Node, stats: &mut Stats) {
         // condition silently scored 0. See issue #370.
         IfStatement | WhileStatement => {
             if let Some(condition) = node.child(2) {
-                csharp_count_condition(&condition, conds);
+                csharp_count_condition(&condition, node, conds);
             }
         }
         // tree-sitter-c-sharp `do_statement` shape:
@@ -236,7 +243,7 @@ fn csharp_walk_for_conditions(node: &Node, stats: &mut Stats) {
         // of the #370 bug.
         DoStatement => {
             if let Some(condition) = node.child(4) {
-                csharp_count_condition(&condition, conds);
+                csharp_count_condition(&condition, node, conds);
             }
         }
         // `return value;` — child(1) is the value expression.
@@ -262,7 +269,7 @@ fn csharp_walk_for_conditions(node: &Node, stats: &mut Stats) {
 fn csharp_walk_conditional(node: &Node, stats: &mut Stats) {
     let conds = &mut stats.conditions;
     if let Some(condition) = node.child(0) {
-        csharp_count_condition(&condition, conds);
+        csharp_count_condition(&condition, node, conds);
     }
     csharp_inspect_child(node, 2, conds);
     csharp_inspect_child(node, 4, conds);
@@ -285,24 +292,29 @@ fn csharp_walk_for_statement(node: &Node, stats: &mut Stats) {
     } else if matches!(kind, csharp_paren_expr_kinds!())
         || matches!(kind, csharp_prefix_unary_expr_kinds!())
     {
-        csharp_inspect_container(&condition, &mut stats.conditions);
+        csharp_inspect_container(&condition, node, &mut stats.conditions);
     }
 }
 
 impl Abc for CsharpCode {
     // See `impl Abc for JavaCode` for the short-circuit-chain rationale
     // and the cross-helper-exclusivity invariant.
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         if csharp_count_token_assignment(node, stats) {
             return;
         }
         if csharp_count_token_branch(node, stats) {
             return;
         }
-        if csharp_count_token_condition(node, stats) {
+        if csharp_count_token_condition(node, ancestors, stats) {
             return;
         }
-        csharp_walk_for_conditions(node, stats);
+        csharp_walk_for_conditions(node, ancestors, stats);
     }
 }
 
@@ -312,17 +324,17 @@ impl Abc for CsharpCode {
 // `csharp_prefix_unary_expr_kinds!()`.
 fn csharp_inspect_child(node: &Node, idx: usize, conditions: &mut f64) {
     if let Some(child) = node.child(idx) {
-        csharp_inspect_container(&child, conditions);
+        csharp_inspect_container(&child, node, conditions);
     }
 }
 
-fn csharp_count_condition(condition: &Node, conditions: &mut f64) {
+fn csharp_count_condition(condition: &Node, parent: &Node, conditions: &mut f64) {
     let kind = condition.kind_id().into();
     if matches!(kind, csharp_bool_terminal_kinds!()) {
         *conditions += 1.;
     } else if matches!(kind, csharp_paren_expr_kinds!())
         || matches!(kind, csharp_prefix_unary_expr_kinds!())
     {
-        csharp_inspect_container(condition, conditions);
+        csharp_inspect_container(condition, parent, conditions);
     }
 }

--- a/src/metrics/abc/elixir.rs
+++ b/src/metrics/abc/elixir.rs
@@ -20,12 +20,11 @@ use crate::*;
 // Negation surfaces as `unary_operator` whose child(0) is the `!` token;
 // parenthesised operands parse as `block`. Both are unwrapped by
 // `elixir_inspect_container`.
-fn elixir_inspect_container(container_node: &Node, conditions: &mut f64) {
+fn elixir_inspect_container(container_node: &Node, parent: &Node, conditions: &mut f64) {
     use Elixir as E;
 
     let mut node = *container_node;
     let mut node_kind = node.kind_id().into();
-    let Some(parent) = node.parent() else { return };
     let mut has_boolean_content = matches!(
         parent.kind_id().into(),
         E::BinaryOperator | E::BinaryOperator2 | E::BinaryOperator3
@@ -86,7 +85,7 @@ fn elixir_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
             {
                 *conditions += 1.;
             } else if node.is_named() {
-                elixir_inspect_container(&node, conditions);
+                elixir_inspect_container(&node, list_node, conditions);
             }
 
             if !cursor.goto_next_sibling() {
@@ -129,7 +128,12 @@ impl Abc for ElixirCode {
     //   nodes; they are still `Call` nodes and so contribute one branch
     //   each, matching the issue's "branches = `|>`, function calls"
     //   instruction.
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Elixir as E;
 
         match node.kind_id().into() {
@@ -216,7 +220,7 @@ impl Abc for ElixirCode {
             // `if` Call already contributing one condition, `if a && b ||
             // c` reports 4 — consistent with the cyclomatic count.
             E::AMPAMP | E::PIPEPIPE | E::And | E::Or => {
-                if let Some(parent) = node.parent() {
+                if let Some(parent) = ancestors.parent(node) {
                     elixir_count_unary_conditions(&parent, &mut stats.conditions);
                 }
             }

--- a/src/metrics/abc/go.rs
+++ b/src/metrics/abc/go.rs
@@ -18,12 +18,11 @@ use crate::*;
 // selector access (`r.Field`), index access (`xs[i]`), and type
 // assertions (`x.(*T)`) — every kind whose evaluated value is implicitly
 // boolean in idiomatic Go for `if` / `for` conditions.
-fn go_inspect_container(container_node: &Node, conditions: &mut f64) {
+fn go_inspect_container(container_node: &Node, parent: &Node, conditions: &mut f64) {
     use Go as G;
 
     let mut node = *container_node;
     let mut node_kind = node.kind_id().into();
-    let Some(parent) = node.parent() else { return };
     let mut has_boolean_content = matches!(
         parent.kind_id().into(),
         G::BinaryExpression | G::IfStatement | G::ForStatement
@@ -55,13 +54,13 @@ fn go_inspect_container(container_node: &Node, conditions: &mut f64) {
 }
 
 // Phase-2B (issue #403): condition-slot dispatcher for Go.
-fn go_count_condition(condition: &Node, conditions: &mut f64) {
+fn go_count_condition(condition: &Node, parent: &Node, conditions: &mut f64) {
     use Go as G;
     let kind = condition.kind_id().into();
     if matches!(kind, go_bool_terminal_kinds!()) {
         *conditions += 1.;
     } else if matches!(kind, G::ParenthesizedExpression | G::UnaryExpression) {
-        go_inspect_container(condition, conditions);
+        go_inspect_container(condition, parent, conditions);
     }
 }
 
@@ -81,7 +80,7 @@ fn go_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
             {
                 *conditions += 1.;
             } else if node.is_named() {
-                go_inspect_container(&node, conditions);
+                go_inspect_container(&node, list_node, conditions);
             }
 
             if !cursor.goto_next_sibling() {
@@ -92,7 +91,12 @@ fn go_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
 }
 
 impl Abc for GoCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         // Aliased because `Go::Go` (the `go` keyword variant) collides
         // with the bare enum name in pattern position under
         // `use Go::*;` (same workaround as in cyclomatic / cognitive).
@@ -132,8 +136,8 @@ impl Abc for GoCode {
                 stats.conditions += 1.;
             }
             G::LT | G::GT
-                if node
-                    .parent()
+                if ancestors
+                    .parent(node)
                     .is_some_and(|p| matches!(p.kind_id().into(), G::BinaryExpression)) =>
             {
                 stats.conditions += 1.;
@@ -142,7 +146,7 @@ impl Abc for GoCode {
             // one condition (issue #403). The walker iterates immediate
             // children of the parent `binary_expression`.
             G::AMPAMP | G::PIPEPIPE => {
-                if let Some(parent) = node.parent() {
+                if let Some(parent) = ancestors.parent(node) {
                     go_count_unary_conditions(&parent, &mut stats.conditions);
                 }
             }
@@ -154,7 +158,7 @@ impl Abc for GoCode {
             // child(2) (not child(1), which is the init slot).
             G::IfStatement => {
                 if let Some(cond) = node.child_by_field_name("condition") {
-                    go_count_condition(&cond, &mut stats.conditions);
+                    go_count_condition(&cond, node, &mut stats.conditions);
                 }
             }
             // Phase-2B follow-up (findings.md #1): Go's `for` is its
@@ -168,7 +172,7 @@ impl Abc for GoCode {
             // dedicated guard.
             G::ForStatement => {
                 if let Some(cond) = node.child(1) {
-                    go_count_condition(&cond, &mut stats.conditions);
+                    go_count_condition(&cond, node, &mut stats.conditions);
                 }
             }
             // `return value` — Go wraps the return values in an

--- a/src/metrics/abc/groovy.rs
+++ b/src/metrics/abc/groovy.rs
@@ -13,17 +13,16 @@ use super::{Abc, DeclKind, Stats};
 use crate::macros::groovy_bool_terminal_kinds;
 use crate::*;
 
-fn groovy_inspect_container(container_node: &Node, conditions: &mut f64) {
+fn groovy_inspect_container(container_node: &Node, parent: &Node, conditions: &mut f64) {
     use Groovy::*;
 
     let mut node = *container_node;
     let mut node_kind = node.kind_id().into();
 
-    let Some(parent) = node.parent() else { return };
     let mut has_boolean_content = match parent.kind_id().into() {
         BinaryExpression | IfStatement | WhileStatement | DoWhileStatement | ForStatement => true,
         TernaryExpression => node
-            .previous_sibling()
+            .previous_sibling_under(parent)
             .is_none_or(|prev_node| !matches!(prev_node.kind_id().into(), QMARK | COLON)),
         _ => false,
     };
@@ -82,7 +81,7 @@ fn groovy_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
             {
                 *conditions += 1.;
             } else {
-                groovy_inspect_container(&node, conditions);
+                groovy_inspect_container(&node, list_node, conditions);
             }
 
             if !cursor.goto_next_sibling() {
@@ -107,7 +106,7 @@ fn groovy_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
 // `ParenthesizedExpression` / `!`-prefixed `UnaryExpression`.
 fn groovy_inspect_child(node: &Node, idx: usize, conditions: &mut f64) {
     if let Some(child) = node.child(idx) {
-        groovy_inspect_container(&child, conditions);
+        groovy_inspect_container(&child, node, conditions);
     }
 }
 
@@ -158,7 +157,11 @@ fn groovy_count_token_branch(node: &Node, stats: &mut Stats) -> bool {
 // unconditional fallthrough, so cyclomatic counts only the `Case` arms
 // (Groovy shares Java's `impl_cyclomatic_java_like!`, which matches
 // `Case` and never `Default`).
-fn groovy_count_token_condition(node: &Node, stats: &mut Stats) -> bool {
+fn groovy_count_token_condition<'a>(
+    node: &Node<'a>,
+    ancestors: Ancestors<'a, '_>,
+    stats: &mut Stats,
+) -> bool {
     use Groovy::*;
     match node.kind_id().into() {
         GTEQ | LTEQ | EQEQ | BANGEQ | Else | Case | QMARK | Try | Catch => {
@@ -166,7 +169,7 @@ fn groovy_count_token_condition(node: &Node, stats: &mut Stats) -> bool {
         }
         // Excludes `<` / `>` used for generic types (e.g. `List<String>`).
         GT | LT => {
-            if let Some(parent) = node.parent()
+            if let Some(parent) = ancestors.parent(node)
                 && !matches!(parent.kind_id().into(), TypeArguments)
             {
                 stats.conditions += 1.;
@@ -177,12 +180,16 @@ fn groovy_count_token_condition(node: &Node, stats: &mut Stats) -> bool {
     true
 }
 
-fn groovy_walk_for_conditions(node: &Node, stats: &mut Stats) {
+fn groovy_walk_for_conditions<'a>(
+    node: &Node<'a>,
+    ancestors: Ancestors<'a, '_>,
+    stats: &mut Stats,
+) {
     use Groovy::*;
     let conds = &mut stats.conditions;
     match node.kind_id().into() {
         AMPAMP | PIPEPIPE => {
-            if let Some(parent) = node.parent() {
+            if let Some(parent) = ancestors.parent(node) {
                 groovy_count_unary_conditions(&parent, conds);
             }
         }
@@ -194,14 +201,14 @@ fn groovy_walk_for_conditions(node: &Node, stats: &mut Stats) {
         // wrap the condition in a `parenthesized_expression`).
         IfStatement | WhileStatement => {
             if let Some(condition) = node.child(2) {
-                groovy_count_condition(&condition, conds);
+                groovy_count_condition(&condition, node, conds);
             }
         }
         // dekobon shape: [`do`, body, `while`, `(`, condition, `)`].
         // Condition is at child index 4.
         DoWhileStatement => {
             if let Some(condition) = node.child(4) {
-                groovy_count_condition(&condition, conds);
+                groovy_count_condition(&condition, node, conds);
             }
         }
         ReturnStatement => groovy_inspect_child(node, 1, conds),
@@ -214,7 +221,7 @@ fn groovy_walk_for_conditions(node: &Node, stats: &mut Stats) {
 fn groovy_walk_ternary(node: &Node, stats: &mut Stats) {
     let conds = &mut stats.conditions;
     if let Some(condition) = node.child(0) {
-        groovy_count_condition(&condition, conds);
+        groovy_count_condition(&condition, node, conds);
     }
     groovy_inspect_child(node, 2, conds);
     groovy_inspect_child(node, 4, conds);
@@ -230,35 +237,40 @@ fn groovy_walk_for_statement(node: &Node, stats: &mut Stats) {
         return;
     };
     if !matches!(condition.kind_id().into(), SEMI) {
-        groovy_count_condition(&condition, &mut stats.conditions);
+        groovy_count_condition(&condition, node, &mut stats.conditions);
         return;
     }
     let Some(cond) = node.child(4) else { return };
     if matches!(cond.kind_id().into(), SEMI | RPAREN) {
         stats.conditions += 1.;
     } else {
-        groovy_count_condition(&cond, &mut stats.conditions);
+        groovy_count_condition(&cond, node, &mut stats.conditions);
     }
 }
 
 impl Abc for GroovyCode {
     // See `impl Abc for JavaCode` for the short-circuit-chain rationale
     // and the cross-helper-exclusivity invariant.
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         if groovy_count_token_assignment(node, stats) {
             return;
         }
         if groovy_count_token_branch(node, stats) {
             return;
         }
-        if groovy_count_token_condition(node, stats) {
+        if groovy_count_token_condition(node, ancestors, stats) {
             return;
         }
-        groovy_walk_for_conditions(node, stats);
+        groovy_walk_for_conditions(node, ancestors, stats);
     }
 }
 
-fn groovy_count_condition(condition: &Node, conditions: &mut f64) {
+fn groovy_count_condition(condition: &Node, parent: &Node, conditions: &mut f64) {
     use Groovy::*;
     // Terminal set mirrors the C# fix in #372 (lesson #19):
     // `FieldAccess` (`obj.flag`), `CastExpression` (`v as Boolean` — the
@@ -274,7 +286,7 @@ fn groovy_count_condition(condition: &Node, conditions: &mut f64) {
             *conditions += 1.;
         }
         ParenthesizedExpression | UnaryExpression => {
-            groovy_inspect_container(condition, conditions);
+            groovy_inspect_container(condition, parent, conditions);
         }
         _ => {}
     }

--- a/src/metrics/abc/irules.rs
+++ b/src/metrics/abc/irules.rs
@@ -14,7 +14,12 @@ use crate::macros::irules_bool_terminal_kinds;
 use crate::*;
 
 impl Abc for IrulesCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         match node.kind_id().into() {
             // The `set name value` production is a first-class node.
             Irules::Set => {
@@ -62,7 +67,7 @@ impl Abc for IrulesCode {
             // a `&&`/`||`/`and`/`or` chain is one condition (#403). iRules'
             // keyword forms (`and`/`or`) get the same treatment as `&&`/`||`.
             Irules::AMPAMP | Irules::PIPEPIPE | Irules::And | Irules::Or => {
-                if let Some(parent) = node.parent() {
+                if let Some(parent) = ancestors.parent(node) {
                     irules_count_unary_conditions(&parent, &mut stats.conditions);
                 }
             }
@@ -91,10 +96,9 @@ fn irules_command_is_assignment(node: &Node, code: &[u8]) -> bool {
 
 // iRules counterpart of `tcl_inspect_container` (Fitzpatrick Rule 9): a
 // negated bare operand (`!$flag`) inside a boolean chain is one condition.
-fn irules_inspect_container(container_node: &Node, conditions: &mut f64) {
+fn irules_inspect_container(container_node: &Node, parent: &Node, conditions: &mut f64) {
     let mut node = *container_node;
     let mut node_kind = node.kind_id().into();
-    let Some(parent) = node.parent() else { return };
     let has_boolean_content = matches!(parent.kind_id().into(), Irules::BinopExpr);
 
     loop {
@@ -135,7 +139,7 @@ fn irules_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
             {
                 *conditions += 1.;
             } else if node.is_named() {
-                irules_inspect_container(&node, conditions);
+                irules_inspect_container(&node, list_node, conditions);
             }
 
             if !cursor.goto_next_sibling() {

--- a/src/metrics/abc/java.rs
+++ b/src/metrics/abc/java.rs
@@ -15,18 +15,17 @@ use crate::*;
 
 // Inspects the content of Java parenthesized expressions
 // and `Not` operators to find unary conditional expressions
-fn java_inspect_container(container_node: &Node, conditions: &mut f64) {
+fn java_inspect_container(container_node: &Node, parent: &Node, conditions: &mut f64) {
     use Java::*;
 
     let mut node = *container_node;
     let mut node_kind = node.kind_id().into();
 
     // Initializes the flag to true if the container is known to contain a boolean value
-    let Some(parent) = node.parent() else { return };
     let mut has_boolean_content = match parent.kind_id().into() {
         BinaryExpression | IfStatement | WhileStatement | DoStatement | ForStatement => true,
         TernaryExpression => node
-            .previous_sibling()
+            .previous_sibling_under(parent)
             .is_none_or(|prev_node| !matches!(prev_node.kind_id().into(), QMARK | COLON)),
         _ => false,
     };
@@ -102,7 +101,7 @@ fn java_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
                 *conditions += 1.;
             } else {
                 // Checks if the node is a unary condition container
-                java_inspect_container(&node, conditions);
+                java_inspect_container(&node, list_node, conditions);
             }
 
             // Moves the cursor to the next sibling node of the current node
@@ -128,7 +127,7 @@ fn java_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
 // `matches!` guard is needed at the call site.
 fn java_inspect_child(node: &Node, idx: usize, conditions: &mut f64) {
     if let Some(child) = node.child(idx) {
-        java_inspect_container(&child, conditions);
+        java_inspect_container(&child, node, conditions);
     }
 }
 
@@ -186,7 +185,11 @@ fn java_count_token_branch(node: &Node, stats: &mut Stats) -> bool {
 // statement switch (`default:`) and arrow switch (`default ->`) both
 // emit the same `Default` token under `switch_label`, so omitting it
 // here covers both forms.
-fn java_count_token_condition(node: &Node, stats: &mut Stats) -> bool {
+fn java_count_token_condition<'a>(
+    node: &Node<'a>,
+    ancestors: Ancestors<'a, '_>,
+    stats: &mut Stats,
+) -> bool {
     use Java::*;
     match node.kind_id().into() {
         GTEQ | LTEQ | EQEQ | BANGEQ | Else | Case | QMARK | Try | Catch => {
@@ -194,7 +197,7 @@ fn java_count_token_condition(node: &Node, stats: &mut Stats) -> bool {
         }
         // Excludes `<` / `>` used for generic types (`Box<T>`).
         GT | LT => {
-            if let Some(parent) = node.parent()
+            if let Some(parent) = ancestors.parent(node)
                 && !matches!(parent.kind_id().into(), TypeArguments)
             {
                 stats.conditions += 1.;
@@ -205,13 +208,13 @@ fn java_count_token_condition(node: &Node, stats: &mut Stats) -> bool {
     true
 }
 
-fn java_walk_for_conditions(node: &Node, stats: &mut Stats) {
+fn java_walk_for_conditions<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>, stats: &mut Stats) {
     use Java::*;
     let conds = &mut stats.conditions;
     match node.kind_id().into() {
         // Unary conditions in elements separated by `&&` / `||`.
         AMPAMP | PIPEPIPE => {
-            if let Some(parent) = node.parent() {
+            if let Some(parent) = ancestors.parent(node) {
                 java_count_unary_conditions(&parent, conds);
             }
         }
@@ -241,7 +244,7 @@ fn java_walk_ternary(node: &Node, stats: &mut Stats) {
         match condition.kind_id().into() {
             java_bool_terminal_kinds!() => *conds += 1.,
             ParenthesizedExpression | UnaryExpression => {
-                java_inspect_container(&condition, conds);
+                java_inspect_container(&condition, node, conds);
             }
             _ => {}
         }
@@ -285,7 +288,7 @@ fn java_walk_for_statement(node: &Node, stats: &mut Stats) {
                         stats.conditions += 1.;
                     }
                     ParenthesizedExpression | UnaryExpression => {
-                        java_inspect_container(&cond, &mut stats.conditions);
+                        java_inspect_container(&cond, node, &mut stats.conditions);
                     }
                     _ => {}
                 }
@@ -295,7 +298,7 @@ fn java_walk_for_statement(node: &Node, stats: &mut Stats) {
             stats.conditions += 1.;
         }
         ParenthesizedExpression | UnaryExpression => {
-            java_inspect_container(&condition, &mut stats.conditions);
+            java_inspect_container(&condition, node, &mut stats.conditions);
         }
         _ => {}
     }
@@ -315,16 +318,21 @@ impl Abc for JavaCode {
     // one helper. If you add a new arm covering a kind already matched
     // by an earlier helper, the earlier helper's `return` will silently
     // hide it — split the kinds across helpers explicitly instead.
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         if java_count_token_assignment(node, stats) {
             return;
         }
         if java_count_token_branch(node, stats) {
             return;
         }
-        if java_count_token_condition(node, stats) {
+        if java_count_token_condition(node, ancestors, stats) {
             return;
         }
-        java_walk_for_conditions(node, stats);
+        java_walk_for_conditions(node, ancestors, stats);
     }
 }

--- a/src/metrics/abc/js_family.rs
+++ b/src/metrics/abc/js_family.rs
@@ -30,19 +30,18 @@ use crate::*;
 // in an `if` / `while` / ternary slot.
 macro_rules! impl_js_family_unary_walker {
     ($Lang:ident, $inspect:ident, $count:ident, $terminals:path) => {
-        fn $inspect(container_node: &Node, conditions: &mut f64) {
+        fn $inspect(container_node: &Node, parent: &Node, conditions: &mut f64) {
             use $Lang::*;
 
             let mut node = *container_node;
             let mut node_kind = node.kind_id().into();
-            let Some(parent) = node.parent() else { return };
             let parent_kind = parent.kind_id().into();
             let mut has_boolean_content = matches!(
                 parent_kind,
                 BinaryExpression | IfStatement | WhileStatement | DoStatement | ForStatement
             ) || (matches!(parent_kind, TernaryExpression)
                 && node
-                    .previous_sibling()
+                    .previous_sibling_under(parent)
                     .is_none_or(|prev| !matches!(prev.kind_id().into(), QMARK | COLON)));
 
             loop {
@@ -84,7 +83,7 @@ macro_rules! impl_js_family_unary_walker {
                     if matches!(node_kind, $terminals!()) && matches!(list_kind, BinaryExpression) {
                         *conditions += 1.;
                     } else if node.is_named() {
-                        $inspect(&node, conditions);
+                        $inspect(&node, list_node, conditions);
                     }
 
                     if !cursor.goto_next_sibling() {
@@ -143,7 +142,12 @@ impl_js_family_unary_walker!(
 // expressions (`++`, `--`) always count.
 macro_rules! ts_abc_compute {
     ($lang:ident, $count_unary:path, $inspect_container:path) => {
-        fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+        fn compute<'a>(
+            node: &Node<'a>,
+            _code: &'a [u8],
+            ancestors: Ancestors<'a, '_>,
+            stats: &mut Stats,
+        ) {
             use $lang::*;
 
             match node.kind_id().into() {
@@ -196,7 +200,7 @@ macro_rules! ts_abc_compute {
                 // parameters (`Array<number>`, `class Foo<T> {}`); skip
                 // those, count only comparison usage.
                 GT | LT
-                    if node.parent().is_some_and(|p| {
+                    if ancestors.parent(node).is_some_and(|p| {
                         !matches!(p.kind_id().into(), TypeArguments | TypeParameters)
                     }) =>
                 {
@@ -205,7 +209,7 @@ macro_rules! ts_abc_compute {
                 // Fitzpatrick Rule 9: each operand of a `&&` / `||`
                 // chain is one condition (issue #403).
                 AMPAMP | PIPEPIPE => {
-                    if let Some(parent) = node.parent() {
+                    if let Some(parent) = ancestors.parent(node) {
                         $count_unary(&parent, &mut stats.conditions);
                     }
                 }
@@ -220,21 +224,21 @@ macro_rules! ts_abc_compute {
                 // parenthesized condition(3), `;`(4)).
                 IfStatement | WhileStatement => {
                     if let Some(cond) = node.child(1) {
-                        $inspect_container(&cond, &mut stats.conditions);
+                        $inspect_container(&cond, node, &mut stats.conditions);
                     }
                 }
                 DoStatement => {
                     // children: `do`(0), body(1), `while`(2),
                     // parenthesized condition(3), `;`(4).
                     if let Some(cond) = node.child(3) {
-                        $inspect_container(&cond, &mut stats.conditions);
+                        $inspect_container(&cond, node, &mut stats.conditions);
                     }
                 }
                 // `return value;` — value at child(1). The bare
                 // `return;` (no value) form has no child(1).
                 ReturnStatement => {
                     if let Some(value) = node.child(1) {
-                        $inspect_container(&value, &mut stats.conditions);
+                        $inspect_container(&value, node, &mut stats.conditions);
                     }
                 }
                 // Method-argument walker for `f(!a, !b)`.
@@ -277,7 +281,12 @@ impl Abc for TsxCode {
 //      assignment of the binding's lifetime.
 macro_rules! js_abc_compute {
     ($lang:ident, $count_unary:path, $inspect_container:path) => {
-        fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+        fn compute<'a>(
+            node: &Node<'a>,
+            _code: &'a [u8],
+            ancestors: Ancestors<'a, '_>,
+            stats: &mut Stats,
+        ) {
             use $lang::*;
 
             match node.kind_id().into() {
@@ -315,7 +324,7 @@ macro_rules! js_abc_compute {
                 // Fitzpatrick Rule 9: each operand of a `&&` / `||`
                 // chain is one condition (issue #403).
                 AMPAMP | PIPEPIPE => {
-                    if let Some(parent) = node.parent() {
+                    if let Some(parent) = ancestors.parent(node) {
                         $count_unary(&parent, &mut stats.conditions);
                     }
                 }
@@ -324,19 +333,19 @@ macro_rules! js_abc_compute {
                 // arm-block for the per-child-index rationale.
                 IfStatement | WhileStatement => {
                     if let Some(cond) = node.child(1) {
-                        $inspect_container(&cond, &mut stats.conditions);
+                        $inspect_container(&cond, node, &mut stats.conditions);
                     }
                 }
                 DoStatement => {
                     // children: `do`(0), body(1), `while`(2),
                     // parenthesized condition(3), `;`(4).
                     if let Some(cond) = node.child(3) {
-                        $inspect_container(&cond, &mut stats.conditions);
+                        $inspect_container(&cond, node, &mut stats.conditions);
                     }
                 }
                 ReturnStatement => {
                     if let Some(value) = node.child(1) {
-                        $inspect_container(&value, &mut stats.conditions);
+                        $inspect_container(&value, node, &mut stats.conditions);
                     }
                 }
                 Arguments => {

--- a/src/metrics/abc/kotlin.rs
+++ b/src/metrics/abc/kotlin.rs
@@ -29,10 +29,13 @@ use crate::*;
 // child of a `property_declaration` or `class_parameter`, and that parent
 // must carry a `val` keyword child. A `var`/plain declaration initialiser
 // and any standalone `assignment` return false (they count).
-fn kotlin_eq_initializes_immutable_binding(eq_node: &Node) -> bool {
+fn kotlin_eq_initializes_immutable_binding<'a>(
+    eq_node: &Node<'a>,
+    ancestors: Ancestors<'a, '_>,
+) -> bool {
     use Kotlin::*;
 
-    let Some(parent) = eq_node.parent() else {
+    let Some(parent) = ancestors.parent(eq_node) else {
         return false;
     };
     if !matches!(
@@ -51,12 +54,11 @@ fn kotlin_eq_initializes_immutable_binding(eq_node: &Node) -> bool {
 // `unary_expression` whose child(0) is the `!` token; the condition slot
 // may also be wrapped in `parenthesized_expression`. Both are unwrapped
 // by `kotlin_inspect_container` to reach the inner bare operand.
-fn kotlin_inspect_container(container_node: &Node, conditions: &mut f64) {
+fn kotlin_inspect_container(container_node: &Node, parent: &Node, conditions: &mut f64) {
     use Kotlin::*;
 
     let mut node = *container_node;
     let mut node_kind = node.kind_id().into();
-    let Some(parent) = node.parent() else { return };
     // A parenthesised / negated operand only contributes when it sits in
     // a boolean-evaluating slot. The chain wrapper (`binary_expression`)
     // and the control-flow headers all qualify; a `!`-operator anywhere
@@ -116,7 +118,7 @@ fn kotlin_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
             {
                 *conditions += 1.;
             } else if node.is_named() {
-                kotlin_inspect_container(&node, conditions);
+                kotlin_inspect_container(&node, list_node, conditions);
             }
 
             if !cursor.goto_next_sibling() {
@@ -140,18 +142,23 @@ fn kotlin_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
 // arm, idiomatic Kotlin bare predicates reported 0 ABC conditions while
 // Kotlin's own cyclomatic counted the decision, breaking the
 // conditions >= decisions invariant (#469/#473/#456/#696); issue #773.
-fn kotlin_count_condition(condition: &Node, conditions: &mut f64) {
+fn kotlin_count_condition(condition: &Node, parent: &Node, conditions: &mut f64) {
     use Kotlin::*;
     let kind = condition.kind_id().into();
     if matches!(kind, kotlin_bool_terminal_kinds!()) {
         *conditions += 1.;
     } else if matches!(kind, ParenthesizedExpression | UnaryExpression) {
-        kotlin_inspect_container(condition, conditions);
+        kotlin_inspect_container(condition, parent, conditions);
     }
 }
 
 impl Abc for KotlinCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Kotlin::*;
 
         match node.kind_id().into() {
@@ -173,7 +180,7 @@ impl Abc for KotlinCode {
             // stack cleared on `SEMI` (the pre-#455 design) never cleared:
             // the immutable-`val` sentinel leaked and suppressed every later
             // standalone assignment in the same function (issue #455).
-            EQ if !kotlin_eq_initializes_immutable_binding(node) => {
+            EQ if !kotlin_eq_initializes_immutable_binding(node, ancestors) => {
                 stats.assignments += 1.;
             }
             // Branches: every call expression plus object construction.
@@ -213,7 +220,7 @@ impl Abc for KotlinCode {
             // by the token arms above — so no double-count (#773).
             IfExpression | WhileStatement | DoWhileStatement => {
                 if let Some(condition) = node.child_by_field_name("condition") {
-                    kotlin_count_condition(&condition, &mut stats.conditions);
+                    kotlin_count_condition(&condition, node, &mut stats.conditions);
                 }
             }
             // A `when` entry is a decision point except for the `else ->`
@@ -228,13 +235,16 @@ impl Abc for KotlinCode {
             // else-clause and `when`'s `else ->` entry. Only count it
             // when it belongs to an `if_expression`; the `WhenEntry`
             // wrapper above already covers the `when` case.
-            Else if node.parent().is_some_and(|p| p.kind_id() == IfExpression) => {
+            Else if ancestors
+                .parent(node)
+                .is_some_and(|p| p.kind_id() == IfExpression) =>
+            {
                 stats.conditions += 1.;
             }
             // `<` and `>` may appear as type-argument brackets
             // (`List<Int>`); exclude those by checking the parent kind.
             LT | GT
-                if node.parent().is_some_and(|p| {
+                if ancestors.parent(node).is_some_and(|p| {
                     !matches!(p.kind_id().into(), TypeArguments | TypeParameters)
                 }) =>
             {
@@ -246,7 +256,7 @@ impl Abc for KotlinCode {
             // policy, #395); the walker fires off the operator token and
             // inspects the parent `binary_expression`.
             AMPAMP | PIPEPIPE => {
-                if let Some(parent) = node.parent() {
+                if let Some(parent) = ancestors.parent(node) {
                     kotlin_count_unary_conditions(&parent, &mut stats.conditions);
                 }
             }

--- a/src/metrics/abc/lua.rs
+++ b/src/metrics/abc/lua.rs
@@ -36,10 +36,9 @@ use crate::*;
 // child is the `not` keyword. Terminal-bool kinds include identifiers,
 // the three keyword literals (`true`, `false`, `nil`), numbers, and
 // every call / indexing form.
-fn lua_inspect_container(container_node: &Node, conditions: &mut f64) {
+fn lua_inspect_container(container_node: &Node, parent: &Node, conditions: &mut f64) {
     let mut node = *container_node;
     let mut node_kind = node.kind_id().into();
-    let Some(parent) = node.parent() else { return };
     let mut has_boolean_content = matches!(
         parent.kind_id().into(),
         Lua::BinaryExpression | Lua::IfStatement | Lua::WhileStatement | Lua::RepeatStatement
@@ -79,12 +78,12 @@ fn lua_inspect_container(container_node: &Node, conditions: &mut f64) {
 // directly: terminal-bool kinds (Identifier, True, False, Nil,
 // FunctionCall, etc.) count at the top level; `(...)` / `not ...`
 // route through `lua_inspect_container`.
-fn lua_count_condition(condition: &Node, conditions: &mut f64) {
+fn lua_count_condition(condition: &Node, parent: &Node, conditions: &mut f64) {
     let kind = condition.kind_id().into();
     if matches!(kind, lua_bool_terminal_kinds!()) {
         *conditions += 1.;
     } else if matches!(kind, Lua::ParenthesizedExpression | Lua::UnaryExpression) {
-        lua_inspect_container(condition, conditions);
+        lua_inspect_container(condition, parent, conditions);
     }
 }
 
@@ -102,7 +101,7 @@ fn lua_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
             {
                 *conditions += 1.;
             } else if node.is_named() {
-                lua_inspect_container(&node, conditions);
+                lua_inspect_container(&node, list_node, conditions);
             }
 
             if !cursor.goto_next_sibling() {
@@ -113,7 +112,12 @@ fn lua_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
 }
 
 impl Abc for LuaCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         match node.kind_id().into() {
             Lua::AssignmentStatement | Lua::AssignmentStatement2 => {
                 stats.assignments += 1.;
@@ -134,7 +138,7 @@ impl Abc for LuaCode {
             // Fitzpatrick Rule 9 walker: each operand of an `and` /
             // `or` chain is one condition (issue #403).
             Lua::And | Lua::Or => {
-                if let Some(parent) = node.parent() {
+                if let Some(parent) = ancestors.parent(node) {
                     lua_count_unary_conditions(&parent, &mut stats.conditions);
                 }
             }
@@ -149,7 +153,7 @@ impl Abc for LuaCode {
             // shift positional child indices.
             Lua::IfStatement | Lua::WhileStatement | Lua::RepeatStatement => {
                 if let Some(cond) = node.child_by_field_name("condition") {
-                    lua_count_condition(&cond, &mut stats.conditions);
+                    lua_count_condition(&cond, node, &mut stats.conditions);
                 }
             }
             // `return value` — Lua wraps return values in

--- a/src/metrics/abc/mozcpp.rs
+++ b/src/metrics/abc/mozcpp.rs
@@ -14,7 +14,12 @@ use super::{Abc, Stats};
 use crate::*;
 
 impl Abc for MozcppCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Mozcpp::*;
 
         match node.kind_id().into() {
@@ -85,7 +90,7 @@ impl Abc for MozcppCode {
             // because the C++ grammar emits the same node under two
             // production-rule paths.
             LT | GT
-                if node.parent().is_some_and(|p| {
+                if ancestors.parent(node).is_some_and(|p| {
                     matches!(p.kind_id().into(), BinaryExpression | BinaryExpression2)
                 }) =>
             {
@@ -94,7 +99,7 @@ impl Abc for MozcppCode {
             // Fitzpatrick Rule 9 (C++ in Figure 3): each operand of a
             // `&&` / `||` chain is one condition (issue #403).
             AMPAMP | PIPEPIPE => {
-                if let Some(parent) = node.parent() {
+                if let Some(parent) = ancestors.parent(node) {
                     cpp_count_unary_conditions(&parent, &mut stats.conditions);
                 }
             }
@@ -113,7 +118,7 @@ impl Abc for MozcppCode {
             // attribute precedes it.
             IfStatement | WhileStatement => {
                 if let Some(cond) = node.child_by_field_name("condition") {
-                    cpp_inspect_container(&cond, &mut stats.conditions);
+                    cpp_inspect_container(&cond, node, &mut stats.conditions);
                 }
             }
             ReturnStatement => {

--- a/src/metrics/abc/objc.rs
+++ b/src/metrics/abc/objc.rs
@@ -28,7 +28,12 @@ use crate::*;
 //     `@throw` is not a condition (the C++ impl likewise does not count
 //     `throw`).
 impl Abc for ObjcCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Objc::*;
 
         match node.kind_id().into() {
@@ -62,20 +67,20 @@ impl Abc for ObjcCode {
             // a `binary_expression`). ObjC has no templates, but the parent
             // check is kept for parity with the C/C++ impl.
             LT | GT
-                if node.parent().is_some_and(|p| {
+                if ancestors.parent(node).is_some_and(|p| {
                     matches!(p.kind_id().into(), BinaryExpression | BinaryExpression2)
                 }) =>
             {
                 stats.conditions += 1.;
             }
             AMPAMP | PIPEPIPE => {
-                if let Some(parent) = node.parent() {
+                if let Some(parent) = ancestors.parent(node) {
                     cpp_count_unary_conditions(&parent, &mut stats.conditions);
                 }
             }
             IfStatement | WhileStatement => {
                 if let Some(cond) = node.child_by_field_name("condition") {
-                    cpp_inspect_container(&cond, &mut stats.conditions);
+                    cpp_inspect_container(&cond, node, &mut stats.conditions);
                 }
             }
             ReturnStatement => {

--- a/src/metrics/abc/perl.rs
+++ b/src/metrics/abc/perl.rs
@@ -52,12 +52,11 @@ use crate::*;
 // wrappers (every kind already counted as a branch), and the variable
 // wrappers (`ScalarVariable`, `ArrayVariable`, `HashVariable` plus the
 // access shapes).
-fn perl_inspect_container(container_node: &Node, conditions: &mut f64) {
+fn perl_inspect_container(container_node: &Node, parent: &Node, conditions: &mut f64) {
     use Perl as P;
 
     let mut node = *container_node;
     let mut node_kind = node.kind_id().into();
-    let Some(parent) = node.parent() else { return };
     let parent_kind = parent.kind_id().into();
     let mut has_boolean_content = matches!(
         parent_kind,
@@ -122,7 +121,7 @@ fn perl_inspect_container(container_node: &Node, conditions: &mut f64) {
 // boolean-literal case.
 fn perl_inspect_child(node: &Node, idx: usize, conditions: &mut f64) {
     if let Some(child) = node.child(idx) {
-        perl_inspect_container(&child, conditions);
+        perl_inspect_container(&child, node, conditions);
     }
 }
 
@@ -186,7 +185,7 @@ fn perl_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
             {
                 *conditions += 1.;
             } else if node.is_named() {
-                perl_inspect_container(&node, conditions);
+                perl_inspect_container(&node, list_node, conditions);
             }
 
             if !cursor.goto_next_sibling() {
@@ -197,7 +196,12 @@ fn perl_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
 }
 
 impl Abc for PerlCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Perl as P;
 
         match node.kind_id().into() {
@@ -242,7 +246,7 @@ impl Abc for PerlCode {
             // outer node has already been counted and this child
             // would double the branch tally.
             P::CallExpressionWithBareword
-                if !node.parent().is_some_and(|p| {
+                if !ancestors.parent(node).is_some_and(|p| {
                     matches!(
                         p.kind_id().into(),
                         P::CallExpressionWithSpacedArgs
@@ -272,7 +276,7 @@ impl Abc for PerlCode {
             // condition (issue #403). Covers `&&`, `||`, `//`,
             // `and`, `or`, `xor`.
             P::AMPAMP | P::PIPEPIPE | P::SLASHSLASH | P::And | P::Or | P::Xor => {
-                if let Some(parent) = node.parent() {
+                if let Some(parent) = ancestors.parent(node) {
                     perl_count_unary_conditions(&parent, &mut stats.conditions);
                 }
             }
@@ -298,7 +302,7 @@ impl Abc for PerlCode {
             // conditions). To avoid re-handling condition slots that
             // were already walked through inspect_container, only
             // dispatch when the parent is a call-expression form.
-            P::Array if node.parent().is_some_and(perl_is_call_argument_parent) => {
+            P::Array if ancestors.parent(node).is_some_and(perl_is_call_argument_parent) => {
                 perl_count_unary_conditions(node, &mut stats.conditions);
             }
             _ => {}

--- a/src/metrics/abc/perl.rs
+++ b/src/metrics/abc/perl.rs
@@ -67,7 +67,7 @@ fn perl_inspect_container(container_node: &Node, parent: &Node, conditions: &mut
             | P::UntilStatement
     ) || (matches!(parent_kind, P::TernaryExpression)
         && node
-            .previous_sibling()
+            .previous_sibling_under(parent)
             .is_none_or(|prev| !matches!(prev.kind_id().into(), P::QMARK | P::COLON)));
 
     loop {

--- a/src/metrics/abc/php.rs
+++ b/src/metrics/abc/php.rs
@@ -31,7 +31,7 @@ fn php_inspect_container(container_node: &Node, parent: &Node, conditions: &mut 
         BinaryExpression | IfStatement | WhileStatement | DoStatement | ForStatement
     ) || (matches!(parent_kind, ConditionalExpression)
         && node
-            .previous_sibling()
+            .previous_sibling_under(parent)
             .is_none_or(|prev| !matches!(prev.kind_id().into(), QMARK | COLON)));
 
     loop {
@@ -111,16 +111,21 @@ fn php_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
             // the last named child to handle both shapes — and skip
             // the rare grammar-error case where Argument has no
             // named children.
-            let inner = if matches!(node_kind, Argument) {
+            // `inner_parent` is carried alongside `inner` because
+            // `php_inspect_container` seeds its boolean-context flag
+            // from the parent kind and must not rediscover it (#1096):
+            // unwrapping an `argument` makes the wrapper the parent,
+            // otherwise it is the list.
+            let (inner, inner_parent) = if matches!(node_kind, Argument) {
                 let Some(value) = php_argument_value(&node) else {
                     if !cursor.goto_next_sibling() {
                         break;
                     }
                     continue;
                 };
-                value
+                (value, node)
             } else {
-                node
+                (node, *list_node)
             };
             let inner_kind = inner.kind_id().into();
 
@@ -129,14 +134,7 @@ fn php_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
             {
                 *conditions += 1.;
             } else if inner.is_named() {
-                // `inner`'s parent is the `argument` wrapper when one
-                // was unwrapped above, and the list itself otherwise.
-                let inner_parent = if inner.id() == node.id() {
-                    list_node
-                } else {
-                    &node
-                };
-                php_inspect_container(&inner, inner_parent, conditions);
+                php_inspect_container(&inner, &inner_parent, conditions);
             }
 
             if !cursor.goto_next_sibling() {

--- a/src/metrics/abc/php.rs
+++ b/src/metrics/abc/php.rs
@@ -20,12 +20,11 @@ use crate::*;
 // `VariableName` (`$x`), `Boolean` (the named `true` / `false` wrapper),
 // and every call / member-access / subscript form. `ParenthesizedExpression`
 // wraps `if (...)`-style condition slots.
-fn php_inspect_container(container_node: &Node, conditions: &mut f64) {
+fn php_inspect_container(container_node: &Node, parent: &Node, conditions: &mut f64) {
     use Php::*;
 
     let mut node = *container_node;
     let mut node_kind = node.kind_id().into();
-    let Some(parent) = node.parent() else { return };
     let parent_kind = parent.kind_id().into();
     let mut has_boolean_content = matches!(
         parent_kind,
@@ -66,7 +65,7 @@ fn php_inspect_container(container_node: &Node, conditions: &mut f64) {
 // unwrap handles the boolean-literal case (`if (true)` counts 1).
 fn php_inspect_child(node: &Node, idx: usize, conditions: &mut f64) {
     if let Some(child) = node.child(idx) {
-        php_inspect_container(&child, conditions);
+        php_inspect_container(&child, node, conditions);
     }
 }
 
@@ -130,7 +129,14 @@ fn php_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
             {
                 *conditions += 1.;
             } else if inner.is_named() {
-                php_inspect_container(&inner, conditions);
+                // `inner`'s parent is the `argument` wrapper when one
+                // was unwrapped above, and the list itself otherwise.
+                let inner_parent = if inner.id() == node.id() {
+                    list_node
+                } else {
+                    &node
+                };
+                php_inspect_container(&inner, inner_parent, conditions);
             }
 
             if !cursor.goto_next_sibling() {
@@ -141,7 +147,12 @@ fn php_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
 }
 
 impl Abc for PhpCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Php::*;
 
         match node.kind_id().into() {
@@ -206,7 +217,7 @@ impl Abc for PhpCode {
             // the walker so `connect() or die();`-style idiom counts
             // the same as `connect() || die();`.
             AMPAMP | PIPEPIPE | And | Or | Xor => {
-                if let Some(parent) = node.parent() {
+                if let Some(parent) = ancestors.parent(node) {
                     php_count_unary_conditions(&parent, &mut stats.conditions);
                 }
             }

--- a/src/metrics/abc/python.rs
+++ b/src/metrics/abc/python.rs
@@ -55,12 +55,11 @@ use crate::*;
 // any `not x and y` / `x == 0 and y` shape. `ParenthesizedExpression`
 // is still unwrapped to catch bare-identifier operands like
 // `if (a) and b:` that the dispatcher would otherwise miss.
-fn python_inspect_container(container_node: &Node, conditions: &mut f64) {
+fn python_inspect_container(container_node: &Node, parent: &Node, conditions: &mut f64) {
     use Python::*;
 
     let mut node = *container_node;
     let mut node_kind = node.kind_id().into();
-    let Some(parent) = node.parent() else { return };
     let has_boolean_content = matches!(
         parent.kind_id().into(),
         BooleanOperator | IfStatement | WhileStatement | ConditionalExpression
@@ -94,19 +93,19 @@ fn python_inspect_container(container_node: &Node, conditions: &mut f64) {
 //     skipped: each is counted by its own top-level dispatcher arm
 //     (the `Or`/`And` keyword walker, the `NotOperator` arm, and
 //     the `ComparisonOperator` arm at lines `~1334-1390`).
-fn python_count_condition(condition: &Node, conditions: &mut f64) {
+fn python_count_condition(condition: &Node, parent: &Node, conditions: &mut f64) {
     use Python::*;
     let kind = condition.kind_id().into();
     if matches!(kind, python_bool_terminal_kinds!()) {
         *conditions += 1.;
     } else if matches!(kind, ParenthesizedExpression) {
-        python_inspect_container(condition, conditions);
+        python_inspect_container(condition, parent, conditions);
     }
 }
 
 fn python_inspect_child(node: &Node, idx: usize, conditions: &mut f64) {
     if let Some(child) = node.child(idx) {
-        python_count_condition(&child, conditions);
+        python_count_condition(&child, node, conditions);
     }
 }
 
@@ -126,7 +125,7 @@ fn python_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
             {
                 *conditions += 1.;
             } else if matches!(node_kind, ParenthesizedExpression) {
-                python_inspect_container(&node, conditions);
+                python_inspect_container(&node, list_node, conditions);
             }
             // NotOperator / ComparisonOperator / nested BooleanOperator
             // children are intentionally not walked here — each has
@@ -141,7 +140,12 @@ fn python_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
 }
 
 impl Abc for PythonCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Python::*;
 
         match node.kind_id().into() {
@@ -203,7 +207,7 @@ impl Abc for PythonCode {
             // `Or` keyword tokens live inside a `boolean_operator`
             // wrapper which the walker iterates as the parent list.
             And | Or => {
-                if let Some(parent) = node.parent() {
+                if let Some(parent) = ancestors.parent(node) {
                     python_count_unary_conditions(&parent, &mut stats.conditions);
                 }
             }

--- a/src/metrics/abc/ruby.rs
+++ b/src/metrics/abc/ruby.rs
@@ -41,12 +41,11 @@ use crate::*;
 // (`Unary`..`Unary5`) whose child(0) is the `!` token; the condition
 // slot may be wrapped in `parenthesized_statements`. Both are unwrapped
 // by `ruby_inspect_container`.
-fn ruby_inspect_container(container_node: &Node, conditions: &mut f64) {
+fn ruby_inspect_container(container_node: &Node, parent: &Node, conditions: &mut f64) {
     use Ruby::*;
 
     let mut node = *container_node;
     let mut node_kind = node.kind_id().into();
-    let Some(parent) = node.parent() else { return };
     let mut has_boolean_content = matches!(
         parent.kind_id().into(),
         Binary | Binary2 | Binary3 | If | Unless | While | Until
@@ -105,7 +104,7 @@ fn ruby_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
             {
                 *conditions += 1.;
             } else if node.is_named() {
-                ruby_inspect_container(&node, conditions);
+                ruby_inspect_container(&node, list_node, conditions);
             }
 
             if !cursor.goto_next_sibling() {
@@ -129,7 +128,7 @@ fn ruby_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
 // bare predicates reported 0 ABC conditions while Ruby's own cyclomatic
 // counted them, breaking the conditions >= decisions invariant
 // (#469/#473/#456); issue #696.
-fn ruby_count_condition(condition: &Node, conditions: &mut f64) {
+fn ruby_count_condition(condition: &Node, parent: &Node, conditions: &mut f64) {
     use Ruby::*;
     let kind = condition.kind_id().into();
     if matches!(kind, ruby_bool_terminal_kinds!()) {
@@ -138,12 +137,17 @@ fn ruby_count_condition(condition: &Node, conditions: &mut f64) {
         kind,
         ParenthesizedStatements | Unary | Unary2 | Unary3 | Unary4 | Unary5
     ) {
-        ruby_inspect_container(condition, conditions);
+        ruby_inspect_container(condition, parent, conditions);
     }
 }
 
 impl Abc for RubyCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Ruby::*;
 
         match node.kind_id().into() {
@@ -157,7 +161,7 @@ impl Abc for RubyCode {
             If | Unless | While | Until | IfModifier | UnlessModifier | WhileModifier
             | UntilModifier => {
                 if let Some(cond) = node.child_by_field_name("condition") {
-                    ruby_count_condition(&cond, &mut stats.conditions);
+                    ruby_count_condition(&cond, node, &mut stats.conditions);
                 }
             }
             Call | Call2 | Call3 | Call4 | Super | Yield | Yield2 => {
@@ -182,7 +186,7 @@ impl Abc for RubyCode {
             // (cross-language policy, #395); the keyword forms `and` / `or`
             // get the same treatment as `&&` / `||`.
             AMPAMP | PIPEPIPE | And | Or => {
-                if let Some(parent) = node.parent() {
+                if let Some(parent) = ancestors.parent(node) {
                     ruby_count_unary_conditions(&parent, &mut stats.conditions);
                 }
             }

--- a/src/metrics/abc/rust.rs
+++ b/src/metrics/abc/rust.rs
@@ -30,12 +30,11 @@ use crate::*;
 // binary parent from contributing — only direct operands of a
 // `binary_expression` count as unary conditions per Rule 7. See issue
 // #403.
-fn rust_inspect_container(container_node: &Node, conditions: &mut f64) {
+fn rust_inspect_container(container_node: &Node, parent: &Node, conditions: &mut f64) {
     use Rust::*;
 
     let mut node = *container_node;
     let mut node_kind = node.kind_id().into();
-    let Some(parent) = node.parent() else { return };
     let mut has_boolean_content = matches!(
         parent.kind_id().into(),
         BinaryExpression | IfExpression | WhileExpression | LetChain | LetChain2
@@ -74,19 +73,19 @@ fn rust_inspect_container(container_node: &Node, conditions: &mut f64) {
 // `rust_inspect_container` unwraps until a terminal is found. Mirrors
 // the `java_count_condition` / `java_inspect_child` helper pair used
 // by `java_walk_ternary` / `java_walk_for_statement`.
-fn rust_count_condition(condition: &Node, conditions: &mut f64) {
+fn rust_count_condition(condition: &Node, parent: &Node, conditions: &mut f64) {
     use Rust::*;
     let kind = condition.kind_id().into();
     if matches!(kind, rust_bool_terminal_kinds!()) {
         *conditions += 1.;
     } else if matches!(kind, ParenthesizedExpression | UnaryExpression) {
-        rust_inspect_container(condition, conditions);
+        rust_inspect_container(condition, parent, conditions);
     }
 }
 
 fn rust_inspect_child(node: &Node, idx: usize, conditions: &mut f64) {
     if let Some(child) = node.child(idx) {
-        rust_count_condition(&child, conditions);
+        rust_count_condition(&child, node, conditions);
     }
 }
 
@@ -114,7 +113,7 @@ fn rust_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
             {
                 *conditions += 1.;
             } else if node.is_named() {
-                rust_inspect_container(&node, conditions);
+                rust_inspect_container(&node, list_node, conditions);
             }
 
             if !cursor.goto_next_sibling() {
@@ -125,7 +124,12 @@ fn rust_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
 }
 
 impl Abc for RustCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Rust::*;
 
         match node.kind_id().into() {
@@ -179,8 +183,8 @@ impl Abc for RustCode {
             // `BinaryExpression` parent check disambiguates without
             // needing to inspect siblings.
             LT | GT
-                if node
-                    .parent()
+                if ancestors
+                    .parent(node)
                     .is_some_and(|p| matches!(p.kind_id().into(), BinaryExpression)) =>
             {
                 stats.conditions += 1.;
@@ -212,7 +216,7 @@ impl Abc for RustCode {
             // counts the inner pair and the outer operator's pass
             // counts only the new outer operand. See issue #403.
             AMPAMP | PIPEPIPE => {
-                if let Some(parent) = node.parent() {
+                if let Some(parent) = ancestors.parent(node) {
                     rust_count_unary_conditions(&parent, &mut stats.conditions);
                 }
             }
@@ -234,7 +238,7 @@ impl Abc for RustCode {
             // in the return slot is not a unary conditional.
             ReturnExpression => {
                 if let Some(value) = node.child(1) {
-                    rust_inspect_container(&value, &mut stats.conditions);
+                    rust_inspect_container(&value, node, &mut stats.conditions);
                 }
             }
             // Method-argument walker: `m(!a, !b)` contributes one

--- a/src/metrics/abc/tcl.rs
+++ b/src/metrics/abc/tcl.rs
@@ -52,10 +52,9 @@ const TCL_ASSIGNMENT_COMMANDS: &[&[u8]] = &[b"incr", b"append", b"lappend"];
 // `simple_word`, the braced / quoted variants, variable substitutions
 // (`$x`), command substitutions (`[cmd]`), the boolean keyword, and
 // the numeric literal.
-fn tcl_inspect_container(container_node: &Node, conditions: &mut f64) {
+fn tcl_inspect_container(container_node: &Node, parent: &Node, conditions: &mut f64) {
     let mut node = *container_node;
     let mut node_kind = node.kind_id().into();
-    let Some(parent) = node.parent() else { return };
     let has_boolean_content = matches!(parent.kind_id().into(), Tcl::BinopExpr);
 
     loop {
@@ -95,7 +94,7 @@ fn tcl_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
             {
                 *conditions += 1.;
             } else if node.is_named() {
-                tcl_inspect_container(&node, conditions);
+                tcl_inspect_container(&node, list_node, conditions);
             }
 
             if !cursor.goto_next_sibling() {
@@ -106,7 +105,12 @@ fn tcl_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
 }
 
 impl Abc for TclCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         match node.kind_id().into() {
             // The `set` production wraps `set name value` as a
             // first-class node distinct from generic commands.
@@ -142,7 +146,7 @@ impl Abc for TclCode {
             // Fitzpatrick Rule 9 walker: each operand of a `&&` / `||`
             // chain inside an `expr` slot is one condition (issue #403).
             Tcl::AMPAMP | Tcl::PIPEPIPE => {
-                if let Some(parent) = node.parent() {
+                if let Some(parent) = ancestors.parent(node) {
                     tcl_count_unary_conditions(&parent, &mut stats.conditions);
                 }
             }

--- a/src/metrics/cyclomatic.rs
+++ b/src/metrics/cyclomatic.rs
@@ -245,7 +245,12 @@ where
     /// (Elixir's `if`/`unless`/`for`/`while`/`with`/`case`/`cond`,
     /// for example) can identify them by inspecting the call target's
     /// text. Most languages discard the parameter with `_`.
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], stats: &mut Stats);
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        _ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    );
 
     /// Like [`Cyclomatic::compute`], but honors per-traversal options.
     ///
@@ -260,11 +265,12 @@ where
     fn compute_with_options<'a>(
         node: &Node<'a>,
         code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
         stats: &mut Stats,
         count_try: bool,
     ) {
         let _ = count_try;
-        Self::compute(node, code, stats);
+        Self::compute(node, code, ancestors, stats);
     }
 }
 
@@ -295,7 +301,12 @@ where
 macro_rules! impl_cyclomatic_c_family {
     ($code:ty, $lang:ident, $ternary:ident, [$($short_circuit:ident),+ $(,)?]) => {
         impl Cyclomatic for $code {
-            fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+            fn compute<'a>(
+                node: &Node<'a>,
+                _code: &'a [u8],
+                _ancestors: Ancestors<'a, '_>,
+                stats: &mut Stats,
+            ) {
                 use $lang::*;
                 match node.kind_id().into() {
                     Case => stats.cyclomatic += 1.,
@@ -382,7 +393,12 @@ macro_rules! impl_cyclomatic_js_family {
 macro_rules! impl_cyclomatic_java_like {
     ($code:ty, $lang:ident, [$($extra:ident),* $(,)?]) => {
         impl Cyclomatic for $code {
-            fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+            fn compute<'a>(
+                node: &Node<'a>,
+                _code: &'a [u8],
+                _ancestors: Ancestors<'a, '_>,
+                stats: &mut Stats,
+            ) {
                 use $lang::*;
 
                 match node.kind_id().into() {

--- a/src/metrics/cyclomatic.rs
+++ b/src/metrics/cyclomatic.rs
@@ -1242,6 +1242,57 @@ mod tests {
         assert_eq!(default_path.cyclomatic_modified_sum(), 5);
     }
 
+    /// `Cyclomatic::compute` for Rust is the trait's plain entry point,
+    /// and the metric walk never reaches it: `compute_per_node` calls
+    /// `compute_with_options` directly so it can pass the
+    /// `count_cyclomatic_try` option through. The plain form is still
+    /// the documented default for any caller that goes through the
+    /// trait, and #409 fixes that default as "`?` counts" — so it needs
+    /// a test of its own rather than inheriting the option tests above,
+    /// which exercise the other entry point.
+    ///
+    /// Asserting only that the two forms agree would be satisfied by a
+    /// `compute` that delegated with `false` *and* a
+    /// `compute_with_options` that ignored the flag, so the count is
+    /// pinned against the opted-out run as well.
+    #[test]
+    fn rust_compute_delegates_with_try_counting_on() {
+        use crate::traits::ParserTrait;
+
+        let parser = crate::RustParser::new(
+            RUST_TRY_FIXTURE.as_bytes().to_vec(),
+            std::path::Path::new("try.rs"),
+            None,
+        );
+        let code = parser.code();
+
+        let mut plain = Stats::default();
+        let mut opted_in = Stats::default();
+        let mut opted_out = Stats::default();
+        for node in parser.root().preorder() {
+            RustCode::compute(&node, code, Ancestors::unknown(), &mut plain);
+            RustCode::compute_with_options(&node, code, Ancestors::unknown(), &mut opted_in, true);
+            RustCode::compute_with_options(
+                &node,
+                code,
+                Ancestors::unknown(),
+                &mut opted_out,
+                false,
+            );
+        }
+
+        assert_eq!(
+            (plain.cyclomatic(), plain.cyclomatic_modified()),
+            (opted_in.cyclomatic(), opted_in.cyclomatic_modified()),
+            "`compute` must be `compute_with_options(.., true)`"
+        );
+        assert_eq!(
+            plain.cyclomatic() - opted_out.cyclomatic(),
+            RUST_TRY_COUNT,
+            "the fixture's {RUST_TRY_COUNT} `?` operators are what the default counts"
+        );
+    }
+
     #[test]
     fn c_switch() {
         check_metrics::<CParser>(

--- a/src/metrics/cyclomatic/bash.rs
+++ b/src/metrics/cyclomatic/bash.rs
@@ -9,7 +9,12 @@
 use super::*;
 
 impl Cyclomatic for BashCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        _ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         match node.kind_id().into() {
             // Standard-only: individual case arms (matches C-family `case:`
             // treatment — only arms contribute, not the container). The

--- a/src/metrics/cyclomatic/c.rs
+++ b/src/metrics/cyclomatic/c.rs
@@ -14,7 +14,12 @@ use super::*;
 // `case`, the `?:` ternary, and the `&&`/`||` short-circuit operators,
 // with `switch` adding only to the modified count (#284).
 impl Cyclomatic for CCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        _ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use C::*;
         match node.kind_id().into() {
             Case => stats.cyclomatic += 1.,

--- a/src/metrics/cyclomatic/csharp.rs
+++ b/src/metrics/cyclomatic/csharp.rs
@@ -9,7 +9,12 @@
 use super::*;
 
 impl Cyclomatic for CsharpCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        _ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Csharp::*;
 
         match node.kind_id().into() {

--- a/src/metrics/cyclomatic/elixir.rs
+++ b/src/metrics/cyclomatic/elixir.rs
@@ -19,10 +19,10 @@ use super::*;
 /// sibling) and report whether it is `node`. Multi-clause `fn`s thus
 /// skip only their first clause; `case`/`cond`/`with` arms have a
 /// `do_block` parent and never match here (issue #776).
-fn elixir_is_anonymous_fn_head_clause(node: &Node) -> bool {
+fn elixir_is_anonymous_fn_head_clause<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>) -> bool {
     use Elixir as E;
 
-    let Some(parent) = node.parent() else {
+    let Some(parent) = ancestors.parent(node) else {
         return false;
     };
     if parent.kind_id() != E::AnonymousFunction as u16 {
@@ -48,7 +48,12 @@ impl Cyclomatic for ElixirCode {
     // `with`/`try`) contribute modified. Single-branch keyword Calls
     // (`if`/`unless`/`for`/`while`) contribute to both. Short-circuit
     // booleans (`&&`, `||`, `and`, `or`) contribute to both.
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Elixir as E;
 
         match node.kind_id().into() {
@@ -68,7 +73,7 @@ impl Cyclomatic for ElixirCode {
             // `fn` are real branches. `case`/`cond`/`with` arms have a
             // `do_block` parent — not `anonymous_function` — so they are
             // unaffected and keep counting.
-            E::StabClause if elixir_is_anonymous_fn_head_clause(node) => {}
+            E::StabClause if elixir_is_anonymous_fn_head_clause(node, ancestors) => {}
             E::StabClause => {
                 stats.cyclomatic += 1.;
             }

--- a/src/metrics/cyclomatic/go.rs
+++ b/src/metrics/cyclomatic/go.rs
@@ -9,7 +9,12 @@
 use super::*;
 
 impl Cyclomatic for GoCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        _ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         // Aliased because `Go::Go` (the `go` keyword variant) collides with
         // the bare enum name in pattern position under `use Go::*;`.
         use Go as G;

--- a/src/metrics/cyclomatic/irules.rs
+++ b/src/metrics/cyclomatic/irules.rs
@@ -9,7 +9,12 @@
 use super::*;
 
 impl Cyclomatic for IrulesCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        _ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         // Unlike Tcl, iRules has a dedicated `switch`/`switch_arm` node: each
         // non-`default` arm is a decision point in standard CCN, while modified
         // CCN collapses the whole `switch` to a single container decision. The

--- a/src/metrics/cyclomatic/kotlin.rs
+++ b/src/metrics/cyclomatic/kotlin.rs
@@ -9,7 +9,12 @@
 use super::*;
 
 impl Cyclomatic for KotlinCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        _ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Kotlin::*;
 
         match node.kind_id().into() {

--- a/src/metrics/cyclomatic/lua.rs
+++ b/src/metrics/cyclomatic/lua.rs
@@ -9,7 +9,12 @@
 use super::*;
 
 impl Cyclomatic for LuaCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        _ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         match node.kind_id().into() {
             Lua::IfStatement
             | Lua::ElseifStatement

--- a/src/metrics/cyclomatic/objc.rs
+++ b/src/metrics/cyclomatic/objc.rs
@@ -18,7 +18,12 @@ use super::*;
 // (issue #284: count keyword tokens, never the statement nodes, or the
 // `For`/`While`/`If` keyword and their `*Statement` wrappers double-count).
 impl Cyclomatic for ObjcCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        _ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Objc::*;
         match node.kind_id().into() {
             Case => stats.cyclomatic += 1.,

--- a/src/metrics/cyclomatic/perl.rs
+++ b/src/metrics/cyclomatic/perl.rs
@@ -9,7 +9,12 @@
 use super::*;
 
 impl Cyclomatic for PerlCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        _ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Perl as P;
 
         match node.kind_id().into() {

--- a/src/metrics/cyclomatic/php.rs
+++ b/src/metrics/cyclomatic/php.rs
@@ -9,7 +9,12 @@
 use super::*;
 
 impl Cyclomatic for PhpCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        _ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Php::*;
 
         match node.kind_id().into() {

--- a/src/metrics/cyclomatic/python.rs
+++ b/src/metrics/cyclomatic/python.rs
@@ -12,7 +12,7 @@ impl Cyclomatic for PythonCode {
     fn compute<'a>(
         node: &Node<'a>,
         _code: &'a [u8],
-        _ancestors: Ancestors<'a, '_>,
+        ancestors: Ancestors<'a, '_>,
         stats: &mut Stats,
     ) {
         use Python::*;
@@ -56,6 +56,7 @@ impl Cyclomatic for PythonCode {
             // counted, so we must NOT fire for `else_clause` parents
             // of `if_statement` — see #229.
             Else if node.parent_grandparent_match(
+                ancestors,
                 |parent| parent.kind_id() == ElseClause,
                 |grand| {
                     matches!(

--- a/src/metrics/cyclomatic/python.rs
+++ b/src/metrics/cyclomatic/python.rs
@@ -9,7 +9,12 @@
 use super::*;
 
 impl Cyclomatic for PythonCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        _ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Python::*;
 
         // Python's `match`/`case` (PEP 634, 3.10+) is treated like Rust's

--- a/src/metrics/cyclomatic/ruby.rs
+++ b/src/metrics/cyclomatic/ruby.rs
@@ -9,7 +9,12 @@
 use super::*;
 
 impl Cyclomatic for RubyCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        _ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Ruby as R;
 
         match node.kind_id().into() {

--- a/src/metrics/cyclomatic/rust.rs
+++ b/src/metrics/cyclomatic/rust.rs
@@ -9,15 +9,21 @@
 use super::*;
 
 impl Cyclomatic for RustCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         // The default (#409): `?` counts toward cyclomatic, matching
         // upstream rust-code-analysis and every published metric value.
-        Self::compute_with_options(node, code, stats, true);
+        Self::compute_with_options(node, code, ancestors, stats, true);
     }
 
     fn compute_with_options<'a>(
         node: &Node<'a>,
         _code: &'a [u8],
+        _ancestors: Ancestors<'a, '_>,
         stats: &mut Stats,
         count_try: bool,
     ) {

--- a/src/metrics/cyclomatic/tcl.rs
+++ b/src/metrics/cyclomatic/tcl.rs
@@ -9,7 +9,12 @@
 use super::*;
 
 impl Cyclomatic for TclCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        _ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         // Tcl `switch` is a generic `command`, not a dedicated kind, so it is
         // matched out-of-band before the kind dispatch (issue #467). Mirroring
         // the C-family convention (see `impl_cyclomatic_c_family`): each

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -381,7 +381,7 @@ fn compute_halstead<'a, T: Getter + Checker>(
         HalsteadType::Operand => {
             *halstead_maps
                 .operands
-                .entry(T::get_operand_id(node, code))
+                .entry(T::get_operand_id(node, code, ancestors))
                 .or_insert(0) += 1;
         }
         _ => {}

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -340,7 +340,16 @@ where
 {
     /// Walk `node` and update `stats` with this metric for the language
     /// implementing the trait.
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], halstead_maps: &mut HalsteadMaps<'a>);
+    ///
+    /// `ancestors` is the chain the walker descended through; it is
+    /// handed to [`Getter::get_op_type`], six of whose impls classify a
+    /// token by what encloses it (#1096).
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        halstead_maps: &mut HalsteadMaps<'a>,
+    );
 }
 
 #[inline]
@@ -352,9 +361,10 @@ fn get_id<'a>(node: &Node<'a>, code: &'a [u8]) -> &'a [u8] {
 fn compute_halstead<'a, T: Getter + Checker>(
     node: &Node<'a>,
     code: &'a [u8],
+    ancestors: Ancestors<'a, '_>,
     halstead_maps: &mut HalsteadMaps<'a>,
 ) {
-    match T::get_op_type_with_code(node, code) {
+    match T::get_op_type_with_code(node, code, ancestors) {
         HalsteadType::Operator => {
             if T::is_primitive(node) {
                 // Store primitive-type operators by text so distinct
@@ -379,110 +389,200 @@ fn compute_halstead<'a, T: Getter + Checker>(
 }
 
 impl Halstead for PythonCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], halstead_maps: &mut HalsteadMaps<'a>) {
-        compute_halstead::<Self>(node, code, halstead_maps);
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        halstead_maps: &mut HalsteadMaps<'a>,
+    ) {
+        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
     }
 }
 
 impl Halstead for MozjsCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], halstead_maps: &mut HalsteadMaps<'a>) {
-        compute_halstead::<Self>(node, code, halstead_maps);
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        halstead_maps: &mut HalsteadMaps<'a>,
+    ) {
+        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
     }
 }
 
 impl Halstead for JavascriptCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], halstead_maps: &mut HalsteadMaps<'a>) {
-        compute_halstead::<Self>(node, code, halstead_maps);
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        halstead_maps: &mut HalsteadMaps<'a>,
+    ) {
+        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
     }
 }
 
 impl Halstead for TypescriptCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], halstead_maps: &mut HalsteadMaps<'a>) {
-        compute_halstead::<Self>(node, code, halstead_maps);
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        halstead_maps: &mut HalsteadMaps<'a>,
+    ) {
+        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
     }
 }
 
 impl Halstead for TsxCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], halstead_maps: &mut HalsteadMaps<'a>) {
-        compute_halstead::<Self>(node, code, halstead_maps);
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        halstead_maps: &mut HalsteadMaps<'a>,
+    ) {
+        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
     }
 }
 
 impl Halstead for RustCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], halstead_maps: &mut HalsteadMaps<'a>) {
-        compute_halstead::<Self>(node, code, halstead_maps);
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        halstead_maps: &mut HalsteadMaps<'a>,
+    ) {
+        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
     }
 }
 
 impl Halstead for CppCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], halstead_maps: &mut HalsteadMaps<'a>) {
-        compute_halstead::<Self>(node, code, halstead_maps);
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        halstead_maps: &mut HalsteadMaps<'a>,
+    ) {
+        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
     }
 }
 
 impl Halstead for CCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], halstead_maps: &mut HalsteadMaps<'a>) {
-        compute_halstead::<Self>(node, code, halstead_maps);
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        halstead_maps: &mut HalsteadMaps<'a>,
+    ) {
+        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
     }
 }
 
 impl Halstead for ObjcCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], halstead_maps: &mut HalsteadMaps<'a>) {
-        compute_halstead::<Self>(node, code, halstead_maps);
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        halstead_maps: &mut HalsteadMaps<'a>,
+    ) {
+        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
     }
 }
 
 impl Halstead for MozcppCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], halstead_maps: &mut HalsteadMaps<'a>) {
-        compute_halstead::<Self>(node, code, halstead_maps);
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        halstead_maps: &mut HalsteadMaps<'a>,
+    ) {
+        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
     }
 }
 
 impl Halstead for JavaCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], halstead_maps: &mut HalsteadMaps<'a>) {
-        compute_halstead::<Self>(node, code, halstead_maps);
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        halstead_maps: &mut HalsteadMaps<'a>,
+    ) {
+        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
     }
 }
 
 impl Halstead for GroovyCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], halstead_maps: &mut HalsteadMaps<'a>) {
-        compute_halstead::<Self>(node, code, halstead_maps);
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        halstead_maps: &mut HalsteadMaps<'a>,
+    ) {
+        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
     }
 }
 
 impl Halstead for CsharpCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], halstead_maps: &mut HalsteadMaps<'a>) {
-        compute_halstead::<Self>(node, code, halstead_maps);
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        halstead_maps: &mut HalsteadMaps<'a>,
+    ) {
+        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
     }
 }
 
 impl Halstead for GoCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], halstead_maps: &mut HalsteadMaps<'a>) {
-        compute_halstead::<Self>(node, code, halstead_maps);
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        halstead_maps: &mut HalsteadMaps<'a>,
+    ) {
+        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
     }
 }
 
 impl Halstead for PerlCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], halstead_maps: &mut HalsteadMaps<'a>) {
-        compute_halstead::<Self>(node, code, halstead_maps);
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        halstead_maps: &mut HalsteadMaps<'a>,
+    ) {
+        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
     }
 }
 
 impl Halstead for KotlinCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], halstead_maps: &mut HalsteadMaps<'a>) {
-        compute_halstead::<Self>(node, code, halstead_maps);
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        halstead_maps: &mut HalsteadMaps<'a>,
+    ) {
+        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
     }
 }
 
 impl Halstead for LuaCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], halstead_maps: &mut HalsteadMaps<'a>) {
-        compute_halstead::<Self>(node, code, halstead_maps);
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        halstead_maps: &mut HalsteadMaps<'a>,
+    ) {
+        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
     }
 }
 
 impl Halstead for PhpCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], halstead_maps: &mut HalsteadMaps<'a>) {
-        compute_halstead::<Self>(node, code, halstead_maps);
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        halstead_maps: &mut HalsteadMaps<'a>,
+    ) {
+        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
     }
 }
 
@@ -490,32 +590,57 @@ impl Halstead for PhpCode {
 implement_metric_trait!(Halstead, PreprocCode, CcommentCode);
 
 impl Halstead for RubyCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], halstead_maps: &mut HalsteadMaps<'a>) {
-        compute_halstead::<Self>(node, code, halstead_maps);
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        halstead_maps: &mut HalsteadMaps<'a>,
+    ) {
+        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
     }
 }
 
 impl Halstead for ElixirCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], halstead_maps: &mut HalsteadMaps<'a>) {
-        compute_halstead::<Self>(node, code, halstead_maps);
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        halstead_maps: &mut HalsteadMaps<'a>,
+    ) {
+        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
     }
 }
 
 impl Halstead for BashCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], halstead_maps: &mut HalsteadMaps<'a>) {
-        compute_halstead::<Self>(node, code, halstead_maps);
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        halstead_maps: &mut HalsteadMaps<'a>,
+    ) {
+        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
     }
 }
 
 impl Halstead for TclCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], halstead_maps: &mut HalsteadMaps<'a>) {
-        compute_halstead::<Self>(node, code, halstead_maps);
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        halstead_maps: &mut HalsteadMaps<'a>,
+    ) {
+        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
     }
 }
 
 impl Halstead for IrulesCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], halstead_maps: &mut HalsteadMaps<'a>) {
-        compute_halstead::<Self>(node, code, halstead_maps);
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        halstead_maps: &mut HalsteadMaps<'a>,
+    ) {
+        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
     }
 }
 

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -388,261 +388,57 @@ fn compute_halstead<'a, T: Getter + Checker>(
     }
 }
 
-impl Halstead for PythonCode {
-    fn compute<'a>(
-        node: &Node<'a>,
-        code: &'a [u8],
-        ancestors: Ancestors<'a, '_>,
-        halstead_maps: &mut HalsteadMaps<'a>,
-    ) {
-        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
-    }
+// Every language's `Halstead::compute` is the same forward to
+// `compute_halstead`, which classifies each node through the language's
+// own `Getter` / `Checker`. Nothing per-language lives here — it lives
+// in `src/getter/<lang>.rs` — so writing the impls out was 23 copies of
+// one signature. (This is the only metric whose per-language impls are
+// all identical; every other trait has real per-language bodies.)
+macro_rules! impl_halstead_forwarding {
+    ($($code:ty),+ $(,)?) => {
+        $(
+            impl Halstead for $code {
+                fn compute<'a>(
+                    node: &Node<'a>,
+                    code: &'a [u8],
+                    ancestors: Ancestors<'a, '_>,
+                    halstead_maps: &mut HalsteadMaps<'a>,
+                ) {
+                    compute_halstead::<Self>(node, code, ancestors, halstead_maps);
+                }
+            }
+        )+
+    };
 }
 
-impl Halstead for MozjsCode {
-    fn compute<'a>(
-        node: &Node<'a>,
-        code: &'a [u8],
-        ancestors: Ancestors<'a, '_>,
-        halstead_maps: &mut HalsteadMaps<'a>,
-    ) {
-        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
-    }
-}
-
-impl Halstead for JavascriptCode {
-    fn compute<'a>(
-        node: &Node<'a>,
-        code: &'a [u8],
-        ancestors: Ancestors<'a, '_>,
-        halstead_maps: &mut HalsteadMaps<'a>,
-    ) {
-        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
-    }
-}
-
-impl Halstead for TypescriptCode {
-    fn compute<'a>(
-        node: &Node<'a>,
-        code: &'a [u8],
-        ancestors: Ancestors<'a, '_>,
-        halstead_maps: &mut HalsteadMaps<'a>,
-    ) {
-        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
-    }
-}
-
-impl Halstead for TsxCode {
-    fn compute<'a>(
-        node: &Node<'a>,
-        code: &'a [u8],
-        ancestors: Ancestors<'a, '_>,
-        halstead_maps: &mut HalsteadMaps<'a>,
-    ) {
-        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
-    }
-}
-
-impl Halstead for RustCode {
-    fn compute<'a>(
-        node: &Node<'a>,
-        code: &'a [u8],
-        ancestors: Ancestors<'a, '_>,
-        halstead_maps: &mut HalsteadMaps<'a>,
-    ) {
-        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
-    }
-}
-
-impl Halstead for CppCode {
-    fn compute<'a>(
-        node: &Node<'a>,
-        code: &'a [u8],
-        ancestors: Ancestors<'a, '_>,
-        halstead_maps: &mut HalsteadMaps<'a>,
-    ) {
-        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
-    }
-}
-
-impl Halstead for CCode {
-    fn compute<'a>(
-        node: &Node<'a>,
-        code: &'a [u8],
-        ancestors: Ancestors<'a, '_>,
-        halstead_maps: &mut HalsteadMaps<'a>,
-    ) {
-        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
-    }
-}
-
-impl Halstead for ObjcCode {
-    fn compute<'a>(
-        node: &Node<'a>,
-        code: &'a [u8],
-        ancestors: Ancestors<'a, '_>,
-        halstead_maps: &mut HalsteadMaps<'a>,
-    ) {
-        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
-    }
-}
-
-impl Halstead for MozcppCode {
-    fn compute<'a>(
-        node: &Node<'a>,
-        code: &'a [u8],
-        ancestors: Ancestors<'a, '_>,
-        halstead_maps: &mut HalsteadMaps<'a>,
-    ) {
-        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
-    }
-}
-
-impl Halstead for JavaCode {
-    fn compute<'a>(
-        node: &Node<'a>,
-        code: &'a [u8],
-        ancestors: Ancestors<'a, '_>,
-        halstead_maps: &mut HalsteadMaps<'a>,
-    ) {
-        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
-    }
-}
-
-impl Halstead for GroovyCode {
-    fn compute<'a>(
-        node: &Node<'a>,
-        code: &'a [u8],
-        ancestors: Ancestors<'a, '_>,
-        halstead_maps: &mut HalsteadMaps<'a>,
-    ) {
-        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
-    }
-}
-
-impl Halstead for CsharpCode {
-    fn compute<'a>(
-        node: &Node<'a>,
-        code: &'a [u8],
-        ancestors: Ancestors<'a, '_>,
-        halstead_maps: &mut HalsteadMaps<'a>,
-    ) {
-        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
-    }
-}
-
-impl Halstead for GoCode {
-    fn compute<'a>(
-        node: &Node<'a>,
-        code: &'a [u8],
-        ancestors: Ancestors<'a, '_>,
-        halstead_maps: &mut HalsteadMaps<'a>,
-    ) {
-        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
-    }
-}
-
-impl Halstead for PerlCode {
-    fn compute<'a>(
-        node: &Node<'a>,
-        code: &'a [u8],
-        ancestors: Ancestors<'a, '_>,
-        halstead_maps: &mut HalsteadMaps<'a>,
-    ) {
-        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
-    }
-}
-
-impl Halstead for KotlinCode {
-    fn compute<'a>(
-        node: &Node<'a>,
-        code: &'a [u8],
-        ancestors: Ancestors<'a, '_>,
-        halstead_maps: &mut HalsteadMaps<'a>,
-    ) {
-        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
-    }
-}
-
-impl Halstead for LuaCode {
-    fn compute<'a>(
-        node: &Node<'a>,
-        code: &'a [u8],
-        ancestors: Ancestors<'a, '_>,
-        halstead_maps: &mut HalsteadMaps<'a>,
-    ) {
-        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
-    }
-}
-
-impl Halstead for PhpCode {
-    fn compute<'a>(
-        node: &Node<'a>,
-        code: &'a [u8],
-        ancestors: Ancestors<'a, '_>,
-        halstead_maps: &mut HalsteadMaps<'a>,
-    ) {
-        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
-    }
-}
+impl_halstead_forwarding!(
+    PythonCode,
+    MozjsCode,
+    JavascriptCode,
+    TypescriptCode,
+    TsxCode,
+    RustCode,
+    CppCode,
+    CCode,
+    ObjcCode,
+    MozcppCode,
+    JavaCode,
+    GroovyCode,
+    CsharpCode,
+    GoCode,
+    PerlCode,
+    KotlinCode,
+    LuaCode,
+    PhpCode,
+    RubyCode,
+    ElixirCode,
+    BashCode,
+    TclCode,
+    IrulesCode,
+);
 
 // Real defaults — no operators / operands to count. Audited in #188.
 implement_metric_trait!(Halstead, PreprocCode, CcommentCode);
-
-impl Halstead for RubyCode {
-    fn compute<'a>(
-        node: &Node<'a>,
-        code: &'a [u8],
-        ancestors: Ancestors<'a, '_>,
-        halstead_maps: &mut HalsteadMaps<'a>,
-    ) {
-        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
-    }
-}
-
-impl Halstead for ElixirCode {
-    fn compute<'a>(
-        node: &Node<'a>,
-        code: &'a [u8],
-        ancestors: Ancestors<'a, '_>,
-        halstead_maps: &mut HalsteadMaps<'a>,
-    ) {
-        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
-    }
-}
-
-impl Halstead for BashCode {
-    fn compute<'a>(
-        node: &Node<'a>,
-        code: &'a [u8],
-        ancestors: Ancestors<'a, '_>,
-        halstead_maps: &mut HalsteadMaps<'a>,
-    ) {
-        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
-    }
-}
-
-impl Halstead for TclCode {
-    fn compute<'a>(
-        node: &Node<'a>,
-        code: &'a [u8],
-        ancestors: Ancestors<'a, '_>,
-        halstead_maps: &mut HalsteadMaps<'a>,
-    ) {
-        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
-    }
-}
-
-impl Halstead for IrulesCode {
-    fn compute<'a>(
-        node: &Node<'a>,
-        code: &'a [u8],
-        ancestors: Ancestors<'a, '_>,
-        halstead_maps: &mut HalsteadMaps<'a>,
-    ) {
-        compute_halstead::<Self>(node, code, ancestors, halstead_maps);
-    }
-}
 
 #[cfg(test)]
 #[allow(

--- a/src/metrics/loc.rs
+++ b/src/metrics/loc.rs
@@ -4597,6 +4597,34 @@ line3\";",
             "foo.rb",
             assert_three_code_rows,
         );
+        // Go, Kotlin, and Mozilla-C++ reach the same shared
+        // `add_multiline_string_ploc` helper through their own
+        // raw-string kinds (`raw_string_literal`,
+        // `multiline_string_literal`, `raw_string_literal`), and were
+        // the three call sites of it that no test exercised. Each needs
+        // its own syntax, so they cannot reuse the quoted form above.
+        check_metrics::<GoParser>(
+            "package p\n\nvar s = `line1\nline2\nline3`",
+            "foo.go",
+            |metric| {
+                // Two extra code rows for `package p` and the blank
+                // between it and the declaration, which Go requires.
+                assert_eq!(metric.loc.sloc(), 5);
+                assert_eq!(metric.loc.ploc(), 4);
+                assert_eq!(metric.loc.cloc(), 0);
+                assert_eq!(metric.loc.blank(), 1);
+            },
+        );
+        check_metrics::<KotlinParser>(
+            "val s = \"\"\"line1\nline2\nline3\"\"\"",
+            "foo.kt",
+            assert_three_code_rows,
+        );
+        check_metrics::<MozcppParser>(
+            "const char* s = R\"(line1\nline2\nline3)\";",
+            "foo.cpp",
+            assert_three_code_rows,
+        );
     }
 
     #[test]

--- a/src/metrics/loc/c.rs
+++ b/src/metrics/loc/c.rs
@@ -25,7 +25,7 @@ impl Loc for CCode {
             // span multiple rows; credit every spanned row to PLOC to match
             // Python's #415 decision (#778).
             StringLiteral => {
-                add_multiline_string_ploc(node, stats, start, end);
+                add_multiline_string_ploc(node, ancestors, stats, start, end);
             }
             Comment => {
                 add_cloc_lines(stats, start, end);

--- a/src/metrics/loc/cpp.rs
+++ b/src/metrics/loc/cpp.rs
@@ -25,7 +25,7 @@ impl Loc for CppCode {
             // across adjacent lines can span multiple rows; credit every
             // spanned row to PLOC to match Python's #415 decision (#778).
             RawStringLiteral | StringLiteral => {
-                add_multiline_string_ploc(node, stats, start, end);
+                add_multiline_string_ploc(node, ancestors, stats, start, end);
             }
             Comment => {
                 add_cloc_lines(stats, start, end);

--- a/src/metrics/loc/csharp.rs
+++ b/src/metrics/loc/csharp.rs
@@ -28,7 +28,7 @@ impl Loc for CsharpCode {
             // several rows; credit every spanned row to PLOC to match Python's
             // #415 decision (#778).
             VerbatimStringLiteral | RawStringLiteral => {
-                add_multiline_string_ploc(node, stats, start, end);
+                add_multiline_string_ploc(node, ancestors, stats, start, end);
             }
             BreakStatement | CheckedStatement | ContinueStatement | DoStatement
             | ExpressionStatement | FixedStatement | ForStatement | ForeachStatement

--- a/src/metrics/loc/elixir.rs
+++ b/src/metrics/loc/elixir.rs
@@ -14,7 +14,7 @@
 use super::*;
 
 impl Loc for ElixirCode {
-    fn compute(node: &Node, _ancestors: Ancestors<'_, '_>, stats: &mut Stats, is_func_space: bool) {
+    fn compute(node: &Node, ancestors: Ancestors<'_, '_>, stats: &mut Stats, is_func_space: bool) {
         use Elixir as E;
 
         let (start, end) = init(node, stats, is_func_space);
@@ -48,7 +48,7 @@ impl Loc for ElixirCode {
             // skip the parent lookup entirely.
             _ => {
                 if node.as_tree_sitter().is_named()
-                    && node.parent().is_some_and(|p| {
+                    && ancestors.parent(node).is_some_and(|p| {
                         matches!(
                             p.kind_id().into(),
                             E::Source

--- a/src/metrics/loc/go.rs
+++ b/src/metrics/loc/go.rs
@@ -27,7 +27,7 @@ impl Loc for GoCode {
             // credit every spanned row to PLOC to match Python's #415
             // decision (#778).
             G::RawStringLiteral => {
-                add_multiline_string_ploc(node, stats, start, end);
+                add_multiline_string_ploc(node, ancestors, stats, start, end);
             }
             G::Comment => {
                 add_cloc_lines(stats, start, end);

--- a/src/metrics/loc/groovy.rs
+++ b/src/metrics/loc/groovy.rs
@@ -40,7 +40,7 @@ impl Loc for GroovyCode {
             // `string_literal` spanning several rows; credit every spanned row
             // to PLOC to match Python's #415 decision (#778).
             StringLiteral => {
-                add_multiline_string_ploc(node, stats, start, end);
+                add_multiline_string_ploc(node, ancestors, stats, start, end);
             }
             // An `ExpressionStatement` whose only child is a bare
             // `Closure` is a Groovy-specific grammar artifact: the

--- a/src/metrics/loc/irules.rs
+++ b/src/metrics/loc/irules.rs
@@ -14,7 +14,7 @@
 use super::*;
 
 impl Loc for IrulesCode {
-    fn compute(node: &Node, _ancestors: Ancestors<'_, '_>, stats: &mut Stats, is_func_space: bool) {
+    fn compute(node: &Node, ancestors: Ancestors<'_, '_>, stats: &mut Stats, is_func_space: bool) {
         let (start, end) = init(node, stats, is_func_space);
 
         match node.kind_id().into() {
@@ -58,8 +58,8 @@ impl Loc for IrulesCode {
             Irules::ExprCmd
             // Commands inside [...] are sub-expressions, not top-level statements.
             | Irules::Command
-                if node
-                    .parent()
+                if ancestors
+                    .parent(node)
                     .is_none_or(|p| p.kind_id() != Irules::CommandSubstitution) =>
             {
                 stats.lloc.logical_lines += 1;

--- a/src/metrics/loc/java.rs
+++ b/src/metrics/loc/java.rs
@@ -30,7 +30,7 @@ impl Loc for JavaCode {
             // is a `multiline_string_fragment` spanning several rows; credit
             // every spanned row to PLOC to match Python's #415 decision (#778).
             StringLiteral => {
-                add_multiline_string_ploc(node, stats, start, end);
+                add_multiline_string_ploc(node, ancestors, stats, start, end);
             }
             AssertStatement | BreakStatement | ContinueStatement | DoStatement
             | EnhancedForStatement | ExpressionStatement | ForStatement | IfStatement

--- a/src/metrics/loc/javascript.rs
+++ b/src/metrics/loc/javascript.rs
@@ -14,7 +14,7 @@
 use super::*;
 
 impl Loc for JavascriptCode {
-    fn compute(node: &Node, _ancestors: Ancestors<'_, '_>, stats: &mut Stats, is_func_space: bool) {
+    fn compute(node: &Node, ancestors: Ancestors<'_, '_>, stats: &mut Stats, is_func_space: bool) {
         use Javascript::*;
 
         let (start, end) = init(node, stats, is_func_space);
@@ -28,7 +28,7 @@ impl Loc for JavascriptCode {
             // A `template_string` (`` `…` ``) can span multiple rows; credit
             // every spanned row to PLOC to match Python's #415 decision (#778).
             TemplateString => {
-                add_multiline_string_ploc(node, stats, start, end);
+                add_multiline_string_ploc(node, ancestors, stats, start, end);
             }
             // `StatementBlock` is deliberately absent — see MozjsCode::compute
             // (#777). It is a brace grouping, not a logical statement.

--- a/src/metrics/loc/kotlin.rs
+++ b/src/metrics/loc/kotlin.rs
@@ -14,7 +14,7 @@
 use super::*;
 
 impl Loc for KotlinCode {
-    fn compute(node: &Node, _ancestors: Ancestors<'_, '_>, stats: &mut Stats, is_func_space: bool) {
+    fn compute(node: &Node, ancestors: Ancestors<'_, '_>, stats: &mut Stats, is_func_space: bool) {
         use Kotlin::*;
 
         let (start, end) = init(node, stats, is_func_space);
@@ -28,7 +28,7 @@ impl Loc for KotlinCode {
             // spanning several rows; credit every spanned row to PLOC to match
             // Python's #415 decision (#778).
             MultilineStringLiteral => {
-                add_multiline_string_ploc(node, stats, start, end);
+                add_multiline_string_ploc(node, ancestors, stats, start, end);
             }
             ForStatement | WhileStatement | DoWhileStatement | IfExpression | WhenExpression
             | TryExpression | ThrowExpression | ReturnExpression | Assignment
@@ -41,7 +41,7 @@ impl Loc for KotlinCode {
             // otherwise fall through to ploc so nested calls still count
             // as physical lines.
             CallExpression | NavigationExpression => {
-                if let Some(parent) = node.parent()
+                if let Some(parent) = ancestors.parent(node)
                     && matches!(
                         parent.kind_id().into(),
                         Block | FunctionBody | SourceFile | CatchBlock | FinallyBlock

--- a/src/metrics/loc/lua.rs
+++ b/src/metrics/loc/lua.rs
@@ -14,7 +14,7 @@
 use super::*;
 
 impl Loc for LuaCode {
-    fn compute(node: &Node, _ancestors: Ancestors<'_, '_>, stats: &mut Stats, is_func_space: bool) {
+    fn compute(node: &Node, ancestors: Ancestors<'_, '_>, stats: &mut Stats, is_func_space: bool) {
         let (start, end) = init(node, stats, is_func_space);
 
         match node.kind_id().into() {
@@ -25,7 +25,7 @@ impl Loc for LuaCode {
             // credit every spanned row to PLOC to match Python's #415
             // decision (#778).
             Lua::String => {
-                add_multiline_string_ploc(node, stats, start, end);
+                add_multiline_string_ploc(node, ancestors, stats, start, end);
             }
 
             // Skip tokens that are children of comment nodes.
@@ -37,7 +37,9 @@ impl Loc for LuaCode {
             // string nodes, so we guard on the parent kind to avoid skipping them there.
             Lua::DASHDASH | Lua::CommentContent | Lua::CommentContent2 => {}
             Lua::LBRACKLBRACK | Lua::RBRACKRBRACK
-                if node.parent().is_some_and(|p| p.kind_id() == Lua::Comment) => {}
+                if ancestors
+                    .parent(node)
+                    .is_some_and(|p| p.kind_id() == Lua::Comment) => {}
 
             Lua::Comment => {
                 add_cloc_lines(stats, start, end);
@@ -46,7 +48,7 @@ impl Loc for LuaCode {
             // Standalone assignment (`x = 1`). Skip when nested inside a local variable
             // declaration (`local x = 1`) — the parent VariableDeclaration already counts.
             Lua::AssignmentStatement | Lua::AssignmentStatement2
-                if !node.parent().is_some_and(|p| {
+                if !ancestors.parent(node).is_some_and(|p| {
                     matches!(
                         p.kind_id().into(),
                         Lua::VariableDeclaration

--- a/src/metrics/loc/mozcpp.rs
+++ b/src/metrics/loc/mozcpp.rs
@@ -25,7 +25,7 @@ impl Loc for MozcppCode {
             // across adjacent lines can span multiple rows; credit every
             // spanned row to PLOC to match Python's #415 decision (#778).
             RawStringLiteral | StringLiteral => {
-                add_multiline_string_ploc(node, stats, start, end);
+                add_multiline_string_ploc(node, ancestors, stats, start, end);
             }
             Comment => {
                 add_cloc_lines(stats, start, end);

--- a/src/metrics/loc/mozjs.rs
+++ b/src/metrics/loc/mozjs.rs
@@ -14,7 +14,7 @@
 use super::*;
 
 impl Loc for MozjsCode {
-    fn compute(node: &Node, _ancestors: Ancestors<'_, '_>, stats: &mut Stats, is_func_space: bool) {
+    fn compute(node: &Node, ancestors: Ancestors<'_, '_>, stats: &mut Stats, is_func_space: bool) {
         use Mozjs::*;
 
         let (start, end) = init(node, stats, is_func_space);
@@ -30,7 +30,7 @@ impl Loc for MozjsCode {
             // A `template_string` (`` `…` ``) can span multiple rows; credit
             // every spanned row to PLOC to match Python's #415 decision (#778).
             TemplateString => {
-                add_multiline_string_ploc(node, stats, start, end);
+                add_multiline_string_ploc(node, ancestors, stats, start, end);
             }
             // `StatementBlock` is a syntactic `{ … }` brace grouping, not a
             // logical statement, so it is deliberately absent here (#777). It

--- a/src/metrics/loc/objc.rs
+++ b/src/metrics/loc/objc.rs
@@ -29,7 +29,7 @@ impl Loc for ObjcCode {
             // credit every spanned row to PLOC to match Python's #415 decision
             // (#778). ObjC has no raw string literals.
             StringLiteral => {
-                add_multiline_string_ploc(node, stats, start, end);
+                add_multiline_string_ploc(node, ancestors, stats, start, end);
             }
             Comment => {
                 add_cloc_lines(stats, start, end);

--- a/src/metrics/loc/perl.rs
+++ b/src/metrics/loc/perl.rs
@@ -14,7 +14,7 @@
 use super::*;
 
 impl Loc for PerlCode {
-    fn compute(node: &Node, _ancestors: Ancestors<'_, '_>, stats: &mut Stats, is_func_space: bool) {
+    fn compute(node: &Node, ancestors: Ancestors<'_, '_>, stats: &mut Stats, is_func_space: bool) {
         use Perl as P;
 
         let (start, end) = init(node, stats, is_func_space);
@@ -49,7 +49,7 @@ impl Loc for PerlCode {
             | P::StringQqQuoted
             | P::BacktickQuoted
             | P::CommandQxQuoted => {
-                add_multiline_string_ploc(node, stats, start, end);
+                add_multiline_string_ploc(node, ancestors, stats, start, end);
             }
             P::Comments | P::PodStatement => {
                 add_cloc_lines(stats, start, end);
@@ -80,7 +80,7 @@ impl Loc for PerlCode {
                 // rather than emitting a dedicated statement kind), so it
                 // contributes one LLOC. Then fall through to the same PLOC
                 // bookkeeping the catch-all arm does.
-                if let Some(parent) = node.parent()
+                if let Some(parent) = ancestors.parent(node)
                     && matches!(parent.kind_id().into(), P::SourceFile | P::Block)
                 {
                     stats.lloc.logical_lines += 1;

--- a/src/metrics/loc/php.rs
+++ b/src/metrics/loc/php.rs
@@ -14,7 +14,7 @@
 use super::*;
 
 impl Loc for PhpCode {
-    fn compute(node: &Node, _ancestors: Ancestors<'_, '_>, stats: &mut Stats, is_func_space: bool) {
+    fn compute(node: &Node, ancestors: Ancestors<'_, '_>, stats: &mut Stats, is_func_space: bool) {
         use Php::*;
 
         let (start, end) = init(node, stats, is_func_space);
@@ -30,7 +30,7 @@ impl Loc for PhpCode {
             // nowdoc bodies already reach PLOC through their inner statement
             // nodes, so they are not routed here.
             EncapsedString | String => {
-                add_multiline_string_ploc(node, stats, start, end);
+                add_multiline_string_ploc(node, ancestors, stats, start, end);
             }
             // Statement kinds that contribute one logical line each.
             ExpressionStatement

--- a/src/metrics/loc/python.rs
+++ b/src/metrics/loc/python.rs
@@ -14,7 +14,7 @@
 use super::*;
 
 impl Loc for PythonCode {
-    fn compute(node: &Node, _ancestors: Ancestors<'_, '_>, stats: &mut Stats, is_func_space: bool) {
+    fn compute(node: &Node, ancestors: Ancestors<'_, '_>, stats: &mut Stats, is_func_space: bool) {
         use Python::*;
 
         let (start, end) = init(node, stats, is_func_space);
@@ -36,7 +36,9 @@ impl Loc for PythonCode {
                 add_cloc_lines(stats, start, end);
             }
             String => {
-                let Some(parent) = node.parent() else { return };
+                let Some(parent) = ancestors.parent(node) else {
+                    return;
+                };
                 if let ExpressionStatement = parent.kind_id().into() {
                     // A bare string statement is treated as a docstring and
                     // counted as comment lines (see issue #415 for the related

--- a/src/metrics/loc/ruby.rs
+++ b/src/metrics/loc/ruby.rs
@@ -14,7 +14,7 @@
 use super::*;
 
 impl Loc for RubyCode {
-    fn compute(node: &Node, _ancestors: Ancestors<'_, '_>, stats: &mut Stats, is_func_space: bool) {
+    fn compute(node: &Node, ancestors: Ancestors<'_, '_>, stats: &mut Stats, is_func_space: bool) {
         use Ruby as R;
 
         let (start, end) = init(node, stats, is_func_space);
@@ -27,7 +27,7 @@ impl Loc for RubyCode {
             // body can span several rows; credit every spanned row to PLOC to
             // match Python's #415 decision (#778).
             R::String | R::HeredocBody => {
-                add_multiline_string_ploc(node, stats, start, end);
+                add_multiline_string_ploc(node, ancestors, stats, start, end);
             }
             // LLOC contributors: control-flow constructs, method/class/module
             // declarations, postfix statement modifiers, and the dedicated

--- a/src/metrics/loc/rust.rs
+++ b/src/metrics/loc/rust.rs
@@ -14,7 +14,7 @@
 use super::*;
 
 impl Loc for RustCode {
-    fn compute(node: &Node, _ancestors: Ancestors<'_, '_>, stats: &mut Stats, is_func_space: bool) {
+    fn compute(node: &Node, ancestors: Ancestors<'_, '_>, stats: &mut Stats, is_func_space: bool) {
         use Rust::*;
 
         let (start, end) = init(node, stats, is_func_space);
@@ -35,7 +35,7 @@ impl Loc for RustCode {
             // rows; credit every spanned row to PLOC to match Python's #415
             // decision (#778).
             StringLiteral | RawStringLiteral => {
-                add_multiline_string_ploc(node, stats, start, end);
+                add_multiline_string_ploc(node, ancestors, stats, start, end);
             }
             BlockComment => {
                 add_cloc_lines(stats, start, end);

--- a/src/metrics/loc/shared.rs
+++ b/src/metrics/loc/shared.rs
@@ -133,9 +133,15 @@ pub(crate) fn add_only_comment_lines(stats: &mut Stats, start: usize, end: usize
 // row is already attributed to the parent — and rows `start + 1..=end`
 // (the interior and closing rows) are always inserted.
 #[inline]
-pub(crate) fn add_multiline_string_ploc(node: &Node, stats: &mut Stats, start: usize, end: usize) {
-    if node
-        .parent()
+pub(crate) fn add_multiline_string_ploc(
+    node: &Node,
+    ancestors: Ancestors<'_, '_>,
+    stats: &mut Stats,
+    start: usize,
+    end: usize,
+) {
+    if ancestors
+        .parent(node)
         .is_none_or(|parent| parent.start_row() != start)
     {
         check_comment_ends_on_code_line(stats, start);

--- a/src/metrics/loc/tcl.rs
+++ b/src/metrics/loc/tcl.rs
@@ -14,7 +14,7 @@
 use super::*;
 
 impl Loc for TclCode {
-    fn compute(node: &Node, _ancestors: Ancestors<'_, '_>, stats: &mut Stats, is_func_space: bool) {
+    fn compute(node: &Node, ancestors: Ancestors<'_, '_>, stats: &mut Stats, is_func_space: bool) {
         let (start, end) = init(node, stats, is_func_space);
 
         match node.kind_id().into() {
@@ -43,8 +43,8 @@ impl Loc for TclCode {
             Tcl::ExprCmd
             // Commands inside [...] are sub-expressions, not top-level statements.
             | Tcl::Command
-                if node
-                    .parent()
+                if ancestors
+                    .parent(node)
                     .is_none_or(|p| p.kind_id() != Tcl::CommandSubstitution) =>
             {
                 stats.lloc.logical_lines += 1;

--- a/src/metrics/loc/tsx.rs
+++ b/src/metrics/loc/tsx.rs
@@ -14,7 +14,7 @@
 use super::*;
 
 impl Loc for TsxCode {
-    fn compute(node: &Node, _ancestors: Ancestors<'_, '_>, stats: &mut Stats, is_func_space: bool) {
+    fn compute(node: &Node, ancestors: Ancestors<'_, '_>, stats: &mut Stats, is_func_space: bool) {
         use Tsx::*;
 
         let (start, end) = init(node, stats, is_func_space);
@@ -28,7 +28,7 @@ impl Loc for TsxCode {
             // A `template_string` (`` `…` ``) can span multiple rows; credit
             // every spanned row to PLOC to match Python's #415 decision (#778).
             TemplateString => {
-                add_multiline_string_ploc(node, stats, start, end);
+                add_multiline_string_ploc(node, ancestors, stats, start, end);
             }
             // `StatementBlock` is deliberately absent — see MozjsCode::compute
             // (#777). It is a brace grouping, not a logical statement.

--- a/src/metrics/loc/typescript.rs
+++ b/src/metrics/loc/typescript.rs
@@ -14,7 +14,7 @@
 use super::*;
 
 impl Loc for TypescriptCode {
-    fn compute(node: &Node, _ancestors: Ancestors<'_, '_>, stats: &mut Stats, is_func_space: bool) {
+    fn compute(node: &Node, ancestors: Ancestors<'_, '_>, stats: &mut Stats, is_func_space: bool) {
         use Typescript::*;
 
         let (start, end) = init(node, stats, is_func_space);
@@ -28,7 +28,7 @@ impl Loc for TypescriptCode {
             // A `template_string` (`` `…` ``) can span multiple rows; credit
             // every spanned row to PLOC to match Python's #415 decision (#778).
             TemplateString => {
-                add_multiline_string_ploc(node, stats, start, end);
+                add_multiline_string_ploc(node, ancestors, stats, start, end);
             }
             // `StatementBlock` is deliberately absent — see MozjsCode::compute
             // (#777). It is a brace grouping, not a logical statement.

--- a/src/metrics/npa.rs
+++ b/src/metrics/npa.rs
@@ -239,7 +239,20 @@ where
     /// it. Languages whose visibility rules are encoded purely in
     /// distinct token kinds (Java's `Public` / `Private`, PHP's
     /// `VisibilityModifier`) ignore the parameter.
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], stats: &mut Stats);
+    ///
+    /// `ancestors` is the chain the walker descended through. The
+    /// C-family, C#, PHP, Ruby, Rust, Kotlin, and Groovy impls read a
+    /// parent from it, because their grammars give a class body, an
+    /// interface body, and (for Rust) a free item the same node kind and
+    /// leave the enclosing declaration to disambiguate. Reaching that
+    /// declaration with [`Node::parent`] costs `O(depth)` per node
+    /// (#1096).
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        _ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    );
 }
 
 // Java and Groovy share their grammar tokens for class/interface
@@ -266,7 +279,12 @@ where
 macro_rules! impl_npa_java_like {
     ($code:ty, $lang:ident) => {
         impl Npa for $code {
-            fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+            fn compute<'a>(
+                node: &Node<'a>,
+                _code: &'a [u8],
+                _ancestors: Ancestors<'a, '_>,
+                stats: &mut Stats,
+            ) {
                 use $lang::*;
 
                 if Self::is_func_space(node) && stats.is_disabled() {
@@ -350,7 +368,12 @@ pub(crate) use shared::*;
 // belong to `npm`.
 macro_rules! ts_npa_compute {
     ($lang:ident) => {
-        fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+        fn compute<'a>(
+            node: &Node<'a>,
+            _code: &'a [u8],
+            _ancestors: Ancestors<'a, '_>,
+            stats: &mut Stats,
+        ) {
             use $lang::*;
 
             if Self::is_func_space(node) && stats.is_disabled() {
@@ -467,7 +490,12 @@ pub(crate) use ts_member_is_public;
 
 macro_rules! js_npa_compute {
     ($lang:ident) => {
-        fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+        fn compute<'a>(
+            node: &Node<'a>,
+            _code: &'a [u8],
+            _ancestors: Ancestors<'a, '_>,
+            stats: &mut Stats,
+        ) {
             use $lang::*;
 
             if Self::is_func_space(node) && stats.is_disabled() {

--- a/src/metrics/npa/cpp.rs
+++ b/src/metrics/npa/cpp.rs
@@ -9,7 +9,12 @@
 use super::*;
 
 impl Npa for CppCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Cpp::*;
 
         // Mark class / struct spaces as class spaces so the metric is
@@ -22,7 +27,7 @@ impl Npa for CppCode {
         if !matches!(node.kind_id().into(), FieldDeclarationList) {
             return;
         }
-        let Some(parent) = node.parent() else {
+        let Some(parent) = ancestors.parent(node) else {
             return;
         };
         // C++ `class` defaults to private; `struct` defaults to public.

--- a/src/metrics/npa/csharp.rs
+++ b/src/metrics/npa/csharp.rs
@@ -9,7 +9,12 @@
 use super::*;
 
 impl Npa for CsharpCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Csharp::*;
 
         if Self::is_func_space(node) && stats.is_disabled() {
@@ -21,7 +26,7 @@ impl Npa for CsharpCode {
         if !matches!(node.kind_id().into(), DeclarationList) {
             return;
         }
-        let Some(parent_kind) = node.parent().map(|p| p.kind_id().into()) else {
+        let Some(parent_kind) = ancestors.parent(node).map(|p| p.kind_id().into()) else {
             return;
         };
         match parent_kind {

--- a/src/metrics/npa/elixir.rs
+++ b/src/metrics/npa/elixir.rs
@@ -23,7 +23,12 @@ use super::*;
 // have no Java-style visibility modifier and the runtime exposes every
 // field via pattern matching and `Map.get/2`.
 impl Npa for ElixirCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        _ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use crate::metrics::cognitive::{elixir_call_keyword, elixir_do_block_call_children};
 
         // `is_func_space_with_code` is not consulted: it is implied.

--- a/src/metrics/npa/go.rs
+++ b/src/metrics/npa/go.rs
@@ -39,7 +39,12 @@ use super::*;
 //   they are method signatures, counted by Npm under
 //   `interface_nm`, not by Npa.
 impl Npa for GoCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        _ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Go as G;
 
         if !matches!(node.kind_id().into(), G::StructType) {

--- a/src/metrics/npa/groovy.rs
+++ b/src/metrics/npa/groovy.rs
@@ -19,7 +19,12 @@ use super::*;
 // `class_npa` unless explicitly annotated `public` — consistent with
 // Groovy's access semantics (we conservatively follow Java).
 impl Npa for GroovyCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Groovy::*;
 
         if Self::is_func_space(node) && stats.is_disabled() {
@@ -28,7 +33,7 @@ impl Npa for GroovyCode {
 
         match node.kind_id().into() {
             ClassBody | EnumBody => {
-                let is_interface_like = groovy_body_is_interface_like(node);
+                let is_interface_like = groovy_body_is_interface_like(node, ancestors);
 
                 for declaration in node
                     .children()

--- a/src/metrics/npa/kotlin.rs
+++ b/src/metrics/npa/kotlin.rs
@@ -30,7 +30,12 @@ fn kotlin_count_property_attrs(decl: &Node) -> usize {
 }
 
 impl Npa for KotlinCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Kotlin::*;
 
         // Enables the `Npa` metric for both class and interface spaces
@@ -63,7 +68,7 @@ impl Npa for KotlinCode {
             // func_space (handled by `spaces.rs`), so they do NOT leak
             // attributes into their outer space.
             ClassBody => {
-                let is_interface = kotlin_class_body_is_interface(node);
+                let is_interface = kotlin_class_body_is_interface(node, ancestors);
                 // tree-sitter-kotlin elides the `class_member_declaration`
                 // and `declaration` rule layers when those rules are pure
                 // forwarding choices, so property declarations appear as

--- a/src/metrics/npa/mozcpp.rs
+++ b/src/metrics/npa/mozcpp.rs
@@ -9,7 +9,12 @@
 use super::*;
 
 impl Npa for MozcppCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Mozcpp::*;
 
         // Mark class / struct spaces as class spaces so the metric is
@@ -22,7 +27,7 @@ impl Npa for MozcppCode {
         if !matches!(node.kind_id().into(), FieldDeclarationList) {
             return;
         }
-        let Some(parent) = node.parent() else {
+        let Some(parent) = ancestors.parent(node) else {
             return;
         };
         // C++ `class` defaults to private; `struct` defaults to public.

--- a/src/metrics/npa/objc.rs
+++ b/src/metrics/npa/objc.rs
@@ -54,7 +54,12 @@ fn objc_count_instance_variables(block: &Node) -> (usize, usize) {
 // class node itself is visited — the same point `is_class_space` is
 // marked (mirroring the C++ impl's marking step).
 impl Npa for ObjcCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        _ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Objc::*;
 
         let is_interface = matches!(node.kind_id().into(), ClassInterface | ProtocolDeclaration);

--- a/src/metrics/npa/php.rs
+++ b/src/metrics/npa/php.rs
@@ -9,7 +9,12 @@
 use super::*;
 
 impl Npa for PhpCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Php::*;
 
         // Enables the `Npa` metric if computing stats of a class-like space.
@@ -33,7 +38,7 @@ impl Npa for PhpCode {
         if !matches!(node.kind_id().into(), DeclarationList) {
             return;
         }
-        let Some(parent_kind) = node.parent().map(|p| p.kind_id().into()) else {
+        let Some(parent_kind) = ancestors.parent(node).map(|p| p.kind_id().into()) else {
             return;
         };
         match parent_kind {

--- a/src/metrics/npa/python.rs
+++ b/src/metrics/npa/python.rs
@@ -33,7 +33,12 @@ use super::*;
 // `self.X = …` lives inside a child `FunctionDefinition` space whose
 // own `npa` stats are not class spaces.
 impl Npa for PythonCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        _ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Python::*;
 
         // Gate on `ClassDefinition` specifically: `is_func_space` is

--- a/src/metrics/npa/ruby.rs
+++ b/src/metrics/npa/ruby.rs
@@ -9,7 +9,12 @@
 use super::*;
 
 impl Npa for RubyCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Ruby::*;
 
         if Self::is_func_space(node) && stats.is_disabled() {
@@ -19,7 +24,7 @@ impl Npa for RubyCode {
         if !matches!(node.kind_id().into(), BodyStatement | BodyStatement2) {
             return;
         }
-        let Some(parent_kind) = node.parent().map(|p| p.kind_id().into()) else {
+        let Some(parent_kind) = ancestors.parent(node).map(|p| p.kind_id().into()) else {
             return;
         };
         if !matches!(parent_kind, Class | SingletonClass) {

--- a/src/metrics/npa/rust.rs
+++ b/src/metrics/npa/rust.rs
@@ -49,7 +49,12 @@ use super::*;
 //   tags, not data fields), mirroring Kotlin's `enum_class_body`
 //   treatment.
 impl Npa for RustCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Rust::*;
 
         // Mark Impl / Trait spaces as class spaces so the metric is
@@ -67,11 +72,11 @@ impl Npa for RustCode {
             // Associated const/static declared in an `impl` block.
             // The current top-of-stack is the Impl space (because we
             // are inside its body), so attribution lands there.
-            ConstItem | StaticItem => rust_count_assoc_const(node, stats),
+            ConstItem | StaticItem => rust_count_assoc_const(node, ancestors, stats),
             // `type Foo;` inside a trait body is an associated type —
             // a placeholder bound that the implementer must supply.
             // Counted as an interface attribute, public by default.
-            AssociatedType => rust_count_assoc_type(node, stats),
+            AssociatedType => rust_count_assoc_type(node, ancestors, stats),
             _ => {}
         }
     }
@@ -131,13 +136,14 @@ fn rust_count_struct_attrs(node: &Node, stats: &mut Stats) {
 // or `trait` body. Impl members count toward the class attribute totals
 // (public if `pub`); trait members are always visible to implementers,
 // so `interface_npa` tracks `interface_na`.
-fn rust_count_assoc_const(node: &Node, stats: &mut Stats) {
+fn rust_count_assoc_const<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>, stats: &mut Stats) {
     use Rust::*;
 
-    let Some(parent) = node.parent() else {
+    let mut climb = ancestors.iter(node);
+    let Some((parent, _)) = climb.next() else {
         return;
     };
-    let Some(grand) = parent.parent() else {
+    let Some((grand, _)) = climb.next() else {
         return;
     };
     match grand.kind_id().into() {
@@ -157,13 +163,14 @@ fn rust_count_assoc_const(node: &Node, stats: &mut Stats) {
 
 // Counts a trait-body `associated_type` (`type Foo;`) as one interface
 // attribute, public by default — the implementer must supply it.
-fn rust_count_assoc_type(node: &Node, stats: &mut Stats) {
+fn rust_count_assoc_type<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>, stats: &mut Stats) {
     use Rust::*;
 
-    let Some(parent) = node.parent() else {
+    let mut climb = ancestors.iter(node);
+    let Some((parent, _)) = climb.next() else {
         return;
     };
-    let Some(grand) = parent.parent() else {
+    let Some((grand, _)) = climb.next() else {
         return;
     };
     if matches!(grand.kind_id().into(), TraitItem)

--- a/src/metrics/npa/shared.rs
+++ b/src/metrics/npa/shared.rs
@@ -21,9 +21,12 @@ use super::*;
 // modifier. The dekobon grammar models all of these bodies as
 // `class_body`, so the discriminant lives on the parent. Shared with
 // `impl Npm for GroovyCode` (`metrics::npm`).
-pub(crate) fn groovy_body_is_interface_like(body: &Node) -> bool {
+pub(crate) fn groovy_body_is_interface_like<'a>(
+    body: &Node<'a>,
+    ancestors: Ancestors<'a, '_>,
+) -> bool {
     use Groovy::*;
-    body.parent().is_some_and(|p| {
+    ancestors.parent(body).is_some_and(|p| {
         matches!(
             p.kind_id().into(),
             InterfaceDeclaration | TraitDeclaration | AnnotationTypeDeclaration
@@ -416,8 +419,11 @@ pub(crate) fn python_is_block(node: &Node) -> bool {
 // `class_declaration` node; the `class` / `interface` keyword child
 // disambiguates. A `ClassBody` belongs to an interface iff its parent
 // `class_declaration` has an `interface` keyword child.
-pub(crate) fn kotlin_class_body_is_interface(class_body: &Node) -> bool {
-    class_body.parent().is_some_and(|p| {
+pub(crate) fn kotlin_class_body_is_interface<'a>(
+    class_body: &Node<'a>,
+    ancestors: Ancestors<'a, '_>,
+) -> bool {
+    ancestors.parent(class_body).is_some_and(|p| {
         matches!(p.kind_id().into(), Kotlin::ClassDeclaration)
             && p.first_child(|id| id == Kotlin::Interface).is_some()
     })

--- a/src/metrics/npm.rs
+++ b/src/metrics/npm.rs
@@ -244,7 +244,20 @@ where
     /// it. Languages whose visibility rules are encoded purely in
     /// distinct token kinds (Java's `Public` / `Private`, PHP's
     /// `VisibilityModifier`) ignore the parameter.
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], stats: &mut Stats);
+    ///
+    /// `ancestors` is the chain the walker descended through. The
+    /// C-family, C#, PHP, Ruby, Rust, Kotlin, and Groovy impls read a
+    /// parent from it, because their grammars give a class body, an
+    /// interface body, and (for Rust) a free item the same node kind and
+    /// leave the enclosing declaration to disambiguate. Reaching that
+    /// declaration with [`Node::parent`] costs `O(depth)` per node
+    /// (#1096).
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        _ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    );
 }
 
 // Java and Groovy share their grammar tokens for class / interface
@@ -264,7 +277,12 @@ where
 macro_rules! impl_npm_java_like {
     ($code:ty, $lang:ident) => {
         impl Npm for $code {
-            fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+            fn compute<'a>(
+                node: &Node<'a>,
+                _code: &'a [u8],
+                _ancestors: Ancestors<'a, '_>,
+                stats: &mut Stats,
+            ) {
                 use $lang::*;
 
                 if Self::is_func_space(node) && stats.is_disabled() {
@@ -334,7 +352,12 @@ macro_rules! impl_npm_java_like {
 // they precede. Counting them would double-count overloaded methods.
 macro_rules! ts_npm_compute {
     ($lang:ident) => {
-        fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+        fn compute<'a>(
+            node: &Node<'a>,
+            _code: &'a [u8],
+            _ancestors: Ancestors<'a, '_>,
+            stats: &mut Stats,
+        ) {
             use $lang::*;
 
             if Self::is_func_space(node) && stats.is_disabled() {
@@ -407,7 +430,12 @@ macro_rules! ts_npm_compute {
 // Modern ES2015+ class syntax is unaffected.
 macro_rules! js_npm_compute {
     ($lang:ident) => {
-        fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+        fn compute<'a>(
+            node: &Node<'a>,
+            _code: &'a [u8],
+            _ancestors: Ancestors<'a, '_>,
+            stats: &mut Stats,
+        ) {
             use $lang::*;
 
             if Self::is_func_space(node) && stats.is_disabled() {

--- a/src/metrics/npm/cpp.rs
+++ b/src/metrics/npm/cpp.rs
@@ -9,7 +9,12 @@
 use super::*;
 
 impl Npm for CppCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Cpp::*;
 
         // Mark class / struct spaces as class spaces so the metric is
@@ -22,7 +27,7 @@ impl Npm for CppCode {
         if !matches!(node.kind_id().into(), FieldDeclarationList) {
             return;
         }
-        let Some(parent) = node.parent() else {
+        let Some(parent) = ancestors.parent(node) else {
             return;
         };
         // C++ `class` defaults to private; `struct` defaults to public.

--- a/src/metrics/npm/csharp.rs
+++ b/src/metrics/npm/csharp.rs
@@ -51,7 +51,12 @@ fn csharp_member_public_method_count(member: &Node) -> usize {
 }
 
 impl Npm for CsharpCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Csharp::*;
 
         if Self::is_func_space(node) && stats.is_disabled() {
@@ -61,7 +66,7 @@ impl Npm for CsharpCode {
         if !matches!(node.kind_id().into(), DeclarationList) {
             return;
         }
-        let Some(parent_kind) = node.parent().map(|p| p.kind_id().into()) else {
+        let Some(parent_kind) = ancestors.parent(node).map(|p| p.kind_id().into()) else {
             return;
         };
 

--- a/src/metrics/npm/elixir.rs
+++ b/src/metrics/npm/elixir.rs
@@ -17,7 +17,12 @@ use super::*;
 // ClassBody pattern but unrolled because Elixir lacks a dedicated
 // "class body" grammar production.
 impl Npm for ElixirCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        _ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use crate::metrics::cognitive::{elixir_call_keyword, elixir_do_block_call_children};
 
         // The space-opening node for a `defmodule` Call is the node

--- a/src/metrics/npm/go.rs
+++ b/src/metrics/npm/go.rs
@@ -9,7 +9,12 @@
 use super::*;
 
 impl Npm for GoCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        _ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Go as G;
 
         match node.kind_id().into() {

--- a/src/metrics/npm/groovy.rs
+++ b/src/metrics/npm/groovy.rs
@@ -16,7 +16,12 @@ use super::*;
 // section) so both impls share the same parent-kind and modifier
 // heuristic.
 impl Npm for GroovyCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use crate::metrics::npa::{groovy_body_is_interface_like, groovy_has_explicit_public};
         use Groovy::*;
 
@@ -26,7 +31,7 @@ impl Npm for GroovyCode {
 
         match node.kind_id().into() {
             ClassBody | EnumBody => {
-                let is_interface_like = groovy_body_is_interface_like(node);
+                let is_interface_like = groovy_body_is_interface_like(node, ancestors);
 
                 for method in direct_child_funcs::<Self>(node) {
                     if is_interface_like {

--- a/src/metrics/npm/kotlin.rs
+++ b/src/metrics/npm/kotlin.rs
@@ -15,7 +15,12 @@ use super::*;
 // package-private-by-default), so the "no modifier → public" branch is the
 // common case.
 impl Npm for KotlinCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Kotlin::*;
 
         // Enables the `Npm` metric for any class-like func_space.
@@ -40,7 +45,7 @@ impl Npm for KotlinCode {
         if !matches!(node.kind_id().into(), ClassBody) {
             return;
         }
-        let is_interface = super::npa::kotlin_class_body_is_interface(node);
+        let is_interface = super::npa::kotlin_class_body_is_interface(node, ancestors);
         // tree-sitter-kotlin elides the `class_member_declaration` and
         // `declaration` rule layers, so function declarations and
         // secondary constructors appear as direct children of

--- a/src/metrics/npm/mozcpp.rs
+++ b/src/metrics/npm/mozcpp.rs
@@ -9,7 +9,12 @@
 use super::*;
 
 impl Npm for MozcppCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Mozcpp::*;
 
         // Mark class / struct spaces as class spaces so the metric is
@@ -22,7 +27,7 @@ impl Npm for MozcppCode {
         if !matches!(node.kind_id().into(), FieldDeclarationList) {
             return;
         }
-        let Some(parent) = node.parent() else {
+        let Some(parent) = ancestors.parent(node) else {
             return;
         };
         // C++ `class` defaults to private; `struct` defaults to public.

--- a/src/metrics/npm/objc.rs
+++ b/src/metrics/npm/objc.rs
@@ -20,7 +20,12 @@ use super::*;
 // C++ impl's marking step). `@property` accessors are auto-generated and
 // carry no `method_declaration` node, so they are not counted here.
 impl Npm for ObjcCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        _ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Objc::*;
 
         let is_interface = matches!(node.kind_id().into(), ClassInterface | ProtocolDeclaration);

--- a/src/metrics/npm/php.rs
+++ b/src/metrics/npm/php.rs
@@ -9,7 +9,12 @@
 use super::*;
 
 impl Npm for PhpCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Php::*;
 
         if Self::is_func_space(node) && stats.is_disabled() {
@@ -18,7 +23,7 @@ impl Npm for PhpCode {
 
         match node.kind_id().into() {
             DeclarationList => {
-                let Some(parent_kind) = node.parent().map(|p| p.kind_id().into()) else {
+                let Some(parent_kind) = ancestors.parent(node).map(|p| p.kind_id().into()) else {
                     return;
                 };
                 match parent_kind {

--- a/src/metrics/npm/python.rs
+++ b/src/metrics/npm/python.rs
@@ -29,7 +29,12 @@ use super::*;
 // `ClassDefinition` children of a class body are skipped here — they
 // open their own class space, where their methods will be counted.
 impl Npm for PythonCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        _ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Python::*;
 
         // Gate on `ClassDefinition` specifically so the flag is not

--- a/src/metrics/npm/ruby.rs
+++ b/src/metrics/npm/ruby.rs
@@ -20,7 +20,12 @@ use super::*;
 // `SpaceKind::Namespace`); they do not contribute to `Npm` so a
 // module-only file reports zero methods.
 impl Npm for RubyCode {
-    fn compute<'a>(node: &Node<'a>, code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Ruby::*;
 
         if Self::is_func_space(node) && stats.is_disabled() {
@@ -30,7 +35,7 @@ impl Npm for RubyCode {
         if !matches!(node.kind_id().into(), BodyStatement | BodyStatement2) {
             return;
         }
-        let Some(parent_kind) = node.parent().map(|p| p.kind_id().into()) else {
+        let Some(parent_kind) = ancestors.parent(node).map(|p| p.kind_id().into()) else {
             return;
         };
         if !matches!(parent_kind, Class | SingletonClass) {

--- a/src/metrics/npm/rust.rs
+++ b/src/metrics/npm/rust.rs
@@ -25,7 +25,12 @@ use super::*;
 // distinctions are tracked by `npa` / `npm` only as a binary public /
 // private flag.
 impl Npm for RustCode {
-    fn compute<'a>(node: &Node<'a>, _code: &'a [u8], stats: &mut Stats) {
+    fn compute<'a>(
+        node: &Node<'a>,
+        _code: &'a [u8],
+        ancestors: Ancestors<'a, '_>,
+        stats: &mut Stats,
+    ) {
         use Rust::*;
 
         // Mark Impl / Trait spaces as class spaces so npm emits.
@@ -41,13 +46,14 @@ impl Npm for RustCode {
         if !matches!(node.kind_id().into(), FunctionItem | FunctionSignatureItem) {
             return;
         }
-        let Some(parent) = node.parent() else {
+        let mut climb = ancestors.iter(node);
+        let Some((parent, _)) = climb.next() else {
             return;
         };
         if !matches!(parent.kind_id().into(), DeclarationList) {
             return;
         }
-        let Some(grand) = parent.parent() else {
+        let Some((grand, _)) = climb.next() else {
             return;
         };
         match grand.kind_id().into() {

--- a/src/node.rs
+++ b/src/node.rs
@@ -182,6 +182,25 @@ impl<'a> Node<'a> {
         self.0.prev_sibling().map(Node)
     }
 
+    /// The sibling immediately before this node among `parent`'s
+    /// children, or `None` when this node is `parent`'s first child.
+    ///
+    /// `tree_sitter`'s own `prev_sibling` resolves the parent first
+    /// (`ts_node__prev_sibling` opens with `ts_node_parent`), so it
+    /// carries [`Node::parent`]'s `O(depth)` cost. Callers that already
+    /// hold the parent — every ABC condition walker does, because it
+    /// descended from it — pay a cursor walk over the siblings instead
+    /// (#1096).
+    ///
+    /// A one-element chain is all [`Ancestors::previous_sibling`] reads,
+    /// so this delegates rather than repeating the scan — including its
+    /// fallback for a node that is not among `parent`'s children, which
+    /// is a caller error here but a legitimate chain/node mismatch
+    /// there.
+    pub(crate) fn previous_sibling_under(&self, parent: &Node<'a>) -> Option<Node<'a>> {
+        Ancestors::known(std::slice::from_ref(parent)).previous_sibling(self)
+    }
+
     /// Returns `true` if any direct child has the given grammar
     /// `kind_id`. See #217 for the motivating perf finding from the
     /// JS/TS template-literal hot path.
@@ -1303,6 +1322,48 @@ mod tests {
         assert!(
             Ancestors::known(&[]).previous_sibling(&second).is_none(),
             "an empty chain means `second` is the root, which has no siblings"
+        );
+    }
+
+    /// `previous_sibling_under` must answer exactly what the
+    /// authoritative `Node::previous_sibling` does, for every child of
+    /// the parent — including the first, whose answer is `None` for a
+    /// reason (no earlier sibling) rather than by accident. The ABC
+    /// container walkers depend on this: they seed their
+    /// boolean-context flag from whether a ternary's `?` / `:` precedes
+    /// the operand (#1096).
+    #[test]
+    fn previous_sibling_under_agrees_with_the_authoritative_lookup() {
+        // Anonymous tokens (`(`, `,`, `)`) sit between the named
+        // arguments, so the sequence exercises both kinds of sibling.
+        let code = b"int main() { f(a, b, c); }";
+        let tree = Tree::new::<crate::langs::CCode>(code);
+        let arguments = tree
+            .get_root()
+            .preorder()
+            .find(|n| n.kind() == "argument_list")
+            .expect("fixture has an argument list");
+        let children: Vec<Node<'_>> = arguments.children().collect();
+        assert!(
+            children.len() > 3,
+            "fixture must have several siblings, got {}",
+            children.len()
+        );
+
+        let mut first_is_none = false;
+        for child in &children {
+            let expected = child.previous_sibling().map(|p| p.id());
+            assert_eq!(
+                child.previous_sibling_under(&arguments).map(|p| p.id()),
+                expected,
+                "disagreed on the sibling before a {} node",
+                child.kind()
+            );
+            first_is_none |= expected.is_none();
+        }
+        assert!(
+            first_is_none,
+            "the first child's `None` is part of what this pins"
         );
     }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -374,18 +374,26 @@ impl<'a> Node<'a> {
     /// satisfies `grand_pred`. Returns `false` as soon as either link
     /// is absent or its predicate fails, so a misordered predicate
     /// cannot silently degrade to a single-predicate check.
+    ///
+    /// `ancestors` is the chain the caller descended through. Passing
+    /// [`Ancestors::unknown`] is always correct and answers
+    /// identically; it just pays [`Node::parent`]'s `O(depth)` for each
+    /// of the two links, which on a per-node metric arm is quadratic in
+    /// nesting depth (#1096).
     pub(crate) fn parent_grandparent_match(
         &self,
+        ancestors: Ancestors<'a, '_>,
         parent_pred: fn(&Node) -> bool,
         grand_pred: fn(&Node) -> bool,
     ) -> bool {
-        let Some(parent) = self.parent() else {
+        let mut climb = ancestors.iter(self);
+        let Some((parent, _)) = climb.next() else {
             return false;
         };
         if !parent_pred(&parent) {
             return false;
         }
-        let Some(grand) = parent.parent() else {
+        let Some((grand, _)) = climb.next() else {
             return false;
         };
         grand_pred(&grand)
@@ -1379,6 +1387,14 @@ mod tests {
             first_is_none,
             "the first child's `None` is part of what this pins"
         );
+        // One break this cannot see: a scan that never finds `node`
+        // among the children falls back to the authoritative lookup and
+        // so still answers correctly, just at `Node::parent`'s cost.
+        // That failure mode is a perf regression, not a wrong answer,
+        // and the `abc/nested-if` probe is what covers it. Every
+        // *wrong-answer* break does fail here — returning the following
+        // sibling, or the parent's first child, fails on the first
+        // child alone.
     }
 
     /// `count_specific_ancestors` must return the same count whichever

--- a/src/node.rs
+++ b/src/node.rs
@@ -155,6 +155,12 @@ impl<'a> Node<'a> {
     /// traversal (see `Walk` in `spaces::compute`) over rediscovering it
     /// upward, and where a predicate genuinely needs an ancestor, take
     /// an [`Ancestors`] rather than calling this (#1084).
+    ///
+    /// As of #1096 no code the metric, `ops`, `bca function`, or
+    /// comment-removal walks reach calls this; the remaining callers are
+    /// `Ancestors` itself (the no-chain fallback), the one-off start
+    /// node of a `dump`, and tests. `rg '\.parent\(\)' src/` is how
+    /// to check that is still true.
     pub(crate) fn parent(&self) -> Option<Node<'a>> {
         self.0.parent().map(Node)
     }
@@ -178,6 +184,14 @@ impl<'a> Node<'a> {
             .is_some_and(|parent| parent.is_child(id))
     }
 
+    /// The sibling immediately before this node.
+    ///
+    /// **`O(depth)`, not `O(1)`**, for [`Node::parent`]'s reason:
+    /// `ts_node__prev_sibling` opens with `ts_node_parent`. Callers on a
+    /// walk should use [`previous_sibling_under`] or
+    /// [`Ancestors::previous_sibling`] instead (#1096).
+    ///
+    /// [`previous_sibling_under`]: Self::previous_sibling_under
     pub(crate) fn previous_sibling(&self) -> Option<Node<'a>> {
         self.0.prev_sibling().map(Node)
     }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -290,7 +290,7 @@ pub(crate) fn ops_inner<T: ParserTrait>(
         };
 
         if let Some(state) = state_stack.last_mut() {
-            T::Halstead::compute(&node, code, &mut state.halstead_maps);
+            T::Halstead::compute(&node, code, ancestors, &mut state.halstead_maps);
         }
 
         chain.push(node);

--- a/src/spaces/compute.rs
+++ b/src/spaces/compute.rs
@@ -243,12 +243,13 @@ fn compute_per_node<'a, T: ParserTrait>(
         T::Cyclomatic::compute_with_options(
             node,
             code,
+            ancestors,
             &mut last.metrics.cyclomatic,
             options.count_cyclomatic_try,
         );
     }
     if selected.contains(Metric::Halstead) {
-        T::Halstead::compute(node, code, &mut state.halstead_maps);
+        T::Halstead::compute(node, code, ancestors, &mut state.halstead_maps);
     }
     if selected.contains(Metric::Loc) {
         T::Loc::compute(node, ancestors, &mut last.metrics.loc, func_space);
@@ -266,13 +267,13 @@ fn compute_per_node<'a, T: ParserTrait>(
         T::Exit::compute(node, code, &mut last.metrics.nexits);
     }
     if selected.contains(Metric::Abc) {
-        T::Abc::compute(node, code, &mut last.metrics.abc);
+        T::Abc::compute(node, code, ancestors, &mut last.metrics.abc);
     }
     if selected.contains(Metric::Npm) {
-        T::Npm::compute(node, code, &mut last.metrics.npm);
+        T::Npm::compute(node, code, ancestors, &mut last.metrics.npm);
     }
     if selected.contains(Metric::Npa) {
-        T::Npa::compute(node, code, &mut last.metrics.npa);
+        T::Npa::compute(node, code, ancestors, &mut last.metrics.npa);
     }
 }
 


### PR DESCRIPTION
Closes #1096.

[#1084][parent-walk] gave the metric walk an ancestor chain and
[#1062][cognitive] / [#1088][remaining] threaded it through every
predicate that took an `Ancestors::unknown()`. What was left was the
same defect one layer down: `node.parent()` calls inside per-language
metric *bodies*, where no chain parameter existed. `tree_sitter` stores
no parent pointer, so `Node::parent` descends from the root and is
`O(depth)` — a per-node call is `O(depth²)` over a deeply nested file
however few steps it takes.

Metric values are unchanged for every language. The whole workspace
suite and the integration snapshots pass with no accepted snapshot.

## The three groups

**Halstead `get_op_type`.** `Getter::get_op_type`,
`get_op_type_with_code`, `get_operand_id`, `Halstead::compute`, and
`compute_halstead` take an `Ancestors`, fed from `compute_per_node` and
`ops_inner` — both already maintained a chain. The six impls that read a
parent (`python`, `rust`, `cpp`, `mozcpp`, `bash`, `irules`) index it
now; Python's docstring arm wants a grandparent as well, which
`Ancestors::iter` hands over in two steps.

**`src/metrics/abc/`.** Not shaped the way the issue described. The
`node.parent()` is not at the top of `compute`; it is inside each
language's `<lang>_inspect_container`, which resolves the condition
slot's parent only to seed a boolean-context flag — and every caller had
already descended from that parent. So the parent is passed in rather
than rediscovered. `Abc::compute` takes an `Ancestors` for the arms that
genuinely ask about the *node's* own parent (`<` / `>` disambiguation,
the `&&` / `||` chain walkers).

**`loc` / `npm` / `npa` / `cyclomatic` / `checker`.** `loc`'s seven arms
and the shared `add_multiline_string_ploc` read the chain
`Loc::compute` already carried. `Npm::compute`, `Npa::compute`,
`Cyclomatic::compute` / `compute_with_options`, and
`Checker::is_useful_comment` gained the parameter. `rm_comments` grew a
chain of its own by the metric walk's truncate/push rule, built through
`Ancestors::checked` so a bookkeeping slip fails a debug build rather
than silently feeding Rust's `is_useful_comment` the wrong parent.

## Two climbs the inventory could not see

`rg '\.parent\(\)' src/` is the authority for direct calls, but two
`O(depth)` climbs hide behind helpers whose call sites it does not
match. This is #1088's lesson — *a chain-fed predicate is only as linear
as the primitives it calls* — arriving from the other direction.

- **`Node::previous_sibling`.** All seven ABC container walkers ask it
  whether a ternary's `?` / `:` precedes the operand, and Kotlin's
  Halstead short-interpolation test asks it once per `string_content`
  token and once per operand. `ts_node__prev_sibling` opens with
  `ts_node_parent`, so it carries the identical cost; without this the
  fix would not have held on a ternary shape. New
  `Node::previous_sibling_under` scans the known parent's children
  instead.
- **`Node::parent_grandparent_match`.** Python's `Cyclomatic` calls it
  for every `else` token to ask whether the token opens a `for` /
  `while` / `try` else-clause rather than an `if`, and both links
  climbed.

## Measurements

Four probes and three shape controls, added to
`big-code-analysis-bench/src/shapes.rs` with the fix, measured on the
same idle host either side:

| probe | k before | k after | depth 4000, before → after |
|---|---|---|---|
| `halstead/nested-not` | 1.99 | 0.99 | ~478 ms → ~0.57 ms |
| `abc/nested-if` | 2.00 | 1.14 | ~808 ms → ~3.3 ms |
| `cyclomatic/nested-ternary` | 2.06 | 1.27 | ~1.13 s → ~3.4 ms |
| `loc/nested-quote` | 2.00 | 1.03 | ~9.6 s → ~9.2 ms |
| `halstead/nested-paren` (control) | 0.99 | 0.97 | — |
| `abc/nested-block` (control) | 1.18 | 1.18 | — |
| `cyclomatic/nested-and` (control) | 1.26 | 1.31 | — |

`loc/nested-quote` has no shape control of its own: Elixir's `loc`
catch-all arm fires for every named node, so there is no version of the
shape with the trigger removed. `nom/nested-quote` — the same source
under a metric that does not ask for a parent — stands in.

## Tests

Both new unit tests were verified by perturbing the production line and
confirming each is the **only** failure:

- `rust_keeps_a_macro_token_comment_and_strips_an_ordinary_one` fails
  alone when `rm_comments` hands `is_useful_comment` an empty chain.
- `previous_sibling_under_agrees_with_the_authoritative_lookup` fails
  alone (alongside `java_ternary_conditions`) when the scan returns the
  wrong sibling. Its comment records the one break it cannot see — a
  scan that never finds the node falls back to the authoritative lookup
  and is correct but slow, which is the `abc/nested-if` probe's job.

The existing ABC suite is not vacuous about either change: passing the
wrong node as `parent` fails `java_if_single_conditions` and
`java_bool_returning_terminal_kinds_count`, and stubbing the ternary
sibling seed to `None` fails `java_ternary_conditions`.

## Also here

- `refactor(halstead)`: every language's `Halstead::compute` forwards to
  `compute_halstead` verbatim, so the added parameter grew 23 identical
  impls from three lines to eight each. One macro emits them all
  (−204 lines). No impl carried a per-language comment to hoist.
- `.bca-baseline.toml` refreshed with
  `make self-scan-write-baseline-headroom` in the same commits, per the
  baseline-refresh discipline in `AGENTS.md`.

## Not in scope

One `previous_sibling` walk is deliberately left: the `exclude_tests`
attribute scan in `Checker::should_skip_subtree`. Porting
`previous_sibling_under` to it would trade `O(attributes × depth)` for
`O(attributes × children)`, which is worse on the shallow-but-wide trees
that dominate — it wants a single forward scan instead, plus a probe
that can select `exclude_tests`, which `Probe` cannot express today.
Filed as #1100.

After this, `rg '\.parent\(\)' src/` returns only the `Ancestors`
fallback itself, `Node::get_parent` (dead code), the one-off start node
of a `dump`, `act_on_node`'s chain seed, and tests.

[parent-walk]: https://github.com/dekobon/big-code-analysis/issues/1084
[cognitive]: https://github.com/dekobon/big-code-analysis/issues/1062
[remaining]: https://github.com/dekobon/big-code-analysis/issues/1088
