### PR TITLE
refactor(cognitive): thread Nesting end to end

### DIFF
--- a/.bca-baseline.toml
+++ b/.bca-baseline.toml
@@ -793,7 +793,7 @@ path = "src/metrics/cognitive/ruby.rs"
 qualified = "RubyCode::compute"
 start_line = 29
 metric = "halstead.effort"
-value = 53802.68593577912
+value = 47981.403382270764
 
 [[entry]]
 path = "src/metrics/loc/c.rs"

--- a/.claude/rules/formatting.md
+++ b/.claude/rules/formatting.md
@@ -1,0 +1,68 @@
+# Formatting Rule
+
+`cargo fmt --check` is not a complete formatting gate. It exits `0`
+over code rustfmt declined to format, and rustfmt declines silently.
+
+## A comment inside a match pattern disables the whole enclosing item
+
+When a comment sits inside a match *pattern* — between the pattern and
+its `=>`, or between `|` alternatives — rustfmt gives up on the entire
+enclosing item and emits it verbatim. No warning, no diagnostic, and
+`cargo fmt --check` still exits `0`.
+
+Both spellings trigger it:
+
+```rust
+// Block comment before `=>`
+Else /*else-if also */ => { … }
+
+// Line comments between `|` alternatives
+P::IfStatement
+| P::UnlessStatement
+// Postfix conditional / loop forms (`return 1 if $cond;`) — the
+// condition is a real cognitive branch.
+| P::IfSimpleStatement
+| P::ForSimpleStatement => { … }
+```
+
+In `src/metrics/cognitive/` this currently affects seven modules:
+`c.rs`, `cpp.rs`, `java.rs`, `mozcpp.rs`, `objc.rs`, `perl.rs`,
+`rust.rs`. Every other module in that directory formats normally.
+
+**Separately**, rustfmt never formats `macro_rules!` bodies at all. Code
+inside `js_cognitive!` in `src/metrics/cognitive.rs` is unformatted for
+that reason, not this one — do not conflate the two when deciding
+whether an edit needs manual review.
+
+## Why it matters
+
+A bulk or regex-driven edit across sibling modules is exactly the change
+that produces misformatted output, and it lands in exactly the files
+where the gate cannot see it. During #1086 a regex rewrite of 43 call
+sites left six files with a hanging-argument call and two lines over 100
+columns; `cargo fmt --all` followed by `cargo fmt --all -- --check`
+reported clean, and the problems were found only by reading the diff.
+
+## How to apply
+
+- After any bulk, scripted, or regex edit under `src/metrics/`, read the
+  resulting diff rather than trusting the fmt gate. Check indentation
+  and line length by eye.
+- Line length is worth a direct check, since it is mechanical:
+
+  ```bash
+  awk 'length > 100 {print FILENAME":"FNR" ("length")"}' <files>
+  ```
+
+  Expect some pre-existing hits in test string literals containing `\n`;
+  those cannot be wrapped and are not what you are looking for.
+- To determine whether a specific file is affected, perturb it rather
+  than guessing from its comments. Copy it to a scratch directory,
+  misindent one line, run `rustfmt --edition 2024` on the copy, and see
+  whether the indentation is restored. Do not suppress stderr — a leaf
+  module formats standalone, but a file with `mod` declarations fails to
+  resolve them outside its tree and rustfmt errors out, which is easy to
+  misread as a bail.
+- Do not remove an explanatory comment merely to re-enable formatting.
+  The per-arm rationale in these modules is load-bearing (see
+  `macro-comments.md`); manual formatting review is the cheaper trade.

--- a/.claude/rules/formatting.md
+++ b/.claude/rules/formatting.md
@@ -3,18 +3,18 @@
 `cargo fmt --check` is not a complete formatting gate. It exits `0`
 over code rustfmt declined to format, and rustfmt declines silently.
 
-## A comment inside a match pattern disables the whole enclosing item
+## A comment inside a match pattern disables that match
 
 When a comment sits inside a match *pattern* — between the pattern and
-its `=>`, or between `|` alternatives — rustfmt gives up on the entire
-enclosing item and emits it verbatim. No warning, no diagnostic, and
+its `=>`, or between `|` alternatives — rustfmt emits the enclosing
+match expression verbatim. No warning, no diagnostic, and
 `cargo fmt --check` still exits `0`.
 
 Both spellings trigger it:
 
 ```rust
 // Block comment before `=>`
-Else /*else-if also */ => { … }
+Else /* else-if also */ => { … }
 
 // Line comments between `|` alternatives
 P::IfStatement
@@ -25,23 +25,49 @@ P::IfStatement
 | P::ForSimpleStatement => { … }
 ```
 
-In `src/metrics/cognitive/` this currently affects seven modules:
-`c.rs`, `cpp.rs`, `java.rs`, `mozcpp.rs`, `objc.rs`, `perl.rs`,
-`rust.rs`. Every other module in that directory formats normally.
+A comment *above* an arm, outside the pattern, is fine and formats
+normally.
 
-**Separately**, rustfmt never formats `macro_rules!` bodies at all. Code
-inside `js_cognitive!` in `src/metrics/cognitive.rs` is unformatted for
-that reason, not this one — do not conflate the two when deciding
-whether an edit needs manual review.
+**The blast radius is the match, not the file or the item.** Statements
+before and after the match in the same function are still formatted. A
+misindented line two statements below a bailing match gets fixed, which
+makes it easy to conclude — wrongly — that the file is unaffected.
+
+**`macro_rules!` bodies are not exempt and are not a separate cause.**
+rustfmt formats macro bodies by default (`format_macro_bodies`, default
+`true`), so a macro body containing a match with an in-pattern comment
+bails for exactly the reason above. In this repository the
+`js_cognitive!` body in `src/metrics/cognitive.rs` is unformatted solely
+because of its `Else /* else-if also */ =>` arm; delete that comment and
+rustfmt reformats the whole body.
+
+## Where it currently bites
+
+Eight sites, all under `src/metrics/`: the modules `c.rs`, `cpp.rs`,
+`java.rs`, `mozcpp.rs`, `objc.rs`, `perl.rs`, and `rust.rs` under
+`cognitive/`, plus the `js_cognitive!` macro body in `cognitive.rs`.
+
+That list is a snapshot — regenerate it rather than trusting it, since
+it moves whenever an arm gains or loses a comment:
+
+```bash
+# Prints modules rustfmt refuses to format. Run from the repo root.
+tmp=$(mktemp -d) && cp -r src/metrics/cognitive "$tmp/" && for f in "$tmp"/cognitive/*.rs; do
+  perl -0pi -e 's/^            _ => \{\}/                        _ => {}/m' "$f"
+  err=$(rustfmt --edition 2024 "$f" 2>&1)
+  [ -n "$err" ] && { echo "ERROR $(basename "$f"): $err"; continue; }
+  grep -qE '^ {20,}_ => \{\}' "$f" && echo "BAILS $(basename "$f")"
+done; rm -rf "$tmp"
+```
 
 ## Why it matters
 
 A bulk or regex-driven edit across sibling modules is exactly the change
 that produces misformatted output, and it lands in exactly the files
 where the gate cannot see it. During #1086 a regex rewrite of 43 call
-sites left six files with a hanging-argument call and two lines over 100
-columns; `cargo fmt --all` followed by `cargo fmt --all -- --check`
-reported clean, and the problems were found only by reading the diff.
+sites left hanging-argument calls and over-length lines across several
+of these files; `cargo fmt --all` followed by `cargo fmt --all --check`
+reported clean, and every one was found by reading the diff instead.
 
 ## How to apply
 
@@ -56,13 +82,20 @@ reported clean, and the problems were found only by reading the diff.
 
   Expect some pre-existing hits in test string literals containing `\n`;
   those cannot be wrapped and are not what you are looking for.
-- To determine whether a specific file is affected, perturb it rather
-  than guessing from its comments. Copy it to a scratch directory,
-  misindent one line, run `rustfmt --edition 2024` on the copy, and see
-  whether the indentation is restored. Do not suppress stderr — a leaf
-  module formats standalone, but a file with `mod` declarations fails to
-  resolve them outside its tree and rustfmt errors out, which is easy to
-  misread as a bail.
+- To decide whether a specific region is affected, perturb *that region*
+  and check *that line* by number. Two traps, both of which have already
+  produced a wrong answer here:
+  - Suppressing stderr. A leaf module formats standalone, but a file
+    with `mod` declarations cannot resolve them outside its own tree, so
+    rustfmt errors out — which reads as a bail if you discard the
+    message.
+  - Grepping for the restored indentation instead of checking the
+    perturbed line. Another untouched line elsewhere in the file matches
+    the pattern and reports a false "formatted". Likewise, perturbing a
+    function that does not contain the bailing match proves nothing,
+    because the bail is match-scoped.
 - Do not remove an explanatory comment merely to re-enable formatting.
