### PR TITLE
feat(cli): derive default metric thresholds from evidence

### DIFF
--- a/.bca-baseline.toml
+++ b/.bca-baseline.toml
@@ -13,13 +13,6 @@ headroom = 0.95
 
 [[entry]]
 path = "big-code-analysis-cli/src/baseline.rs"
-qualified = "<file>"
-start_line = 1
-metric = "loc.sloc"
-value = 1080.0
-
-[[entry]]
-path = "big-code-analysis-cli/src/baseline.rs"
 qualified = "Baseline::from_str"
 start_line = 380
 metric = "halstead.effort"
@@ -147,14 +140,14 @@ value = 5.0
 [[entry]]
 path = "big-code-analysis-cli/src/commands/init.rs"
 qualified = "run_command_init"
-start_line = 211
+start_line = 184
 metric = "nargs"
 value = 7.0
 
 [[entry]]
 path = "big-code-analysis-cli/src/commands/init.rs"
 qualified = "scaffold_baseline"
-start_line = 143
+start_line = 116
 metric = "nargs"
 value = 7.0
 
@@ -251,6 +244,13 @@ value = 8.0
 
 [[entry]]
 path = "big-code-analysis-cli/src/html_report/sections.rs"
+qualified = "<file>"
+start_line = 1
+metric = "loc.ploc"
+value = 551.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/html_report/sections.rs"
 qualified = "write_language_section"
 start_line = 664
 metric = "halstead.effort"
@@ -266,7 +266,7 @@ value = 7.0
 [[entry]]
 path = "big-code-analysis-cli/src/lib.rs"
 qualified = "legacy_hint"
-start_line = 654
+start_line = 655
 metric = "halstead.effort"
 value = 59351.805921378844
 
@@ -274,8 +274,8 @@ value = 59351.805921378844
 path = "big-code-analysis-cli/src/markdown_report.rs"
 qualified = "<file>"
 start_line = 1
-metric = "loc.sloc"
-value = 883.0
+metric = "loc.ploc"
+value = 601.0
 
 [[entry]]
 path = "big-code-analysis-cli/src/markdown_report.rs"
@@ -288,8 +288,8 @@ value = 52993.355167839094
 path = "big-code-analysis-cli/src/markdown_report/hotspot.rs"
 qualified = "<file>"
 start_line = 1
-metric = "loc.sloc"
-value = 987.0
+metric = "loc.ploc"
+value = 650.0
 
 [[entry]]
 path = "big-code-analysis-cli/src/markdown_report/sections.rs"
@@ -328,24 +328,10 @@ value = 66737.04848699087
 
 [[entry]]
 path = "big-code-analysis-cli/src/thresholds.rs"
-qualified = "<file>"
-start_line = 1
-metric = "loc.sloc"
-value = 908.0
-
-[[entry]]
-path = "big-code-analysis-cli/src/thresholds.rs"
 qualified = "ThresholdSet::evaluate_with_policy"
 start_line = 790
 metric = "halstead.effort"
 value = 56531.05676283881
-
-[[entry]]
-path = "big-code-analysis-cli/src/vcs_command.rs"
-qualified = "<file>"
-start_line = 1
-metric = "loc.sloc"
-value = 787.0
 
 [[entry]]
 path = "big-code-analysis-cli/src/vcs_command.rs"
@@ -409,13 +395,6 @@ qualified = "analyze_paths"
 start_line = 622
 metric = "nexits"
 value = 5.0
-
-[[entry]]
-path = "big-code-analysis-py/src/lib.rs"
-qualified = "<file>"
-start_line = 1
-metric = "loc.sloc"
-value = 913.0
 
 [[entry]]
 path = "big-code-analysis-py/src/lib.rs"
@@ -505,8 +484,8 @@ value = 6.0
 path = "big-code-analysis-py/src/types_codegen.rs"
 qualified = "<file>"
 start_line = 1
-metric = "loc.sloc"
-value = 875.0
+metric = "loc.ploc"
+value = 745.0
 
 [[entry]]
 path = "big-code-analysis-py/src/vcs.rs"
@@ -563,6 +542,13 @@ qualified = "options_from"
 start_line = 180
 metric = "nexits"
 value = 8.0
+
+[[entry]]
+path = "src/alterator.rs"
+qualified = "<file>"
+start_line = 1
+metric = "loc.ploc"
+value = 545.0
 
 [[entry]]
 path = "src/ast.rs"
@@ -654,13 +640,6 @@ qualified = "RubyCode::get_op_type"
 start_line = 21
 metric = "halstead.effort"
 value = 84039.86210807812
-
-[[entry]]
-path = "src/macros/mod.rs"
-qualified = "<file>"
-start_line = 1
-metric = "loc.sloc"
-value = 768.0
 
 [[entry]]
 path = "src/metrics/abc/c.rs"
@@ -819,7 +798,7 @@ value = 55025.91689557041
 [[entry]]
 path = "src/metrics/loc/shared.rs"
 qualified = "add_multiline_string_ploc"
-start_line = 136
+start_line = 171
 metric = "nargs"
 value = 7.0
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -376,6 +376,47 @@ A behaviour-changing fix without the matching submodule bump leaves
 the next fresh clone with either an unfetchable submodule SHA or
 stranded `.snap.new` drift that blocks CI on every subsequent change.
 
+## Metric thresholds
+
+The limits `bca init` scaffolds are defined once, in
+`big-code-analysis-cli/src/default_thresholds.rs`. They are derived
+from published thresholds plus a 20-language corpus measurement (#1140),
+and each carries its rationale inline. Change them there, not in a
+copy: the scaffolded `bca.toml` renders its `[thresholds]` block from
+that table, and `init_template_thresholds_match_the_default_table` fails
+if a second copy appears.
+
+| Metric | Default | Scope |
+|--------|---------|-------|
+| `cognitive` | 15 | function |
+| `cyclomatic` | 15 | function |
+| `abc` | 40 | function |
+| `nargs` | 5 | function |
+| `nexits` | 5 | function |
+| `halstead.effort` | 50000 | function |
+| `loc.ploc` | 600 | file |
+| `loc.sloc` | 1200 | file |
+| `nom` | 30 | container |
+| `wmc` | 60 | container |
+
+Three things to know before quoting a number at anyone:
+
+- **These are language-agnostic defaults, and no language is
+  agnostic.** Measured 97.5th-percentile `cognitive` runs from 4 (C#)
+  to 50 (C). C, Tcl, Bash, Lua, Perl, and Go want roughly double the
+  defaults; Java, Ruby, Kotlin, C#, and Elixir sit far under them. The
+  per-language table lives in
+  [Choosing thresholds](big-code-analysis-book/src/recipes/thresholds.md).
+- **The right limit depends on the job.** A blocking CI gate, an agent
+  edit loop, a legacy triage pass, and a safety-critical build want
+  four different tables. That page has one profile for each.
+- **This repository's own `bca.toml` deliberately differs from the
+  shipped defaults.** It is a Rust-specific calibration with
+  `exclude_tests = true` and a comment-dense house style. `cognitive`,
+  `nargs`, and `abc` are still at their pre-#1140 values here, tracked
+  in #1143. Do not "fix" one file to match the other; they answer
+  different questions.
+
 ## Responding to bca metric feedback
 
 This repo dogfoods its own analyzer: a `bca check` threshold violation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -383,8 +383,13 @@ The limits `bca init` scaffolds are defined once, in
 from published thresholds plus a 20-language corpus measurement (#1140),
 and each carries its rationale inline. Change them there, not in a
 copy: the scaffolded `bca.toml` renders its `[thresholds]` block from
-that table, and `init_template_thresholds_match_the_default_table` fails
-if a second copy appears.
+that table, so there is no second copy of the numbers to drift.
+
+Two copies of the *summary table* do exist — the one below and the one
+in the book's recipe — and `doc_summary_tables_match_the_default_table`
+pins both, in each direction. Do not add a third: it would be
+unguarded, since that test only knows the paths listed in
+`DOCS_REPEATING_THE_TABLE`.
 
 | Metric | Default | Scope |
 |--------|---------|-------|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,18 @@ for historical reference.
 
 ### Changed
 
+- Retuned the `[thresholds]` table `bca init` scaffolds, deriving each
+  limit from published thresholds plus a 20-language corpus measurement
+  (#1140). `cognitive` 25 to 15 (SonarSource's own default for the
+  metric), `nargs` 7 to 5 (RuboCop's value; 7 fired on under 1% of
+  functions and so could not catch anything), `abc` 50 to 40, and file
+  size split into a `loc.ploc` working limit of 600 with `loc.sloc`
+  demoted to a 1200-line bloat backstop (#1138). `cyclomatic`,
+  `nexits`, `halstead.effort`, `nom`, and `wmc` are unchanged. Existing
+  `bca.toml` files are unaffected; this changes what a fresh `bca init`
+  writes. The derivation, a per-language override table, and
+  per-use-case profiles are in the book's new *Choosing thresholds*
+  recipe.
 - `make test` now runs the suite through `cargo-nextest` when it is
   available, matching CI, and falls back to `cargo test` otherwise
   (#1120). nextest schedules every binary's tests into one global pool

--- a/bca.toml
+++ b/bca.toml
@@ -47,7 +47,7 @@ exclude_tests = true
 [check]
 baseline = ".bca-baseline.toml"
 
-# bca per-function threshold configuration.
+# bca metric threshold configuration.
 #
 # These limits are this repository's own calibration and are expected to
 # differ from the defaults `bca init` scaffolds (which live in
@@ -83,7 +83,12 @@ baseline = ".bca-baseline.toml"
 #     that were previously invisible to the gate.
 #
 # Metrics intentionally NOT gated (yet):
-#   halstead.{volume,difficulty,time,bugs}, cyclomatic.modified, mi.*
+#         cyclomatic.modified,
+#         halstead.volume, halstead.difficulty, halstead.time,
+#         halstead.bugs,
+#         loc.lloc, loc.cloc, loc.blank,
+#         mi.original, mi.sei, mi.visual_studio,
+#         npm, npa, tokens
 # Their distributions on this codebase are dominated by macro-expanded
 # language modules; gating them would either require thresholds high
 # enough to be meaningless, or fire on the long tail of dispatch arms.

--- a/bca.toml
+++ b/bca.toml
@@ -49,6 +49,14 @@ baseline = ".bca-baseline.toml"
 
 # bca per-function threshold configuration.
 #
+# These limits are this repository's own calibration and are expected to
+# differ from the defaults `bca init` scaffolds (which live in
+# `big-code-analysis-cli/src/default_thresholds.rs` and are derived in
+# the book's `Choosing thresholds` recipe). Until #1140 a drift test
+# forced the two equal, which meant this project's Rust-specific
+# calibration was also what every adopter got on day one. Where this
+# file diverges, the divergence is noted inline with its reason.
+#
 # Editing rules:
 #   * Each key is a stable metric name (or dotted sub-metric name) from
 #     `bca list-metrics` / `bca check --help`. Available names:
@@ -81,26 +89,41 @@ baseline = ".bca-baseline.toml"
 # enough to be meaningless, or fire on the long tail of dispatch arms.
 # They are still computed and visible in `bca report markdown|html`.
 [thresholds]
+# cognitive, nargs, and abc are looser here than the shipped defaults
+# (15 / 5 / 40). That is not a calibration — it is the pre-#1140
+# folklore value, kept because converging costs ~95 new baseline
+# entries in one commit, which reads as debt rather than as a decision.
+# Tracked in #1143; tighten one metric per change, absorbing offenders
+# as they are genuinely fixed rather than baselining the lot.
 cognitive = 25
 cyclomatic = 15
 "halstead.effort" = 50000
-# Set to 800 from the observed file-level distribution: the median
-# source file is ~380 SLOC and the dense cluster of normal hand-
-# written modules runs up to ~890. Rust co-locates `#[cfg(test)]`
-# tests in-file, so file SLOC runs 2-3x what it would with separate
-# test files; a healthy ~300-350 non-test ceiling maps to this range.
-# 800 lets most ordinary documented modules pass without an
-# artificial split or a baseline entry. Still on the baseline ratchet:
-# the genuinely large / test-heavy modules (metrics/*, macros, the big
-# report files), plus a few mid-size modules in the ~760-890 band
-# (alterator.rs, ops.rs, baseline.rs, ...). The soft tier scales this
-# limit to 760 (BCA_HEADROOM 0.95), so files between 760 and 800 are
-# baselined for the soft gate even though they clear the hard one.
-# loc.sloc is File-scoped (#969): it gates the whole-file root only, not
-# each function — a per-function SLOC gate would be redundant here, since
-# cognitive / cyclomatic / abc catch an oversized function long before it
-# nears 800 lines.
-"loc.sloc" = 800
+# File size is gated in two tiers (#1138, #1140). Both are File-scoped
+# (#969): they gate the whole-file root, never each function — an
+# oversized function trips cognitive / cyclomatic / abc long before it
+# nears any of these line counts.
+#
+# `loc.ploc` is the working limit: physical lines of code, blanks and
+# comments excluded. 550 sits just above this repo's p99 (545) with the
+# current distribution at p50 68 / p90 331 / p95 421. That is stricter
+# than the shipped default of 600 on purpose — a house style that asks
+# for a why-comment whenever the reasoning is non-obvious should be
+# measured on its code, and then held to a tighter bound on it.
+"loc.ploc" = 550
+# `loc.sloc` is a bloat backstop, not the working limit: it counts
+# comments and blanks, so its only job is to stop a file growing without
+# bound on comment volume alone while still clearing loc.ploc. 1300
+# leaves real headroom over today's largest file (1080) and over the
+# 0.95 soft tier, so ordinary documentation growth never trips it.
+#
+# This replaces the previous single `loc.sloc = 800` gate, whose stated
+# derivation ("Rust co-locates #[cfg(test)] tests in-file, so file SLOC
+# runs 2-3x...") stopped holding when `exclude_tests = true` landed
+# twelve days after the limit was set, and which in practice charged the
+# same price for documenting a decision as for adding code — #1138 found
+# seven files clustered in a four-line band ending exactly on the soft
+# limit, which is trimming-to-fit rather than a natural distribution.
+"loc.sloc" = 1300
 nom = 30
 nargs = 7
 nexits = 5

--- a/big-code-analysis-book/src/SUMMARY.md
+++ b/big-code-analysis-book/src/SUMMARY.md
@@ -19,6 +19,7 @@
   - [CI integration](recipes/ci.md)
   - [Baselines](recipes/baselines.md)
   - [Local threshold gates](recipes/local-gates.md)
+  - [Choosing thresholds](recipes/thresholds.md)
   - [Feeding metrics to an agent](recipes/agent-feedback.md)
   - [AST queries](recipes/ast-queries.md)
   - [Exporting metric data](recipes/exporting-data.md)

--- a/big-code-analysis-book/src/commands/check.md
+++ b/big-code-analysis-book/src/commands/check.md
@@ -102,6 +102,12 @@ project-wide default and tighten a single metric for a specific run:
 bca check --paths src/ --config bca.toml
 ```
 
+`bca init` scaffolds a starting table for you. For where those numbers
+come from, which ones to override for the language you are gating, and
+how to pick a different set for agent feedback, legacy triage, or
+safety-critical work, see
+[Choosing thresholds](../recipes/thresholds.md).
+
 ### Accepted metric names
 
 Top-level scalar metrics use their `list-metrics` names directly:

--- a/big-code-analysis-book/src/recipes/README.md
+++ b/big-code-analysis-book/src/recipes/README.md
@@ -19,6 +19,10 @@ The recipes are grouped by goal:
   gate on a developer machine with a two-tier (hard + headroom)
   Makefile / `just` / `pre-commit` pattern, so regressions never
   reach the pull request.
+- [Choosing thresholds](thresholds.md) — where the shipped default
+  limits come from, which ones to override for the language you are
+  gating, and how to pick a different set for CI, agent feedback,
+  legacy triage, or safety-critical work.
 - [Feeding metrics to an agent](agent-feedback.md) — wire `bca check`
   into an agentic coding tool's after-edit feedback loop (Claude Code
   `PostToolUse` hook, opencode plugin), with the anti-gaming guidance

--- a/big-code-analysis-book/src/recipes/agent-feedback.md
+++ b/big-code-analysis-book/src/recipes/agent-feedback.md
@@ -52,8 +52,15 @@ would run by hand:
 # Exit 2 ⇒ this file has at least one offender. Thresholds come from
 # the repo-root bca.toml (discovered automatically); override ad hoc
 # with one or more --threshold flags.
-bca check path/to/edited_file.rs --threshold cognitive=25
+bca check path/to/edited_file.rs --threshold cognitive=10
 ```
+
+An agent loop wants tighter limits than a blocking CI gate: a false
+positive costs one wasted refactor rather than a blocked merge, and the
+signal arrives while the code is still being written. See the
+[agent feedback profile](thresholds.md#profile-agent) for the rest of
+the table, and [Choosing thresholds](thresholds.md) for where the
+shipped defaults come from.
 
 With a `bca.toml` at the repo root (see
 [Local threshold gates](local-gates.md#zero-config-the-bcatoml-manifest))

--- a/big-code-analysis-book/src/recipes/thresholds.md
+++ b/big-code-analysis-book/src/recipes/thresholds.md
@@ -112,8 +112,8 @@ tighten, not evidence that you should.
 | TSX | 14 | 10 | 65 | 95000 | 400 |
 
 "Thin sample" marks a language whose file count in the corpus is too small to derive a file-size
-figure from. The per-function figures for Bash, Tcl, JavaScript, and C++ rest on the smallest
-samples in the table and are the ones most worth re-deriving against your own code.
+figure from. The per-function figures for Bash, Tcl, JavaScript, and Objective-C rest on the
+smallest samples in the table and are the ones most worth re-deriving against your own code.
 
 ### What to change, and why {#per-language-changes}
 

--- a/big-code-analysis-book/src/recipes/thresholds.md
+++ b/big-code-analysis-book/src/recipes/thresholds.md
@@ -1,0 +1,329 @@
+# Choosing thresholds {#choosing-thresholds}
+
+`bca check` compares each metric against a limit you configure. This page explains where the
+shipped defaults come from, how to adjust them for the language you are gating, and how to pick a
+different set for a different job. It is for anyone editing a `[thresholds]` table, whether by hand
+or through a coding agent.
+
+If you have not set up a gate yet, start with [Local threshold gates](./local-gates.md) for the
+mechanics and [Baselines](./baselines.md) for absorbing the offenders you already have. This page is
+about the numbers.
+
+## The shipped defaults {#shipped-defaults}
+
+`bca init` scaffolds this table. It is defined once in
+`big-code-analysis-cli/src/default_thresholds.rs`.
+
+| Metric | Limit | Scope | Anchor |
+| --- | --- | --- | --- |
+| `cognitive` | 15 | function | [SonarSource](https://www.sonarsource.com/docs/CognitiveComplexity.pdf) default |
+| `cyclomatic` | 15 | function | [lizard](https://github.com/terryyin/lizard) default; MISRA and NASA safety-critical ceiling |
+| `abc` | 40 | function | between [RuboCop](https://docs.rubocop.org/rubocop/cops_metrics.html) `AbcSize` 17 and Flog's "60 and above is dangerous" |
+| `nargs` | 5 | function | RuboCop `ParameterLists` 5; [Code Climate](https://docs.codeclimate.com/docs/default-analysis-configuration) is stricter at 4 |
+| `nexits` | 5 | function | Code Climate `return-statements` 4 |
+| `halstead.effort` | 50000 | function | none published; percentile-derived |
+| `loc.ploc` | 600 | file | none published; percentile-derived |
+| `loc.sloc` | 1200 | file | bloat backstop, not the working limit |
+| `nom` | 30 | container | Code Climate `method-count` 20; [PMD](https://docs.pmd-code.org/latest/pmd_rules_java_design.html) `TooManyMethods` 10 |
+| `wmc` | 60 | container | none published; percentile-derived |
+
+Scope matters when you read these. A `cognitive` limit applies to each function; `nom` and `wmc`
+apply to each class, struct, trait, impl, namespace, or interface; `loc.*` applies to the whole-file
+root. `bca check` will not compare a container's method count against a per-function limit. See
+[Check](../commands/check.md) for the full scope rules.
+
+Two of these limits deserve their reasoning spelled out.
+
+`loc.ploc` and `loc.sloc` are a pair. PLOC counts physical lines of code with blanks and comments
+excluded, so it is the working file-size limit: growing a file by documenting a decision costs
+nothing against it. SLOC counts everything, so it sits far looser and does one job only, which is
+stopping a file from growing without bound on comment volume while still clearing `loc.ploc`. Gating
+file size on SLOC alone charges the same price for a paragraph of rationale as for a new branch, and
+the observable result is that people delete the rationale.
+
+`cyclomatic` at 15 rather than McCabe's 10 is a deliberate loosening.
+[NIST 500-235](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication500-235.pdf), the
+document that made 10 the canonical number, allows raising it for teams with the process to justify
+it, and observes that limits as high as 15 have been used successfully. Measured against real code,
+10 flags roughly twice as many functions as 15 without a corresponding change in what a reviewer
+would call a problem.
+
+## How the defaults were derived {#derivation}
+
+Published thresholds disagree with each other by wide margins. For cyclomatic complexity alone the
+defaults in common tools span 7 (RuboCop) to 30 (`gocyclo`), with Checkstyle and PMD at 10, lizard
+and MISRA at 15, and ESLint at 20. Picking one by authority means picking an authority.
+
+So each limit here is checked against measurement as well. The reference corpus is 43 real-world
+repositories across 20 languages, cloned at their default branch on 2026-07-31, with test trees,
+vendored code, and generated files excluded. Measured with `bca metrics`, that is roughly a quarter
+of a million function spaces, forty thousand container spaces, and twenty-seven thousand files.
+Values are binned by the same File, Function, and Container scope `bca check` applies, so a
+container's `nom` never lands in a per-function distribution.
+
+The design rule is that a default should flag roughly the worst 1% to 3% of spaces in the median
+language. Below that a limit is inert and gives false comfort. Above it the gate stops being a gate
+and becomes a style rule that people route around. This is a stricter reading of the benchmark
+approach in
+[Alves, Ypma, and Visser](https://webarchive.di.uminho.pt/wiki.di.uminho.pt/twiki/pub/Personal/Joost/PublicationList/AlvesYpmaVisserICSM2010.pdf),
+who derive risk bands at the 70th, 80th, and 90th percentiles. Their 90th percentile is a useful
+"worth looking at" line; it is far too noisy to fail a build on.
+
+Two of the previous defaults failed that rule and changed as a result. `nargs` at 7 fired on under
+1% of functions in the median language and on nothing at all in this project's own source, which
+makes it a limit that cannot catch anything. `cognitive` at 25 was inherited from
+[clippy](https://rust-lang.github.io/rust-clippy/master/#cognitive_complexity), which is
+deliberately conservative because it lints rather than gates; 15 is what the metric's designers
+chose.
+
+## Per-language overrides {#per-language}
+
+Metric distributions vary by language more than by project. The 90th-percentile per-function
+`cognitive` value in the reference corpus runs from 0 in C# to 21 in Tcl. Median file `loc.ploc`
+runs from 16 in TypeScript to 283 in C, an eighteen-fold spread. A single table cannot fit both
+ends.
+
+The table below gives the measured 97.5th percentile per language, which is the value a limit would
+need to flag the worst 2.5% of that language's code. Read it as calibration data, not as a
+prescription: a low number means the language's code is mostly simple, which is a reason you *can*
+tighten, not evidence that you should.
+
+| Language | `cognitive` | `cyclomatic` | `abc` | `halstead.effort` | `loc.ploc` |
+| --- | --- | --- | --- | --- | --- |
+| Bash | 35 | 25 | 60 | 95000 | (thin sample) |
+| C | 50 | 30 | 60 | 200000 | 3500 |
+| C++ | 14 | 10 | 25 | 50000 | (thin sample) |
+| C# | 4 | 4 | 13 | 9500 | 700 |
+| Elixir | 5 | 7 | 20 | 15000 | 1500 |
+| Go | 25 | 17 | 45 | 120000 | 1500 |
+| Groovy | 16 | 13 | 25 | 30000 | 450 |
+| Java | 7 | 5 | 16 | 15000 | 800 |
+| JavaScript | 20 | 15 | 35 | 55000 | (thin sample) |
+| Kotlin | 10 | 8 | 20 | 20000 | 300 |
+| Lua | 35 | 20 | 40 | 85000 | 800 |
+| Objective-C | 18 | 12 | 35 | 60000 | (thin sample) |
+| Perl | 35 | 25 | 45 | 140000 | 1500 |
+| PHP | 10 | 9 | 25 | 50000 | 900 |
+| Python | 20 | 13 | 25 | 25000 | 700 |
+| Ruby | 7 | 6 | 19 | 10000 | 400 |
+| Rust | 8 | 8 | 20 | 35000 | 900 |
+| Tcl | 45 | 25 | 85 | 90000 | (thin sample) |
+| TypeScript | 20 | 13 | 25 | 55000 | 450 |
+| TSX | 14 | 10 | 65 | 95000 | 400 |
+
+"Thin sample" marks a language whose file count in the corpus is too small to derive a file-size
+figure from. The per-function figures for Bash, Tcl, JavaScript, and C++ rest on the smallest
+samples in the table and are the ones most worth re-deriving against your own code.
+
+### What to change, and why {#per-language-changes}
+
+Most languages need no override. The cases that do fall into three groups.
+
+**Procedural languages with large dispatch functions.** C, Tcl, Bash, Lua, Perl, and Go all run two
+to three times the defaults. These languages lack exceptions or discourage them, so error handling
+is inline branching, and they favour long `switch`-style dispatch over polymorphism. The default
+`cognitive` limit flags 5% to 15% of their functions, against 3% in the median language. Raise
+`cognitive` and `halstead.effort` first; those two carry most of the excess.
+
+```toml
+# Gating a C, Tcl, Bash, Lua, Perl, or Go codebase.
+[thresholds]
+cognitive = 30
+cyclomatic = 20
+abc = 50
+"halstead.effort" = 120000
+"loc.ploc" = 1200
+"loc.sloc" = 2000
+```
+
+**Languages whose module construct is not a class.** `nom` and `wmc` are Container-scoped, and a
+container is whatever the grammar calls a class, struct, trait, impl, namespace, or interface. An
+Elixir `defmodule` holds dozens of functions by design, so roughly a third of Elixir modules breach
+`nom = 30`. That is a scope mismatch, not a code smell. Rust sits at the other end: an `impl` block
+is usually a handful of methods, so the default never fires.
+
+```toml
+# Elixir.
+[thresholds]
+nom = 150
+wmc = 300
+
+# Rust.
+[thresholds]
+nom = 20
+wmc = 40
+```
+
+**Compact, heavily-abstracted languages.** Java, Ruby, Kotlin, C#, and Elixir sit far under the
+defaults on every per-function metric. Their 97.5th percentile `cyclomatic` is 4 to 8. Gating them
+at 15 means the gate will effectively never fire, so tighten if you want it to do work.
+
+Read the C# row with care. Its distribution is dominated by property accessors, which `bca` counts
+as functions and which are almost always trivial, so its percentiles sit lower than the code a
+reviewer would actually be looking at. The same effect applies more weakly to Java, Kotlin, and
+Ruby. Prefer re-deriving from your own repository over adopting any of those four rows directly; see
+[Re-deriving for your own codebase](#re-deriving).
+
+### Metrics that do not apply to every language {#language-gaps}
+
+`nargs` reports 0 for every Bash, Perl, and Elixir function. Bash and Perl have no formal parameter
+lists, so 0 is correct and the limit is simply inert. Elixir does have them and the zero is a gap,
+tracked in [issue #1142](https://github.com/dekobon/big-code-analysis/issues/1142). In all three
+cases a `nargs` limit passes unconditionally, which reads as "no offenders" rather than "not
+measured".
+
+`wmc`, `npm`, and `npa` are only produced for languages with a class-like container. They are absent
+from Bash, C, Go, Lua, Perl, and Tcl output.
+
+### Applying overrides today {#applying-overrides}
+
+A single `bca.toml` carries one `[thresholds]` table for the whole project. Per-language tables in
+the manifest are proposed in
+[issue #1141](https://github.com/dekobon/big-code-analysis/issues/1141) and are not implemented yet.
+Until they are, a polyglot repository has two options.
+
+Run `bca check` once per language, selecting files by glob and passing that language's limits on the
+command line:
+
+```bash
+bca check --no-config -I '*.rs' \
+  --threshold cognitive=15 --threshold cyclomatic=15 --threshold nargs=5
+bca check --no-config -I '*.c' \
+  --threshold cognitive=30 --threshold cyclomatic=20 --threshold nargs=5
+```
+
+Note that `.h` is analyzed with the C++ grammar, not the C one, so a C project's headers land in
+whichever glob covers `*.h`. See [Supported Languages](../languages.md) for the extension map.
+
+Or keep one table sized for the loosest language and let per-file baselines carry the rest. That is
+simpler to maintain and strictly weaker: the stricter languages stop being gated.
+
+## Per-use-case profiles {#profiles}
+
+The same codebase wants different limits depending on what the gate is for.
+
+### Blocking CI gate {#profile-ci}
+
+This is what the shipped defaults are for. A limit that fails a pull request has to be one the team
+agrees is a real problem, because the cost of a false positive is a blocked merge and an argument.
+Pair it with a baseline so the gate fails only on new offenders and regressions, and tighten from
+there.
+
+Use the shipped defaults unchanged, plus:
+
+```toml
+[check]
+baseline = ".bca-baseline.toml"
+```
+
+### Agent feedback loop {#profile-agent}
+
+When the consumer is a coding agent rather than a human reviewer, a false positive costs one wasted
+refactor rather than a blocked merge, and the signal arrives while the code is still being written.
+Tighten toward the published per-function values, and drop the file-size and container limits, which
+an agent editing one function cannot act on.
+
+```toml
+[thresholds]
+cognitive = 10
+cyclomatic = 10
+abc = 25
+nargs = 4
+nexits = 4
+"halstead.effort" = 25000
+```
+
+See [Feeding metrics to an agent](./agent-feedback.md) for wiring this into an edit loop, and
+[Suppression markers](../commands/suppression.md) for telling the agent when complexity is
+essential rather than accidental.
+
+### Legacy audit and triage {#profile-legacy}
+
+When the goal is to rank an unfamiliar codebase rather than to gate it, you want the handful of
+functions that are genuinely worst, not a list of thousands. Set limits at roughly twice the
+defaults so only extreme outliers surface, run without a baseline, and use
+`bca report markdown` rather than `bca check`.
+
+```toml
+[thresholds]
+cognitive = 40
+cyclomatic = 30
+abc = 80
+"halstead.effort" = 250000
+"loc.ploc" = 1500
+nom = 60
+wmc = 120
+```
+
+[Quality reports](./quality-reports.md) covers the report output. Adding `--vcs` ranks by change
+history as well, which is usually a better triage order than complexity alone: a complex function
+nobody has touched in three years is not where the bugs are.
+
+### Safety-critical and regulated {#profile-safety}
+
+Standards in this space specify limits directly, and the standard wins over any measurement. MISRA
+and NASA both cap cyclomatic complexity at 15; the
+[JSF C++ standard](https://www.abxsoft.com/jsf/JSF_AV_C++_Coding_Standards_Rev_C.htm) allows 20 with
+a documented exception for large `switch` statements. McCabe's original 10 applies where the
+testing budget supports it, since the number is a bound on the basis-path test count, not a style
+opinion.
+
+```toml
+[thresholds]
+cognitive = 15
+cyclomatic = 10
+abc = 30
+nargs = 5
+nexits = 1
+"halstead.effort" = 25000
+```
+
+`nexits = 1` encodes the single-exit rule from MISRA C:2023 Rule 15.5. It is contentious outside
+regulated work, and in most codebases early returns make code simpler rather than harder to follow,
+so treat it as a compliance setting rather than a general recommendation.
+
+## Metrics not gated by default {#not-gated}
+
+These are computed and visible in `bca report markdown|html`. They are left out of the default
+table on purpose.
+
+`halstead.volume` has the most widely-cited threshold of any Halstead measure, the guideline that a
+function's volume should stay under 1000. Measured against the corpus it flags about 7% of functions
+in the median language and 20% in the worst, which makes it useful for ranking and unusable as a
+gate.
+
+`mi.original`, `mi.sei`, and `mi.visual_studio` are the Maintainability Index family, and they are
+lower-is-worse: the violation is a value below the limit. Visual Studio's bands (below 10 poor, 10
+to 19 moderate, 20 and above good) apply to its own rescaled 0 to 100 output, which `bca` reports as
+`mi.visual_studio`. `mi.original` is unbounded above and reaches 167 on the corpus, so the original
+[SEI](https://insights.sei.cmu.edu/) bands of 65 and 85 do not transfer. The index is also a
+function of the metrics you are already gating, so gating it too double-counts. See
+[Supported Code Metrics](../metrics.md) for the formulas.
+
+`npm`, `npa`, `tokens`, and `cyclomatic.modified` are omitted because each duplicates something
+already in the table, or because their distributions are dominated by a language idiom rather than
+by design quality.
+
+## Re-deriving for your own codebase {#re-deriving}
+
+Corpus percentiles are a starting point. Your own distribution is better evidence, and producing it
+takes one command plus a short script.
+
+```bash
+bca metrics --no-config -O json -I '*.rs' -X '**/tests/**' . > metrics.jsonl
+```
+
+Each line is one file's `FuncSpace` tree. Walk it, keep each space's own value for the metric you
+care about, filter by `kind` to match the metric's scope (`"function"`, `"unit"` for `loc.*`, or a
+container kind for `nom` and `wmc`), and take the 97.5th percentile. Setting a limit there flags
+your worst 2.5%.
+
+Two checks are worth running afterwards. Count the offenders the limit produces: if it is more than
+a few percent of your spaces, the gate will be ignored rather than obeyed. Then look at where the
+values pile up. A natural distribution tails off smoothly, so a cluster of files sitting just under
+the limit means the limit is shaping the code rather than measuring it, and people are trimming to
+fit. That happened to this project's own `loc.sloc` gate, which is documented in
+[issue #1138](https://github.com/dekobon/big-code-analysis/issues/1138).
+
+`bca check --write-baseline` records today's offenders so you can adopt a stricter limit without
+failing on day one. [Baselines](./baselines.md) covers the bootstrap, refresh, and retire flow.

--- a/big-code-analysis-book/src/recipes/thresholds.md
+++ b/big-code-analysis-book/src/recipes/thresholds.md
@@ -166,11 +166,13 @@ Ruby. Prefer re-deriving from your own repository over adopting any of those fou
 
 ### Metrics that do not apply to every language {#language-gaps}
 
-`nargs` reports 0 for every Bash, Perl, and Elixir function. Bash and Perl have no formal parameter
-lists, so 0 is correct and the limit is simply inert. Elixir does have them and the zero is a gap,
-tracked in [issue #1142](https://github.com/dekobon/big-code-analysis/issues/1142). In all three
-cases a `nargs` limit passes unconditionally, which reads as "no offenders" rather than "not
-measured".
+`nargs` reports 0 for every Bash, Perl, and Elixir function. For Bash that is correct: the shell has
+no formal parameter list, arguments arrive as `$1`, `$2`, and so on, and the limit is simply inert.
+For Perl and Elixir it is a gap. Both have formal parameter lists, and both are parsed but not
+counted — Perl subroutine signatures (`sub add($x, $y)`, stable since 5.20 and on by default under
+`use v5.36`) in [issue #1147](https://github.com/dekobon/big-code-analysis/issues/1147), Elixir in
+[issue #1142](https://github.com/dekobon/big-code-analysis/issues/1142). In all three cases a
+`nargs` limit passes unconditionally, which reads as "no offenders" rather than "not measured".
 
 `wmc`, `npm`, and `npa` are only produced for languages with a class-like container. They are absent
 from Bash, C, Go, Lua, Perl, and Tcl output.

--- a/big-code-analysis-cli/src/commands/init.rs
+++ b/big-code-analysis-cli/src/commands/init.rs
@@ -6,20 +6,23 @@ use super::*;
 /// This is the consolidated config `bca` auto-discovers when climbing
 /// from the working directory to the repo root (#374, #483): a bare
 /// `bca check` (no flags) reproduces the gate once this file exists.
-/// The `[thresholds]` values mirror the project's own root `bca.toml`,
-/// so `bca init` hands adopters the same limits the project gates
-/// itself with. The two `[thresholds]` tables are kept in lock-step by
-/// the `init_template_thresholds_match_repo_root` drift test: retuning
-/// the root gate fails that test until this template is updated to
-/// match, and vice versa.
 ///
-/// Only the surrounding prose differs by design — the root file
-/// carries the repo-specific rationale for each limit, while this
-/// template keeps the generic editing-rules header. Adopters typically
-/// run `--write-baseline` right after `init`, which pins today's
-/// offenders so subsequent runs fail only on regressions, then tighten
-/// limits over time.
-pub(crate) const INIT_MANIFEST_TEMPLATE: &str = "\
+/// The `[thresholds]` block is rendered from
+/// [`crate::default_thresholds::DEFAULT_THRESHOLDS`], the single source
+/// of truth for the shipped limits. Before #1140 it was a hand-written
+/// literal held equal to this repository's own root `bca.toml` by a
+/// drift test; that conflated two different questions — what an
+/// arbitrary project should gate at on day one, versus what this
+/// particular Rust codebase gates itself at — so retuning either forced
+/// retuning the other. The two are now free to diverge, and the root
+/// manifest says so in its own prose.
+///
+/// Adopters typically run `--write-baseline` right after `init`, which
+/// pins today's offenders so subsequent runs fail only on regressions,
+/// then tighten limits over time.
+pub(crate) fn init_manifest_template() -> String {
+    format!(
+        "\
 # bca.toml — project manifest, auto-discovered by `bca` when climbing
 # from the working directory to the repo root. This is the single
 # source of truth for the metric gate: with this file present, a bare
@@ -43,40 +46,7 @@ exclude_from = \".bcaignore\"
 [check]
 baseline = \".bca-baseline.toml\"
 
-# bca per-function threshold configuration.
-#
-# Editing rules:
-#   * Each key is a stable metric name (or dotted sub-metric name) from
-#     `bca list-metrics` / `bca check --help`. Available names:
-#         cognitive, cyclomatic, cyclomatic.modified,
-#         halstead.volume, halstead.difficulty, halstead.effort,
-#         halstead.time, halstead.bugs,
-#         loc.sloc, loc.ploc, loc.lloc, loc.cloc, loc.blank,
-#         nom, tokens, nexits, nargs,
-#         mi.original, mi.sei, mi.visual_studio,
-#         abc, wmc, npm, npa
-#   * Quote keys containing a dot (TOML requires it).
-#   * Values are per-function limits. A function whose metric exceeds the
-#     limit becomes an offender; the baseline file decides whether it
-#     fails CI.
-#   * Adding a metric is a tightening — regenerate `.bca-baseline.toml`
-#     in the same change so day-one CI does not flip red on offenders
-#     that were previously invisible to the gate.
-#
-# Metrics intentionally NOT gated (yet):
-#   halstead.{volume,difficulty,time,bugs}, cyclomatic.modified, mi.*
-# They are still computed and visible in `bca report markdown|html`.
-[thresholds]
-cognitive = 25
-cyclomatic = 15
-\"halstead.effort\" = 50000
-\"loc.sloc\" = 800
-nom = 30
-nargs = 7
-nexits = 5
-abc = 50
-wmc = 60
-
+{thresholds}
 # Aggregated-report options for `bca report markdown|html` (#501). By
 # default the report honours in-source suppression markers
 # (`bca: suppress`, `bca: suppress-file`, `#lizard forgives`) and omits a
@@ -86,7 +56,10 @@ wmc = 60
 # `bca report --no-suppress`).
 # [report]
 # no_suppress = true
-";
+",
+        thresholds = crate::default_thresholds::render_thresholds_block(),
+    )
+}
 
 /// Canonical contents of a freshly-scaffolded `.bcaignore`. The
 /// patterns are commented out so the file is a no-op until the
@@ -249,7 +222,7 @@ pub(crate) fn run_command_init(
         }
     }
 
-    write_atomic(&manifest_path, INIT_MANIFEST_TEMPLATE.as_bytes())
+    write_atomic(&manifest_path, init_manifest_template().as_bytes())
         .unwrap_or_else(|e| die_io("write", &manifest_path, e));
     eprintln!("bca init: wrote {}", manifest_path.display());
 

--- a/big-code-analysis-cli/src/commands/init.rs
+++ b/big-code-analysis-cli/src/commands/init.rs
@@ -2,7 +2,9 @@
 
 use super::*;
 
-/// Canonical contents of a freshly-scaffolded `bca.toml` manifest.
+/// Render the canonical contents of a freshly-scaffolded `bca.toml`
+/// manifest.
+///
 /// This is the consolidated config `bca` auto-discovers when climbing
 /// from the working directory to the repo root (#374, #483): a bare
 /// `bca check` (no flags) reproduces the gate once this file exists.

--- a/big-code-analysis-cli/src/commands_tests.rs
+++ b/big-code-analysis-cli/src/commands_tests.rs
@@ -982,29 +982,38 @@ fn exit_code_tiered_maps_each_category() {
     assert_eq!(CheckOutcome::HardBreach.exit_code(true), Some(5));
 }
 
-/// `bca init` writes a `bca.toml` manifest from the embedded
-/// [`INIT_MANIFEST_TEMPLATE`], whose doc-comment promises its
-/// `[thresholds]` values mirror the repo's own gate. Since #483 the
-/// repo's own gate lives in the consolidated root `bca.toml` manifest,
-/// so this guard compares the template's `[thresholds]` against the
-/// manifest's `[thresholds]` table. Nothing else enforces that, so
-/// this guards against the two silently diverging when either gate is
-/// retuned (e.g. the `loc.sloc` 300->800 change that motivated this
-/// test). Only the `[thresholds]` table is compared — the two files
-/// carry different explanatory prose by design.
+/// `bca init` writes a `bca.toml` manifest whose `[thresholds]` block
+/// is rendered from `default_thresholds::DEFAULT_THRESHOLDS`. This
+/// guard pins the *assembled* manifest to that table — the round-trip
+/// test in `default_thresholds_tests.rs` only covers the rendered block
+/// in isolation, so without this one a bad `format!` in
+/// [`init_manifest_template`] could drop or mangle the block and no
+/// test would notice.
+///
+/// Until #1140 this test compared the template against the repo-root
+/// `bca.toml` instead. That coupling is gone deliberately: the shipped
+/// defaults answer "what should an arbitrary project gate at", while
+/// the root manifest answers "what does this Rust codebase, with
+/// `exclude_tests = true` and a comment-dense house style, gate itself
+/// at". They are expected to differ, and asserting they do not is what
+/// kept the shipped defaults uncalibrated.
 #[test]
-fn init_template_thresholds_match_repo_root() {
-    let root_text = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/../bca.toml"))
-        .expect("repo-root bca.toml must be readable from the CLI crate dir");
-    let root: toml::Table = toml::from_str(&root_text).expect("root bca.toml parses");
+fn init_template_thresholds_match_the_default_table() {
     let template: toml::Table =
-        toml::from_str(INIT_MANIFEST_TEMPLATE).expect("INIT_MANIFEST_TEMPLATE parses");
+        toml::from_str(&init_manifest_template()).expect("init manifest template parses");
+    let thresholds = template
+        .get("thresholds")
+        .and_then(toml::Value::as_table)
+        .expect("the scaffolded manifest has a [thresholds] table");
+    let expected: toml::Table = crate::default_thresholds::DEFAULT_THRESHOLDS
+        .iter()
+        .map(|e| (e.name.to_string(), toml::Value::Integer(i64::from(e.limit))))
+        .collect();
     assert_eq!(
-        template.get("thresholds"),
-        root.get("thresholds"),
-        "the `bca init` scaffold's [thresholds] drifted from the repo-root \
-         bca.toml manifest; update INIT_MANIFEST_TEMPLATE (commands.rs) and \
-         the manifest's [thresholds] table together"
+        *thresholds, expected,
+        "the `bca init` scaffold's [thresholds] drifted from \
+         default_thresholds::DEFAULT_THRESHOLDS, which is the single source \
+         of truth for the shipped limits"
     );
 }
 

--- a/big-code-analysis-cli/src/default_thresholds.rs
+++ b/big-code-analysis-cli/src/default_thresholds.rs
@@ -38,8 +38,11 @@ pub(crate) struct DefaultThreshold {
     /// scaffold should emit; a future fractional default would need
     /// this widened and [`render_thresholds_block`] adjusted.
     pub(crate) limit: u32,
-    /// Why this value, in one or two rendered comment lines. Wrapped by
-    /// the caller at the manifest's 72-column comment width.
+    /// Why this value, in one or more rendered comment lines. Wrapped at
+    /// authoring time rather than reflowed at render time, so a line
+    /// that overflows the manifest's comment column fails a test instead
+    /// of silently rewrapping. The width itself lives with the test that
+    /// enforces it, `every_default_has_a_rationale_that_fits_the_comment_column`.
     pub(crate) rationale: &'static [&'static str],
 }
 
@@ -139,16 +142,16 @@ pub(crate) const DEFAULT_THRESHOLDS: &[DefaultThreshold] = &[
     },
 ];
 
-/// Render the `[thresholds]` block for the `bca init` scaffold from
-/// [`DEFAULT_THRESHOLDS`], header prose included.
+/// Prose that heads the rendered `[thresholds]` block. Split from
+/// [`render_thresholds_block`] because the two change for unrelated
+/// reasons: this is copy that moves when the docs move, the renderer is
+/// loop logic that moves when [`DefaultThreshold`] changes shape.
 ///
-/// Keeping this a render rather than a hand-maintained string literal is
-/// what makes the table above the single source of truth: there is no
-/// second copy of the numbers to drift.
-pub(crate) fn render_thresholds_block() -> String {
-    let mut out = String::from(
-        "\
-# bca per-function threshold configuration.
+/// The two metric-name inventories below are hand-curated for grouping
+/// rather than rendered from the registry, and are pinned against it by
+/// `rendered_prose_lists_every_known_metric`.
+const THRESHOLDS_HEADER: &str = "\
+# bca metric threshold configuration.
 #
 # These are the shipped defaults (#1140): anchored to published
 # thresholds where one exists, and calibrated against a 20-language
@@ -178,17 +181,34 @@ pub(crate) fn render_thresholds_block() -> String {
 #     that were previously invisible to the gate.
 #
 # Metrics intentionally NOT gated:
-#   halstead.{volume,difficulty,time,bugs}, cyclomatic.modified, mi.*,
-#   npm, npa, tokens
+#         cyclomatic.modified,
+#         halstead.volume, halstead.difficulty, halstead.time,
+#         halstead.bugs,
+#         loc.lloc, loc.cloc, loc.blank,
+#         mi.original, mi.sei, mi.visual_studio,
+#         npm, npa, tokens
 # They are still computed and visible in `bca report markdown|html`.
 # halstead.volume is the notable omission: the widely-cited \"function
 # volume under 1000\" guideline fires on ~7% of functions in the median
 # language and 20% in the worst, which is advisory-grade, not
 # gate-grade.
 [thresholds]
-",
-    );
-    for entry in DEFAULT_THRESHOLDS {
+";
+
+/// Render the `[thresholds]` block for the `bca init` scaffold from
+/// [`DEFAULT_THRESHOLDS`], header prose included.
+///
+/// Keeping this a render rather than a hand-maintained string literal is
+/// what makes the table the single source of truth: there is no second
+/// copy of the numbers to drift.
+pub(crate) fn render_thresholds_block() -> String {
+    let mut out = String::from(THRESHOLDS_HEADER);
+    for (index, entry) in DEFAULT_THRESHOLDS.iter().enumerate() {
+        // Blank line between entries so a rationale block visibly
+        // attaches to the key below it rather than to the key above.
+        if index > 0 {
+            out.push('\n');
+        }
         for line in entry.rationale {
             out.push_str("# ");
             out.push_str(line);

--- a/big-code-analysis-cli/src/default_thresholds.rs
+++ b/big-code-analysis-cli/src/default_thresholds.rs
@@ -1,0 +1,215 @@
+//! The shipped default `[thresholds]` table (issue #1140).
+//!
+//! This is the single source of truth for the limits `bca init`
+//! scaffolds. It is deliberately *not* tied to this repository's own
+//! `bca.toml`: the two answer different questions. This table answers
+//! "what should an arbitrary project gate at on day one"; the repo-root
+//! manifest answers "what does this Rust codebase, with
+//! `exclude_tests = true` and a house style that front-loads rationale
+//! comments, gate itself at". Before #1140 a drift test forced them
+//! equal, which made every retune of one a retune of the other.
+//!
+//! # How these numbers were chosen
+//!
+//! Each limit is anchored to a published threshold wherever one exists,
+//! and checked against a measured corpus: 43 real-world repositories
+//! across 20 languages (tests, vendored trees, and generated code
+//! excluded), 254k function spaces, 40k container spaces, 27k files.
+//! The design rule is that a default should flag genuine outliers —
+//! roughly 1-3% of in-scope spaces in the median language — because a
+//! gate that fires on a tenth of a codebase is a style rule, not a
+//! gate. The full derivation, the per-language override table, and the
+//! per-use-case profiles live in the book's *Choosing thresholds*
+//! recipe.
+//!
+//! Metrics deliberately left out of the default table are documented in
+//! [`render_thresholds_block`]'s emitted prose, not here, so an adopter
+//! reading their own scaffolded `bca.toml` sees the reasoning.
+
+/// One shipped default limit, plus the rationale rendered above it in
+/// the scaffolded manifest.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DefaultThreshold {
+    /// Stable metric name, as accepted by `--threshold` and the
+    /// `[thresholds]` TOML table.
+    pub(crate) name: &'static str,
+    /// The limit itself. `u32` rather than `f64` because every shipped
+    /// default is integral, and an integral TOML literal is what the
+    /// scaffold should emit; a future fractional default would need
+    /// this widened and [`render_thresholds_block`] adjusted.
+    pub(crate) limit: u32,
+    /// Why this value, in one or two rendered comment lines. Wrapped by
+    /// the caller at the manifest's 72-column comment width.
+    pub(crate) rationale: &'static [&'static str],
+}
+
+/// The shipped defaults. Order is the order they appear in a
+/// freshly-scaffolded `bca.toml`: the per-function complexity family
+/// first, then the per-function size family, then file size, then the
+/// container-scoped OO size metrics.
+pub(crate) const DEFAULT_THRESHOLDS: &[DefaultThreshold] = &[
+    DefaultThreshold {
+        name: "cognitive",
+        limit: 15,
+        rationale: &[
+            "SonarSource's own default for the metric they designed. Fires on",
+            "~3% of functions in the median language of the reference corpus.",
+        ],
+    },
+    DefaultThreshold {
+        name: "cyclomatic",
+        limit: 15,
+        rationale: &[
+            "lizard's default, and the ceiling MISRA and NASA use for",
+            "safety-critical work. McCabe's original 10 is stricter than most",
+            "modern codebases sustain; NIST 500-235 already allows raising it",
+            "for teams with the process to back it up.",
+        ],
+    },
+    DefaultThreshold {
+        name: "abc",
+        limit: 40,
+        rationale: &[
+            "Between RuboCop's Ruby-tuned AbcSize of 17 and the folk \"60 and",
+            "above is dangerous\" line from Flog. Chosen so ABC's strictness",
+            "matches cyclomatic's rather than sitting a tier looser.",
+        ],
+    },
+    DefaultThreshold {
+        name: "nargs",
+        limit: 5,
+        rationale: &[
+            "Matches RuboCop's ParameterLists; Code Climate is stricter at 4.",
+            "Note Bash, Perl, and Elixir report 0 arguments unconditionally,",
+            "so this limit is inert for them (#1142).",
+        ],
+    },
+    DefaultThreshold {
+        name: "nexits",
+        limit: 5,
+        rationale: &[
+            "Code Climate's return-statements limit of 4 is the only published",
+            "anchor; 5 leaves room for the Go and C `if err != nil` idiom,",
+            "which pushes honest functions past 4 exits.",
+        ],
+    },
+    DefaultThreshold {
+        name: "halstead.effort",
+        limit: 50_000,
+        rationale: &[
+            "No published threshold exists for effort, so this one is purely",
+            "percentile-derived. It is also the most language-dependent limit",
+            "in the table — median-language p90 effort ranges from 2k (Java)",
+            "to 56k (C) — so it is the first one worth overriding per language.",
+        ],
+    },
+    DefaultThreshold {
+        name: "loc.ploc",
+        limit: 600,
+        rationale: &[
+            "The working file-size limit: physical lines of code, excluding",
+            "blanks and comments. Gating code volume rather than total lines",
+            "means documenting a decision costs nothing against the cap.",
+        ],
+    },
+    DefaultThreshold {
+        name: "loc.sloc",
+        limit: 1200,
+        rationale: &[
+            "A loose bloat backstop, not the working limit — it counts",
+            "comments and blanks, so a file cannot grow without bound on",
+            "comment volume alone while still clearing loc.ploc.",
+        ],
+    },
+    DefaultThreshold {
+        name: "nom",
+        limit: 30,
+        rationale: &[
+            "Code Climate's method-count is stricter at 20. Container-scoped:",
+            "on languages whose module construct is not a class (Elixir's",
+            "defmodule most sharply) this measures the module, not a class,",
+            "and wants raising substantially — see the book's per-language",
+            "table.",
+        ],
+    },
+    DefaultThreshold {
+        name: "wmc",
+        limit: 60,
+        rationale: &["Container-scoped, with the same Elixir caveat as nom."],
+    },
+];
+
+/// Render the `[thresholds]` block for the `bca init` scaffold from
+/// [`DEFAULT_THRESHOLDS`], header prose included.
+///
+/// Keeping this a render rather than a hand-maintained string literal is
+/// what makes the table above the single source of truth: there is no
+/// second copy of the numbers to drift.
+pub(crate) fn render_thresholds_block() -> String {
+    let mut out = String::from(
+        "\
+# bca per-function threshold configuration.
+#
+# These are the shipped defaults (#1140): anchored to published
+# thresholds where one exists, and calibrated against a 20-language
+# corpus so each limit flags roughly the worst 1-3% of spaces rather
+# than a tenth of the codebase. They are a starting point, not a
+# verdict on your code — the book's `Choosing thresholds` recipe has
+# per-language overrides and per-use-case profiles (CI gate, agent
+# feedback, legacy audit, safety-critical).
+#
+# Editing rules:
+#   * Each key is a stable metric name (or dotted sub-metric name) from
+#     `bca list-metrics` / `bca check --help`. Available names:
+#         cognitive, cyclomatic, cyclomatic.modified,
+#         halstead.volume, halstead.difficulty, halstead.effort,
+#         halstead.time, halstead.bugs,
+#         loc.sloc, loc.ploc, loc.lloc, loc.cloc, loc.blank,
+#         nom, tokens, nexits, nargs,
+#         mi.original, mi.sei, mi.visual_studio,
+#         abc, wmc, npm, npa
+#   * Quote keys containing a dot (TOML requires it).
+#   * Each limit is checked against the space kind the metric actually
+#     measures: the complexity and per-function metrics gate individual
+#     functions, the OO size metrics (nom, wmc, npm, npa) gate container
+#     spaces, and loc.* gates the whole-file root.
+#   * Adding a metric is a tightening — regenerate `.bca-baseline.toml`
+#     in the same change so day-one CI does not flip red on offenders
+#     that were previously invisible to the gate.
+#
+# Metrics intentionally NOT gated:
+#   halstead.{volume,difficulty,time,bugs}, cyclomatic.modified, mi.*,
+#   npm, npa, tokens
+# They are still computed and visible in `bca report markdown|html`.
+# halstead.volume is the notable omission: the widely-cited \"function
+# volume under 1000\" guideline fires on ~7% of functions in the median
+# language and 20% in the worst, which is advisory-grade, not
+# gate-grade.
+[thresholds]
+",
+    );
+    for entry in DEFAULT_THRESHOLDS {
+        for line in entry.rationale {
+            out.push_str("# ");
+            out.push_str(line);
+            out.push('\n');
+        }
+        // TOML requires quoting on dotted keys; bare keys stay bare so
+        // the scaffold reads the way the docs spell these names.
+        if entry.name.contains('.') {
+            out.push('"');
+            out.push_str(entry.name);
+            out.push('"');
+        } else {
+            out.push_str(entry.name);
+        }
+        out.push_str(" = ");
+        out.push_str(&entry.limit.to_string());
+        out.push('\n');
+    }
+    out
+}
+
+#[cfg(test)]
+#[path = "default_thresholds_tests.rs"]
+mod tests;

--- a/big-code-analysis-cli/src/default_thresholds.rs
+++ b/big-code-analysis-cli/src/default_thresholds.rs
@@ -215,14 +215,12 @@ pub(crate) fn render_thresholds_block() -> String {
             out.push('\n');
         }
         // TOML requires quoting on dotted keys; bare keys stay bare so
-        // the scaffold reads the way the docs spell these names.
-        if entry.name.contains('.') {
-            out.push('"');
-            out.push_str(entry.name);
-            out.push('"');
-        } else {
-            out.push_str(entry.name);
-        }
+        // the scaffold reads the way the docs spell these names. Deciding
+        // the quoting separately keeps the name itself emitted once.
+        let quote = if entry.name.contains('.') { "\"" } else { "" };
+        out.push_str(quote);
+        out.push_str(entry.name);
+        out.push_str(quote);
         out.push_str(" = ");
         out.push_str(&entry.limit.to_string());
         out.push('\n');

--- a/big-code-analysis-cli/src/default_thresholds.rs
+++ b/big-code-analysis-cli/src/default_thresholds.rs
@@ -84,7 +84,7 @@ pub(crate) const DEFAULT_THRESHOLDS: &[DefaultThreshold] = &[
         rationale: &[
             "Matches RuboCop's ParameterLists; Code Climate is stricter at 4.",
             "Note Bash, Perl, and Elixir report 0 arguments unconditionally,",
-            "so this limit is inert for them (#1142).",
+            "so this limit is inert for them (#1142, #1147).",
         ],
     },
     DefaultThreshold {

--- a/big-code-analysis-cli/src/default_thresholds_tests.rs
+++ b/big-code-analysis-cli/src/default_thresholds_tests.rs
@@ -271,6 +271,30 @@ fn inventory_after(rendered: &str, marker: &str) -> BTreeSet<String> {
         .collect()
 }
 
+/// `loc.sloc` is a backstop, not the working limit: it counts comments
+/// and blanks on top of the code `loc.ploc` counts, so it must sit
+/// looser. Inverting the two would make the backstop the binding
+/// constraint and quietly turn the gate back into a comment gate, which
+/// is the exact failure #1138 diagnosed. The reasoning otherwise lives
+/// only in the rendered prose, where nothing checks it.
+#[test]
+fn the_sloc_backstop_is_looser_than_the_ploc_working_limit() {
+    let limit = |name: &str| {
+        DEFAULT_THRESHOLDS
+            .iter()
+            .find(|e| e.name == name)
+            .unwrap_or_else(|| panic!("the default table must gate {name:?}"))
+            .limit
+    };
+    let (ploc, sloc) = (limit("loc.ploc"), limit("loc.sloc"));
+    assert!(
+        sloc > ploc,
+        "loc.sloc ({sloc}) must stay looser than loc.ploc ({ploc}); a backstop \
+         at or below the working limit is the binding constraint, which makes \
+         the file-size gate a comment gate again"
+    );
+}
+
 /// Every default carries a rationale, and it fits the manifest's
 /// comment column. An unexplained number in a scaffolded config is how
 /// the pre-#1140 defaults became folklore in the first place.

--- a/big-code-analysis-cli/src/default_thresholds_tests.rs
+++ b/big-code-analysis-cli/src/default_thresholds_tests.rs
@@ -1,6 +1,6 @@
 //! Tests for the shipped default `[thresholds]` table (#1140).
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use big_code_analysis::metric_catalog::MetricScope;
 
@@ -146,11 +146,7 @@ fn doc_summary_tables_match_the_default_table() {
             .unwrap_or_else(|e| panic!("{path} must be readable from the CLI crate dir: {e}"));
 
         for entry in DEFAULT_THRESHOLDS {
-            let scope = match metric_scope(entry.name) {
-                MetricScope::File => "file",
-                MetricScope::Container => "container",
-                MetricScope::Function => "function",
-            };
+            let scope = scope_word(entry.name);
             // A prefix match, so a table may carry extra trailing
             // columns (the book's adds an "Anchor" column).
             let row = format!("| `{}` | {} | {scope} |", entry.name, entry.limit);
@@ -161,7 +157,51 @@ fn doc_summary_tables_match_the_default_table() {
                  default_thresholds::DEFAULT_THRESHOLDS"
             );
         }
+
+        // The per-entry loop above only catches a *missing* row. Retiring
+        // or renaming a default leaves its old row behind, and a stale row
+        // advertises a default `bca init` does not write — so pin the set
+        // of documented metrics as well, not just its members.
+        let documented = documented_threshold_rows(&text);
+        let expected: BTreeSet<String> = DEFAULT_THRESHOLDS
+            .iter()
+            .map(|e| e.name.to_string())
+            .collect();
+        assert_eq!(
+            documented, expected,
+            "{path}: the threshold summary table documents a different set of \
+             metrics than default_thresholds::DEFAULT_THRESHOLDS; drop the \
+             rows for metrics that are no longer shipped defaults"
+        );
     }
+}
+
+/// The scope column as the doc tables spell it.
+fn scope_word(name: &str) -> &'static str {
+    match metric_scope(name) {
+        MetricScope::File => "file",
+        MetricScope::Container => "container",
+        MetricScope::Function => "function",
+    }
+}
+
+/// Metric names appearing as threshold-summary rows in a Markdown doc.
+///
+/// A row is recognized only by its full shape — backticked name, integer
+/// limit, then one of the three scope words — because both documents
+/// carry unrelated tables whose first cell is also backticked (AGENTS.md
+/// lists the workspace crates that way, and the book's per-language table
+/// backticks metric names in its header row).
+fn documented_threshold_rows(text: &str) -> BTreeSet<String> {
+    text.lines()
+        .filter_map(|line| {
+            let (name, rest) = line.strip_prefix("| `")?.split_once("` | ")?;
+            let (limit, rest) = rest.split_once(" | ")?;
+            limit.parse::<u32>().ok()?;
+            let scope = rest.split(" |").next()?;
+            matches!(scope, "file" | "container" | "function").then(|| name.to_owned())
+        })
+        .collect()
 }
 
 /// The rendered prose carries two hand-curated metric-name inventories:
@@ -171,33 +211,64 @@ fn doc_summary_tables_match_the_default_table() {
 ///
 /// This caught a real omission: the NOT-gated list read as exhaustive
 /// while silently missing `loc.lloc`, `loc.cloc`, and `loc.blank`.
+///
+/// Both halves assert against the parsed inventory block, never against
+/// the whole rendered string. Searching the whole string makes the
+/// assertion unfalsifiable: every known metric also appears as a
+/// rendered `name = limit` key or in the *other* inventory, so deleting
+/// the "Available names" list outright failed zero tests. Token
+/// equality rather than `contains` additionally stops `cyclomatic` from
+/// being satisfied by `cyclomatic.modified`.
 #[test]
 fn rendered_prose_lists_every_known_metric() {
     let rendered = render_thresholds_block();
     let gated: Vec<&str> = DEFAULT_THRESHOLDS.iter().map(|e| e.name).collect();
+    let available = inventory_after(&rendered, "Available names:");
+    let not_gated = inventory_after(&rendered, "# Metrics intentionally NOT gated:");
 
     for name in known_metric_names() {
         assert!(
-            rendered.contains(name),
+            available.contains(name),
             "the scaffold's \"Available names\" list omits the known metric \
-             {name:?}; add it in default_thresholds::THRESHOLDS_HEADER"
+             {name:?}; add it in default_thresholds::THRESHOLDS_HEADER. \
+             Listed: {available:?}"
         );
         if gated.contains(&name) {
             continue;
         }
-        // An ungated metric must be named in the NOT-gated paragraph.
-        // Split on its heading so a hit in the available-names list
-        // above cannot satisfy this half of the assertion.
-        let (_, not_gated) = rendered
-            .split_once("# Metrics intentionally NOT gated:")
-            .expect("the rendered header names its NOT-gated section");
         assert!(
             not_gated.contains(name),
             "{name:?} is a known metric that no default gates, but the \
              scaffold's \"NOT gated\" list does not mention it; that list \
-             reads as exhaustive, so a gap there is a wrong claim"
+             reads as exhaustive, so a gap there is a wrong claim. \
+             Listed: {not_gated:?}"
         );
     }
+}
+
+/// Parse one of the rendered header's hand-curated metric-name
+/// inventories: the run of deeply-indented comment lines that follows
+/// `marker`, split into comma-separated names.
+///
+/// The indent is what delimits the block — an inventory continuation
+/// line is `#` plus nine spaces, while the surrounding editing-rule
+/// bullets use `#   * ` / `#     `. Bounding the block this way is the
+/// point of the helper: prose elsewhere in the header happens to name
+/// `nom`, `wmc`, `npm`, and `npa`, so a looser slice would let those
+/// four go missing from the inventory undetected.
+fn inventory_after(rendered: &str, marker: &str) -> BTreeSet<String> {
+    const CONTINUATION: &str = "#         ";
+    let (_, rest) = rendered
+        .split_once(marker)
+        .unwrap_or_else(|| panic!("the rendered header is missing {marker:?}"));
+    rest.lines()
+        .skip_while(|line| !line.starts_with(CONTINUATION))
+        .take_while(|line| line.starts_with(CONTINUATION))
+        .flat_map(|line| line[CONTINUATION.len()..].split(','))
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+        .map(str::to_owned)
+        .collect()
 }
 
 /// Every default carries a rationale, and it fits the manifest's

--- a/big-code-analysis-cli/src/default_thresholds_tests.rs
+++ b/big-code-analysis-cli/src/default_thresholds_tests.rs
@@ -5,12 +5,23 @@ use std::collections::BTreeMap;
 use big_code_analysis::metric_catalog::MetricScope;
 
 use super::{DEFAULT_THRESHOLDS, render_thresholds_block};
-use crate::thresholds::{ThresholdSet, known_metric_names};
+use crate::thresholds::{ThresholdSet, known_metric_names, metric_scope};
 
-/// Longest line the scaffolded manifest's comment prose may occupy.
-/// The rendered rationale is prefixed with `"# "`, so a rationale line
-/// may be two characters shorter than this.
+/// Longest line the scaffolded manifest's comment prose may occupy. A
+/// [`super::DefaultThreshold::rationale`] line renders with a `"# "`
+/// prefix, so it may be two characters shorter than this. Lives here
+/// rather than beside the field because this test is the only thing
+/// that enforces it, and a production const nothing reads is dead code.
 const MANIFEST_COMMENT_WIDTH: usize = 72;
+
+/// Docs that repeat the default table verbatim. Each is a second copy
+/// of the numbers, and a second copy drifts, so each is pinned by
+/// `doc_summary_tables_match_the_default_table`. Paths are relative to
+/// the CLI crate directory.
+const DOCS_REPEATING_THE_TABLE: &[&str] = &[
+    "/../AGENTS.md",
+    "/../big-code-analysis-book/src/recipes/thresholds.md",
+];
 
 #[test]
 fn every_default_name_is_a_known_metric() {
@@ -28,8 +39,13 @@ fn every_default_name_is_a_known_metric() {
 }
 
 /// The names must also survive `ThresholdSet::build`, which is what
-/// `bca check` actually calls — `known_metric_names` only proves the
-/// registry lists them, not that a limit of this magnitude is accepted.
+/// `bca check` actually calls, and which additionally validates the
+/// limit itself.
+///
+/// This does not subsume `every_default_name_is_a_known_metric`:
+/// `build` runs `metric_alias::normalize_for_check` first, so it would
+/// happily accept a default spelled `sloc`. Rejecting alias spellings
+/// in the scaffold is what the other test uniquely covers.
 #[test]
 fn default_table_builds_a_threshold_set() {
     let raw: BTreeMap<String, f64> = DEFAULT_THRESHOLDS
@@ -114,34 +130,72 @@ fn dotted_keys_are_quoted_and_bare_keys_are_not() {
     }
 }
 
-/// `AGENTS.md` repeats the default table so a coding agent reads the
-/// numbers without following a link. That is a second copy, and a
-/// second copy drifts. Pin it: the summary table there must list every
-/// default, with the same limit and the same scope.
+/// The docs repeat the default table so a reader (or a coding agent)
+/// gets the numbers without following a link. Pin every such copy: each
+/// must list every default, with the same limit and the same scope.
 ///
-/// The scope column is checked against the library catalog rather than
-/// against a hand-written list, so a metric whose scope is later
-/// corrected in `metric_catalog` fails here until the doc follows.
+/// The scope column is resolved through the gate's own
+/// `thresholds::metric_scope` rather than re-deriving the
+/// unknown-id fallback here, so a metric whose scope is later corrected
+/// in `metric_catalog` fails until the docs follow.
 #[test]
-fn agents_md_summary_table_matches_the_default_table() {
-    let text = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/../AGENTS.md"))
-        .expect("repo-root AGENTS.md must be readable from the CLI crate dir");
+fn doc_summary_tables_match_the_default_table() {
+    for relative in DOCS_REPEATING_THE_TABLE {
+        let path = format!("{}{relative}", env!("CARGO_MANIFEST_DIR"));
+        let text = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("{path} must be readable from the CLI crate dir: {e}"));
 
-    for entry in DEFAULT_THRESHOLDS {
-        let scope = match big_code_analysis::metric_catalog::scope(entry.name) {
-            Some(MetricScope::File) => "file",
-            Some(MetricScope::Container) => "container",
-            // `Function` is also the fallback the CLI gate applies to an
-            // id the catalog does not know, so an unknown id renders the
-            // narrowest scope here too rather than failing obscurely.
-            Some(MetricScope::Function) | None => "function",
-        };
-        let row = format!("| `{}` | {} | {scope} |", entry.name, entry.limit);
+        for entry in DEFAULT_THRESHOLDS {
+            let scope = match metric_scope(entry.name) {
+                MetricScope::File => "file",
+                MetricScope::Container => "container",
+                MetricScope::Function => "function",
+            };
+            // A prefix match, so a table may carry extra trailing
+            // columns (the book's adds an "Anchor" column).
+            let row = format!("| `{}` | {} | {scope} |", entry.name, entry.limit);
+            assert!(
+                text.contains(&row),
+                "{path}: threshold summary table is missing or has drifted from \
+                 the row {row:?}; update it to match \
+                 default_thresholds::DEFAULT_THRESHOLDS"
+            );
+        }
+    }
+}
+
+/// The rendered prose carries two hand-curated metric-name inventories:
+/// the "Available names" list and the "NOT gated" list. Both are copies
+/// of the registry, kept by hand for their family grouping, so both can
+/// rot when a metric is added or newly gated.
+///
+/// This caught a real omission: the NOT-gated list read as exhaustive
+/// while silently missing `loc.lloc`, `loc.cloc`, and `loc.blank`.
+#[test]
+fn rendered_prose_lists_every_known_metric() {
+    let rendered = render_thresholds_block();
+    let gated: Vec<&str> = DEFAULT_THRESHOLDS.iter().map(|e| e.name).collect();
+
+    for name in known_metric_names() {
         assert!(
-            text.contains(&row),
-            "AGENTS.md's threshold summary table is missing or has drifted from \
-             the row {row:?}; update the table under `## Metric thresholds` to \
-             match default_thresholds::DEFAULT_THRESHOLDS"
+            rendered.contains(name),
+            "the scaffold's \"Available names\" list omits the known metric \
+             {name:?}; add it in default_thresholds::THRESHOLDS_HEADER"
+        );
+        if gated.contains(&name) {
+            continue;
+        }
+        // An ungated metric must be named in the NOT-gated paragraph.
+        // Split on its heading so a hit in the available-names list
+        // above cannot satisfy this half of the assertion.
+        let (_, not_gated) = rendered
+            .split_once("# Metrics intentionally NOT gated:")
+            .expect("the rendered header names its NOT-gated section");
+        assert!(
+            not_gated.contains(name),
+            "{name:?} is a known metric that no default gates, but the \
+             scaffold's \"NOT gated\" list does not mention it; that list \
+             reads as exhaustive, so a gap there is a wrong claim"
         );
     }
 }

--- a/big-code-analysis-cli/src/default_thresholds_tests.rs
+++ b/big-code-analysis-cli/src/default_thresholds_tests.rs
@@ -1,0 +1,175 @@
+//! Tests for the shipped default `[thresholds]` table (#1140).
+
+use std::collections::BTreeMap;
+
+use big_code_analysis::metric_catalog::MetricScope;
+
+use super::{DEFAULT_THRESHOLDS, render_thresholds_block};
+use crate::thresholds::{ThresholdSet, known_metric_names};
+
+/// Longest line the scaffolded manifest's comment prose may occupy.
+/// The rendered rationale is prefixed with `"# "`, so a rationale line
+/// may be two characters shorter than this.
+const MANIFEST_COMMENT_WIDTH: usize = 72;
+
+#[test]
+fn every_default_name_is_a_known_metric() {
+    let known = known_metric_names();
+    for entry in DEFAULT_THRESHOLDS {
+        assert!(
+            known.contains(&entry.name),
+            "default threshold {:?} is not a known metric name; \
+             `bca init` would scaffold a manifest that `bca check` rejects. \
+             Known: {}",
+            entry.name,
+            known.join(", ")
+        );
+    }
+}
+
+/// The names must also survive `ThresholdSet::build`, which is what
+/// `bca check` actually calls — `known_metric_names` only proves the
+/// registry lists them, not that a limit of this magnitude is accepted.
+#[test]
+fn default_table_builds_a_threshold_set() {
+    let raw: BTreeMap<String, f64> = DEFAULT_THRESHOLDS
+        .iter()
+        .map(|e| (e.name.to_string(), f64::from(e.limit)))
+        .collect();
+    let set = ThresholdSet::build(&raw).expect("the shipped defaults must build a ThresholdSet");
+    assert!(!set.is_empty(), "the default table must not be empty");
+    assert_eq!(
+        set.iter().count(),
+        DEFAULT_THRESHOLDS.len(),
+        "every default must resolve to exactly one threshold entry"
+    );
+}
+
+#[test]
+fn default_names_are_unique() {
+    let mut seen: BTreeMap<&str, u32> = BTreeMap::new();
+    for entry in DEFAULT_THRESHOLDS {
+        assert!(
+            seen.insert(entry.name, entry.limit).is_none(),
+            "duplicate default threshold {:?}; the later entry would silently \
+             win when the rendered TOML is parsed",
+            entry.name
+        );
+    }
+}
+
+/// The rendered block is the only copy of these numbers an adopter
+/// sees, so it must parse back to exactly the table. This is the
+/// property that replaced the old
+/// `init_template_thresholds_match_repo_root` drift test: the scaffold
+/// is now pinned to the default table rather than to this repository's
+/// own calibration.
+#[test]
+fn rendered_block_round_trips_to_the_table() {
+    let rendered = render_thresholds_block();
+    let parsed: toml::Table =
+        toml::from_str(&rendered).expect("rendered [thresholds] block parses");
+    let thresholds = parsed
+        .get("thresholds")
+        .and_then(toml::Value::as_table)
+        .expect("rendered block has a [thresholds] table");
+
+    assert_eq!(
+        thresholds.len(),
+        DEFAULT_THRESHOLDS.len(),
+        "rendered table has {} keys but the source table has {}",
+        thresholds.len(),
+        DEFAULT_THRESHOLDS.len()
+    );
+    for entry in DEFAULT_THRESHOLDS {
+        let value = thresholds
+            .get(entry.name)
+            .unwrap_or_else(|| panic!("rendered table is missing {:?}", entry.name));
+        assert_eq!(
+            value.as_integer(),
+            Some(i64::from(entry.limit)),
+            "rendered limit for {:?} does not match the table",
+            entry.name
+        );
+    }
+}
+
+/// A dotted key rendered bare is a TOML parse error, and a bare key
+/// rendered quoted is merely ugly — but the round-trip test above
+/// passes either way for the quoted case, so assert the spelling
+/// directly.
+#[test]
+fn dotted_keys_are_quoted_and_bare_keys_are_not() {
+    let rendered = render_thresholds_block();
+    for entry in DEFAULT_THRESHOLDS {
+        let expected = if entry.name.contains('.') {
+            format!("\"{}\" = {}\n", entry.name, entry.limit)
+        } else {
+            format!("{} = {}\n", entry.name, entry.limit)
+        };
+        assert!(
+            rendered.contains(&expected),
+            "expected the rendered block to contain {expected:?}"
+        );
+    }
+}
+
+/// `AGENTS.md` repeats the default table so a coding agent reads the
+/// numbers without following a link. That is a second copy, and a
+/// second copy drifts. Pin it: the summary table there must list every
+/// default, with the same limit and the same scope.
+///
+/// The scope column is checked against the library catalog rather than
+/// against a hand-written list, so a metric whose scope is later
+/// corrected in `metric_catalog` fails here until the doc follows.
+#[test]
+fn agents_md_summary_table_matches_the_default_table() {
+    let text = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/../AGENTS.md"))
+        .expect("repo-root AGENTS.md must be readable from the CLI crate dir");
+
+    for entry in DEFAULT_THRESHOLDS {
+        let scope = match big_code_analysis::metric_catalog::scope(entry.name) {
+            Some(MetricScope::File) => "file",
+            Some(MetricScope::Container) => "container",
+            // `Function` is also the fallback the CLI gate applies to an
+            // id the catalog does not know, so an unknown id renders the
+            // narrowest scope here too rather than failing obscurely.
+            Some(MetricScope::Function) | None => "function",
+        };
+        let row = format!("| `{}` | {} | {scope} |", entry.name, entry.limit);
+        assert!(
+            text.contains(&row),
+            "AGENTS.md's threshold summary table is missing or has drifted from \
+             the row {row:?}; update the table under `## Metric thresholds` to \
+             match default_thresholds::DEFAULT_THRESHOLDS"
+        );
+    }
+}
+
+/// Every default carries a rationale, and it fits the manifest's
+/// comment column. An unexplained number in a scaffolded config is how
+/// the pre-#1140 defaults became folklore in the first place.
+#[test]
+fn every_default_has_a_rationale_that_fits_the_comment_column() {
+    for entry in DEFAULT_THRESHOLDS {
+        assert!(
+            !entry.rationale.is_empty(),
+            "default threshold {:?} has no rationale",
+            entry.name
+        );
+        for line in entry.rationale {
+            assert!(
+                !line.trim().is_empty(),
+                "default threshold {:?} has a blank rationale line",
+                entry.name
+            );
+            let rendered_width = line.chars().count() + "# ".len();
+            assert!(
+                rendered_width <= MANIFEST_COMMENT_WIDTH,
+                "rationale line for {:?} renders {rendered_width} columns wide, \
+                 over the {MANIFEST_COMMENT_WIDTH}-column manifest comment width: {line:?}",
+                entry.name
+            );
+        }
+    }
+}

--- a/big-code-analysis-cli/src/lib.rs
+++ b/big-code-analysis-cli/src/lib.rs
@@ -41,6 +41,7 @@ mod check_flags;
 mod check_format;
 mod cli_args;
 mod commands;
+mod default_thresholds;
 mod deprecations;
 mod diag;
 mod diff;

--- a/big-code-analysis-cli/src/thresholds.rs
+++ b/big-code-analysis-cli/src/thresholds.rs
@@ -32,7 +32,7 @@ use crate::qualified_name::qualified_symbol;
 /// the library catalog so the CLI gate and the Python `to_sarif` binding
 /// cannot drift on which kinds a metric measures, exactly as they share
 /// the lower-is-worse direction.
-fn metric_scope(name: &str) -> MetricScope {
+pub(crate) fn metric_scope(name: &str) -> MetricScope {
     // Every name reaching here has resolved to a catalog entry (pinned by
     // `extractor_ids_match_library_catalog`), so the lookup is infallible;
     // an unknown id defaults to the narrowest scope rather than ever

--- a/big-code-analysis-cli/tests/init.rs
+++ b/big-code-analysis-cli/tests/init.rs
@@ -230,3 +230,47 @@ fn init_refuses_to_baseline_a_partially_readable_tree() {
         "a partially-read tree must not produce a baseline"
     );
 }
+
+/// A function with one parameter more than the shipped `nargs` limit.
+/// Deliberately breaches a *default* rather than a hand-passed
+/// `--threshold`, so the assertion is about what `bca init` scaffolds.
+const SIX_ARG_RUST: &str = "
+pub fn wide(a: i32, b: i32, c: i32, d: i32, e: i32, f: i32) -> i32 {
+    a + b + c + d + e + f
+}
+";
+
+#[test]
+fn init_scaffold_thresholds_catch_an_offender() {
+    // The complement of `init_scaffold_is_discovered_by_zero_config_check`.
+    // That test proves a clean file passes, which a scaffold whose limits
+    // were all absurdly high would also do — so on its own it cannot tell
+    // a working gate from an inert one. #1140 retuned these defaults
+    // precisely because `nargs = 7` fired on under 1% of functions and on
+    // nothing in this repository at all; a limit that cannot fire is the
+    // bug, not the baseline. So pin the other direction too: a file that
+    // breaches a shipped default must fail the gate.
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("lib.rs"), TRIVIAL_RUST).unwrap();
+
+    // `--no-baseline` writes the empty placeholder, so the offender below
+    // is a *new* one rather than an absorbed one. Without this the
+    // implicit `--write-baseline` would record it and the gate would pass.
+    cli()
+        .current_dir(dir.path())
+        .args(["init", "--no-baseline"])
+        .assert()
+        .success();
+
+    fs::write(dir.path().join("wide.rs"), SIX_ARG_RUST).unwrap();
+
+    // Exit 2 is the metric-gate signal; exit 1 would mean a tool error
+    // (and would pass a bare `.failure()` assertion, hence the exact code).
+    cli()
+        .current_dir(dir.path())
+        .args(["check"])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("nargs"))
+        .stderr(predicate::str::contains("wide"));
+}


### PR DESCRIPTION
## Summary

The `[thresholds]` table `bca init` scaffolds was chosen by eye and pinned
byte-for-byte to this repository's own `bca.toml` by a drift test, so "what
adopters get on day one" and "what this Rust project gates itself at" were the
same numbers by construction. This derives them from evidence instead,
decouples the two, and documents per-language and per-use-case guidance that
did not exist anywhere.

## Evidence

43 shallow-cloned real-world repositories across 20 languages (test, vendored,
and generated trees excluded), measured with the release `bca` binary: ~254k
function spaces, 40k container spaces, 27k files. Values binned by the same
File / Function / Container scope `bca check` applies, so a container's `nom`
never lands in a per-function distribution.

Published anchors disagree by wide margins — cyclomatic defaults alone span 7
(RuboCop) to 30 (`gocyclo`) — so each limit is anchored to a published value
*and* checked against measurement. The sizing rule: a default should flag
roughly the worst 1-3% of spaces in the median language. Below that it is inert
and gives false comfort; above it the gate becomes a style rule people route
around.

## Shipped defaults

| Metric | From | To | Why |
|---|---|---|---|
| `cognitive` | 25 | **15** | SonarSource's own default for the metric they designed; 25 came from clippy, which lints rather than gates |
| `nargs` | 7 | **5** | RuboCop's value. 7 fired on under 1% of functions and on **nothing** in this repository — a limit that cannot fire |
| `abc` | 50 | **40** | Was the loosest gate in the set; 40 matches cyclomatic's strictness |
| `loc.ploc` | — | **600** | New: the working file-size limit, code only |
| `loc.sloc` | 800 | **1200** | Demoted to a comment-inclusive bloat backstop |

`cyclomatic`, `nexits`, `halstead.effort`, `nom`, and `wmc` are unchanged.
`halstead.volume` is deliberately not gated: the widely-cited "function volume
under 1000" guideline fires on ~7% of functions in the median language and 20%
in the worst, which is advisory-grade, not gate-grade.

Existing `bca.toml` files are unaffected; this changes what a fresh `bca init`
writes.

## Decoupling

`default_thresholds.rs` is now the single source of truth, and the scaffold
renders its `[thresholds]` block from it, rationale comments included. The
`init_template_thresholds_match_repo_root` drift test is replaced by one
pinning the scaffold to that table, leaving the repo-root manifest free to keep
its own Rust-specific calibration (it says so inline).

## Documentation

New book recipe `Choosing thresholds`: the derivation, a per-language table
with the measured 97.5th percentile for every supported language, and four
use-case profiles (blocking CI gate, agent feedback loop, legacy triage,
safety-critical). `AGENTS.md` carries the summary table and the caveats so
coding agents read them by default.

Recorded caveats that make the numbers honest: C#'s distribution is dominated
by property accessors, which `bca` counts as functions; `nom` and `wmc` measure
an Elixir `defmodule` rather than a class, so ~1/3 of Elixir modules breach;
`nargs` is inert for Bash, Perl, and Elixir; and four languages have samples
too thin to derive file-size figures from.

## Repo self-scan (closes #1138)

`loc.sloc = 800` was calibrated for test-inclusive SLOC and never revisited
after `exclude_tests = true` landed twelve days later. Because SLOC counts
comments, it charged the same price for a paragraph of rationale as for a new
branch, and seven files had settled into a four-line band ending exactly on the
soft limit — trimming-to-fit, not a natural distribution.

This repo now gates `loc.ploc = 550` (just above its p99 of 545) with
`loc.sloc = 1300` as the backstop. Baseline regenerated in the same commit; net
21 fewer entries.

## Testing

`make pre-commit` green. Every new guard was verified by perturbation rather
than by passing alone — each fails with the intended message, and nothing else
does:

- rendering `entry.limit + 1` fails the round-trip, scaffold, and quoting tests
- dropping a name from either rendered inventory fails the registry guard
- editing one row of the `AGENTS.md` or book table fails the doc drift guard
- raising `nargs` to 500 fails the new offender test
- dropping `loc.sloc` below `loc.ploc` fails the two-tier invariant

The offender test is the one worth calling out: the pre-existing scaffold test
asserts a clean file passes, which a scaffold with every limit at 1,000,000
would also do. Since this PR's central finding is that an inert limit is the
bug, "the defaults catch something" needed its own coverage.

## Follow-ups filed

- #1141 — per-language `[thresholds]` in `bca.toml`. The per-language table is
  currently advice a polyglot repo cannot apply, since one manifest carries one
  table.
- #1142 — Elixir `nargs` reports 0 for every function.
- #1147 — Perl `nargs` reports 0 for signature subs. Found while correcting a
  claim in this PR's own docs that said the Perl zero was correct.
- #1143 — converge this repo's `cognitive` / `nargs` / `abc` onto the shipped
  defaults, one metric per change. Deliberately not done here: converging all
  three at once costs ~95 baseline entries in one commit, which reads as debt
  rather than as a decision. `bca.toml` says so inline.

Closes #1140