-  The per-arm rationale in these modules is load-bearing (see
-  `macro-comments.md`); manual formatting review is the cheaper trade.
+  The per-arm rationale in these modules is load-bearing; hoisting it
+  above the arm (outside the pattern) is a legitimate fix when the
+  comment reads just as well there, but manual formatting review is
+  otherwise the cheaper trade.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -110,3 +110,38 @@ evidence is inspection rather than a perturbation run.
 See lesson #82 for the related walker case, where the production
 bookkeeping and the test's replica of it are two different things and
 only a debug assertion in the real walker covers the former.
+
+## Seed the state you claim to assert on
+
+An assertion that a function *resets* or *accumulates* something proves
+nothing when the fixture starts from the default-constructed value.
+`Foo::default()` is usually all zeroes and `None`s, which is exactly the
+state a reset produces and exactly the value `+=` and `=` agree on — so
+the assertion holds whether or not the line under test exists.
+
+This is not a hypothetical failure mode. Both instances below shipped in
+the *same* test during #1086, and both were measured, not guessed:
+
+- **A reset asserted from a default fixture** (#1086). The test built
+  `Stats::default()`, called `increase_nesting`, and asserted
+  `stats.boolean_seq == BoolSequence::default()`. Deleting
+  `stats.boolean_seq.reset()` from the production helper failed
+  **zero** tests across the whole 3,130-test lib suite — the line was
+  entirely uncovered, and the new test that claimed to cover it did not.
+  Seeding `boolean_op = Some((1, 0))` first made it the only failure.
+- **An accumulation asserted from zero** (#1086). The same test asserted
+  `stats.structural == 8` from a zeroed `structural`, where
+  `increment`'s `stats.structural += stats.nesting + 1` is
+  indistinguishable from a plain `=`. Seeding `structural: 5` and
+  asserting `13` made the `+=`-to-`=` perturbation fail.
+
+The tell is that the expected value equals the default. When you write
+`assert_eq!(x.field, 0)` or compare against `Default::default()` after
+calling something that is *supposed* to zero it, stop: either seed a
+distinguishable value first, or accept that the assertion is decoration.
+
+**Lesson:** pick fixture values that differ from both the default and
+each other, so the assertion can only pass for the intended reason. Then
+confirm it by perturbing the exact production line the assertion names —
+per the sections above, a test that cannot fail is worse than no test,
+because it reads as coverage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,13 @@ for historical reference.
   `src/test_support.rs`, retiring that file's `loc.sloc` baseline entry
   (#1066); `python_comprehension_clause_nesting` takes the `Nesting`
   struct rather than three positional `usize` parameters, completing
-  the threading started in #1062 (#1070); and `node_text`'s safety
+  the threading started in #1062 (#1070); `increase_nesting` does the
+  same at its 43 call sites across the 19 per-language cognitive
+  modules and the shared `js_cognitive!` macro (23 language impls),
+  which now hold the `Nesting` struct end to end instead of
+  destructuring it into three same-typed locals and rebuilding it, with
+  the `conditional + function_depth + lambda` sum folded into a new
+  `Nesting::total()` (#1086); and `node_text`'s safety
   documentation no longer describes a UTF-8 char-boundary panic that
   cannot occur for a `&[u8]` parameter, with the same-parse
   precondition now stated on the `Getter` trait (#1059). `bca.toml`'s

--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -306,11 +306,18 @@ fn increment_function_depth<'a, T: PartialEq + From<u16>>(
     }
 }
 
+/// Charges `node`'s construct at the current nesting level and opens a
+/// new structural level for its children.
+///
+/// Takes the whole [`Nesting`] rather than its three same-typed fields
+/// positionally: the previous signature was
+/// `(stats, &mut nesting, depth, lambda)` at 43 call sites, where any
+/// two of the trailing arguments could be transposed silently (#1086).
 #[inline]
-fn increase_nesting(stats: &mut Stats, nesting: &mut usize, depth: usize, lambda: usize) {
-    stats.nesting = *nesting + depth + lambda;
+fn increase_nesting(stats: &mut Stats, nesting: &mut Nesting) {
+    stats.nesting = nesting.total();
     increment(stats);
-    *nesting += 1;
+    nesting.conditional += 1;
     stats.boolean_seq.reset();
 }
 
@@ -342,18 +349,20 @@ macro_rules! js_cognitive {
             nesting_map: &mut NestingMap,
         ) {
             use $lang::*;
-            let Nesting {
-            conditional: mut nesting,
-            function_depth: mut depth,
-            mut lambda,
-        } = get_nesting_from_map(node, nesting_map);
+            let mut nesting = get_nesting_from_map(node, nesting_map);
 
             match node.kind_id().into() {
                 IfStatement if !Self::is_else_if(node, ancestors) => {
-                    increase_nesting(stats, &mut nesting, depth, lambda);
+                    increase_nesting(stats, &mut nesting);
                 }
-                ForStatement | ForInStatement | WhileStatement | DoStatement | SwitchStatement | CatchClause | TernaryExpression => {
-                    increase_nesting(stats, &mut nesting, depth, lambda);
+                ForStatement
+                | ForInStatement
+                | WhileStatement
+                | DoStatement
+                | SwitchStatement
+                | CatchClause
+                | TernaryExpression => {
+                    increase_nesting(stats, &mut nesting);
                 }
                 Else /* else-if also */ => {
                     increment_by_one(stats);
@@ -392,20 +401,22 @@ macro_rules! js_cognitive {
                 }
                 FunctionDeclaration => {
                     // Reset lambda nesting at function for JS
-                    nesting = 0;
-                    lambda = 0;
+                    nesting.conditional = 0;
+                    nesting.lambda = 0;
                     // Increase depth function nesting if needed
-                    increment_function_depth(&mut depth, node, ancestors, &[FunctionDeclaration]);
+                    increment_function_depth(
+                        &mut nesting.function_depth,
+                        node,
+                        ancestors,
+                        &[FunctionDeclaration],
+                    );
                 }
                 ArrowFunction => {
-                    lambda += 1;
+                    nesting.lambda += 1;
                 }
                 _ => {}
             }
-            nesting_map.insert(
-            node.id(),
-            Nesting { conditional: nesting, function_depth: depth, lambda },
-        );
+            nesting_map.insert(node.id(), nesting);
         }
     };
 }
@@ -9850,6 +9861,88 @@ end",
         assert_eq!(
             measured, expected,
             "an `if` must cost 1 in a top-level function and 2 one function deeper",
+        );
+    }
+
+    /// Every [`Nesting`] channel contributes to `total()`.
+    ///
+    /// Distinct powers of two, so dropping a channel or summing one
+    /// twice — the failure modes of the open-coded
+    /// `conditional + function_depth + lambda` this method replaced at
+    /// its two sites (#1086) — is distinguishable from the total alone
+    /// rather than just reading as a bad number.
+    #[test]
+    fn nesting_total_sums_every_channel() {
+        assert_eq!(
+            Nesting {
+                conditional: 1,
+                function_depth: 2,
+                lambda: 4,
+            }
+            .total(),
+            7,
+            "1/2/4 encoding: short by 1 means `conditional` was dropped, \
+             by 2 `function_depth`, by 4 `lambda`; over by the same \
+             amount means that channel was summed twice",
+        );
+        // Weak on its own — every field is zero, so this survives any
+        // linear combination of them. It only rules out a `total()` that
+        // returns a nonzero constant.
+        assert_eq!(Nesting::default().total(), 0);
+    }
+
+    /// `increase_nesting` charges the *summed* level but advances only
+    /// the `conditional` channel.
+    ///
+    /// Before #1086 this helper took `&mut usize` for the conditional
+    /// channel and `depth` / `lambda` as by-value non-`mut` params, so
+    /// bumping the wrong one was *inert* rather than unrepresentable:
+    /// `depth += 1` needed a `mut` added to compile, and then wrote to a
+    /// copy nobody read. It now holds the whole struct, which makes
+    /// `function_depth += 1` a one-character slip that persists —
+    /// invisible in the *charge* itself, since `total()` is symmetric,
+    /// and detectable only downstream where the channels are read apart.
+    ///
+    /// Perturbing the production line to `function_depth += 1` fails this
+    /// test plus five nested-function tests (`java_nested_method_…`,
+    /// `cpp_nested_function_…`, `groovy_…`, `php_…`,
+    /// `csharp_local_function_in_if_…`) — those catch it only because a
+    /// function boundary resets `conditional` alone, leaving the misplaced
+    /// increment behind. This test pins it at the helper, where the
+    /// mistake is, rather than five languages away from it.
+    #[test]
+    fn increase_nesting_charges_the_total_but_advances_only_conditional() {
+        let mut nesting = Nesting {
+            conditional: 1,
+            function_depth: 2,
+            lambda: 4,
+        };
+        // Both fields are seeded rather than defaulted. From
+        // `Stats::default()` the `boolean_seq` assertion holds even with
+        // `reset()` deleted, and the `structural` assertion cannot tell
+        // `increment`'s `+=` from a plain `=`, since both start at zero.
+        let mut stats = Stats {
+            structural: 5,
+            boolean_seq: BoolSequence {
+                boolean_op: Some((1, 0)),
+            },
+            ..Stats::default()
+        };
+
+        increase_nesting(&mut stats, &mut nesting);
+
+        // Charged at the inherited level (7), and `increment`
+        // accumulates `nesting + 1` onto the seeded 5.
+        assert_eq!(stats.nesting, 7);
+        assert_eq!(stats.structural, 13);
+        assert_eq!(stats.boolean_seq, BoolSequence::default());
+        assert_eq!(
+            nesting,
+            Nesting {
+                conditional: 2,
+                function_depth: 2,
+                lambda: 4,
+            }
         );
     }
 }

--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -3338,6 +3338,33 @@ mod tests {
         );
     }
 
+    /// The `mozcpp` fork must charge a lambda the same nesting surcharge
+    /// as upstream C++ — the same source through `CppParser`
+    /// (`cpp_lambda_inside_function` above) scores identically.
+    ///
+    /// `mozcpp`'s `LambdaExpression` arm had no cognitive test before
+    /// this, so the whole arm measured zero-coverage even though the
+    /// fork is expected to stay metric-equivalent to `cpp`.
+    #[test]
+    fn mozcpp_lambda_inside_function() {
+        check_metrics::<MozcppParser>(
+            "int f(const std::vector<int>& v) {
+                 auto pred = [](int x) {
+                     if (x > 0) { // +2 (lambda nesting = 1)
+                         return true;
+                     }
+                     return false;
+                 };
+                 return std::count_if(v.begin(), v.end(), pred);
+             }",
+            "foo.cpp",
+            |metric| {
+                assert_eq!(metric.cognitive.cognitive_sum(), 2);
+                assert_eq!(metric.cognitive.cognitive_max(), 2);
+            },
+        );
+    }
+
     #[test]
     fn c_switch_fall_through() {
         // A `case` without `break` (fall-through) does not add cognitive cost
@@ -9370,6 +9397,27 @@ end",
     fn irules_switch_nesting() {
         check_metrics::<IrulesParser>(
             "when X { if { $a } { switch $h { a { log local0. \"a\" } b { log local0. \"b\" } } } }\n",
+            "foo.irule",
+            |metric| {
+                assert_eq!(metric.cognitive.cognitive_sum(), 3);
+            },
+        );
+    }
+
+    /// `catch` is a conditional error handler — its body runs only when
+    /// the guarded command errors — so it pays nesting like any other
+    /// branch. Flat: 1. Nested in an `if`: `if` (1) + `catch`
+    /// (1 + nesting 1 = 2) = 3, matching `irules_switch_nesting`.
+    ///
+    /// The `Catch` arm had no test before this: the whole arm measured
+    /// zero-coverage while every other iRules branch kind was exercised.
+    #[test]
+    fn irules_catch_nesting() {
+        check_metrics::<IrulesParser>("when X { catch { foo } }\n", "foo.irule", |metric| {
+            assert_eq!(metric.cognitive.cognitive_sum(), 1);
+        });
+        check_metrics::<IrulesParser>(
+            "when X { if { $a } { catch { foo } } }\n",
             "foo.irule",
             |metric| {
                 assert_eq!(metric.cognitive.cognitive_sum(), 3);

--- a/src/metrics/cognitive/bash.rs
+++ b/src/metrics/cognitive/bash.rs
@@ -23,11 +23,7 @@ impl Cognitive for BashCode {
     ) {
         use Bash::*;
 
-        let Nesting {
-            conditional: mut nesting,
-            function_depth: mut depth,
-            lambda,
-        } = get_nesting_from_map(node, nesting_map);
+        let mut nesting = get_nesting_from_map(node, nesting_map);
 
         match node.kind_id().into() {
             // `WhileStatement` covers both `while` and `until`; `ForStatement`
@@ -35,7 +31,7 @@ impl Cognitive for BashCode {
             // `for ((…))` arithmetic form. `ElifClause` is a dedicated node,
             // not a nested `if`, so no `is_else_if` check is needed.
             IfStatement | WhileStatement | ForStatement | CStyleForStatement | CaseStatement => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             ElifClause | ElseClause => {
                 increment_branch_extension(stats);
@@ -51,18 +47,16 @@ impl Cognitive for BashCode {
                 compute_booleans(node, stats, AMPAMP, PIPEPIPE);
             }
             FunctionDefinition => {
-                nesting = 0;
-                increment_function_depth(&mut depth, node, ancestors, &[FunctionDefinition]);
+                nesting.conditional = 0;
+                increment_function_depth(
+                    &mut nesting.function_depth,
+                    node,
+                    ancestors,
+                    &[FunctionDefinition],
+                );
             }
             _ => {}
         }
-        nesting_map.insert(
-            node.id(),
-            Nesting {
-                conditional: nesting,
-                function_depth: depth,
-                lambda,
-            },
-        );
+        nesting_map.insert(node.id(), nesting);
     }
 }

--- a/src/metrics/cognitive/c.rs
+++ b/src/metrics/cognitive/c.rs
@@ -24,22 +24,18 @@ impl Cognitive for CCode {
         use C::*;
 
         // Macro expansion is not tracked; macros are treated as opaque tokens.
-        let Nesting {
-            conditional: mut nesting,
-            function_depth: mut depth,
-            lambda,
-        } = get_nesting_from_map(node, nesting_map);
+        let mut nesting = get_nesting_from_map(node, nesting_map);
 
         match node.kind_id().into() {
             IfStatement if !Self::is_else_if(node, ancestors) => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             ForStatement
             | WhileStatement
             | DoStatement
             | SwitchStatement
             | ConditionalExpression => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             GotoStatement | Else /* else-if also */ => {
                 increment_by_one(stats);
@@ -56,9 +52,9 @@ impl Cognitive for CCode {
             // definition missed the SonarSource B-nesting amplification
             // (#696).
             FunctionDefinition | FunctionDefinition2 => {
-                nesting = 0;
+                nesting.conditional = 0;
                 increment_function_depth(
-                    &mut depth,
+                    &mut nesting.function_depth,
                     node,
                     ancestors,
                     &[FunctionDefinition, FunctionDefinition2],
@@ -66,13 +62,6 @@ impl Cognitive for CCode {
             }
             _ => {}
         }
-        nesting_map.insert(
-            node.id(),
-            Nesting {
-                conditional: nesting,
-                function_depth: depth,
-                lambda,
-            },
-        );
+        nesting_map.insert(node.id(), nesting);
     }
 }

--- a/src/metrics/cognitive/cpp.rs
+++ b/src/metrics/cognitive/cpp.rs
@@ -24,15 +24,11 @@ impl Cognitive for CppCode {
         use Cpp::*;
 
         // Macro expansion is not tracked; macros are treated as opaque tokens.
-        let Nesting {
-            conditional: mut nesting,
-            function_depth: mut depth,
-            mut lambda,
-        } = get_nesting_from_map(node, nesting_map);
+        let mut nesting = get_nesting_from_map(node, nesting_map);
 
         match node.kind_id().into() {
             IfStatement if !Self::is_else_if(node, ancestors) => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             ForStatement
             | ForRangeLoop
@@ -41,7 +37,7 @@ impl Cognitive for CppCode {
             | SwitchStatement
             | CatchClause
             | ConditionalExpression => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             GotoStatement | Else /* else-if also */ => {
                 increment_by_one(stats);
@@ -50,7 +46,7 @@ impl Cognitive for CppCode {
                 compute_booleans(node, stats, AMPAMP, PIPEPIPE);
             }
             LambdaExpression => {
-                lambda += 1;
+                nesting.lambda += 1;
             }
             // At a (possibly nested) function-definition boundary, reset
             // structural nesting to zero and bump the function-depth
@@ -60,10 +56,13 @@ impl Cognitive for CppCode {
             // construct inherited the enclosing nesting and every nested
             // definition missed the SonarSource B-nesting amplification
             // (#696).
-            FunctionDefinition | FunctionDefinition2 | FunctionDefinition3 | FunctionDefinition4 => {
-                nesting = 0;
+            FunctionDefinition
+            | FunctionDefinition2
+            | FunctionDefinition3
+            | FunctionDefinition4 => {
+                nesting.conditional = 0;
                 increment_function_depth(
-                    &mut depth,
+                    &mut nesting.function_depth,
                     node,
                     ancestors,
                     &[
@@ -76,13 +75,6 @@ impl Cognitive for CppCode {
             }
             _ => {}
         }
-        nesting_map.insert(
-            node.id(),
-            Nesting {
-                conditional: nesting,
-                function_depth: depth,
-                lambda,
-            },
-        );
+        nesting_map.insert(node.id(), nesting);
     }
 }

--- a/src/metrics/cognitive/csharp.rs
+++ b/src/metrics/cognitive/csharp.rs
@@ -23,15 +23,11 @@ impl Cognitive for CsharpCode {
     ) {
         use Csharp::*;
 
-        let Nesting {
-            conditional: mut nesting,
-            function_depth: mut depth,
-            mut lambda,
-        } = get_nesting_from_map(node, nesting_map);
+        let mut nesting = get_nesting_from_map(node, nesting_map);
 
         match node.kind_id().into() {
             IfStatement if !Self::is_else_if(node, ancestors) => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             ForStatement
             | ForeachStatement
@@ -41,7 +37,7 @@ impl Cognitive for CsharpCode {
             | SwitchExpression
             | CatchClause
             | ConditionalExpression => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             // `else` is an anonymous keyword token. Each occurrence carries
             // a flat +1 for the alternative branch (matches Java's `Else`
@@ -77,7 +73,7 @@ impl Cognitive for CsharpCode {
                 compute_booleans_with(node, stats, |id| matches!(id.into(), QMARKQMARKEQ));
             }
             LambdaExpression | AnonymousMethodExpression => {
-                lambda += 1;
+                nesting.lambda += 1;
             }
             // At a (possibly nested) function boundary, reset structural
             // nesting to zero and bump the function-depth surcharge when
@@ -96,9 +92,9 @@ impl Cognitive for CsharpCode {
             | AccessorDeclaration
             | LocalFunctionStatement
             | LocalFunctionDeclaration => {
-                nesting = 0;
+                nesting.conditional = 0;
                 increment_function_depth(
-                    &mut depth,
+                    &mut nesting.function_depth,
                     node,
                     ancestors,
                     &[
@@ -115,13 +111,6 @@ impl Cognitive for CsharpCode {
             }
             _ => {}
         }
-        nesting_map.insert(
-            node.id(),
-            Nesting {
-                conditional: nesting,
-                function_depth: depth,
-                lambda,
-            },
-        );
+        nesting_map.insert(node.id(), nesting);
     }
 }

--- a/src/metrics/cognitive/elixir.rs
+++ b/src/metrics/cognitive/elixir.rs
@@ -39,15 +39,17 @@ impl Cognitive for ElixirCode {
     // - `if` / `unless` / `for` / `while`: single-branch control flow,
     //   `+nesting`. Their `else` (token `Elixir::Else` inside an
     //   `ElseBlock`) adds `+1` without nesting, matching Java.
-    // - `case` / `cond` / `with` / `try`: switch-/multi-arm, `+nesting`
-    //   once on the container. Individual `stab_clause` arms do NOT
-    //   add extra cost (matches Java `SwitchBlock` / `case:` rule).
-    //   `try`'s `rescue` / `catch` arms surface as `RescueBlock` /
-    //   `CatchBlock` and each one adds `+nesting`, matching Java's
-    //   `CatchClause` treatment.
+    // - `case` / `cond` / `with`: switch-/multi-arm, `+nesting` once on
+    //   the container. Individual `stab_clause` arms do NOT add extra
+    //   cost (matches Java `SwitchBlock` / `case:` rule).
+    // - `try`: `+0` on the container itself — it is a wrapper, and its
+    //   `rescue` / `catch` arms surface as `RescueBlock` / `CatchBlock`
+    //   and each one adds `+nesting`, matching Java's `CatchClause`
+    //   treatment. See the arm comment below.
     // - `def` / `defp` / `defmacro` / `defmacrop`: method-defining
-    //   macros. Treated like Bash's `FunctionDefinition` — nesting
-    //   resets, function depth bumps so nested functions amplify cost.
+    //   macros. Nesting resets at the boundary, as in Bash's
+    //   `FunctionDefinition` rule, but the function depth deliberately
+    //   does NOT bump — see the arm comment below for why.
     // - `AnonymousFunction` (`fn x -> y end`): lambda nesting bumps.
     // - `&&` / `||` / `and` / `or`: boolean sequence cost.
     //
@@ -70,16 +72,12 @@ impl Cognitive for ElixirCode {
     ) {
         use Elixir as E;
 
-        let Nesting {
-            conditional: mut nesting,
-            function_depth: depth,
-            mut lambda,
-        } = get_nesting_from_map(node, nesting_map);
+        let mut nesting = get_nesting_from_map(node, nesting_map);
 
         match node.kind_id().into() {
             E::Call => match elixir_call_keyword(node, code) {
                 Some("if" | "unless" | "for" | "while" | "case" | "cond" | "with") => {
-                    increase_nesting(stats, &mut nesting, depth, lambda);
+                    increase_nesting(stats, &mut nesting);
                 }
                 // `try` is intentionally absent: it is a wrapper for
                 // `rescue` / `catch` arms (each of which earns its own
@@ -101,7 +99,7 @@ impl Cognitive for ElixirCode {
                     // concern — the lambda channel via
                     // `AnonymousFunction` handles the analogous
                     // higher-order case.
-                    nesting = 0;
+                    nesting.conditional = 0;
                 }
                 _ => {}
             },
@@ -114,13 +112,13 @@ impl Cognitive for ElixirCode {
             // `rescue` / `catch` arms of a `try` Call each add +nesting,
             // matching Java's `CatchClause` treatment.
             E::RescueBlock | E::CatchBlock => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             // Anonymous functions are Elixir's lambdas. Increment the
             // lambda depth so the cost of control flow inside them is
             // amplified, matching Kotlin's `LambdaLiteral` rule.
             E::AnonymousFunction => {
-                lambda += 1;
+                nesting.lambda += 1;
             }
             // Short-circuit booleans (token-form `&&` / `||` and word-
             // form `and` / `or`) contribute one structural cost per
@@ -134,13 +132,6 @@ impl Cognitive for ElixirCode {
             }
             _ => {}
         }
-        nesting_map.insert(
-            node.id(),
-            Nesting {
-                conditional: nesting,
-                function_depth: depth,
-                lambda,
-            },
-        );
+        nesting_map.insert(node.id(), nesting);
     }
 }

--- a/src/metrics/cognitive/go.rs
+++ b/src/metrics/cognitive/go.rs
@@ -23,21 +23,17 @@ impl Cognitive for GoCode {
     ) {
         use Go as G;
 
-        let Nesting {
-            conditional: mut nesting,
-            function_depth: mut depth,
-            mut lambda,
-        } = get_nesting_from_map(node, nesting_map);
+        let mut nesting = get_nesting_from_map(node, nesting_map);
 
         match node.kind_id().into() {
             G::IfStatement if !Self::is_else_if(node, ancestors) => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             G::ForStatement
             | G::ExpressionSwitchStatement
             | G::TypeSwitchStatement
             | G::SelectStatement => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             G::Else | G::GotoStatement => {
                 increment_by_one(stats);
@@ -49,26 +45,19 @@ impl Cognitive for GoCode {
                 compute_booleans(node, stats, G::AMPAMP, G::PIPEPIPE);
             }
             G::FunctionDeclaration | G::MethodDeclaration => {
-                nesting = 0;
+                nesting.conditional = 0;
                 increment_function_depth(
-                    &mut depth,
+                    &mut nesting.function_depth,
                     node,
                     ancestors,
                     &[G::FunctionDeclaration, G::MethodDeclaration],
                 );
             }
             G::FuncLiteral => {
-                lambda += 1;
+                nesting.lambda += 1;
             }
             _ => {}
         }
-        nesting_map.insert(
-            node.id(),
-            Nesting {
-                conditional: nesting,
-                function_depth: depth,
-                lambda,
-            },
-        );
+        nesting_map.insert(node.id(), nesting);
     }
 }

--- a/src/metrics/cognitive/groovy.rs
+++ b/src/metrics/cognitive/groovy.rs
@@ -23,15 +23,11 @@ impl Cognitive for GroovyCode {
     ) {
         use Groovy::*;
 
-        let Nesting {
-            conditional: mut nesting,
-            function_depth: mut depth,
-            mut lambda,
-        } = get_nesting_from_map(node, nesting_map);
+        let mut nesting = get_nesting_from_map(node, nesting_map);
 
         match node.kind_id().into() {
             IfStatement if !Self::is_else_if(node, ancestors) => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             // `for_in_statement` is the dekobon grammar's distinct node
             // for `for (x in xs)` / `for (Foo x : xs)` (the prior amaanq
@@ -39,7 +35,7 @@ impl Cognitive for GroovyCode {
             // and `switch_block` keep their familiar names.
             ForStatement | ForInStatement | WhileStatement | DoWhileStatement | SwitchBlock
             | CatchClause | TernaryExpression => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             // `Else` covers plain `else` blocks *and* the chained
             // `else if` form, because the grammar inlines the
@@ -75,7 +71,7 @@ impl Cognitive for GroovyCode {
             // is `Groovy::Closure` — also recognized by `is_closure` and
             // the `nargs` `closure_parameters` path.
             Closure => {
-                lambda += 1;
+                nesting.lambda += 1;
             }
             // At a (possibly nested) method / constructor boundary, reset
             // structural nesting to zero and bump the function-depth
@@ -85,9 +81,9 @@ impl Cognitive for GroovyCode {
             // nested method previously inherited the enclosing nesting and
             // missed the SonarSource B-nesting amplification (#696).
             MethodDeclaration | ConstructorDeclaration => {
-                nesting = 0;
+                nesting.conditional = 0;
                 increment_function_depth(
-                    &mut depth,
+                    &mut nesting.function_depth,
                     node,
                     ancestors,
                     &[MethodDeclaration, ConstructorDeclaration],
@@ -95,13 +91,6 @@ impl Cognitive for GroovyCode {
             }
             _ => {}
         }
-        nesting_map.insert(
-            node.id(),
-            Nesting {
-                conditional: nesting,
-                function_depth: depth,
-                lambda,
-            },
-        );
+        nesting_map.insert(node.id(), nesting);
     }
 }

--- a/src/metrics/cognitive/irules.rs
+++ b/src/metrics/cognitive/irules.rs
@@ -23,17 +23,13 @@ impl Cognitive for IrulesCode {
     ) {
         use Irules::*;
 
-        let Nesting {
-            conditional: mut nesting,
-            function_depth: mut depth,
-            lambda,
-        } = get_nesting_from_map(node, nesting_map);
+        let mut nesting = get_nesting_from_map(node, nesting_map);
 
         match node.kind_id().into() {
             // Defensive guard for parity with sibling impls; iRules' dedicated
             // `Elseif` node means `is_else_if` is never true for an `If`.
             If if !Self::is_else_if(node, ancestors) => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             // `elseif` extends the chain: +1 without increasing nesting.
             Elseif => {
@@ -45,18 +41,18 @@ impl Cognitive for IrulesCode {
             // Loops and ternary. `DictFor` iterates; `dict update`/`dict with`
             // do not and are excluded.
             For | Foreach | While | DictFor | TernaryExpr => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             // `catch` is a conditional error handler; its body only runs when
             // the guarded command errors.
             Catch => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             // iRules `switch` is a dedicated node (unlike Tcl): +1 plus current
             // nesting, with the `default` arm free, matching the C-family
             // `SwitchStatement` cognitive handling (lesson 11).
             Switch => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             // Boolean sequences inside expressions: both symbolic (`&&`/`||`)
             // and the iRules keyword forms (`and`/`or`).
@@ -68,9 +64,9 @@ impl Cognitive for IrulesCode {
             // All four function-space kinds reset nesting and bump the
             // function depth (see the `IrulesCode` Checker impl).
             Procedure | WhenEvent | OnHandler | TrapHandler => {
-                nesting = 0;
+                nesting.conditional = 0;
                 increment_function_depth(
-                    &mut depth,
+                    &mut nesting.function_depth,
                     node,
                     ancestors,
                     &[Procedure, WhenEvent, OnHandler, TrapHandler],
@@ -78,13 +74,6 @@ impl Cognitive for IrulesCode {
             }
             _ => {}
         }
-        nesting_map.insert(
-            node.id(),
-            Nesting {
-                conditional: nesting,
-                function_depth: depth,
-                lambda,
-            },
-        );
+        nesting_map.insert(node.id(), nesting);
     }
 }

--- a/src/metrics/cognitive/java.rs
+++ b/src/metrics/cognitive/java.rs
@@ -23,15 +23,11 @@ impl Cognitive for JavaCode {
     ) {
         use Java::*;
 
-        let Nesting {
-            conditional: mut nesting,
-            function_depth: mut depth,
-            mut lambda,
-        } = get_nesting_from_map(node, nesting_map);
+        let mut nesting = get_nesting_from_map(node, nesting_map);
 
         match node.kind_id().into() {
             IfStatement if !Self::is_else_if(node, ancestors) => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             ForStatement
             | EnhancedForStatement
@@ -40,7 +36,7 @@ impl Cognitive for JavaCode {
             | SwitchBlock
             | CatchClause
             | TernaryExpression => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             Else /* else-if also */ => {
                 increment_by_one(stats);
@@ -57,7 +53,7 @@ impl Cognitive for JavaCode {
                 compute_booleans(node, stats, AMPAMP, PIPEPIPE);
             }
             LambdaExpression => {
-                lambda += 1;
+                nesting.lambda += 1;
             }
             // At a (possibly nested) method / constructor boundary, reset
             // structural nesting to zero and bump the function-depth
@@ -68,9 +64,9 @@ impl Cognitive for JavaCode {
             // enclosing nesting and every nested method missed the
             // SonarSource B-nesting amplification (#696).
             MethodDeclaration | ConstructorDeclaration => {
-                nesting = 0;
+                nesting.conditional = 0;
                 increment_function_depth(
-                    &mut depth,
+                    &mut nesting.function_depth,
                     node,
                     ancestors,
                     &[MethodDeclaration, ConstructorDeclaration],
@@ -78,13 +74,6 @@ impl Cognitive for JavaCode {
             }
             _ => {}
         }
-        nesting_map.insert(
-            node.id(),
-            Nesting {
-                conditional: nesting,
-                function_depth: depth,
-                lambda,
-            },
-        );
+        nesting_map.insert(node.id(), nesting);
     }
 }

--- a/src/metrics/cognitive/kotlin.rs
+++ b/src/metrics/cognitive/kotlin.rs
@@ -42,18 +42,14 @@ impl Cognitive for KotlinCode {
     ) {
         use Kotlin::*;
 
-        let Nesting {
-            conditional: mut nesting,
-            function_depth: mut depth,
-            mut lambda,
-        } = get_nesting_from_map(node, nesting_map);
+        let mut nesting = get_nesting_from_map(node, nesting_map);
 
         match node.kind_id().into() {
             IfExpression if !Self::is_else_if(node, ancestors) => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             ForStatement | WhileStatement | DoWhileStatement | WhenExpression | CatchBlock => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             Else => {
                 // Per the SonarSource spec, `else ->` inside a `when`
@@ -88,26 +84,19 @@ impl Cognitive for KotlinCode {
                 });
             }
             FunctionDeclaration | SecondaryConstructor => {
-                nesting = 0;
+                nesting.conditional = 0;
                 increment_function_depth(
-                    &mut depth,
+                    &mut nesting.function_depth,
                     node,
                     ancestors,
                     &[FunctionDeclaration, SecondaryConstructor],
                 );
             }
             LambdaLiteral | AnonymousFunction => {
-                lambda += 1;
+                nesting.lambda += 1;
             }
             _ => {}
         }
-        nesting_map.insert(
-            node.id(),
-            Nesting {
-                conditional: nesting,
-                function_depth: depth,
-                lambda,
-            },
-        );
+        nesting_map.insert(node.id(), nesting);
     }
 }

--- a/src/metrics/cognitive/lua.rs
+++ b/src/metrics/cognitive/lua.rs
@@ -23,18 +23,14 @@ impl Cognitive for LuaCode {
     ) {
         use Lua::*;
 
-        let Nesting {
-            conditional: mut nesting,
-            function_depth: mut depth,
-            mut lambda,
-        } = get_nesting_from_map(node, nesting_map);
+        let mut nesting = get_nesting_from_map(node, nesting_map);
 
         match node.kind_id().into() {
             // `is_else_if` returns true for `ElseifStatement`, but Lua's
             // grammar makes that node a child field of `IfStatement` rather
             // than a nested `if_statement`, so the guard is defensive only.
             IfStatement if !Self::is_else_if(node, ancestors) => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             // `elseif` adds +1 at the same nesting level as the parent `if`,
             // matching how Tcl/Bash handle their dedicated elseif/elif nodes.
@@ -42,7 +38,7 @@ impl Cognitive for LuaCode {
                 increment_branch_extension(stats);
             }
             ForStatement | WhileStatement | RepeatStatement => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             // `else` increments without nesting. Lua's `break` is always
             // unlabeled (the grammar has no labeled break, and no
@@ -57,9 +53,9 @@ impl Cognitive for LuaCode {
                 compute_booleans(node, stats, And, Or);
             }
             FunctionDeclaration | FunctionDeclaration2 | FunctionDeclaration3 => {
-                nesting = 0;
+                nesting.conditional = 0;
                 increment_function_depth(
-                    &mut depth,
+                    &mut nesting.function_depth,
                     node,
                     ancestors,
                     &[
@@ -70,17 +66,10 @@ impl Cognitive for LuaCode {
                 );
             }
             FunctionDefinition => {
-                lambda += 1;
+                nesting.lambda += 1;
             }
             _ => {}
         }
-        nesting_map.insert(
-            node.id(),
-            Nesting {
-                conditional: nesting,
-                function_depth: depth,
-                lambda,
-            },
-        );
+        nesting_map.insert(node.id(), nesting);
     }
 }

--- a/src/metrics/cognitive/mozcpp.rs
+++ b/src/metrics/cognitive/mozcpp.rs
@@ -24,15 +24,11 @@ impl Cognitive for MozcppCode {
         use Mozcpp::*;
 
         // Macro expansion is not tracked; macros are treated as opaque tokens.
-        let Nesting {
-            conditional: mut nesting,
-            function_depth: mut depth,
-            mut lambda,
-        } = get_nesting_from_map(node, nesting_map);
+        let mut nesting = get_nesting_from_map(node, nesting_map);
 
         match node.kind_id().into() {
             IfStatement if !Self::is_else_if(node, ancestors) => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             ForStatement
             | ForRangeLoop
@@ -41,7 +37,7 @@ impl Cognitive for MozcppCode {
             | SwitchStatement
             | CatchClause
             | ConditionalExpression => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             GotoStatement | Else /* else-if also */ => {
                 increment_by_one(stats);
@@ -50,7 +46,7 @@ impl Cognitive for MozcppCode {
                 compute_booleans(node, stats, AMPAMP, PIPEPIPE);
             }
             LambdaExpression => {
-                lambda += 1;
+                nesting.lambda += 1;
             }
             // At a (possibly nested) function-definition boundary, reset
             // structural nesting to zero and bump the function-depth
@@ -60,10 +56,13 @@ impl Cognitive for MozcppCode {
             // construct inherited the enclosing nesting and every nested
             // definition missed the SonarSource B-nesting amplification
             // (#696).
-            FunctionDefinition | FunctionDefinition2 | FunctionDefinition3 | FunctionDefinition4 => {
-                nesting = 0;
+            FunctionDefinition
+            | FunctionDefinition2
+            | FunctionDefinition3
+            | FunctionDefinition4 => {
+                nesting.conditional = 0;
                 increment_function_depth(
-                    &mut depth,
+                    &mut nesting.function_depth,
                     node,
                     ancestors,
                     &[
@@ -76,13 +75,6 @@ impl Cognitive for MozcppCode {
             }
             _ => {}
         }
-        nesting_map.insert(
-            node.id(),
-            Nesting {
-                conditional: nesting,
-                function_depth: depth,
-                lambda,
-            },
-        );
+        nesting_map.insert(node.id(), nesting);
     }
 }

--- a/src/metrics/cognitive/objc.rs
+++ b/src/metrics/cognitive/objc.rs
@@ -24,15 +24,11 @@ impl Cognitive for ObjcCode {
         use Objc::*;
 
         // Macro expansion is not tracked; macros are treated as opaque tokens.
-        let Nesting {
-            conditional: mut nesting,
-            function_depth: mut depth,
-            mut lambda,
-        } = get_nesting_from_map(node, nesting_map);
+        let mut nesting = get_nesting_from_map(node, nesting_map);
 
         match node.kind_id().into() {
             IfStatement if !Self::is_else_if(node, ancestors) => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             // `@catch` (the `catch_clause` node) nests like a C++ catch.
             // Fast enumeration folds into `for_statement`, so `ForStatement`
@@ -43,7 +39,7 @@ impl Cognitive for ObjcCode {
             | SwitchStatement
             | CatchClause
             | ConditionalExpression => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             GotoStatement | Else /* else-if also */ => {
                 increment_by_one(stats);
@@ -57,15 +53,15 @@ impl Cognitive for ObjcCode {
             }
             // ObjC blocks `^{ … }` are the language's closures.
             BlockLiteral => {
-                lambda += 1;
+                nesting.lambda += 1;
             }
             // Functions and `@implementation` methods are definition
             // boundaries: reset structural nesting and bump the
             // function-depth surcharge when nested inside another (#696).
             FunctionDefinition | FunctionDefinition2 | MethodDefinition => {
-                nesting = 0;
+                nesting.conditional = 0;
                 increment_function_depth(
-                    &mut depth,
+                    &mut nesting.function_depth,
                     node,
                     ancestors,
                     &[FunctionDefinition, FunctionDefinition2, MethodDefinition],
@@ -73,13 +69,6 @@ impl Cognitive for ObjcCode {
             }
             _ => {}
         }
-        nesting_map.insert(
-            node.id(),
-            Nesting {
-                conditional: nesting,
-                function_depth: depth,
-                lambda,
-            },
-        );
+        nesting_map.insert(node.id(), nesting);
     }
 }

--- a/src/metrics/cognitive/perl.rs
+++ b/src/metrics/cognitive/perl.rs
@@ -45,11 +45,7 @@ impl Cognitive for PerlCode {
     ) {
         use Perl as P;
 
-        let Nesting {
-            conditional: mut nesting,
-            function_depth: mut depth,
-            mut lambda,
-        } = get_nesting_from_map(node, nesting_map);
+        let mut nesting = get_nesting_from_map(node, nesting_map);
 
         match node.kind_id().into() {
             // tree-sitter-perl parses `elsif_clause` as a direct child of
@@ -71,7 +67,7 @@ impl Cognitive for PerlCode {
             | P::WhileSimpleStatement
             | P::UntilSimpleStatement
             | P::ForSimpleStatement => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             // `else` and `elsif` each contribute a flat +1.
             P::Else | P::ElsifClause => {
@@ -99,26 +95,19 @@ impl Cognitive for PerlCode {
                 compute_perl_booleans(node, stats);
             }
             P::FunctionDefinition | P::FunctionDefinitionWithoutSub => {
-                nesting = 0;
+                nesting.conditional = 0;
                 increment_function_depth(
-                    &mut depth,
+                    &mut nesting.function_depth,
                     node,
                     ancestors,
                     &[P::FunctionDefinition, P::FunctionDefinitionWithoutSub],
                 );
             }
             P::AnonymousFunction => {
-                lambda += 1;
+                nesting.lambda += 1;
             }
             _ => {}
         }
-        nesting_map.insert(
-            node.id(),
-            Nesting {
-                conditional: nesting,
-                function_depth: depth,
-                lambda,
-            },
-        );
+        nesting_map.insert(node.id(), nesting);
     }
 }

--- a/src/metrics/cognitive/php.rs
+++ b/src/metrics/cognitive/php.rs
@@ -23,11 +23,7 @@ impl Cognitive for PhpCode {
     ) {
         use Php::*;
 
-        let Nesting {
-            conditional: mut nesting,
-            function_depth: mut depth,
-            mut lambda,
-        } = get_nesting_from_map(node, nesting_map);
+        let mut nesting = get_nesting_from_map(node, nesting_map);
 
         match node.kind_id().into() {
             // The two-word `else if` form parses as `else_clause →
@@ -38,7 +34,7 @@ impl Cognitive for PhpCode {
             // dedicated `ElseIfClause` node handled by the branch-extension
             // arm below.
             IfStatement if !Self::is_else_if(node, ancestors) => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             ForStatement
             | ForeachStatement
@@ -48,7 +44,7 @@ impl Cognitive for PhpCode {
             | MatchExpression
             | CatchClause
             | ConditionalExpression => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             ElseClause | ElseClause2 | ElseIfClause | ElseIfClause2 => {
                 increment_branch_extension(stats);
@@ -84,7 +80,7 @@ impl Cognitive for PhpCode {
                 compute_booleans_with(node, stats, |id| matches!(id.into(), QMARKQMARKEQ));
             }
             AnonymousFunction | ArrowFunction => {
-                lambda += 1;
+                nesting.lambda += 1;
             }
             // At a (possibly nested) named-function / method boundary, reset
             // structural nesting to zero and bump the function-depth
@@ -97,9 +93,9 @@ impl Cognitive for PhpCode {
             // the lambda arm above and intentionally do *not* reset nesting,
             // mirroring how the siblings treat lambda vs named-function arms.
             FunctionDefinition | MethodDeclaration => {
-                nesting = 0;
+                nesting.conditional = 0;
                 increment_function_depth(
-                    &mut depth,
+                    &mut nesting.function_depth,
                     node,
                     ancestors,
                     &[FunctionDefinition, MethodDeclaration],
@@ -107,13 +103,6 @@ impl Cognitive for PhpCode {
             }
             _ => {}
         }
-        nesting_map.insert(
-            node.id(),
-            Nesting {
-                conditional: nesting,
-                function_depth: depth,
-                lambda,
-            },
-        );
+        nesting_map.insert(node.id(), nesting);
     }
 }

--- a/src/metrics/cognitive/python.rs
+++ b/src/metrics/cognitive/python.rs
@@ -103,11 +103,7 @@ impl Cognitive for PythonCode {
         use Python::*;
 
         // Get nesting of the parent
-        let Nesting {
-            conditional: mut nesting,
-            function_depth: mut depth,
-            mut lambda,
-        } = get_nesting_from_map(node, nesting_map);
+        let mut nesting = get_nesting_from_map(node, nesting_map);
 
         match node.kind_id().into() {
             // `else: if x:` chains surface as an `if_statement` wrapped
@@ -115,10 +111,10 @@ impl Cognitive for PythonCode {
             // so the nesting increment lands only on the outer chain
             // (matching the `elif_clause` accounting one arm below).
             IfStatement if !Self::is_else_if(node, ancestors) => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             ForStatement | WhileStatement | ConditionalExpression | MatchStatement => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             // A comprehension / generator expression is a loop with an
             // optional filter, so it carries cognitive load just like the
@@ -149,15 +145,8 @@ impl Cognitive for PythonCode {
             | DictionaryComprehension
             | SetComprehension
             | GeneratorExpression => {
-                nesting += python_comprehension_clause_nesting(
-                    node,
-                    Nesting {
-                        conditional: nesting,
-                        function_depth: depth,
-                        lambda,
-                    },
-                    nesting_map,
-                );
+                nesting.conditional +=
+                    python_comprehension_clause_nesting(node, nesting, nesting_map);
             }
             ForInClause | IfClause => {
                 // `nesting` already holds this clause's own value: the
@@ -167,7 +156,7 @@ impl Cognitive for PythonCode {
                 // up. Before #1062 a node read its *parent's* slot, so this
                 // arm had to re-read the slot explicitly; that override is
                 // now a no-op and has been removed.
-                stats.nesting = nesting + depth + lambda;
+                stats.nesting = nesting.total();
                 increment(stats);
                 stats.boolean_seq.reset();
             }
@@ -186,7 +175,7 @@ impl Cognitive for PythonCode {
                 increment_by_one(stats);
             }
             ExceptClause => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             ExpressionList | ExpressionStatement | Tuple => {
                 stats.boolean_seq.reset();
@@ -199,23 +188,21 @@ impl Cognitive for PythonCode {
             // drift guard in checker.rs flags a bump that emits Lambda2).
             Lambda | Lambda2 => {
                 // Increase lambda nesting
-                lambda += 1;
+                nesting.lambda += 1;
             }
             FunctionDefinition => {
                 // Increase depth function nesting if needed
-                increment_function_depth(&mut depth, node, ancestors, &[FunctionDefinition]);
+                increment_function_depth(
+                    &mut nesting.function_depth,
+                    node,
+                    ancestors,
+                    &[FunctionDefinition],
+                );
             }
             _ => {}
         }
         // Add node to nesting map
-        nesting_map.insert(
-            node.id(),
-            Nesting {
-                conditional: nesting,
-                function_depth: depth,
-                lambda,
-            },
-        );
+        nesting_map.insert(node.id(), nesting);
     }
 }
 
@@ -234,46 +221,63 @@ mod tests {
     // checkable at the call site too.
     #[test]
     fn python_comprehension_clauses_carry_inherited_depth_and_lambda() {
-        // Clause order: `for a in xs` (0 preceding `for`s), `if a` (1),
-        // `for b in ys` (1). The trailing clause is a `for`, which has
-        // already advanced the count, so the element sits 2 levels deep.
-        let parser = PythonParser::new(
-            b"[x for a in xs if a for b in ys]".to_vec(),
-            std::path::Path::new("comprehension.py"),
-            None,
-        );
-        let root = parser.root();
-        let comprehension = *root
-            .descendants_by_kind(&["list_comprehension"])
-            .first()
-            .expect("the fixture contains exactly one list comprehension");
-        let clauses: Vec<_> = comprehension
-            .children()
-            .filter(|child| matches!(child.kind(), "for_in_clause" | "if_clause"))
-            .collect();
-        assert_eq!(clauses.len(), 3, "fixture must expose all three clauses");
+        // Both fixtures have three clauses and differ only in which kind
+        // trails, which is what selects the `last_clause_is_if` term of
+        // the returned element depth. A trailing `for` has already
+        // advanced `for_count`, so the term contributes 0 and covering
+        // only that shape leaves the term untested — the element depth
+        // is the same with it deleted.
+        let cases = [
+            // `for a in xs` (0 preceding `for`s), `if a` (1),
+            // `for b in ys` (1); trailing `for` → element at 2.
+            ("[x for a in xs if a for b in ys]", [1, 2, 2], 2),
+            // `for a in xs` (0), `for b in ys` (1), `if b` (2);
+            // trailing `if` → one deeper than the 2 `for`s → 3.
+            ("[x for a in xs for b in ys if b]", [1, 2, 3], 3),
+        ];
 
-        let inherited = Nesting {
-            conditional: 1,
-            function_depth: 2,
-            lambda: 3,
-        };
-        let mut nesting_map = NestingMap::default();
-        let element_nesting =
-            python_comprehension_clause_nesting(&comprehension, inherited, &mut nesting_map);
-
-        assert_eq!(element_nesting, 2);
-        for (clause, expected_conditional) in clauses.iter().zip([1, 2, 2]) {
-            assert_eq!(
-                nesting_map.get(&clause.id()),
-                Some(&Nesting {
-                    conditional: expected_conditional,
-                    function_depth: 2,
-                    lambda: 3,
-                }),
-                "wrong nesting recorded for the `{}` clause",
-                clause.kind()
+        for (source, expected_conditionals, expected_element) in cases {
+            let parser = PythonParser::new(
+                source.as_bytes().to_vec(),
+                std::path::Path::new("comprehension.py"),
+                None,
             );
+            let root = parser.root();
+            let comprehension = *root
+                .descendants_by_kind(&["list_comprehension"])
+                .first()
+                .expect("the fixture contains exactly one list comprehension");
+            let clauses: Vec<_> = comprehension
+                .children()
+                .filter(|child| matches!(child.kind(), "for_in_clause" | "if_clause"))
+                .collect();
+            assert_eq!(clauses.len(), 3, "`{source}` must expose all three clauses");
+
+            let inherited = Nesting {
+                conditional: 1,
+                function_depth: 2,
+                lambda: 3,
+            };
+            let mut nesting_map = NestingMap::default();
+            let element_nesting =
+                python_comprehension_clause_nesting(&comprehension, inherited, &mut nesting_map);
+
+            assert_eq!(
+                element_nesting, expected_element,
+                "wrong element depth for `{source}`"
+            );
+            for (clause, expected_conditional) in clauses.iter().zip(expected_conditionals) {
+                assert_eq!(
+                    nesting_map.get(&clause.id()),
+                    Some(&Nesting {
+                        conditional: expected_conditional,
+                        function_depth: 2,
+                        lambda: 3,
+                    }),
+                    "wrong nesting recorded for the `{}` clause of `{source}`",
+                    clause.kind()
+                );
+            }
         }
     }
 }

--- a/src/metrics/cognitive/ruby.rs
+++ b/src/metrics/cognitive/ruby.rs
@@ -35,11 +35,7 @@ impl Cognitive for RubyCode {
     ) {
         use Ruby as R;
 
-        let Nesting {
-            conditional: mut nesting,
-            function_depth: mut depth,
-            mut lambda,
-        } = get_nesting_from_map(node, nesting_map);
+        let mut nesting = get_nesting_from_map(node, nesting_map);
 
         match node.kind_id().into() {
             // Nesting-increasing constructs. tree-sitter-ruby models
@@ -49,7 +45,7 @@ impl Cognitive for RubyCode {
             // defensive only — mirrors the equivalent pattern in the
             // Lua impl.
             R::If if !Self::is_else_if(node, ancestors) => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             R::Unless
             | R::While
@@ -66,7 +62,7 @@ impl Cognitive for RubyCode {
             | R::RescueModifier
             | R::RescueModifier2
             | R::RescueModifier3 => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             // `elsif` and the `else` of an `if`/`elsif` chain extend the
             // parent branch at the same nesting level (+1).
@@ -134,9 +130,9 @@ impl Cognitive for RubyCode {
                 compute_ruby_booleans(node, stats);
             }
             R::Method | R::SingletonMethod => {
-                nesting = 0;
+                nesting.conditional = 0;
                 increment_function_depth(
-                    &mut depth,
+                    &mut nesting.function_depth,
                     node,
                     ancestors,
                     &[R::Method, R::SingletonMethod],
@@ -144,17 +140,10 @@ impl Cognitive for RubyCode {
             }
             // Blocks, do-blocks and lambdas are the closure/lambda forms.
             R::Block | R::DoBlock | R::Lambda => {
-                lambda += 1;
+                nesting.lambda += 1;
             }
             _ => {}
         }
-        nesting_map.insert(
-            node.id(),
-            Nesting {
-                conditional: nesting,
-                function_depth: depth,
-                lambda,
-            },
-        );
+        nesting_map.insert(node.id(), nesting);
     }
 }

--- a/src/metrics/cognitive/rust.rs
+++ b/src/metrics/cognitive/rust.rs
@@ -23,18 +23,14 @@ impl Cognitive for RustCode {
     ) {
         use Rust::*;
         // Macro expansion is not tracked; macros are treated as opaque tokens.
-        let Nesting {
-            conditional: mut nesting,
-            function_depth: mut depth,
-            mut lambda,
-        } = get_nesting_from_map(node, nesting_map);
+        let mut nesting = get_nesting_from_map(node, nesting_map);
 
         match node.kind_id().into() {
             IfExpression if !Self::is_else_if(node, ancestors) => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             ForExpression | WhileExpression | LoopExpression | MatchExpression => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             Else /*else-if also */ => {
                 increment_by_one(stats);
@@ -58,22 +54,20 @@ impl Cognitive for RustCode {
                 compute_booleans(node, stats, AMPAMP, PIPEPIPE);
             }
             FunctionItem => {
-                nesting = 0;
+                nesting.conditional = 0;
                 // Increase depth function nesting if needed
-                increment_function_depth(&mut depth, node, ancestors, &[FunctionItem]);
+                increment_function_depth(
+                    &mut nesting.function_depth,
+                    node,
+                    ancestors,
+                    &[FunctionItem],
+                );
             }
             ClosureExpression => {
-                lambda += 1;
+                nesting.lambda += 1;
             }
             _ => {}
         }
-        nesting_map.insert(
-            node.id(),
-            Nesting {
-                conditional: nesting,
-                function_depth: depth,
-                lambda,
-            },
-        );
+        nesting_map.insert(node.id(), nesting);
     }
 }

--- a/src/metrics/cognitive/tcl.rs
+++ b/src/metrics/cognitive/tcl.rs
@@ -23,17 +23,13 @@ impl Cognitive for TclCode {
     ) {
         use Tcl::*;
 
-        let Nesting {
-            conditional: mut nesting,
-            function_depth: mut depth,
-            lambda,
-        } = get_nesting_from_map(node, nesting_map);
+        let mut nesting = get_nesting_from_map(node, nesting_map);
 
         match node.kind_id().into() {
             // Guard kept for defensive consistency with sibling impls; Tcl's dedicated
             // Elseif node means this guard is always true in practice.
             If if !Self::is_else_if(node, ancestors) => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             // elseif adds +1 without increasing nesting for its own children.
             Elseif => {
@@ -43,11 +39,11 @@ impl Cognitive for TclCode {
                 increment_by_one(stats);
             }
             While | Foreach | TernaryExpr => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             // `catch` is a conditional error handler; only executes when the body errors.
             Catch => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             // Tcl `switch` is a generic `command`, not a dedicated kind, so it
             // would otherwise fall through to `_` (issue #467). It is a
@@ -56,24 +52,22 @@ impl Cognitive for TclCode {
             // handling (lesson 11). `tcl_switch_decision_arms` returns `Some`
             // only for a leading-word `switch` command.
             Command if tcl_switch_decision_arms(node, code).is_some() => {
-                increase_nesting(stats, &mut nesting, depth, lambda);
+                increase_nesting(stats, &mut nesting);
             }
             BinopExpr => {
                 compute_booleans(node, stats, AMPAMP, PIPEPIPE);
             }
             Procedure => {
-                nesting = 0;
-                increment_function_depth(&mut depth, node, ancestors, &[Procedure]);
+                nesting.conditional = 0;
+                increment_function_depth(
+                    &mut nesting.function_depth,
+                    node,
+                    ancestors,
+                    &[Procedure],
+                );
             }
             _ => {}
         }
-        nesting_map.insert(
-            node.id(),
-            Nesting {
-                conditional: nesting,
-                function_depth: depth,
-                lambda,
-            },
-        );
+        nesting_map.insert(node.id(), nesting);
     }
 }

--- a/src/spaces.rs
+++ b/src/spaces.rs
@@ -44,6 +44,21 @@ pub(crate) struct Nesting {
     pub(crate) lambda: usize,
 }
 
+impl Nesting {
+    /// The effective nesting level a construct at this state pays for:
+    /// the sum of all three channels.
+    ///
+    /// SonarSource's Cognitive Complexity raises the nesting level for
+    /// enclosing control constructs (`conditional`) *and* for nested
+    /// methods and method-like structures such as lambdas, so
+    /// `function_depth` (#696) and `lambda` are spec nesting increments
+    /// too — tracked apart only because the walk resets them at
+    /// different boundaries. All three add on equal footing.
+    pub(crate) const fn total(self) -> usize {
+        self.conditional + self.function_depth + self.lambda
+    }
+}
+
 /// Node-id keyed [`Nesting`] state; see
 /// `spaces::compute::propagate_nesting_to_children`.
 pub(crate) type NestingMap = IntKeyHashMap<usize, Nesting>;


### PR DESCRIPTION
Closes #1086.

`increase_nesting` was the last bare-positional-`usize` triple in the
cognitive walk — `(stats, &mut nesting, depth, lambda)` at 43 call sites
across the 19 per-language modules and the `js_cognitive!` macro. It now
takes `&mut Nesting`, and every `compute` body holds the struct end to
end instead of destructuring it into three same-typed locals and
rebuilding it on the way out. Adds `Nesting::total()` for the
`conditional + function_depth + lambda` sum, which was open-coded at two
sites.

**Net −120 lines** across the cognitive modules. No behaviour change:
`cargo test --workspace --all-features` is bit-identical.

## Corrections to the issue's framing

**The issue was wrong that a field transposition here is unobservable**,
and that mattered — it was the stated justification for landing with no
test. Perturbing `nesting.conditional += 1` to
`nesting.function_depth += 1` fails **six** tests: the new unit test
plus `java_nested_method_resets_nesting_and_adds_depth`,
`cpp_nested_function_resets_nesting_and_adds_depth`,
`groovy_nested_method_resets_nesting_and_adds_depth`,
`php_nested_function_resets_nesting_775`, and
`csharp_local_function_in_if_does_not_inherit_nesting`.

The charge itself is symmetric so the mistake is invisible there, but a
function boundary resets `conditional` **alone**, so a misplaced
increment survives into `function_depth` and moves the score. This is
the *opposite* of #1070's case, where every transposition genuinely was
unobservable; the two should not be cited together.

Two smaller corrections: the call sites span **19** modules plus the
macro (not "21 of 23"), and `total()` replaced **two** open-coded sums
(not three).

## Tests

Two new unit tests pin what the new shape makes newly expressible —
bumping the wrong channel, and dropping one from the sum. Both were
verified by perturbing the production line per
`.claude/rules/testing.md`, not merely by passing.

Reviewing the diff surfaced adjacent gaps in files this already touches,
fixed here rather than deferred — each also verified by perturbation:

- `python_comprehension_clauses_carry_inherited_depth_and_lambda`
  covered only a trailing-`for` fixture, so the
  `+ usize::from(last_clause_is_if)` term of the returned element depth
  contributed 0 and was untested — **deleting it left the test green.**
  Added a trailing-`if` fixture (`[x for a in xs for b in ys if b]`,
  element depth 3).
- The new `increase_nesting` test first asserted the `boolean_seq` reset
  from `Stats::default()`, where it cannot fail; deleting
  `stats.boolean_seq.reset()` was measured at **zero** failures
  suite-wide. Now seeded. Same for `increment`'s `+=` vs `=`, which was
  indistinguishable from a zeroed `structural`.
- `elixir.rs`'s header comment contradicted its own code twice: it
  documented `try` as adding `+nesting` on the container (deliberately
  excluded) and `def` as bumping the function depth (deliberately not —
  every `def` inside a `defmodule` has a `Call` ancestor, which would
  falsely raise it).

As a sanity check on the suite itself, gutting `increase_nesting` to a
near-no-op fails 263 of 3,130 lib tests.

## Gates

`make pre-commit` green: clippy (both feature flavours), fmt, `cargo doc
-D warnings`, udeps, workspace tests with zero failures and no
`.snap.new` drift, both self-scan tiers, and the
`--no-default-features` / `--features rust,typescript` CI matrix legs.

`.bca-baseline.toml` needed one refresh: `RubyCode::compute`'s
`halstead.effort` dropped 53802 → 47981, a tightening consistent with
the smaller module.

## Known trade-off

Threading the struct removes the compile-time guard that `bash.rs`,
`c.rs`, `irules.rs`, and `tcl.rs` got from binding `lambda` immutably —
a stray `nesting.lambda += 1` there now compiles. The residual risk is
low and untestable in a meaningful way: those four languages have no
lambda or closure construct, so there is no arm that could plausibly
grow such a write, and the real protection was always "the grammar has
no such node" rather than the binding.

## Follow-up

**#1103** — the `nesting.conditional = 0;` +
`increment_function_depth(...)` pair now repeats verbatim in 17 of 23
modules and wants an `enter_function_boundary` helper (~−55 lines). Kept
out of this PR so the diff stays atomic and bit-identical by inspection.

## Toolchain gotcha for reviewers

`cargo fmt --check` exits **0** over misformatted code in these modules.
Any comment inside a match pattern — a block comment before `=>`
(`Else /* else-if also */ =>`) or `//` lines between `|` alternatives
(`perl.rs`) — makes rustfmt emit the **enclosing match** verbatim.

**Eight sites** are affected: the modules `c.rs`, `cpp.rs`, `java.rs`,
`mozcpp.rs`, `objc.rs`, `perl.rs`, `rust.rs`, plus the `js_cognitive!`
macro body in `cognitive.rs`. `macro_rules!` bodies are *not* exempt —
rustfmt formats them by default, so the macro bails for the same reason
as the rest.

This bit the PR: a regex rewrite of 43 call sites left hanging-argument
calls and over-length lines that `cargo fmt --all -- --check` reported
as clean, all found by reading the diff. Written up with a
list-regeneration snippet in `.claude/rules/formatting.md`.

*(Two earlier revisions of this section got the count and the cause
wrong — first eight-with-the-wrong-reason, then seven. The commit
`cda402f1` records the corrected version and the two measurement traps
that produced the wrong answers.)*
