### PR TITLE
perf(cli): four walk and gate performance fixes (#1113, #1119, #1116, #1114)

### DIFF
--- a/.bca-baseline.toml
+++ b/.bca-baseline.toml
@@ -72,7 +72,7 @@ path = "big-code-analysis-cli/src/commands/analyze.rs"
 qualified = "run_command_metrics"
 start_line = 88
 metric = "halstead.effort"
-value = 70299.5881450017
+value = 69608.24451083591
 
 [[entry]]
 path = "big-code-analysis-cli/src/commands/analyze.rs"
@@ -91,14 +91,14 @@ value = 7.0
 [[entry]]
 path = "big-code-analysis-cli/src/commands/check.rs"
 qualified = "emit_check_results"
-start_line = 544
+start_line = 552
 metric = "nargs"
 value = 8.0
 
 [[entry]]
 path = "big-code-analysis-cli/src/commands/check.rs"
 qualified = "filter_by_baseline"
-start_line = 355
+start_line = 363
 metric = "nargs"
 value = 8.0
 
@@ -131,23 +131,16 @@ metric = "nargs"
 value = 8.0
 
 [[entry]]
-path = "big-code-analysis-cli/src/commands/diff_cmd.rs"
-qualified = "compute_since_diff"
-start_line = 113
-metric = "nexits"
-value = 5.0
-
-[[entry]]
 path = "big-code-analysis-cli/src/commands/init.rs"
 qualified = "run_command_init"
-start_line = 184
+start_line = 186
 metric = "nargs"
 value = 7.0
 
 [[entry]]
 path = "big-code-analysis-cli/src/commands/init.rs"
 qualified = "scaffold_baseline"
-start_line = 116
+start_line = 118
 metric = "nargs"
 value = 7.0
 
@@ -156,7 +149,7 @@ path = "big-code-analysis-cli/src/commands/report.rs"
 qualified = "run_command_report"
 start_line = 5
 metric = "halstead.effort"
-value = 65869.50535980989
+value = 63112.954051595756
 
 [[entry]]
 path = "big-code-analysis-cli/src/diff.rs"
@@ -188,13 +181,6 @@ value = 6.0
 
 [[entry]]
 path = "big-code-analysis-cli/src/dispatch.rs"
-qualified = "dispatch_exemptions"
-start_line = 580
-metric = "nexits"
-value = 5.0
-
-[[entry]]
-path = "big-code-analysis-cli/src/dispatch.rs"
 qualified = "dispatch_metrics"
 start_line = 231
 metric = "nargs"
@@ -203,7 +189,7 @@ value = 7.0
 [[entry]]
 path = "big-code-analysis-cli/src/dispatch.rs"
 qualified = "dispatch_ops"
-start_line = 292
+start_line = 290
 metric = "nargs"
 value = 8.0
 
@@ -266,7 +252,7 @@ value = 7.0
 [[entry]]
 path = "big-code-analysis-cli/src/lib.rs"
 qualified = "legacy_hint"
-start_line = 655
+start_line = 678
 metric = "halstead.effort"
 value = 59351.805921378844
 
@@ -301,7 +287,7 @@ value = 8.0
 [[entry]]
 path = "big-code-analysis-cli/src/metric_diff.rs"
 qualified = "MetricDiff::from_sets"
-start_line = 221
+start_line = 238
 metric = "nargs"
 value = 8.0
 
@@ -328,8 +314,15 @@ value = 66737.04848699087
 
 [[entry]]
 path = "big-code-analysis-cli/src/thresholds.rs"
+qualified = "<file>"
+start_line = 1
+metric = "loc.ploc"
+value = 526.0
+
+[[entry]]
+path = "big-code-analysis-cli/src/thresholds.rs"
 qualified = "ThresholdSet::evaluate_with_policy"
-start_line = 790
+start_line = 851
 metric = "halstead.effort"
 value = 56531.05676283881
 
@@ -575,20 +568,6 @@ value = 66515.67234293568
 path = "src/c_macro.rs"
 qualified = "step_normal"
 start_line = 119
-metric = "nexits"
-value = 6.0
-
-[[entry]]
-path = "src/concurrent_files.rs"
-qualified = "ConcurrentRunner<Config>::run"
-start_line = 360
-metric = "halstead.effort"
-value = 60410.49600898003
-
-[[entry]]
-path = "src/concurrent_files.rs"
-qualified = "ConcurrentRunner<Config>::run"
-start_line = 360
 metric = "nexits"
 value = 6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ for historical reference.
 
 ### Added
 
+- `ConcurrentRunner::without_path_verification`, which skips the
+  per-path `is_file()` check during dispatch (#1114). `FilesData::paths`
+  is documented as a terminal file list, so the check is a safety net for
+  a caller that hands in something else; a caller whose own traversal
+  already read each entry's kind — the `bca` CLI walk — was paying one
+  redundant `stat` per file. Additive: the default is unchanged.
+
 - Benchmark harness for the metric walk, in the new workspace member
   `big-code-analysis-bench` (#1068). `cargo bench -p
   big-code-analysis-bench --bench scaling` (or `make bench-scaling`)
@@ -87,6 +94,19 @@ for historical reference.
 
 ### Changed
 
+- `ConcurrentRunner::new`'s `num_jobs` is now the consumer-thread count
+  rather than a budget shared with a dedicated producer thread, which
+  spawned `max(2, num_jobs) - 1` consumers and left one slot idle
+  (#1114). Dispatch happens on the calling thread instead. The signature
+  is unchanged; a caller passing `n` now gets `n` consumers rather than
+  `n - 1`. `ConcurrentErrors::Producer` is consequently never
+  constructed — retained so a downstream `match` still compiles, and
+  scheduled for removal in the next major.
+- `bca`'s per-file output order for a directory walk is now sorted
+  rather than readdir order (#1114). It was never specified, and the
+  parallel walker would otherwise vary it run to run; sorting also makes
+  it independent of the filesystem and the machine. Any consumer that
+  pinned the previous order sees a one-time reshuffle.
 - Retuned the `[thresholds]` table `bca init` scaffolds, deriving each
   limit from published thresholds plus a 20-language corpus measurement
   (#1140). `cognitive` 25 to 15 (SonarSource's own default for the
@@ -165,6 +185,31 @@ for historical reference.
 
 ### Performance
 
+- `bca check` computes only the metric families its resolved thresholds
+  read, instead of the whole suite (#1113). Over
+  `tests/repositories/DeepSpeech` (12.7k files), median user CPU of five
+  runs: a one- or two-metric gate falls from 28.6–29.2 s to 22.4–23.3 s
+  (1.24–1.28×). A gate naming nine families — this repository's own
+  `bca.toml` — is unchanged, since it already selects nearly
+  everything; the ~22 s parse-and-walk floor bounds the saving.
+- `bca diff --since` builds both sides' metric sets in memory rather
+  than writing one JSON document per source file to a temp tree and
+  immediately re-walking, re-reading and re-parsing it (#1116). On
+  DeepSpeech, median of three: wall 11.73 s → 8.74 s (1.34×), system
+  time 2.75 s → 1.57 s. Output is byte-identical.
+- The CLI's directory walk runs on `ignore`'s parallel walker instead of
+  its single-threaded iterator, and the worker pool no longer reserves a
+  slot for a producer thread that finished almost immediately (#1114).
+  Walking DeepSpeech in isolation falls from 100.8 ms to 33.6 ms (3.0×);
+  a full `check` over it improves ~1.12×. The resolved file list is now
+  sorted, so per-file output order is deterministic and independent of
+  readdir order — previously it followed the filesystem's own ordering.
+- The walk's five result channels are plain `crossbeam` senders rather
+  than `Mutex<std::sync::mpsc::Sender<_>>`, so workers no longer take a
+  lock per file (#1119). No measurable throughput change at `--jobs 32`
+  or `--jobs 64` on a 16-core host; the lock was taken once per file,
+  never per record. The change removes a global serialization point and
+  four unreachable poisoned-lock branches.
 - Every file destination and terminal dump writes through an
   explicitly-flushed 64 KiB buffer, replacing the raw `File` and
   `LineWriter` handles the incremental serializers wrote through one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,13 @@ for historical reference.
   parallel walker would otherwise vary it run to run; sorting also makes
   it independent of the filesystem and the machine. Any consumer that
   pinned the previous order sees a one-time reshuffle.
+- A file that disappears between the walk and its analysis is now a tool
+  error (exit 1) rather than a warning-and-exit-0 (#1114). The CLI opts
+  out of the runner's redundant `is_file()` re-check, so such a path is
+  no longer silently skipped during dispatch; it fails at the read and
+  is counted by the same `read_failures` guard that already refuses to
+  report a result derived from a partially analysed input set (#1098).
+  The previous silent skip was the inconsistency.
 - Retuned the `[thresholds]` table `bca init` scaffolds, deriving each
   limit from published thresholds plus a 20-language corpus measurement
   (#1140). `cognitive` 25 to 15 (SonarSource's own default for the
@@ -194,9 +201,20 @@ for historical reference.
   everything; the ~22 s parse-and-walk floor bounds the saving.
 - `bca diff --since` builds both sides' metric sets in memory rather
   than writing one JSON document per source file to a temp tree and
-  immediately re-walking, re-reading and re-parsing it (#1116). On
-  DeepSpeech, median of three: wall 11.73 s → 8.74 s (1.34×), system
-  time 2.75 s → 1.57 s. Output is byte-identical.
+  immediately re-walking, re-reading and re-parsing it (#1116). Each
+  tree is reduced to its metric values by a collector running alongside
+  the walk, over a bounded channel, so the trees are dropped as they
+  arrive rather than all held at once. On `tests/repositories/DeepSpeech`
+  (12,732 files), median of three: wall 9.42 s → 7.62 s, system time
+  3.59 s → 2.34 s. Output is byte-identical.
+
+  **Peak memory rises**: 437 MB → 599 MB (+37%) on that tree. The
+  `MetricSet` for a side is now accumulated during its walk instead of
+  in a separate pass afterwards, so the two overlap — that overlap is
+  what buys the speed. Draining after the walk instead of during it
+  would take the same tree to 831 MB, which is what the bounded channel
+  and the concurrent collector exist to avoid. Size CI containers
+  accordingly for very large trees.
 - The CLI's directory walk runs on `ignore`'s parallel walker instead of
   its single-threaded iterator, and the worker pool no longer reserves a
   slot for a producer thread that finished almost immediately (#1114).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,6 +492,7 @@ dependencies = [
  "big-code-analysis",
  "ciborium",
  "clap",
+ "crossbeam",
  "csv",
  "globset",
  "ignore",

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -123,6 +123,19 @@ section.
     than over the source bytes behind it. The order is part of the
     contract now — callers may diff or hash `ops` output — and will
     not change before `3.0`.
+  - `ConcurrentRunner` in `src/concurrent_files.rs`: `new`'s `num_jobs`
+    is the number of consumer threads. Through the `2.0` line it was a
+    budget shared with a dedicated producer thread and `run` spawned
+    `max(2, num_jobs) - 1` consumers; since #1114 dispatch happens on
+    the calling thread and all `num_jobs` go to consumers. The signature
+    did not change, so this is a behavioural change, not a source break:
+    a caller passing `n` gets one more worker than before.
+    `without_path_verification` (added #1114) opts out of the per-path
+    `is_file()` check for a caller whose own traversal already
+    classified every entry. `ConcurrentErrors::Producer` is no longer
+    constructed — the enum is `#[non_exhaustive]`, but removing a
+    variant would still break a downstream `match`, so it stays until
+    `3.0`.
   - `NumJobs` in `src/concurrent_files.rs` (added in 1.x, #560): the
     shared `<N|auto>` worker-count selector for `ConcurrentRunner`,
     used by both the `bca` CLI and the `bca-web` server. A

--- a/big-code-analysis-cli/Cargo.toml
+++ b/big-code-analysis-cli/Cargo.toml
@@ -27,11 +27,11 @@ big-code-analysis = { path = "..", version = "=2.1.0", default-features = false,
   "vcs",
 ] }
 ciborium = "^0.2"
-# The walk's result channels (#1119). `crossbeam::channel::Sender` is
-# `Sync`, so the worker pool shares one sender per channel directly;
-# `std::sync::mpsc::Sender` is `Send`-only and had to be wrapped in a
-# `Mutex` that every worker locked once per file. Same pin as the
-# library's `ConcurrentRunner`.
+# The walk's result channels (#1119): `Sync` senders the worker pool
+# shares without a `Mutex`. `std::sync::mpsc` would do as well — its
+# `Sender` has been `Sync` since Rust 1.72 — but the library's
+# `ConcurrentRunner` already routes its job queue through crossbeam, so
+# the workspace carries one channel implementation. Same pin.
 crossbeam = { version = "^0.8", features = ["crossbeam-channel"] }
 # `bca vcs` writes a flat CSV ranking (issue #328); the workspace pin is
 # shared with the library's CSV writer.

--- a/big-code-analysis-cli/Cargo.toml
+++ b/big-code-analysis-cli/Cargo.toml
@@ -27,6 +27,12 @@ big-code-analysis = { path = "..", version = "=2.1.0", default-features = false,
   "vcs",
 ] }
 ciborium = "^0.2"
+# The walk's result channels (#1119). `crossbeam::channel::Sender` is
+# `Sync`, so the worker pool shares one sender per channel directly;
+# `std::sync::mpsc::Sender` is `Send`-only and had to be wrapped in a
+# `Mutex` that every worker locked once per file. Same pin as the
+# library's `ConcurrentRunner`.
+crossbeam = { version = "^0.8", features = ["crossbeam-channel"] }
 # `bca vcs` writes a flat CSV ranking (issue #328); the workspace pin is
 # shared with the library's CSV writer.
 csv.workspace = true

--- a/big-code-analysis-cli/src/commands/analyze.rs
+++ b/big-code-analysis-cli/src/commands/analyze.rs
@@ -160,8 +160,8 @@ pub(crate) fn run_command_metrics(
     // channel, collected and written once after the walk.
     let (aggregate_tx, aggregate_rx) = match output_target {
         StructuredOutput::AggregateFile(_) => {
-            let (tx, rx) = std::sync::mpsc::channel();
-            (Some(Mutex::new(tx)), Some(rx))
+            let (tx, rx) = crossbeam::channel::unbounded();
+            (Some(tx), Some(rx))
         }
         _ => (None, None),
     };
@@ -295,8 +295,8 @@ pub(crate) fn run_command_ops(
     let explicit_unrecognized = Arc::new(AtomicUsize::new(0));
     let (aggregate_tx, aggregate_rx) = match output_target {
         StructuredOutput::AggregateFile(_) => {
-            let (tx, rx) = std::sync::mpsc::channel();
-            (Some(Mutex::new(tx)), Some(rx))
+            let (tx, rx) = crossbeam::channel::unbounded();
+            (Some(tx), Some(rx))
         }
         _ => (None, None),
     };

--- a/big-code-analysis-cli/src/commands/check.rs
+++ b/big-code-analysis-cli/src/commands/check.rs
@@ -206,7 +206,7 @@ fn run_check_walk(
     preproc: Option<Arc<PreprocResults>>,
     set: Arc<ThresholdSet>,
 ) -> CheckWalk {
-    let (tx, rx) = std::sync::mpsc::channel();
+    let (tx, rx) = crossbeam::channel::unbounded();
     let files_dispatched = Arc::new(AtomicUsize::new(0));
     // Compute only the metric families the resolved thresholds read
     // (#1113). A gate on one metric used to pay for the whole suite —
@@ -218,7 +218,7 @@ fn run_check_walk(
     let cfg = Config {
         threshold_set: Some(set),
         selected_metrics,
-        check_tx: Some(Mutex::new(tx)),
+        check_tx: Some(tx),
         files_dispatched: Some(Arc::clone(&files_dispatched)),
         suppression_policy: SuppressionPolicy::from_no_suppress(args.no_suppress),
         report_suppressed: args.report_suppressed,

--- a/big-code-analysis-cli/src/commands/check.rs
+++ b/big-code-analysis-cli/src/commands/check.rs
@@ -208,8 +208,16 @@ fn run_check_walk(
 ) -> CheckWalk {
     let (tx, rx) = std::sync::mpsc::channel();
     let files_dispatched = Arc::new(AtomicUsize::new(0));
+    // Compute only the metric families the resolved thresholds read
+    // (#1113). A gate on one metric used to pay for the whole suite —
+    // Halstead being the most expensive per node — and throw the rest
+    // away. `validate_and_build_thresholds` rejects an empty set before
+    // the walk, so this is never an empty selection, which `with_only`
+    // would read as "compute nothing".
+    let selected_metrics = Some(set.selected_metrics());
     let cfg = Config {
         threshold_set: Some(set),
+        selected_metrics,
         check_tx: Some(Mutex::new(tx)),
         files_dispatched: Some(Arc::clone(&files_dispatched)),
         suppression_policy: SuppressionPolicy::from_no_suppress(args.no_suppress),

--- a/big-code-analysis-cli/src/commands/diff_cmd.rs
+++ b/big-code-analysis-cli/src/commands/diff_cmd.rs
@@ -176,11 +176,9 @@ pub(crate) fn compute_since_diff(
     let before_tree = tempfile::TempDir::new().map_err(io_to_diff_error)?;
     diff::materialize_tree(since_ref, before_tree.path()).unwrap_or_else(|reason| die(reason));
 
-    let before_json = tempfile::TempDir::new().map_err(io_to_diff_error)?;
     let before = crate::walk_metric_set(
         before_tree.path(),
         side_globals(globals, scope),
-        before_json.path(),
         DiffSide::Before,
     )?;
 
@@ -193,13 +191,7 @@ pub(crate) fn compute_since_diff(
     // so a subtree positional (`bca diff --since HEAD src`) selects the
     // same files on each side instead of mis-rooting the after walk.
     let after_root = diff::git_repo_root().unwrap_or_else(|reason| die(reason));
-    let after_json = tempfile::TempDir::new().map_err(io_to_diff_error)?;
-    let after = crate::walk_metric_set(
-        &after_root,
-        side_globals(globals, scope),
-        after_json.path(),
-        DiffSide::After,
-    )?;
+    let after = crate::walk_metric_set(&after_root, side_globals(globals, scope), DiffSide::After)?;
 
     Ok(crate::metric_diff::MetricDiff::from_sets(
         &before,

--- a/big-code-analysis-cli/src/commands/exemptions.rs
+++ b/big-code-analysis-cli/src/commands/exemptions.rs
@@ -73,9 +73,9 @@ pub(crate) fn collect_marker_rows(
     globals: GlobalOpts,
     preproc: Option<Arc<PreprocResults>>,
 ) -> Vec<MarkerRow> {
-    let (tx, rx) = std::sync::mpsc::channel();
+    let (tx, rx) = crossbeam::channel::unbounded();
     let cfg = Config {
-        exemptions_tx: Some(Mutex::new(tx)),
+        exemptions_tx: Some(tx),
         ..Config::new(Action::Exemptions, &globals, preproc)
     };
     run_walk(globals, cfg);

--- a/big-code-analysis-cli/src/commands/report.rs
+++ b/big-code-analysis-cli/src/commands/report.rs
@@ -27,19 +27,19 @@ pub(crate) fn run_command_report(
         .vcs
         .then(|| crate::vcs_command::build_default_report(&globals, args.top))
         .flatten();
-    let (tx, rx) = std::sync::mpsc::channel();
+    let (tx, rx) = crossbeam::channel::unbounded();
     // When the change-history section is present, also collect each file's
     // cyclomatic sum so its hotspot score can be joined after the walk
     // (issue #615). Only wired for `report --vcs`; a plain `report` leaves
     // the sender `None` and the hotspot column omitted downstream.
     let (hotspot_rx, report_hotspot_tx) = if vcs.is_some() {
-        let (htx, hrx) = std::sync::mpsc::channel();
-        (Some(hrx), Some(Mutex::new(htx)))
+        let (htx, hrx) = crossbeam::channel::unbounded();
+        (Some(hrx), Some(htx))
     } else {
         (None, None)
     };
     let cfg = Config {
-        markdown_tx: Some(Mutex::new(tx)),
+        markdown_tx: Some(tx),
         report_hotspot_tx,
         strip_prefix: args.strip_prefix,
         ..Config::new(Action::Report, &globals, preproc)

--- a/big-code-analysis-cli/src/dispatch.rs
+++ b/big-code-analysis-cli/src/dispatch.rs
@@ -259,9 +259,7 @@ fn dispatch_metrics(
             // per-file document. The format is applied once, to the whole
             // collected set, by the command runner.
             if let Some(tx) = &cfg.aggregate_tx {
-                if let Ok(sender) = tx.lock() {
-                    let _ = sender.send(crate::AggregateItem::Metrics(Box::new(space), path));
-                }
+                let _ = tx.send(crate::AggregateItem::Metrics(Box::new(space), path));
                 return Ok(());
             }
             // Per-file directory mode (`--output-dir <DIR>`) or stdout.
@@ -303,9 +301,7 @@ fn dispatch_ops(
             // Single-file aggregate mode (`--output <FILE>`, #669): stream
             // the ops tree to the post-walk collector.
             if let Some(tx) = &cfg.aggregate_tx {
-                if let Ok(sender) = tx.lock() {
-                    let _ = sender.send(crate::AggregateItem::Ops(Box::new(ops)));
-                }
+                let _ = tx.send(crate::AggregateItem::Ops(Box::new(ops)));
                 return Ok(());
             }
             // CSV is rejected upstream in `run()` for the Ops command,
@@ -477,17 +473,8 @@ fn dispatch_report(
             &cfg.strip_prefix,
             &mut summaries,
         );
-        let Ok(sender) = tx.lock() else {
-            if cfg.warning {
-                warn(format_args!(
-                    "skipping {}: report channel lock poisoned",
-                    path.display()
-                ));
-            }
-            return Ok(());
-        };
         for s in summaries {
-            let _ = sender.send(s);
+            let _ = tx.send(s);
         }
         // `report --vcs` joins the file's hotspot score (complexity ×
         // recent churn) onto the change-history section, mirroring
@@ -495,12 +482,10 @@ fn dispatch_report(
         // by the absolute walk path so the downstream join canonicalizes
         // and matches against the index work-tree exactly like
         // `vcs_command::inject` (issue #615).
-        if let Some(ref hotspot_tx) = cfg.report_hotspot_tx
-            && let Ok(hotspot_sender) = hotspot_tx.lock()
-        {
+        if let Some(ref hotspot_tx) = cfg.report_hotspot_tx {
             #[allow(clippy::cast_precision_loss)]
             let cyclomatic_sum = space.metrics.cyclomatic.cyclomatic_sum() as f64;
-            let _ = hotspot_sender.send((path.clone(), cyclomatic_sum));
+            let _ = hotspot_tx.send((path, cyclomatic_sum));
         }
     }
     Ok(())
@@ -551,24 +536,12 @@ fn dispatch_check_file(
                 ));
             }
         }
-        if !violations.is_empty() {
-            let Ok(sender) = tx.lock() else {
-                if cfg.warning {
-                    warn(format_args!(
-                        "skipping {}: check channel lock poisoned",
-                        path.display()
-                    ));
-                }
-                return Ok(());
-            };
-            // Receiver lives until `run_check` drains `rx`, which
-            // happens only after `run_walk` joins all worker threads —
-            // so `send` cannot fail here. Use `let _` rather than
-            // `expect` to avoid panicking the worker pool on the
-            // (unreachable) drop path.
-            for v in violations {
-                let _ = sender.send(v);
-            }
+        // Receiver lives until `run_check` drains `rx`, which happens
+        // only after `run_walk` joins all worker threads — so `send`
+        // cannot fail here. Use `let _` rather than `expect` to avoid
+        // panicking the worker pool on the (unreachable) drop path.
+        for v in violations {
+            let _ = tx.send(v);
         }
     }
     Ok(())
@@ -615,20 +588,11 @@ fn dispatch_exemptions(
     if markers.is_empty() {
         return Ok(());
     }
-    let Ok(sender) = tx.lock() else {
-        if cfg.warning {
-            warn(format_args!(
-                "skipping {}: exemptions channel lock poisoned",
-                path.display()
-            ));
-        }
-        return Ok(());
-    };
     // Receiver lives until the post-walk aggregator drains `rx`, which
     // happens only after all worker threads join — so `send` cannot
     // fail. Use `let _` rather than `expect` to avoid panicking the
     // worker pool on the unreachable drop path.
-    let _ = sender.send(FileMarkers {
+    let _ = tx.send(FileMarkers {
         path: file_str.to_owned(),
         markers,
     });

--- a/big-code-analysis-cli/src/lib.rs
+++ b/big-code-analysis-cli/src/lib.rs
@@ -549,18 +549,22 @@ fn run_walk_collecting(globals: GlobalOpts, mut cfg: Config) -> Vec<PathBuf> {
 pub(crate) fn walk_metric_set(
     root: &Path,
     globals: GlobalOpts,
-    json_out_dir: &Path,
     side: DiffSide,
 ) -> Result<metric_diff::MetricSet, metric_diff::DiffError> {
     let action = Action::Metrics {
         format: Some(MetricsFormat::Json),
         pretty: false,
     };
+    // Stream each file's space back over the aggregate channel and build
+    // the set in memory (#1116). This used to run with
+    // `output_dir: Some(temp)`, writing one JSON document per source
+    // file and then re-walking, re-reading and re-parsing the whole
+    // temp tree — while the `FuncSpace` trees were already in the
+    // workers' hands. The format stays `Json` because the set's values
+    // are `serde_json::Value`s built from the same `Serialize` impl.
+    let (tx, rx) = crossbeam::channel::unbounded();
     let cfg = Config {
-        // `bca diff --since` writes a per-file JSON tree it later reloads;
-        // that is the directory-tree mode, which now lives on `output_dir`
-        // (#669) rather than `output` (a single aggregate file).
-        output_dir: Some(json_out_dir.to_path_buf()),
+        aggregate_tx: Some(tx),
         ..Config::new(action, &globals, None)
     };
 
@@ -585,6 +589,11 @@ pub(crate) fn walk_metric_set(
             count: failures.read,
         });
     }
+    // Nothing is written per file any more, so this tally is expected to
+    // be zero. Kept because `write_failures` is generic walk machinery
+    // that a future dispatch change could start incrementing: the rule
+    // it enforces — never report a diff derived from an incomplete walk
+    // (#1098) — outlives the particular way the walk emits.
     if failures.write > 0 {
         return Err(metric_diff::DiffError::UnwritableOutputs {
             side,
@@ -592,10 +601,10 @@ pub(crate) fn walk_metric_set(
         });
     }
 
-    // The JSON writer emitted one document per source file under
-    // `json_out_dir`, keyed by the root-relative source path — the same
-    // shape `bca diff`'s directory inputs use, so reuse its loader.
-    metric_diff::load_dir_set(json_out_dir)
+    // `run_walk_tallying` took `cfg` by value and has joined every
+    // worker, so the sender is dropped and the receiver is drained to
+    // disconnect rather than blocking.
+    metric_diff::set_from_spaces(rx)
 }
 
 const SUBCOMMANDS: &[&str] = &[

--- a/big-code-analysis-cli/src/lib.rs
+++ b/big-code-analysis-cli/src/lib.rs
@@ -145,13 +145,19 @@ struct Config {
     /// document. `None` for the directory / stdout paths, which write
     /// per-file inline.
     ///
-    /// A `crossbeam` sender rather than `std::sync::mpsc`: it is `Sync`,
-    /// so the shared `Config` hands every worker the same sender
-    /// directly. The `mpsc` equivalent is `Send`-only and had to sit
-    /// behind a `Mutex` that each worker locked once per file — a single
-    /// point of contention across the pool that scaled *worse* with core
-    /// count, on top of a poisoned-lock branch nothing could reach
-    /// (#1119). The same reasoning covers every `*_tx` below.
+    /// Held bare by the shared `Config`, with no `Mutex`: the sender is
+    /// `Sync`, so every worker sends through the same one. The wrapper
+    /// each `*_tx` used to carry dated from a Rust in which
+    /// `std::sync::mpsc::Sender` was `Send`-only; it has been `Sync`
+    /// since 1.72, so by the time #1119 removed the `Mutex` it was
+    /// buying nothing but a lock taken once per file across the whole
+    /// pool and a poisoned-lock branch nothing could reach.
+    ///
+    /// `crossbeam` rather than `std::sync::mpsc` only because the
+    /// library's `ConcurrentRunner` already routes its job queue through
+    /// it, so the workspace carries one channel implementation; `mpsc`
+    /// would serve here equally well. The same applies to every `*_tx`
+    /// below.
     aggregate_tx: Option<crossbeam::channel::Sender<AggregateItem>>,
     language: Option<LANG>,
     line_start: Option<usize>,
@@ -526,9 +532,9 @@ fn run_walk_collecting(globals: GlobalOpts, mut cfg: Config) -> Vec<PathBuf> {
 
 /// Analyze the source tree rooted at `root` with `globals` (whose
 /// `paths` the caller has set to seeds *relative to* `root`, and whose
-/// `include`/`exclude` carry the user's selection), writing per-file
-/// JSON into `json_out_dir`, and return the resulting in-memory
-/// [`MetricSet`] keyed by each file's path relative to `root`.
+/// `include`/`exclude` carry the user's selection), returning the
+/// resulting in-memory [`MetricSet`] keyed by each file's path relative
+/// to `root`.
 ///
 /// This is the metric-extraction half of `bca diff --since`: the
 /// "before" side runs it against a tempdir holding the tree at a git
@@ -539,11 +545,14 @@ fn run_walk_collecting(globals: GlobalOpts, mut cfg: Config) -> Vec<PathBuf> {
 ///
 /// The walk runs with the process CWD anchored at `root` (via the
 /// drop-restoring [`with_cwd`] guard) and the caller's seeds expressed
-/// relative to it, so the JSON writer emits each per-file document under
-/// `json_out_dir` named by the root-relative source path
-/// (`src/foo.rs.json`). The key is then just that path relative to
-/// `json_out_dir` — byte-identical across the two sides whenever the
-/// same logical file exists in both trees.
+/// relative to it, so each analyzed file's emitted name *is* its
+/// root-relative path (`src/foo.rs`) with no absolute prefix to strip.
+/// That name is the key — read off the serialized document, never
+/// reconstructed from an output path — so it is byte-identical across
+/// the two sides whenever the same logical file exists in both trees.
+/// [`metric_diff::set_from_spaces`] and [`metric_diff::load_dir_set`]
+/// share one keying helper precisely so the in-memory side here and the
+/// on-disk side of `bca diff <old> <new>` cannot diverge on it.
 ///
 /// `side` names this tree in the error a partially-readable walk raises
 /// ("before" / "after"). Unreadable input is an error rather than a gap
@@ -568,17 +577,24 @@ pub(crate) fn walk_metric_set(
     // temp tree — while the `FuncSpace` trees were already in the
     // workers' hands. The format stays `Json` because the set's values
     // are `serde_json::Value`s built from the same `Serialize` impl.
-    let (tx, rx) = crossbeam::channel::unbounded();
+    let (tx, rx) =
+        crossbeam::channel::bounded(globals.num_jobs.resolve() * AGGREGATE_BACKLOG_PER_JOB);
     let cfg = Config {
         aggregate_tx: Some(tx),
         ..Config::new(action, &globals, None)
     };
+    // Collect concurrently with the walk rather than draining afterwards.
+    // Each tree is reduced to its metrics `Value` and dropped as it
+    // arrives, so the peak holds the channel backlog instead of one
+    // `FuncSpace` per file — and the conversion overlaps the walk instead
+    // of running after it.
+    let collector = std::thread::spawn(move || metric_diff::set_from_spaces(rx));
 
     // Walk with the process CWD anchored at `root` and the seeds
-    // expressed relative to it (the caller passes `.`/`<subdir>`),
-    // so the JSON writer emits files under `json_out_dir` named by the
-    // root-relative source path (`src/foo.rs.json`) with no absolute
-    // prefix to strip. This is what makes the "before" side (a
+    // expressed relative to it (the caller passes `.`/`<subdir>`), so
+    // each space's emitted name is the root-relative source path
+    // (`src/foo.rs`) with no absolute prefix to strip. This is what
+    // makes the "before" side (a
     // /tmp/… extraction) and the "after" side (the working tree or an
     // explicit dir) pair on the same keys despite different absolute
     // roots, without depending on `reanchor_seed`'s under-CWD rewrite.
@@ -589,6 +605,13 @@ pub(crate) fn walk_metric_set(
     let restore = with_cwd(root)?;
     let failures = run_walk_tallying(globals, cfg);
     drop(restore);
+
+    // `run_walk_tallying` took `cfg` by value and has joined every
+    // worker, so the sender is dropped and the collector's receiver sees
+    // disconnect. Joined before the failure guards below so the thread is
+    // always reaped, even on the error paths.
+    let collected = collector.join();
+
     if failures.read > 0 {
         return Err(metric_diff::DiffError::UnreadableInputs {
             side,
@@ -607,11 +630,33 @@ pub(crate) fn walk_metric_set(
         });
     }
 
-    // `run_walk_tallying` took `cfg` by value and has joined every
-    // worker, so the sender is dropped and the receiver is drained to
-    // disconnect rather than blocking.
-    metric_diff::set_from_spaces(rx)
+    collected.map_err(|_| metric_diff::DiffError::CollectorPanicked { side })?
 }
+
+/// Un-collected `FuncSpace` trees allowed between the worker pool and
+/// the `--since` collector, as a multiple of the pool width.
+///
+/// The bound exists to stop *unbounded* growth, not to tune the peak.
+/// Draining after the walk rather than during it let the channel hold
+/// one tree per file, which took `diff --since` over a 12,732-file tree
+/// to 849 MB resident against 453 MB for the temp-JSON route it
+/// replaced. Any finite bound fixes that; the value chosen barely moves
+/// the result, because what remains at peak is the accumulated
+/// `MetricSet`, not the backlog.
+///
+/// Measured on that tree at 16 workers, median of three:
+///
+/// | backlog | wall (min) | peak RSS |
+/// |---------|-----------|----------|
+/// | unbounded | 7.62 s | 849 MB |
+/// | 16x (this value) | 5.13 s | 591 MB |
+/// | 4x | 6.55 s | 600 MB |
+///
+/// So a tighter bound costs wall time and saves nothing: it starts
+/// throttling the pool while the peak stays put. Scaled per job rather
+/// than fixed so a wider pool cannot be throttled by a constant sized
+/// on a 16-core box.
+const AGGREGATE_BACKLOG_PER_JOB: usize = 16;
 
 const SUBCOMMANDS: &[&str] = &[
     "metrics",

--- a/big-code-analysis-cli/src/lib.rs
+++ b/big-code-analysis-cli/src/lib.rs
@@ -404,6 +404,12 @@ fn run_walk_resolved_tallying(paths: Vec<PathBuf>, num_jobs: usize, cfg: Config)
     let read_failures = Arc::clone(&cfg.read_failures);
     let write_failures = Arc::clone(&cfg.write_failures);
     ConcurrentRunner::new(num_jobs, act_on_file)
+        // `expand_seed_paths` classified every entry from the walker's
+        // `dirent`, so the runner's own `is_file()` check is a second
+        // `stat` for a question already answered (#1114). A path that
+        // has since vanished still surfaces through `read_failures`,
+        // which is where the walk reports unreadable inputs anyway.
+        .without_path_verification()
         .run(cfg, FilesData { paths })
         .unwrap_or_else(|e| die(format_args!("{e:?}")));
     WalkFailures {

--- a/big-code-analysis-cli/src/lib.rs
+++ b/big-code-analysis-cli/src/lib.rs
@@ -289,11 +289,16 @@ struct Config {
     /// library `*_with_color` dump entry points, so piped output is
     /// escape-free by default. Inert for structured / file output.
     color: big_code_analysis::ColorMode,
-    /// Subset of metrics to compute, from `bca metrics --metrics`
-    /// (issue #691). `None` (the default) computes every metric;
-    /// `Some(set)` restricts via [`MetricsOptions::with_only`], which
-    /// auto-resolves each metric's dependencies. Set only by
-    /// `run_command_metrics`; every other flow leaves it `None`.
+    /// Subset of metrics to compute. `None` (the default) computes
+    /// every metric; `Some(set)` restricts via
+    /// [`MetricsOptions::with_only`], which auto-resolves each metric's
+    /// dependencies.
+    ///
+    /// Two flows set it. `run_command_metrics` passes the user's
+    /// `bca metrics --metrics` selection (issue #691). `run_check_walk`
+    /// derives it from the resolved `ThresholdSet` (issue #1113), since
+    /// a gate reads only the families it thresholds. Every other flow
+    /// leaves it `None`.
     selected_metrics: Option<Vec<big_code_analysis::Metric>>,
 }
 

--- a/big-code-analysis-cli/src/lib.rs
+++ b/big-code-analysis-cli/src/lib.rs
@@ -143,9 +143,16 @@ struct Config {
     /// run in single-file aggregate mode (`--output <FILE>`, #669). The
     /// command runner collects the records after the walk and writes one
     /// document. `None` for the directory / stdout paths, which write
-    /// per-file inline. Wrapped in `Mutex` because `mpsc::Sender` is
-    /// `Send` but not `Sync`.
-    aggregate_tx: Option<Mutex<std::sync::mpsc::Sender<AggregateItem>>>,
+    /// per-file inline.
+    ///
+    /// A `crossbeam` sender rather than `std::sync::mpsc`: it is `Sync`,
+    /// so the shared `Config` hands every worker the same sender
+    /// directly. The `mpsc` equivalent is `Send`-only and had to sit
+    /// behind a `Mutex` that each worker locked once per file — a single
+    /// point of contention across the pool that scaled *worse* with core
+    /// count, on top of a poisoned-lock branch nothing could reach
+    /// (#1119). The same reasoning covers every `*_tx` below.
+    aggregate_tx: Option<crossbeam::channel::Sender<AggregateItem>>,
     language: Option<LANG>,
     line_start: Option<usize>,
     line_end: Option<usize>,
@@ -153,8 +160,7 @@ struct Config {
     preproc: Option<Arc<PreprocResults>>,
     count_lock: Option<CountCollector>,
     /// Sender for streaming `FunctionSummary` records when running `report`.
-    /// Wrapped in `Mutex` because `mpsc::Sender` is `Send` but not `Sync`.
-    markdown_tx: Option<Mutex<std::sync::mpsc::Sender<FunctionSummary>>>,
+    markdown_tx: Option<crossbeam::channel::Sender<FunctionSummary>>,
     /// Sender for streaming each file's `(absolute path, cyclomatic sum)`
     /// when running `report --vcs`, so the change-history section can join
     /// the same hotspot score (`complexity × recent churn`) that
@@ -162,21 +168,18 @@ struct Config {
     /// path is canonicalized against the index work-tree downstream — the
     /// identical match `vcs_command::inject` uses — so the join is correct
     /// regardless of `--strip-prefix` or the walk-root spelling. `None`
-    /// for every flow other than `report --vcs`. Wrapped in `Mutex` for the
-    /// same reason as `markdown_tx`.
-    report_hotspot_tx: Option<Mutex<std::sync::mpsc::Sender<(PathBuf, f64)>>>,
+    /// for every flow other than `report --vcs`.
+    report_hotspot_tx: Option<crossbeam::channel::Sender<(PathBuf, f64)>>,
     /// Path prefix stripped from file paths in the markdown report.
     strip_prefix: String,
     /// Pre-resolved thresholds for `Action::Check`. `None` for every
     /// other action.
     threshold_set: Option<Arc<ThresholdSet>>,
     /// Sender for streaming [`Violation`] records when running `check`.
-    /// Wrapped in `Mutex` for the same reason as `markdown_tx`.
-    check_tx: Option<Mutex<std::sync::mpsc::Sender<Violation>>>,
+    check_tx: Option<crossbeam::channel::Sender<Violation>>,
     /// Sender for streaming per-file suppression-marker batches when
-    /// running `exemptions`. Wrapped in `Mutex` for the same reason as
-    /// `markdown_tx`.
-    exemptions_tx: Option<Mutex<std::sync::mpsc::Sender<exemptions::FileMarkers>>>,
+    /// running `exemptions`.
+    exemptions_tx: Option<crossbeam::channel::Sender<exemptions::FileMarkers>>,
     /// Counts how many files survived expansion and glob filtering and
     /// were actually dispatched to `act_on_file`. `Action::Check` reads
     /// this after the walk to distinguish "all clean" (counter > 0,

--- a/big-code-analysis-cli/src/metric_diff.rs
+++ b/big-code-analysis-cli/src/metric_diff.rs
@@ -596,13 +596,29 @@ pub(crate) fn load_dir_set(root: &Path) -> Result<MetricSet, DiffError> {
     let mut set = MetricSet::new();
     for entry in walk_json_files(root)? {
         let value = read_json(&entry)?;
-        let key = value.get(NAME_KEY).and_then(Value::as_str).map_or_else(
-            || path_to_key(entry.strip_prefix(root).unwrap_or(&entry)),
-            |name| Ok(name.to_string()),
-        )?;
-        set.insert(key, extract_metrics(value));
+        insert_document(&mut set, value, entry.strip_prefix(root).unwrap_or(&entry))?;
     }
     Ok(set)
+}
+
+/// Key one per-file document into `set` and store its `metrics` object.
+///
+/// Shared by [`load_dir_set`] and [`set_from_spaces`] so the two cannot
+/// drift on how a document becomes a pairing key (#1116). That agreement
+/// is load-bearing: `bca diff --since` builds one side in memory and
+/// `bca diff <old> <new>` reads the other off disk, and a key derived
+/// differently would pair nothing.
+///
+/// `fallback` supplies the key only for a document with no `name` field
+/// — the relative path within the set, so it stays comparable across
+/// sides.
+fn insert_document(set: &mut MetricSet, value: Value, fallback: &Path) -> Result<(), DiffError> {
+    let key = value
+        .get(NAME_KEY)
+        .and_then(Value::as_str)
+        .map_or_else(|| path_to_key(fallback), |name| Ok(name.to_owned()))?;
+    set.insert(key, extract_metrics(value));
+    Ok(())
 }
 
 /// Build a [`MetricSet`] from the `FuncSpace` trees a `--since` walk
@@ -635,11 +651,7 @@ pub(crate) fn set_from_spaces(
             path: path.clone(),
             source,
         })?;
-        let key = value
-            .get(NAME_KEY)
-            .and_then(Value::as_str)
-            .map_or_else(|| path_to_key(&path), |name| Ok(name.to_owned()))?;
-        set.insert(key, extract_metrics(value));
+        insert_document(&mut set, value, &path)?;
     }
     Ok(set)
 }

--- a/big-code-analysis-cli/src/metric_diff.rs
+++ b/big-code-analysis-cli/src/metric_diff.rs
@@ -106,6 +106,17 @@ pub(crate) enum DiffError {
     /// (no `to_string_lossy`), so this is a hard error rather than a
     /// silent rename.
     NonUtf8Path { path: PathBuf },
+    /// The `--since` collector thread panicked, so that side's set is
+    /// incomplete. Surfaced as an error rather than resumed: a partial
+    /// set would report its missing files as added or removed, which is
+    /// the wrong-answer failure mode #1098 exists to prevent.
+    CollectorPanicked { side: DiffSide },
+    /// A `--since` walk streamed an aggregate item that was not a
+    /// metrics space. Unreachable today — `--since` only ever runs
+    /// `Action::Metrics`, and `ops` is a separate subcommand — but
+    /// dropping the item would silently shorten the set, so it is
+    /// refused rather than skipped.
+    UnexpectedAggregate,
     /// A `--since` walk could not read every file on one side, so that
     /// side's set is missing files the other side has — which the
     /// comparison would otherwise report as added or removed rather
@@ -135,6 +146,12 @@ impl std::fmt::Display for DiffError {
             }
             Self::NonUtf8Path { path } => {
                 write!(f, "path is not valid UTF-8: {}", path.display())
+            }
+            Self::CollectorPanicked { side } => {
+                write!(f, "diff --since {side} tree: metric collector panicked")
+            }
+            Self::UnexpectedAggregate => {
+                f.write_str("diff --since walk produced a non-metrics result")
             }
             Self::UnwritableOutputs { side, count } => {
                 write!(
@@ -643,9 +660,15 @@ pub(crate) fn set_from_spaces(
     for item in items {
         // `ops` never shares a walk with `metrics` — separate
         // subcommands — and `--since` only ever runs the metrics action,
-        // so the `Ops` arm cannot occur here.
+        // so the `Ops` arm cannot occur here. Rejected rather than
+        // skipped anyway: silently dropping an item would leave the file
+        // absent from this side's set, and an absent file reads as one
+        // the commit added or removed. That is the wrong-answer failure
+        // mode the surrounding `UnreadableInputs` guard exists to
+        // prevent (#1098), so it must not be reintroduced here by a
+        // `continue`.
         let crate::AggregateItem::Metrics(space, path) = item else {
-            continue;
+            return Err(DiffError::UnexpectedAggregate);
         };
         let value = serde_json::to_value(&*space).map_err(|source| DiffError::Serialize {
             path: path.clone(),

--- a/big-code-analysis-cli/src/metric_diff.rs
+++ b/big-code-analysis-cli/src/metric_diff.rs
@@ -91,6 +91,16 @@ pub(crate) enum DiffError {
         path: PathBuf,
         source: serde_json::Error,
     },
+    /// A `--since` walk produced a `FuncSpace` that would not serialize
+    /// to a JSON value (#1116). Unreachable in practice — the same
+    /// `Serialize` impl backs `bca metrics --format json`, and
+    /// `serde_json` renders even a non-finite float as `null` rather
+    /// than failing — but `to_value` is fallible and the project bans
+    /// `unwrap` outside tests.
+    Serialize {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
     /// A path component was not valid UTF-8, so it cannot serve as a
     /// stable pairing key. Identifier paths must round-trip losslessly
     /// (no `to_string_lossy`), so this is a hard error rather than a
@@ -115,6 +125,13 @@ impl std::fmt::Display for DiffError {
             }
             Self::Parse { path, source } => {
                 write!(f, "failed to parse JSON {}: {source}", path.display())
+            }
+            Self::Serialize { path, source } => {
+                write!(
+                    f,
+                    "failed to serialize metrics for {}: {source}",
+                    path.display()
+                )
             }
             Self::NonUtf8Path { path } => {
                 write!(f, "path is not valid UTF-8: {}", path.display())
@@ -583,6 +600,45 @@ pub(crate) fn load_dir_set(root: &Path) -> Result<MetricSet, DiffError> {
             || path_to_key(entry.strip_prefix(root).unwrap_or(&entry)),
             |name| Ok(name.to_string()),
         )?;
+        set.insert(key, extract_metrics(value));
+    }
+    Ok(set)
+}
+
+/// Build a [`MetricSet`] from the `FuncSpace` trees a `--since` walk
+/// streamed back, without a filesystem round-trip (#1116).
+///
+/// The in-memory twin of [`load_dir_set`], and deliberately keyed the
+/// same way: `serde_json::to_value` runs the identical `Serialize` impl
+/// the per-file JSON writer used, so the document this sees is the one
+/// that used to be written out and parsed back. Keys still come from the
+/// document's `name` field, falling back to the emitted path — which is
+/// what `name` is set from anyway, so the fallback only matters for a
+/// space that somehow carries none.
+///
+/// The old route wrote one JSON document per source file (each behind a
+/// `create_dir_all`), then re-walked the temp tree and re-parsed every
+/// document into a `Value`. Both sides of every `bca diff --since` paid
+/// that twice over while the trees were already in memory.
+pub(crate) fn set_from_spaces(
+    items: impl IntoIterator<Item = crate::AggregateItem>,
+) -> Result<MetricSet, DiffError> {
+    let mut set = MetricSet::new();
+    for item in items {
+        // `ops` never shares a walk with `metrics` — separate
+        // subcommands — and `--since` only ever runs the metrics action,
+        // so the `Ops` arm cannot occur here.
+        let crate::AggregateItem::Metrics(space, path) = item else {
+            continue;
+        };
+        let value = serde_json::to_value(&*space).map_err(|source| DiffError::Serialize {
+            path: path.clone(),
+            source,
+        })?;
+        let key = value
+            .get(NAME_KEY)
+            .and_then(Value::as_str)
+            .map_or_else(|| path_to_key(&path), |name| Ok(name.to_owned()))?;
         set.insert(key, extract_metrics(value));
     }
     Ok(set)

--- a/big-code-analysis-cli/src/metric_diff_tests.rs
+++ b/big-code-analysis-cli/src/metric_diff_tests.rs
@@ -388,3 +388,100 @@ fn unreadable_inputs_error_names_the_side() {
         "rendered: {after}"
     );
 }
+
+// --- #1116: the in-memory set must equal the file round-trip --------
+
+/// `set_from_spaces` must produce exactly what `load_dir_set` produced
+/// from the same walk (#1116).
+///
+/// `bca diff --since` used to serialize every `FuncSpace` to a temp JSON
+/// tree and immediately parse it back. Dropping that round-trip is only
+/// safe if the two routes agree on *both* halves of every entry: the
+/// pairing key (the document's `name`, not the path the writer chose)
+/// and the `metrics` value (which must survive `f64` -> text -> `f64`
+/// unchanged — the workspace enables `serde_json`'s `float_roundtrip`
+/// precisely so it does).
+///
+/// The fixture is real parsed source, not a hand-built `Value`, so the
+/// comparison covers the actual `Serialize` impl and the actual float
+/// values a walk produces.
+#[test]
+fn set_from_spaces_matches_the_file_round_trip() {
+    use big_code_analysis::{Ast, LANG, MetricsOptions, Source};
+
+    // Branchy enough to give Halstead and MI irrational values, which
+    // are what a lossy float round-trip would corrupt.
+    const RUST: &str = r"
+pub fn classify(n: i32, m: i32) -> &'static str {
+    if n < 0 {
+        'neg'
+    } else if n == 0 && m > 3 {
+        'zero'
+    } else if n < m {
+        'small'
+    } else {
+        'large'
+    }
+}
+";
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let name = "./src/sample.rs";
+    let space = Ast::parse(
+        Source::new(LANG::Rust, RUST.replace('\'', "\"").as_bytes())
+            .with_name(Some(name.to_owned())),
+    )
+    .expect("fixture parses")
+    .metrics(MetricsOptions::default())
+    .expect("metrics");
+
+    // Route A: what the walk now does — straight from the in-memory tree.
+    let in_memory = set_from_spaces([crate::AggregateItem::Metrics(
+        Box::new(space.clone()),
+        PathBuf::from(name),
+    )])
+    .expect("in-memory set builds");
+
+    // Route B: what it used to do — write the per-file document, then
+    // re-walk and re-parse the directory.
+    let doc = dir.path().join("src");
+    std::fs::create_dir_all(&doc).expect("create output dir");
+    let file = doc.join("sample.rs.json");
+    serde_json::to_writer(
+        std::fs::File::create(&file).expect("create document"),
+        &space,
+    )
+    .expect("write document");
+    let round_tripped = load_dir_set(dir.path()).expect("directory set loads");
+
+    assert_eq!(
+        in_memory, round_tripped,
+        "in-memory set diverged from the JSON round-trip it replaced"
+    );
+    // Guard against the comparison passing because both sides are empty.
+    let metrics = in_memory.values().next().expect("one entry");
+    assert!(
+        metrics
+            .get("halstead")
+            .is_some_and(|h| h.get("volume").is_some()),
+        "fixture produced no halstead.volume; the equality above proves little: {metrics}"
+    );
+
+    // The key comes from the document's `name`, never from the streamed
+    // path. In a real `--since` walk the two coincide — the CWD is
+    // anchored at the side's root and the seeds are relative, so the
+    // emitted path *is* the name — which means swapping them is
+    // unobservable in the equality above. It is pinned separately here
+    // because `load_dir_set` reads `name` too, and that agreement is the
+    // entire reason the before side (a /tmp extraction) pairs with the
+    // after side (the working tree) despite different absolute roots.
+    let divergent = set_from_spaces([crate::AggregateItem::Metrics(
+        Box::new(space),
+        PathBuf::from("some/other/spelling.rs"),
+    )])
+    .expect("in-memory set builds");
+    assert_eq!(
+        divergent.keys().collect::<Vec<_>>(),
+        vec![name],
+        "the in-memory set must key on the document's `name`, not the streamed path"
+    );
+}

--- a/big-code-analysis-cli/src/thresholds.rs
+++ b/big-code-analysis-cli/src/thresholds.rs
@@ -20,7 +20,7 @@ use std::rc::Rc;
 
 use big_code_analysis::metric_catalog::MetricScope;
 use big_code_analysis::{
-    CodeMetrics, FuncSpace, SpaceKind, SuppressionPolicy, threshold_metric_for_name,
+    CodeMetrics, FuncSpace, Metric, SpaceKind, SuppressionPolicy, threshold_metric_for_name,
 };
 use serde::Deserialize;
 
@@ -49,6 +49,19 @@ struct MetricExtractor {
     /// loc.*, nargs, ...) round-trip exactly through `f64` for the ranges
     /// that occur in practice.
     extract: fn(&CodeMetrics) -> f64,
+    /// The library metric family `extract` reads from, so a check walk
+    /// can compute only the families its thresholds actually gate
+    /// (#1113).
+    ///
+    /// Declared per entry rather than derived from `name`, because the
+    /// two vocabularies disagree: [`threshold_metric_for_name`] maps
+    /// `tokens` to `None` (a suppression marker may never silence it),
+    /// yet `tokens` *is* a configurable threshold. Narrowing the walk by
+    /// that mapping would leave `m.tokens` at its zero default and
+    /// silently disarm the gate. Naming the family here makes this
+    /// registry the single source of truth and forces every future
+    /// extractor to declare one.
+    metric: Metric,
 }
 
 /// Source of truth for accepted threshold names. Order matters only for
@@ -81,98 +94,122 @@ const EXTRACTORS: &[MetricExtractor] = &[
     MetricExtractor {
         name: "cognitive",
         extract: |m| m.cognitive.cognitive() as f64,
+        metric: Metric::Cognitive,
     },
     MetricExtractor {
         name: "cyclomatic",
         extract: |m| m.cyclomatic.cyclomatic() as f64,
+        metric: Metric::Cyclomatic,
     },
     MetricExtractor {
         name: "cyclomatic.modified",
         extract: |m| m.cyclomatic.cyclomatic_modified() as f64,
+        metric: Metric::Cyclomatic,
     },
     MetricExtractor {
         name: "halstead.volume",
         extract: |m| m.halstead.volume(),
+        metric: Metric::Halstead,
     },
     MetricExtractor {
         name: "halstead.difficulty",
         extract: |m| m.halstead.difficulty(),
+        metric: Metric::Halstead,
     },
     MetricExtractor {
         name: "halstead.effort",
         extract: |m| m.halstead.effort(),
+        metric: Metric::Halstead,
     },
     MetricExtractor {
         name: "halstead.time",
         extract: |m| m.halstead.time(),
+        metric: Metric::Halstead,
     },
     MetricExtractor {
         name: "halstead.bugs",
         extract: |m| m.halstead.bugs(),
+        metric: Metric::Halstead,
     },
     MetricExtractor {
         name: "loc.sloc",
         extract: |m| m.loc.sloc() as f64,
+        metric: Metric::Loc,
     },
     MetricExtractor {
         name: "loc.ploc",
         extract: |m| m.loc.ploc() as f64,
+        metric: Metric::Loc,
     },
     MetricExtractor {
         name: "loc.lloc",
         extract: |m| m.loc.lloc() as f64,
+        metric: Metric::Loc,
     },
     MetricExtractor {
         name: "loc.cloc",
         extract: |m| m.loc.cloc() as f64,
+        metric: Metric::Loc,
     },
     MetricExtractor {
         name: "loc.blank",
         extract: |m| m.loc.blank() as f64,
+        metric: Metric::Loc,
     },
     MetricExtractor {
         name: "nom",
         extract: |m| m.nom.total() as f64,
+        metric: Metric::Nom,
     },
     MetricExtractor {
         name: "tokens",
         extract: |m| m.tokens.tokens_sum() as f64,
+        metric: Metric::Tokens,
     },
     MetricExtractor {
         name: "nexits",
         extract: |m| m.nexits.nexits_sum() as f64,
+        metric: Metric::Nexits,
     },
     MetricExtractor {
         name: "nargs",
         extract: |m| m.nargs.total() as f64,
+        metric: Metric::Nargs,
     },
     MetricExtractor {
         name: "mi.original",
         extract: |m| m.mi.original(),
+        metric: Metric::Mi,
     },
     MetricExtractor {
         name: "mi.sei",
         extract: |m| m.mi.sei(),
+        metric: Metric::Mi,
     },
     MetricExtractor {
         name: "mi.visual_studio",
         extract: |m| m.mi.visual_studio(),
+        metric: Metric::Mi,
     },
     MetricExtractor {
         name: "abc",
         extract: |m| m.abc.magnitude(),
+        metric: Metric::Abc,
     },
     MetricExtractor {
         name: "wmc",
         extract: |m| m.wmc.total_wmc() as f64,
+        metric: Metric::Wmc,
     },
     MetricExtractor {
         name: "npm",
         extract: |m| m.npm.total_npm() as f64,
+        metric: Metric::Npm,
     },
     MetricExtractor {
         name: "npa",
         extract: |m| m.npa.total_npa() as f64,
+        metric: Metric::Npa,
     },
 ];
 
@@ -743,6 +780,30 @@ impl ThresholdSet {
     /// thresholds is a usage error, not a clean pass.
     pub(crate) fn is_empty(&self) -> bool {
         self.entries.is_empty()
+    }
+
+    /// The metric families this set actually reads, for
+    /// [`MetricsOptions::with_only`](big_code_analysis::MetricsOptions::with_only)
+    /// (#1113).
+    ///
+    /// A `bca check` gating one or two metrics previously paid for the
+    /// whole suite — Halstead above all — and discarded the rest. Every
+    /// consumer downstream of the walk reads [`Violation`] records, never
+    /// a [`CodeMetrics`], so narrowing the computation is invisible to
+    /// the gate, the baseline, and every report format.
+    ///
+    /// Deduplicated (five `halstead.*` thresholds name one family) but
+    /// otherwise in registry order, so the value is deterministic.
+    /// `with_only` resolves each family's dependencies, so an `mi.*`
+    /// threshold still pulls in Loc, Cyclomatic, and Halstead.
+    pub(crate) fn selected_metrics(&self) -> Vec<Metric> {
+        let mut selected: Vec<Metric> = Vec::with_capacity(self.entries.len());
+        for entry in &self.entries {
+            if !selected.contains(&entry.extractor.metric) {
+                selected.push(entry.extractor.metric);
+            }
+        }
+        selected
     }
 
     /// Iterate the resolved `(name, limit)` pairs. Used by

--- a/big-code-analysis-cli/src/thresholds_tests.rs
+++ b/big-code-analysis-cli/src/thresholds_tests.rs
@@ -1166,3 +1166,159 @@ fn mi_lower_is_worse_skips_unit_root() {
         "the file aggregate must not be flagged for a Function-scoped mi.*: {out:?}"
     );
 }
+
+// --- #1113: the metric family each extractor reads ------------------
+
+/// The `metric` field must agree with `threshold_metric_for_name`
+/// wherever that helper commits to an answer, so the two mappings cannot
+/// drift as new extractors land.
+///
+/// `tokens` is the one deliberate divergence and the reason the field
+/// exists at all: the helper answers a *suppression* question and
+/// returns `None` there, but `tokens` is a real threshold whose family
+/// must still be computed. Asserting it explicitly means deleting the
+/// divergence (by "simplifying" `metric` away into a call to the helper)
+/// fails here rather than silently disarming the `tokens` gate.
+#[test]
+fn extractor_metric_family_agrees_with_the_suppression_mapping() {
+    for extractor in EXTRACTORS {
+        match threshold_metric_for_name(extractor.name) {
+            Some(family) => assert_eq!(
+                extractor.metric, family,
+                "extractor `{}` declares {:?} but resolves to {family:?}",
+                extractor.name, extractor.metric,
+            ),
+            None => assert_eq!(
+                extractor.name, "tokens",
+                "extractor `{}` has no suppression mapping; only `tokens` may",
+                extractor.name,
+            ),
+        }
+    }
+    // The divergence itself: the helper declines, the registry does not.
+    let tokens = lookup_extractor("tokens").expect("tokens is a threshold");
+    assert!(threshold_metric_for_name("tokens").is_none());
+    assert_eq!(tokens.metric, Metric::Tokens);
+}
+
+/// `selected_metrics` collapses the several dotted names that share one
+/// family down to a single entry, and keeps registry order.
+#[test]
+fn selected_metrics_dedupes_families_sharing_a_name_prefix() {
+    let raw = BTreeMap::from([
+        ("halstead.volume".to_owned(), 1.0),
+        ("halstead.effort".to_owned(), 1.0),
+        ("loc.sloc".to_owned(), 1.0),
+        ("loc.ploc".to_owned(), 1.0),
+        ("cyclomatic".to_owned(), 1.0),
+    ]);
+    let set = ThresholdSet::build(&raw).expect("builds");
+
+    assert_eq!(
+        set.selected_metrics(),
+        vec![Metric::Cyclomatic, Metric::Halstead, Metric::Loc],
+        "five thresholds span exactly three families, in registry order",
+    );
+}
+
+/// Every extractor's declared `metric` must be *sufficient* to compute
+/// the accessor it reads (#1113).
+///
+/// This is the assertion that actually protects the gate. Narrowing the
+/// check walk means each threshold is evaluated against a `CodeMetrics`
+/// built with `with_only(&[that one family])`; if the declared family is
+/// wrong, or if a derived metric's dependencies are not resolved, the
+/// accessor reads a default-constructed `Stats` and silently returns
+/// zero instead of erroring. So compare the narrow computation against
+/// the full suite at every space in the tree — an exact match at each
+/// one is the only outcome that means "this family was enough".
+///
+/// The equality alone could pass vacuously if a value were zero on both
+/// sides, so each extractor must also read non-zero at *some* space.
+/// That is why the fixture is Java with a populated class: `wmc`, `npm`,
+/// `npa`, and `loc.cloc` are zero inside a method body and only become
+/// observable at the class or file space, while `cognitive`, `abc`, and
+/// the branch-driven families are zero at the file space and only
+/// observable inside the method.
+#[test]
+fn every_extractor_metric_family_suffices_to_compute_its_accessor() {
+    use big_code_analysis::{Ast, LANG, MetricsOptions, Source};
+
+    /// Class with public members, branches, arguments, comments, blank
+    /// lines and several exits, so no extractor reads zero everywhere.
+    const JAVA: &str = r#"
+// A class with public members, branches, args and several exits.
+public class Sample {
+    public int width;
+    public int height;
+
+    public String classify(int n, int m, boolean flag, String tag, int limit) {
+        if (n < 0) {
+            return "neg";
+        } else if (n == 0 && flag) {
+            return "zero";
+        }
+
+        for (int i = 0; i < m; i++) {
+            if (i > limit) {
+                return tag;
+            }
+        }
+        return "other";
+    }
+
+    public int area() {
+        return width * height;
+    }
+}
+"#;
+
+    /// Walk two structurally identical trees in lockstep, applying
+    /// `visit` to each `(full, narrow)` space pair.
+    fn zip_spaces(
+        full: &FuncSpace,
+        narrow: &FuncSpace,
+        visit: &mut impl FnMut(&FuncSpace, &FuncSpace),
+    ) {
+        visit(full, narrow);
+        assert_eq!(
+            full.spaces.len(),
+            narrow.spaces.len(),
+            "metric selection must not change the shape of the space tree",
+        );
+        for (f, n) in full.spaces.iter().zip(&narrow.spaces) {
+            zip_spaces(f, n, visit);
+        }
+    }
+
+    let ast = Ast::parse(Source::new(LANG::Java, JAVA.as_bytes())).expect("fixture parses");
+    let full = ast
+        .metrics(MetricsOptions::default())
+        .expect("full metrics");
+
+    for extractor in EXTRACTORS {
+        let narrow = ast
+            .metrics(MetricsOptions::default().with_only(&[extractor.metric]))
+            .expect("narrowed metrics");
+
+        let mut any_non_zero = false;
+        zip_spaces(&full, &narrow, &mut |f, n| {
+            let expected = (extractor.extract)(&f.metrics);
+            let actual = (extractor.extract)(&n.metrics);
+            assert_eq!(
+                actual.to_bits(),
+                expected.to_bits(),
+                "`{}` computed with only {:?} disagrees with the full suite at space {:?}",
+                extractor.name,
+                extractor.metric,
+                f.name,
+            );
+            any_non_zero |= expected != 0.0;
+        });
+        assert!(
+            any_non_zero,
+            "`{}` is zero at every space in the fixture, so the comparison above proves nothing",
+            extractor.name,
+        );
+    }
+}

--- a/big-code-analysis-cli/src/walk.rs
+++ b/big-code-analysis-cli/src/walk.rs
@@ -193,6 +193,7 @@ pub(crate) fn expand_seed_paths(
     mut paths: Vec<PathBuf>,
     paths_from: Option<PathBuf>,
     no_ignore: bool,
+    threads: usize,
     filters: &WalkFilters<'_>,
 ) -> ResolvedFiles {
     if let Some(src) = paths_from {
@@ -261,7 +262,16 @@ pub(crate) fn expand_seed_paths(
             }
             continue;
         }
-        walk_directory_seed(&seed, no_ignore, filters, &mut out, &mut seen);
+        for path in walk_directory_seed(&seed, no_ignore, threads, filters) {
+            // Overlapping seeds (`--paths src --paths src/lib.rs`, or
+            // two seeds whose trees intersect) must contribute each file
+            // exactly once (#704). The dedupe lives here, with the
+            // caller that owns `seen` across every seed — the walk of a
+            // single seed cannot see the others.
+            if seen.insert(path.clone()) {
+                out.push(path);
+            }
+        }
     }
     // A walk that resolved zero files is almost always a mistake — an
     // over-narrow `--include`, an `--exclude` that swept everything, or
@@ -278,11 +288,14 @@ pub(crate) fn expand_seed_paths(
     }
 }
 
-/// Walk the directory `seed`, pushing every supported file that passes the
-/// include/exclude `filters` into `out` exactly once (deduped through `seen`).
+/// Walk the directory `seed` with `threads` walker threads, returning every
+/// supported file that passes the include/exclude `filters`, sorted.
 /// Factored out of [`expand_seed_paths`] so its per-seed loop reads as
 /// "handle a file seed, else expand a directory seed" rather than inlining the
 /// whole `ignore::WalkBuilder` setup and per-entry handling.
+///
+/// Deduping against the other seeds is the caller's job: `seen` spans every
+/// seed, and one seed's walk cannot see the others.
 ///
 /// A per-entry walk error (an unreadable subdirectory, a broken symlink, a
 /// racing unlink) skips that entry with a warning rather than aborting the
@@ -292,11 +305,10 @@ pub(crate) fn expand_seed_paths(
 fn walk_directory_seed(
     seed: &Path,
     no_ignore: bool,
+    threads: usize,
     filters: &WalkFilters<'_>,
-    out: &mut Vec<PathBuf>,
-    seen: &mut std::collections::HashSet<PathBuf>,
-) {
-    use ignore::WalkBuilder;
+) -> Vec<PathBuf> {
+    use ignore::{WalkBuilder, WalkState};
     let mut wb = WalkBuilder::new(seed);
     wb.hidden(true)
         .follow_links(false)
@@ -305,30 +317,64 @@ fn walk_directory_seed(
         .git_exclude(!no_ignore)
         .git_global(!no_ignore)
         .ignore(!no_ignore)
-        .parents(!no_ignore);
-    for entry in wb.build() {
-        let entry = match entry {
-            Ok(entry) => entry,
-            Err(e) => {
-                eprintln!(
-                    "bca: warning: skipping walk entry in {}: {e}",
-                    seed.display()
-                );
-                continue;
+        .parents(!no_ignore)
+        // `getdents` plus gitignore matching over a large tree used to
+        // run single-threaded on the main thread while every worker sat
+        // idle waiting for the list (#1114).
+        .threads(threads);
+
+    // Visitors hand matches over a channel rather than a shared `Vec`
+    // behind a `Mutex`: crossbeam's unbounded sender takes no lock, so
+    // the per-entry hot path does not serialize the walker threads
+    // against each other.
+    let (tx, rx) = crossbeam::channel::unbounded();
+    wb.build_parallel().run(|| {
+        let tx = tx.clone();
+        Box::new(move |entry| {
+            match entry {
+                Ok(entry) => {
+                    if entry.file_type().is_some_and(|t| t.is_file()) {
+                        let path = entry.into_path();
+                        // Anchor the glob match to the walk root rather than
+                        // the emitted (possibly absolute) path, so
+                        // `./`-anchored excludes match regardless of how the
+                        // seed resolved — including a manifest root above the
+                        // CWD (#489).
+                        if filters.passes(&walk_seed::match_path_for(seed, &path)) {
+                            // The receiver outlives the walk (it is drained
+                            // below), so this cannot fail.
+                            let _ = tx.send(path);
+                        }
+                    }
+                }
+                // A per-entry error skips that entry rather than aborting
+                // the run (#704): a single EACCES directory deep in a large
+                // tree must not take down every file the walk has yet to
+                // reach.
+                Err(e) => {
+                    eprintln!(
+                        "bca: warning: skipping walk entry in {}: {e}",
+                        seed.display()
+                    );
+                }
             }
-        };
-        if entry.file_type().is_some_and(|t| t.is_file()) {
-            let path = entry.into_path();
-            // Anchor the glob match to the walk root rather than the emitted
-            // (possibly absolute) path, so `./`-anchored excludes match
-            // regardless of how the seed resolved — including a manifest root
-            // above the CWD (#489).
-            if filters.passes(&walk_seed::match_path_for(seed, &path)) && seen.insert(path.clone())
-            {
-                out.push(path);
-            }
-        }
-    }
+            WalkState::Continue
+        })
+    });
+    // Drop the builder's own sender so the drain below terminates; every
+    // visitor clone is already gone, `run` having joined its threads.
+    drop(tx);
+
+    // A parallel walk yields entries in whatever order its threads
+    // happen to finish, so without this sort the resolved file list —
+    // and therefore the order `bca metrics` prints per-file documents at
+    // `--jobs 1` — would differ run to run on the same tree. Sorting
+    // also makes that order independent of readdir order, so it no
+    // longer varies by filesystem or machine, which the previous
+    // single-threaded walk never guaranteed.
+    let mut found: Vec<PathBuf> = rx.into_iter().collect();
+    found.sort_unstable();
+    found
 }
 
 /// Resolve the seeds into the terminal, walk-root-anchored file list
@@ -354,6 +400,10 @@ pub(crate) fn resolve_walk_files(globals: GlobalOpts) -> (ResolvedFiles, usize) 
         globals.paths,
         globals.paths_from,
         globals.no_ignore,
+        // Same budget the worker pool gets: the walk and the analysis
+        // never run at the same time, so there is nothing to split it
+        // with (#1114).
+        num_jobs,
         &filters,
     );
     (resolved, num_jobs)
@@ -392,3 +442,7 @@ pub(crate) fn with_cwd(dir: &Path) -> Result<CwdGuard, metric_diff::DiffError> {
     })?;
     Ok(CwdGuard { previous })
 }
+
+#[cfg(test)]
+#[path = "walk_tests.rs"]
+mod tests;

--- a/big-code-analysis-cli/src/walk_tests.rs
+++ b/big-code-analysis-cli/src/walk_tests.rs
@@ -1,0 +1,63 @@
+// Sibling-file unit tests for the walk seam. Wired via
+// `#[path = "walk_tests.rs"] mod tests;`. Matched by the
+// `./**/*_tests.rs` rule in `.bcaignore`.
+
+use super::*;
+
+/// A directory-seed walk must return its files in sorted order (#1114).
+///
+/// `ignore`'s parallel walker hands entries to its visitors in whatever
+/// order the threads finish, so the resolved list is sorted before it
+/// reaches dispatch. Without that, two runs over an unchanged tree would
+/// emit their per-file documents in different orders at `--jobs 1` —
+/// output that used to be reproducible.
+///
+/// Asserted here rather than through the binary on purpose: end to end,
+/// the ordering bug is a race, so a test that shells out passes or fails
+/// by luck. It did — a five-run comparison through `bca metrics` stayed
+/// green with the sort deleted. Checking the returned list is the only
+/// version of this that fails every time.
+///
+/// The fixture names files so that creation order, readdir order, and
+/// sorted order all disagree: `z*` files are created before `a*` ones,
+/// and `-` (0x2d) sorts before `_` (0x5f) while both follow the digits.
+#[test]
+fn walk_directory_seed_returns_sorted_paths() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let root = tmp.path();
+    let mut created = Vec::new();
+    for d in 0..6 {
+        let dir = root.join(format!("pkg{d}")).join("nested");
+        std::fs::create_dir_all(&dir).expect("create dir");
+        for f in 0..8 {
+            for stem in [format!("z{f}_mod"), format!("a{f}-impl")] {
+                let path = dir.join(format!("{stem}.rs"));
+                std::fs::write(&path, b"pub fn f() {}\n").expect("write fixture");
+                created.push(path);
+            }
+        }
+    }
+
+    let empty = mk_globset(Vec::new()).expect("empty globset");
+    let filters = WalkFilters {
+        include: &empty,
+        exclude: &empty,
+    };
+    let found = walk_directory_seed(root, true, 8, &filters);
+
+    assert_eq!(
+        found.len(),
+        created.len(),
+        "the walk must find every fixture file"
+    );
+    let mut want = found.clone();
+    want.sort_unstable();
+    assert_eq!(found, want, "walk_directory_seed must return sorted paths");
+    // The fixture has to be one the sort actually reorders, or the
+    // assertion above holds for any implementation.
+    assert_ne!(
+        created, want,
+        "fixture creation order already matches sorted order; \
+         the sortedness assertion above would pass unsorted"
+    );
+}

--- a/big-code-analysis-cli/tests/check_thresholds.rs
+++ b/big-code-analysis-cli/tests/check_thresholds.rs
@@ -1929,9 +1929,13 @@ fn check_tokens_threshold_fires_under_narrowed_metric_selection() {
 /// MI is derived from Loc, Cyclomatic, and Halstead. If
 /// `MetricsOptions::with_only` failed to pull those dependencies in, MI
 /// would be computed from zeroed inputs and report a different number
-/// rather than failing outright. Comparing the narrow run against one
-/// whose extra thresholds widen the selection to four families pins that
-/// without hardcoding a bit-brittle float.
+/// rather than failing outright.
+///
+/// The comparison run must therefore name thresholds in *those three*
+/// families, so it selects them without relying on the closure under
+/// test. An earlier version widened with `tokens`/`abc`/`nom` instead
+/// and was worthless: deleting Mi's dependency list drove both sides to
+/// `mi.original = 0`, so they still matched and the test passed.
 #[test]
 fn check_mi_value_is_identical_whether_or_not_the_walk_is_narrowed() {
     let dir = TempDir::new().unwrap();
@@ -1966,14 +1970,15 @@ fn check_mi_value_is_identical_whether_or_not_the_walk_is_narrowed() {
 
     // Mi alone -> selection is [Mi] plus whatever `with_only` resolves.
     let narrow = mi_line(&[]);
-    // Mi + Tokens + Abc + Nom -> a four-family selection.
+    // Mi + Loc + Cyclomatic + Halstead -> the same four families,
+    // but selected explicitly rather than through Mi's closure.
     let wide = mi_line(&[
         "--threshold",
-        "tokens=5",
+        "loc.sloc=1",
         "--threshold",
-        "abc=0",
+        "cyclomatic=1",
         "--threshold",
-        "nom=0",
+        "halstead.volume=1",
     ]);
 
     assert_eq!(

--- a/big-code-analysis-cli/tests/check_thresholds.rs
+++ b/big-code-analysis-cli/tests/check_thresholds.rs
@@ -1889,3 +1889,149 @@ fn check_no_fail_does_not_mask_an_unreadable_input() {
         .code(1)
         .stderr(predicate::str::contains("1 input file could not be read"));
 }
+
+// --- #1113: the check walk computes only the thresholded families ----
+
+/// `tokens` is the trap in narrowing the check walk (#1113).
+///
+/// The obvious way to derive the metric selection is the library's
+/// `threshold_metric_for_name`, but that helper answers a *suppression*
+/// question and returns `None` for `tokens` — a marker may never silence
+/// it. `tokens` is nonetheless a real configurable threshold, so
+/// selecting by that mapping omits `Metric::Tokens`, leaves `m.tokens`
+/// at its zero default, and the gate silently never fires: `0 > 5` is
+/// false, so the run exits 0 with no offender at all.
+///
+/// The value is asserted as non-zero rather than pinned to an exact
+/// count, which a grammar bump legitimately moves.
+#[test]
+fn check_tokens_threshold_fires_under_narrowed_metric_selection() {
+    let dir = TempDir::new().unwrap();
+    let path = write_fixture(&dir, "branchy.rs", BRANCHY_RUST);
+
+    cli(dir.path())
+        .args([
+            "check",
+            "--no-config",
+            "--paths",
+            &path,
+            "--threshold",
+            "tokens=5",
+        ])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::is_match(r"classify: tokens = [1-9]\d* \(limit 5\)").unwrap());
+}
+
+/// Narrowing must not change a single reported value (#1113).
+///
+/// `mi.original` is the sharpest case: it selects only `Metric::Mi`, and
+/// MI is derived from Loc, Cyclomatic, and Halstead. If
+/// `MetricsOptions::with_only` failed to pull those dependencies in, MI
+/// would be computed from zeroed inputs and report a different number
+/// rather than failing outright. Comparing the narrow run against one
+/// whose extra thresholds widen the selection to four families pins that
+/// without hardcoding a bit-brittle float.
+#[test]
+fn check_mi_value_is_identical_whether_or_not_the_walk_is_narrowed() {
+    let dir = TempDir::new().unwrap();
+    let path = write_fixture(&dir, "branchy.rs", BRANCHY_RUST);
+
+    let mi_line = |extra: &[&str]| -> String {
+        let mut args = vec![
+            "check",
+            "--no-config",
+            "--paths",
+            &path,
+            "--threshold",
+            // A limit far above any real MI score, so the lower-is-worse
+            // `mi.*` gate always reports the observed value.
+            "mi.original=200",
+        ];
+        args.extend_from_slice(extra);
+        let out = cli(dir.path())
+            .args(args)
+            .assert()
+            .code(2)
+            .get_output()
+            .stderr
+            .clone();
+        let stderr = String::from_utf8(out).expect("utf8 stderr");
+        stderr
+            .lines()
+            .find(|l| l.contains("mi.original ="))
+            .unwrap_or_else(|| panic!("no mi.original offender in:\n{stderr}"))
+            .to_owned()
+    };
+
+    // Mi alone -> selection is [Mi] plus whatever `with_only` resolves.
+    let narrow = mi_line(&[]);
+    // Mi + Tokens + Abc + Nom -> a four-family selection.
+    let wide = mi_line(&[
+        "--threshold",
+        "tokens=5",
+        "--threshold",
+        "abc=0",
+        "--threshold",
+        "nom=0",
+    ]);
+
+    assert_eq!(
+        narrow, wide,
+        "narrowing the walk to the thresholded families changed the reported MI value"
+    );
+}
+
+/// A multi-metric `[thresholds]` table must gate on every metric it
+/// names, not just the first — the union of families, deduplicated
+/// (#1113).
+#[test]
+fn check_multi_metric_config_gates_on_every_named_metric() {
+    let dir = TempDir::new().unwrap();
+    let path = write_fixture(&dir, "branchy.rs", BRANCHY_RUST);
+    let config_path = dir.path().join("thresholds.toml");
+    // Five names spanning four families: the two `halstead.*` keys
+    // collapse to one `Metric::Halstead` in the selection. The dotted
+    // names are quoted — bare `halstead.volume` is a TOML *table*, which
+    // the threshold loader rejects.
+    fs::write(
+        &config_path,
+        "[thresholds]\n\
+         cyclomatic = 1\n\
+         abc = 0\n\
+         tokens = 5\n\
+         \"halstead.volume\" = 1\n\
+         \"halstead.difficulty\" = 1\n",
+    )
+    .expect("write config");
+    let config_str = config_path.to_str().expect("utf8 config path");
+
+    let out = cli(dir.path())
+        .args([
+            "check",
+            "--no-config",
+            "--paths",
+            &path,
+            "--config",
+            config_str,
+        ])
+        .assert()
+        .code(2)
+        .get_output()
+        .stderr
+        .clone();
+    let stderr = String::from_utf8(out).expect("utf8 stderr");
+
+    for metric in [
+        "cyclomatic",
+        "abc",
+        "tokens",
+        "halstead.volume",
+        "halstead.difficulty",
+    ] {
+        assert!(
+            stderr.contains(&format!("classify: {metric} = ")),
+            "no {metric} offender in:\n{stderr}"
+        );
+    }
+}

--- a/big-code-analysis-cli/tests/paths_discovery.rs
+++ b/big-code-analysis-cli/tests/paths_discovery.rs
@@ -659,3 +659,82 @@ fn unreadable_subdir_warns_but_continues() {
         "ok.py must still be analyzed after the unreadable subdir is skipped",
     );
 }
+
+// --- #1114: the directory walk runs in parallel -----------------------
+
+/// Build a wide, nested tree: enough directories that the parallel
+/// walker actually splits the work, and file names whose readdir order
+/// is unlikely to match sorted order.
+fn wide_tree(root: &Path) -> Vec<String> {
+    let mut expected = Vec::new();
+    for d in 0..12 {
+        let dir = root.join(format!("pkg{d}")).join("deep").join("nested");
+        std::fs::create_dir_all(&dir).expect("create nested dir");
+        for f in 0..15 {
+            // Interleave two naming shapes so lexical order and creation
+            // order differ.
+            for stem in [format!("z{f}_mod"), format!("a{f}-impl")] {
+                let path = dir.join(format!("{stem}.rs"));
+                std::fs::write(&path, format!("pub fn f{f}() -> u32 {{ {f} }}\n"))
+                    .expect("write fixture");
+                expected.push(format!("{stem}.rs"));
+            }
+        }
+    }
+    expected.sort();
+    expected
+}
+
+/// The parallel walk (#1114) must find exactly the same files the
+/// single-threaded one did — no entry lost to a race, none duplicated
+/// across walker threads.
+#[test]
+fn parallel_walk_finds_every_file_at_every_job_count() {
+    let home = TempDir::new().unwrap();
+    let tree = TempDir::new().unwrap();
+    let expected = wide_tree(tree.path());
+    let root = tree.path().to_str().expect("utf8 tree path");
+
+    for jobs in ["1", "2", "8", "16"] {
+        let out = cli(home.path())
+            .args([
+                "metrics",
+                "--no-config",
+                "--paths",
+                root,
+                "--format",
+                "json",
+            ])
+            .args(["--jobs", jobs])
+            .output()
+            .expect("bca runs");
+        let stdout = String::from_utf8(out.stdout).expect("utf8 stdout");
+        // One JSON document per file; take each `name` and keep the
+        // path in full, so a file walked twice shows up as a duplicate
+        // rather than collapsing into its same-named sibling.
+        let mut found: Vec<String> = stdout
+            .lines()
+            .filter_map(|l| l.split_once("\"name\":\""))
+            .filter_map(|(_, rest)| rest.split_once('"'))
+            .map(|(name, _)| name.to_owned())
+            .collect();
+        let total = found.len();
+        found.sort();
+        found.dedup();
+        assert_eq!(
+            found.len(),
+            total,
+            "--jobs {jobs} walked at least one file twice"
+        );
+        let mut basenames: Vec<String> = found
+            .iter()
+            .filter_map(|p| p.rsplit('/').next())
+            .map(str::to_owned)
+            .collect();
+        basenames.sort();
+        assert_eq!(
+            basenames, expected,
+            "--jobs {jobs} walked a different file set than expected"
+        );
+    }
+}

--- a/big-code-analysis-cli/tests/paths_discovery.rs
+++ b/big-code-analysis-cli/tests/paths_discovery.rs
@@ -726,10 +726,13 @@ fn parallel_walk_finds_every_file_at_every_job_count() {
             total,
             "--jobs {jobs} walked at least one file twice"
         );
+        // `Path::file_name` rather than splitting on '/': the emitted
+        // name carries the platform separator, so on Windows a manual
+        // '/' split returns the whole `C:\…\a0-impl.rs` path and every
+        // basename mismatches.
         let mut basenames: Vec<String> = found
             .iter()
-            .filter_map(|p| p.rsplit('/').next())
-            .map(str::to_owned)
+            .filter_map(|p| Path::new(p).file_name()?.to_str().map(str::to_owned))
             .collect();
         basenames.sort();
         assert_eq!(

--- a/big-code-analysis-cli/tests/walk_channel_completeness.rs
+++ b/big-code-analysis-cli/tests/walk_channel_completeness.rs
@@ -184,9 +184,15 @@ fn report_body_is_identical_serially_and_in_parallel() {
     let (serial, _) = run_at_jobs(&dir, "1", &args);
     let (parallel, _) = run_at_jobs(&dir, "16", &args);
 
+    // An absolute count, not just non-emptiness. Serial-vs-parallel
+    // equality alone cannot see a *deterministic* drop — it removes the
+    // same record from both sides — so the summary header, which is
+    // derived from every streamed `FunctionSummary`, is what pins that
+    // all 120 arrived.
     assert!(
-        serial.contains("classify_0"),
-        "fixture drifted; report names no fixture function:\n{serial}"
+        serial.contains("| Functions/methods | 120 |")
+            || serial.contains("| Functions/methods |   120 |"),
+        "report should summarise 120 functions, one per fixture file:\n{serial}"
     );
     assert_eq!(
         sorted_lines(&serial),
@@ -219,9 +225,11 @@ fn exemptions_audit_is_identical_serially_and_in_parallel() {
     let (serial, _) = run_at_jobs(&dir, "1", &args);
     let (parallel, _) = run_at_jobs(&dir, "16", &args);
 
+    // The header count is the absolute guard, for the same reason as the
+    // report test above: 40 of the 120 fixture files carry a marker.
     assert!(
-        serial.contains("f0.rs"),
-        "fixture drifted; audit lists no marked file:\n{serial}"
+        serial.contains("# In-source markers (40)"),
+        "audit should list all 40 marked files:\n{serial}"
     );
     assert_eq!(
         sorted_lines(&serial),

--- a/big-code-analysis-cli/tests/walk_channel_completeness.rs
+++ b/big-code-analysis-cli/tests/walk_channel_completeness.rs
@@ -1,9 +1,10 @@
 //! Every walk result channel must deliver every record, whatever the
 //! job count (#1119).
 //!
-//! The walk streams its per-file results back over four channels hung
-//! off `Config` — `check_tx`, `markdown_tx`, `exemptions_tx`, and the
-//! `aggregate_tx` shared by `metrics` / `ops`. #1119 replaced
+//! The walk streams its per-file results back over five channels hung
+//! off `Config` — `check_tx`, `markdown_tx`, `report_hotspot_tx`,
+//! `exemptions_tx`, and the `aggregate_tx` shared by `metrics` / `ops`.
+//! #1119 replaced
 //! `Mutex<std::sync::mpsc::Sender<_>>` with a bare
 //! `crossbeam::channel::Sender<_>`, which is `Sync` and so needs no
 //! per-file lock. That rewires the send path of all four.
@@ -16,6 +17,7 @@
 //! none of them are visible in a single-threaded run, which is what the
 //! rest of the suite exercises.
 
+use std::fmt::Write as _;
 use std::fs;
 use std::path::Path;
 
@@ -225,5 +227,113 @@ fn exemptions_audit_is_identical_serially_and_in_parallel() {
         sorted_lines(&serial),
         sorted_lines(&parallel),
         "exemptions audit differs between --jobs 1 and --jobs 16"
+    );
+}
+
+/// `report_hotspot_tx`: the fifth channel #1119 rewired, and the only
+/// one whose call site changed shape rather than merely losing a lock
+/// (`hotspot_sender.send((path.clone(), …))` became
+/// `hotspot_tx.send((path, …))`).
+///
+/// It carries each file's `(absolute path, cyclomatic sum)` so
+/// `report --vcs` can join a hotspot score onto the change-history
+/// section. A lost record does not fail anything — it silently blanks a
+/// Hotspot cell — so serial-vs-parallel equality is the only thing that
+/// would catch it.
+///
+/// Needs a real git repo, hence the local fixture rather than the shared
+/// `corpus` above.
+#[test]
+fn report_vcs_hotspots_are_identical_serially_and_in_parallel() {
+    /// Seconds per day, for dating fixture commits.
+    const DAY: i64 = 86_400;
+
+    let now = i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_secs(),
+    )
+    .expect("now fits i64");
+
+    let git = |dir: &Path, secs: i64, args: &[&str]| {
+        let date = format!("@{secs} +0000");
+        let status = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .env("GIT_AUTHOR_NAME", "Ada")
+            .env("GIT_AUTHOR_EMAIL", "ada@example.com")
+            .env("GIT_AUTHOR_DATE", &date)
+            .env("GIT_COMMITTER_NAME", "Ada")
+            .env("GIT_COMMITTER_EMAIL", "ada@example.com")
+            .env("GIT_COMMITTER_DATE", &date)
+            .status()
+            .expect("spawn git");
+        assert!(status.success(), "git {args:?} failed");
+    };
+
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    git(root, now, &["init", "-q", "-b", "main"]);
+    git(root, now, &["config", "commit.gpgsign", "false"]);
+    // Enough distinct files that the pool interleaves, each branchy so
+    // its cyclomatic sum — the value on the channel — is non-zero and
+    // differs per file.
+    std::fs::create_dir(root.join("src")).expect("mkdir");
+    for i in 0..40 {
+        let mut body = format!("pub fn f{i}(n: i32) -> i32 {{\n");
+        for b in 0..=i % 5 {
+            let _ = writeln!(body, "    if n == {b} {{ return {b}; }}");
+        }
+        body.push_str("    0\n}\n");
+        std::fs::write(root.join(format!("src/f{i}.rs")), body).expect("write fixture");
+    }
+    git(root, now - 30 * DAY, &["add", "."]);
+    git(root, now - 30 * DAY, &["commit", "-q", "-m", "add sources"]);
+
+    let run = |jobs: &str| -> String {
+        let out = cli(root)
+            .args(["report", "--no-config", "--vcs", "--paths", "src"])
+            .args(["--jobs", jobs])
+            .current_dir(root)
+            .output()
+            .expect("bca runs");
+        String::from_utf8(out.stdout).expect("utf8 stdout")
+    };
+
+    let serial = run("1");
+    let parallel = run("16");
+
+    // Guard against comparing two failures. A lost record blanks that
+    // file's Hotspot cell rather than erroring, so the assertion has to
+    // be that every change-history row *has* one: count the rows whose
+    // last column holds a number. Comparing two reports where the join
+    // silently produced nothing would otherwise pass.
+    // Scoped to the change-history section: the per-metric hotspot
+    // tables above it also hold `.rs` rows ending in a number, and those
+    // come from `markdown_tx`, not the channel under test. The table is
+    // capped at 20 rows even though the fixture has 40 files.
+    let scored = |text: &str| -> usize {
+        text.lines()
+            .skip_while(|l| !l.starts_with("## Change-history risk"))
+            .skip(1)
+            .take_while(|l| !l.starts_with("## ") && !l.starts_with("### "))
+            .filter(|l| l.starts_with('|') && l.contains(".rs"))
+            .filter(|l| {
+                l.rsplit('|')
+                    .nth(1)
+                    .is_some_and(|cell| cell.trim().parse::<f64>().is_ok())
+            })
+            .count()
+    };
+    assert_eq!(
+        scored(&serial),
+        20,
+        "every change-history row should carry a joined hotspot score:\n{serial}"
+    );
+    assert_eq!(
+        sorted_lines(&serial),
+        sorted_lines(&parallel),
+        "report --vcs hotspots differ between --jobs 1 and --jobs 16"
     );
 }

--- a/big-code-analysis-cli/tests/walk_channel_completeness.rs
+++ b/big-code-analysis-cli/tests/walk_channel_completeness.rs
@@ -1,0 +1,229 @@
+//! Every walk result channel must deliver every record, whatever the
+//! job count (#1119).
+//!
+//! The walk streams its per-file results back over four channels hung
+//! off `Config` — `check_tx`, `markdown_tx`, `exemptions_tx`, and the
+//! `aggregate_tx` shared by `metrics` / `ops`. #1119 replaced
+//! `Mutex<std::sync::mpsc::Sender<_>>` with a bare
+//! `crossbeam::channel::Sender<_>`, which is `Sync` and so needs no
+//! per-file lock. That rewires the send path of all four.
+//!
+//! Each test below runs the same corpus serially and at high
+//! concurrency and demands byte-identical output. A lost send under
+//! contention, a sender clone that outlives the walk (the receiver
+//! would never see disconnect and the run would hang), or an ordering
+//! dependency that only appears with many workers all fail here — and
+//! none of them are visible in a single-threaded run, which is what the
+//! rest of the suite exercises.
+
+use std::fs;
+use std::path::Path;
+
+use assert_cmd::Command;
+use tempfile::TempDir;
+
+mod common;
+
+fn cli(dir: &Path) -> Command {
+    common::cli_in(dir)
+}
+
+/// Enough distinct files that the pool genuinely interleaves, each with
+/// a branchy function so `check` has something to report. Bodies differ
+/// per index so no two files collapse to the same output.
+fn corpus(dir: &TempDir) -> String {
+    let root = dir.path().join("src");
+    fs::create_dir_all(&root).expect("create corpus dir");
+    for i in 0..120 {
+        let body = format!(
+            "pub fn classify_{i}(n: i32) -> &'static str {{\n\
+             \x20   if n < {i} {{\n\
+             \x20       \"low\"\n\
+             \x20   }} else if n == {i} {{\n\
+             \x20       \"exact\"\n\
+             \x20   }} else if n < {} {{\n\
+             \x20       \"mid\"\n\
+             \x20   }} else {{\n\
+             \x20       \"high\"\n\
+             \x20   }}\n\
+             }}\n",
+            i + 100,
+        );
+        fs::write(root.join(format!("f{i}.rs")), body).expect("write fixture");
+    }
+    root.to_str().expect("utf8 corpus path").to_owned()
+}
+
+/// Run `bca` with `args` plus an explicit `--jobs`, returning
+/// `(stdout, stderr)` as text.
+fn run_at_jobs(dir: &TempDir, jobs: &str, args: &[&str]) -> (String, String) {
+    let mut cmd = cli(dir.path());
+    cmd.args(args).args(["--jobs", jobs]);
+    let out = cmd.output().expect("bca runs");
+    (
+        String::from_utf8(out.stdout).expect("utf8 stdout"),
+        String::from_utf8(out.stderr).expect("utf8 stderr"),
+    )
+}
+
+/// Sorted lines, so a comparison isolates *content* loss from the
+/// arrival-order nondeterminism a parallel walk is entitled to.
+fn sorted_lines(text: &str) -> Vec<&str> {
+    let mut lines: Vec<&str> = text.lines().collect();
+    lines.sort_unstable();
+    lines
+}
+
+/// `check_tx`: one `Violation` per offending function, many per file.
+#[test]
+fn check_reports_the_same_violations_serially_and_in_parallel() {
+    let dir = TempDir::new().unwrap();
+    let root = corpus(&dir);
+    let args = [
+        "check",
+        "--no-config",
+        "--paths",
+        &root,
+        "--threshold",
+        "cyclomatic=1",
+        "--no-fail",
+        "--no-summary",
+    ];
+
+    let (_, serial) = run_at_jobs(&dir, "1", &args);
+    let (_, parallel) = run_at_jobs(&dir, "16", &args);
+
+    // 120 files, one offending function each: a dropped send shows up
+    // as a short count before the line comparison even runs. Count only
+    // offender lines — stderr also carries the trailing remediation
+    // block, which `--no-summary` does not suppress.
+    let offenders = |text: &str| {
+        text.lines()
+            .filter(|l| l.contains(": cyclomatic = "))
+            .count()
+    };
+    assert_eq!(
+        offenders(&serial),
+        120,
+        "fixture drifted; expected one offender per file:\n{serial}"
+    );
+    assert_eq!(
+        sorted_lines(&serial),
+        sorted_lines(&parallel),
+        "check violations differ between --jobs 1 and --jobs 16"
+    );
+}
+
+/// `aggregate_tx`: `metrics --output <FILE>` streams every file's space
+/// to a post-walk collector that writes one document.
+#[test]
+fn metrics_aggregate_output_is_identical_serially_and_in_parallel() {
+    let dir = TempDir::new().unwrap();
+    let root = corpus(&dir);
+
+    let collect = |jobs: &str, name: &str| -> String {
+        let out = dir.path().join(name);
+        let out_str = out.to_str().expect("utf8 output path").to_owned();
+        run_at_jobs(
+            &dir,
+            jobs,
+            &[
+                "metrics",
+                "--no-config",
+                "--paths",
+                &root,
+                "--output",
+                &out_str,
+                "--format",
+                "json",
+            ],
+        );
+        fs::read_to_string(&out).expect("aggregate document written")
+    };
+
+    let serial = collect("1", "serial.json");
+    let parallel = collect("16", "parallel.json");
+
+    // The aggregate is one JSON document; compare it structurally so a
+    // legitimate difference in file arrival order is not mistaken for a
+    // lost record.
+    let as_set = |text: &str| -> Vec<String> {
+        let v: serde_json::Value = serde_json::from_str(text).expect("valid JSON aggregate");
+        let mut items: Vec<String> = v
+            .as_array()
+            .expect("aggregate is a JSON array")
+            .iter()
+            .map(std::string::ToString::to_string)
+            .collect();
+        items.sort();
+        items
+    };
+    let serial_items = as_set(&serial);
+    assert_eq!(
+        serial_items.len(),
+        120,
+        "expected one aggregate record per file"
+    );
+    assert_eq!(
+        serial_items,
+        as_set(&parallel),
+        "metrics aggregate differs between --jobs 1 and --jobs 16"
+    );
+}
+
+/// `markdown_tx`: one `FunctionSummary` per function, streamed and then
+/// rendered into the report body after the walk.
+#[test]
+fn report_body_is_identical_serially_and_in_parallel() {
+    let dir = TempDir::new().unwrap();
+    let root = corpus(&dir);
+    let args = ["report", "--no-config", "--paths", &root];
+
+    let (serial, _) = run_at_jobs(&dir, "1", &args);
+    let (parallel, _) = run_at_jobs(&dir, "16", &args);
+
+    assert!(
+        serial.contains("classify_0"),
+        "fixture drifted; report names no fixture function:\n{serial}"
+    );
+    assert_eq!(
+        sorted_lines(&serial),
+        sorted_lines(&parallel),
+        "report body differs between --jobs 1 and --jobs 16"
+    );
+}
+
+/// `exemptions_tx`: one batch per file that carries a marker, skipped
+/// entirely for files that carry none — so the fixture seeds markers in
+/// a subset, exercising both arms under contention.
+#[test]
+fn exemptions_audit_is_identical_serially_and_in_parallel() {
+    let dir = TempDir::new().unwrap();
+    let root = corpus(&dir);
+    // Every third file gets a marker; the rest take the early return
+    // that never touches the channel.
+    for i in (0..120).step_by(3) {
+        let path = Path::new(&root).join(format!("f{i}.rs"));
+        let body = fs::read_to_string(&path).expect("read fixture");
+        let marked = body.replace(
+            " -> &'static str {",
+            " -> &'static str {\n    // bca: suppress(cyclomatic)",
+        );
+        assert_ne!(body, marked, "marker insertion found no anchor");
+        fs::write(&path, marked).expect("write marked fixture");
+    }
+    let args = ["exemptions", "--no-config", "--paths", &root];
+
+    let (serial, _) = run_at_jobs(&dir, "1", &args);
+    let (parallel, _) = run_at_jobs(&dir, "16", &args);
+
+    assert!(
+        serial.contains("f0.rs"),
+        "fixture drifted; audit lists no marked file:\n{serial}"
+    );
+    assert_eq!(
+        sorted_lines(&serial),
+        sorted_lines(&parallel),
+        "exemptions audit differs between --jobs 1 and --jobs 16"
+    );
+}

--- a/src/concurrent_files.rs
+++ b/src/concurrent_files.rs
@@ -426,13 +426,13 @@ impl<Config: 'static + Send + Sync> ConcurrentRunner<Config> {
         // here still has to fall through to the join below, or the
         // consumers block forever on a channel that never gets its
         // poison pills.
-        let dispatch = explore(files_data, &cfg, &sender, self.verify_paths);
+        let mut result = explore(files_data, &cfg, &sender, self.verify_paths);
 
         // Poison the receiver, now that dispatch is finished. Sent even
         // when dispatch failed: the consumers must be told to stop
         // before the joins below, and the dispatch error is returned
-        // afterwards.
-        let mut result = dispatch;
+        // afterwards. Each step keeps the *first* error rather than the
+        // last, so the failure a caller sees is the one that started it.
         for _ in 0..self.num_jobs {
             if let Err(e) = sender.send(None)
                 && result.is_ok()

--- a/src/concurrent_files.rs
+++ b/src/concurrent_files.rs
@@ -216,9 +216,13 @@ fn explore<Config: 'static + Send + Sync>(
     files_data: FilesData,
     cfg: &Arc<Config>,
     sender: &JobSender<Config>,
+    verify_paths: bool,
 ) -> Result<(), ConcurrentErrors> {
     for path in files_data.paths {
-        if !path.is_file() {
+        // One `stat` per path, skipped when the caller has already
+        // classified every entry (#1114) — see
+        // [`ConcurrentRunner::without_path_verification`].
+        if verify_paths && !path.is_file() {
             eprintln!("Warning: not a regular file, skipping: {}", path.display());
             continue;
         }
@@ -246,6 +250,13 @@ pub enum ConcurrentErrors {
     /// The producer thread panicked and joining it failed. The panic
     /// payload is not a [`std::error::Error`], so this variant carries
     /// only a message and has no [`source`](std::error::Error::source).
+    ///
+    /// No longer produced since #1114 moved dispatch onto the calling
+    /// thread: there is no producer thread left to join, so a panic
+    /// there now unwinds the caller directly. Retained because
+    /// [`ConcurrentErrors`] is a published type and removing a variant
+    /// would break a downstream `match`; it is scheduled for removal in
+    /// the next major.
     Producer(String),
     /// Sender side error.
     ///
@@ -312,27 +323,55 @@ pub struct FilesData {
 pub struct ConcurrentRunner<Config> {
     proc_files: Box<ProcFilesFunction<Config>>,
     num_jobs: usize,
+    /// Whether dispatch re-`stat`s each path to confirm it is a regular
+    /// file. On by default; see
+    /// [`without_path_verification`](ConcurrentRunner::without_path_verification).
+    verify_paths: bool,
 }
 
 impl<Config: 'static + Send + Sync> ConcurrentRunner<Config> {
     /// Creates a new `ConcurrentRunner`.
     ///
-    /// * `num_jobs` - Total worker budget (one producer thread plus the
-    ///   consumer threads). [`run`](Self::run) always spawns a single
-    ///   producer thread, so the number of consumer threads it spawns is
-    ///   `max(2, num_jobs) - 1`. This means `0`, `1`, and `2` all collapse
-    ///   to a single consumer (no panic, no linear scaling below 2);
-    ///   values of `3` or more yield `num_jobs - 1` consumers.
+    /// * `num_jobs` - Number of consumer threads, floored at 1 so `0`
+    ///   does not mean "no workers".
+    ///
+    ///   Before #1114 this was a budget shared with a dedicated producer
+    ///   thread, and [`run`](Self::run) spawned `max(2, num_jobs) - 1`
+    ///   consumers — one slot permanently reserved for a thread that
+    ///   finished almost immediately, costing ~1/N of throughput at
+    ///   `--jobs auto`. Dispatch now happens on the calling thread, so
+    ///   the whole count goes to consumers and `num_jobs` means what it
+    ///   says.
     /// * `proc_files` - Function that processes each file in the list.
     pub fn new<ProcFiles>(num_jobs: usize, proc_files: ProcFiles) -> Self
     where
         ProcFiles: 'static + Fn(PathBuf, &Config) -> std::io::Result<()> + Send + Sync,
     {
-        let num_jobs = std::cmp::max(2, num_jobs) - 1;
         Self {
             proc_files: Box::new(proc_files),
-            num_jobs,
+            num_jobs: std::cmp::max(1, num_jobs),
+            verify_paths: true,
         }
+    }
+
+    /// Skip the per-path `is_file()` check during dispatch.
+    ///
+    /// [`FilesData::paths`] is documented as a *terminal* file list, and
+    /// the default check is a safety net for a library caller who hands
+    /// in something else. A caller whose own traversal already
+    /// classified every entry — the `bca` CLI walk, which reads the kind
+    /// straight off the `dirent` — is paying one redundant `stat` per
+    /// file for a question it has already answered (#1114).
+    ///
+    /// Opting out does not make a bad path unsafe: a path that is not a
+    /// readable regular file still fails at the read in the worker, and
+    /// that failure is reported through the same per-file error channel
+    /// as any other unreadable input. It only moves *where* the run
+    /// notices.
+    #[must_use]
+    pub fn without_path_verification(mut self) -> Self {
+        self.verify_paths = false;
+        self
     }
 
     /// Runs the producer-consumer pool over the terminal file list in
@@ -346,11 +385,9 @@ impl<Config: 'static + Send + Sync> ConcurrentRunner<Config> {
     ///
     /// # Errors
     ///
-    /// Returns [`ConcurrentErrors::Thread`] when any worker thread
-    /// (the single producer OR one of the `num_jobs` consumers)
-    /// cannot be spawned via [`std::thread::Builder::spawn`];
-    /// [`ConcurrentErrors::Producer`] when the producer thread
-    /// panics and join fails;
+    /// Returns [`ConcurrentErrors::Thread`] when one of the `num_jobs`
+    /// consumer threads cannot be spawned via
+    /// [`std::thread::Builder::spawn`];
     /// [`ConcurrentErrors::Sender`] when a worker cannot place an
     /// item (or the post-dispatch `None` poison-pill) on the channel;
     /// [`ConcurrentErrors::Receiver`] when a consumer thread panics
@@ -361,18 +398,6 @@ impl<Config: 'static + Send + Sync> ConcurrentRunner<Config> {
         let cfg = Arc::new(config);
 
         let (sender, receiver) = unbounded();
-
-        let producer = {
-            let sender = sender.clone();
-
-            match thread::Builder::new()
-                .name(String::from("Producer"))
-                .spawn(move || explore(files_data, &cfg, &sender))
-            {
-                Ok(producer) => producer,
-                Err(e) => return Err(ConcurrentErrors::Thread(Box::new(e))),
-            }
-        };
 
         let mut receivers = Vec::with_capacity(self.num_jobs);
         let proc_files = Arc::new(self.proc_files);
@@ -392,29 +417,39 @@ impl<Config: 'static + Send + Sync> ConcurrentRunner<Config> {
             receivers.push(t);
         }
 
-        let Ok(walk_result) = producer.join() else {
-            return Err(ConcurrentErrors::Producer(
-                "Child thread panicked".to_owned(),
-            ));
-        };
-        walk_result?;
+        // Dispatch on the calling thread rather than a dedicated
+        // producer thread (#1114). The consumers are already running, so
+        // they start draining the channel as the first paths land — the
+        // overlap a producer thread bought — but the caller's own thread
+        // does the pushing instead of occupying one of the `num_jobs`
+        // slots for work that finishes almost immediately. A failure
+        // here still has to fall through to the join below, or the
+        // consumers block forever on a channel that never gets its
+        // poison pills.
+        let dispatch = explore(files_data, &cfg, &sender, self.verify_paths);
 
-        // Poison the receiver, now that the producer is finished.
+        // Poison the receiver, now that dispatch is finished. Sent even
+        // when dispatch failed: the consumers must be told to stop
+        // before the joins below, and the dispatch error is returned
+        // afterwards.
+        let mut result = dispatch;
         for _ in 0..self.num_jobs {
-            if let Err(e) = sender.send(None) {
-                return Err(ConcurrentErrors::Sender(Box::new(e)));
+            if let Err(e) = sender.send(None)
+                && result.is_ok()
+            {
+                result = Err(ConcurrentErrors::Sender(Box::new(e)));
             }
         }
 
         for receiver in receivers {
-            if receiver.join().is_err() {
-                return Err(ConcurrentErrors::Receiver(
+            if receiver.join().is_err() && result.is_ok() {
+                result = Err(ConcurrentErrors::Receiver(
                     "A thread used to process a file panicked".to_owned(),
                 ));
             }
         }
 
-        Ok(())
+        result
     }
 }
 

--- a/src/concurrent_files.rs
+++ b/src/concurrent_files.rs
@@ -197,21 +197,22 @@ fn send_file<T: 'static + Send + Sync>(
         .map_err(|e| ConcurrentErrors::Sender(Box::new(e)))
 }
 
-/// Producer body: dispatch each resolved file in `files_data.paths`
-/// to the consumer pool.
+/// Dispatch each resolved file in `files_data.paths` to the consumer
+/// pool. Runs on the calling thread since #1114; before that it was the
+/// body of a dedicated producer thread.
 ///
 /// `paths` is a **terminal file list** — already resolved, anchored,
 /// and filtered by the caller (the `big-code-analysis-cli` walk seam
 /// resolves it via its gitignore-aware `expand_seed_paths`). This
 /// function therefore performs no directory traversal and no glob
-/// filtering of its own: it skips entries that are missing or are not
-/// regular files (warning to stderr) and sends the rest. For the
-/// `big-code-analysis-cli` caller this skip is a safety net only —
-/// `expand_seed_paths` already yields existing regular files — but it
-/// keeps this public entry point robust for a direct library caller
-/// that hands in an arbitrary path. Re-walking or re-filtering here
-/// would re-introduce the emitted-path-form dependence that #488/#489
-/// removed (see #495).
+/// filtering of its own. When `verify_paths` is set (the default) it
+/// additionally skips entries that are missing or are not regular files,
+/// warning to stderr; that skip is a safety net for a direct library
+/// caller handing in an arbitrary path, and a caller whose own traversal
+/// already classified every entry turns it off via
+/// [`ConcurrentRunner::without_path_verification`]. Re-walking or
+/// re-filtering here would re-introduce the emitted-path-form dependence
+/// that #488/#489 removed (see #495).
 fn explore<Config: 'static + Send + Sync>(
     files_data: FilesData,
     cfg: &Arc<Config>,

--- a/src/concurrent_files_tests.rs
+++ b/src/concurrent_files_tests.rs
@@ -5,6 +5,7 @@
 
 use super::*;
 use std::error::Error;
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tempfile::Builder;
 
@@ -372,4 +373,148 @@ fn num_jobs_resolve_is_at_least_one() {
 #[test]
 fn num_jobs_default_is_auto() {
     assert_eq!(NumJobs::default(), NumJobs::Auto);
+}
+
+// ── #1114: dispatch on the calling thread, opt-out path verification ──
+
+/// The default still `stat`s each path, so the sibling
+/// `without_path_verification` test below is measuring a real switch
+/// rather than a no-op. Same shape as
+/// `run_skips_directories_and_missing_paths_without_walking`, kept
+/// adjacent to its opt-out twin so the pair reads as one contrast.
+#[test]
+fn run_verifies_paths_by_default() {
+    let tmp = Builder::new()
+        .prefix("verify-on")
+        .tempdir()
+        .expect("tempdir");
+    let root = tmp.path();
+    let file = root.join("keep.rs");
+    std::fs::write(&file, b"// keep").expect("write keep");
+    let subdir = root.join("sub");
+    std::fs::create_dir(&subdir).expect("mkdir sub");
+
+    let processed = Arc::new(AtomicUsize::new(0));
+    let seen = Arc::clone(&processed);
+    ConcurrentRunner::new(4, move |_path: PathBuf, _cfg: &()| {
+        seen.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    })
+    .run(
+        (),
+        FilesData {
+            paths: vec![file, subdir, root.join("gone.rs")],
+        },
+    )
+    .expect("run should succeed");
+
+    assert_eq!(
+        processed.load(Ordering::SeqCst),
+        1,
+        "the directory and the missing path must be filtered by the default stat"
+    );
+}
+
+/// `without_path_verification` skips the `is_file()` check, so every
+/// path reaches the callback and the caller's own error handling
+/// decides what to do with a bad one (#1114).
+///
+/// The `bca` CLI opts out because its walk already read each entry's
+/// kind off the `dirent`; the redundant `stat` was one extra syscall
+/// per file on every run.
+#[test]
+fn without_path_verification_dispatches_every_path() {
+    let tmp = Builder::new()
+        .prefix("verify-off")
+        .tempdir()
+        .expect("tempdir");
+    let root = tmp.path();
+    let file = root.join("keep.rs");
+    std::fs::write(&file, b"// keep").expect("write keep");
+    let subdir = root.join("sub");
+    std::fs::create_dir(&subdir).expect("mkdir sub");
+    let missing = root.join("gone.rs");
+
+    let dispatched = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&dispatched);
+    ConcurrentRunner::new(4, move |path: PathBuf, _cfg: &()| {
+        sink.lock().expect("uncontended in test").push(path);
+        Ok(())
+    })
+    .without_path_verification()
+    .run(
+        (),
+        FilesData {
+            paths: vec![file.clone(), subdir.clone(), missing.clone()],
+        },
+    )
+    .expect("run should succeed");
+
+    let mut got = dispatched.lock().expect("uncontended in test").clone();
+    got.sort();
+    let mut want = vec![file, subdir, missing];
+    want.sort();
+    assert_eq!(
+        got, want,
+        "opting out must hand every path to the callback, unfiltered"
+    );
+}
+
+/// `num_jobs` is now the consumer count, not a budget shared with a
+/// producer thread (#1114).
+///
+/// Before the change `run` spawned `max(2, num_jobs) - 1` consumers and
+/// reserved the remaining slot for a producer thread that finished
+/// almost immediately — at `--jobs auto` that idled ~1/N of the pool.
+/// Counting the distinct threads that actually ran the callback is the
+/// only way to observe the difference from outside: dispatch itself now
+/// happens on this thread.
+///
+/// Asserted as an upper bound plus "more than one", because the pool is
+/// work-stealing: with few files a fast consumer can drain the channel
+/// before its peers wake, so the exact count is not deterministic. The
+/// old `num_jobs - 1` behaviour is still excluded — at `num_jobs = 2` it
+/// permitted exactly one thread, and this fixture reaches two.
+#[test]
+fn num_jobs_is_the_consumer_count_not_a_budget_shared_with_a_producer() {
+    let tmp = Builder::new().prefix("jobs").tempdir().expect("tempdir");
+    let root = tmp.path();
+    let mut paths = Vec::new();
+    for i in 0..200 {
+        let p = root.join(format!("f{i}.rs"));
+        std::fs::write(&p, b"// x").expect("write fixture");
+        paths.push(p);
+    }
+
+    let threads = Arc::new(Mutex::new(std::collections::HashSet::new()));
+    let sink = Arc::clone(&threads);
+    let caller = thread::current().id();
+    ConcurrentRunner::new(2, move |_path: PathBuf, _cfg: &()| {
+        sink.lock()
+            .expect("uncontended in test")
+            .insert(thread::current().id());
+        // Hold the worker briefly so the second consumer is given a
+        // chance to pick up work rather than losing every race.
+        thread::sleep(std::time::Duration::from_micros(50));
+        Ok(())
+    })
+    .run((), FilesData { paths })
+    .expect("run should succeed");
+
+    let ids = threads.lock().expect("uncontended in test").clone();
+    assert!(
+        ids.len() > 1,
+        "num_jobs = 2 must give two consumers; got {} (the pre-#1114 \
+         `max(2, n) - 1` gave one)",
+        ids.len()
+    );
+    assert!(
+        ids.len() <= 2,
+        "num_jobs = 2 must not exceed two consumers; got {}",
+        ids.len()
+    );
+    assert!(
+        !ids.contains(&caller),
+        "the calling thread dispatches, it must not also consume"
+    );
 }

--- a/src/metric_set.rs
+++ b/src/metric_set.rs
@@ -139,9 +139,16 @@ impl Metric {
 
     /// Every metric except [`Metric::Tokens`], in declaration order.
     ///
-    /// `tokens` is the one metric with no configurable threshold, so it
-    /// is the one metric that cannot be named in a suppression marker
-    /// (`bca: suppress(tokens)` is rejected). This is the single source
+    /// `tokens` is the one metric that cannot be named in a suppression
+    /// marker (`bca: suppress(tokens)` is rejected). It *is* a
+    /// configurable threshold — `bca check --threshold tokens=N` gates
+    /// on it — so the exclusion is about suppressibility alone. Reading
+    /// it as "no threshold either" is the trap #1113 had to work
+    /// around: deriving a metric selection from
+    /// [`crate::threshold_metric_for_name`], which returns `None` here,
+    /// silently leaves `tokens` uncomputed and disarms that gate.
+    ///
+    /// This is the single source
     /// of truth for the suppressible vocabulary: the suppression
     /// parser's "known metrics" hint and the threshold-name resolver
     /// both derive from it rather than hardcoding the list.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -153,21 +153,19 @@ pub fn compare_rca_output_with_files_under(
     exclude: &[&str],
     expected_files: usize,
 ) {
-    // `ConcurrentRunner` reserves one job for the producer thread
-    // (`max(2, n) - 1` consumers), so ask for one more than the machine's
-    // parallelism to get one consumer per core. The previous hardcoded `4`
-    // left 3 consumers analyzing DeepSpeech's 1042 files while the rest of
-    // the box idled.
+    // One consumer per core. `num_jobs` is the consumer count directly
+    // since #1114 moved dispatch onto the calling thread; before that
+    // `ConcurrentRunner` reserved a slot for a producer thread and
+    // spawned `max(2, n) - 1` consumers, so this asked for one more than
+    // the machine's parallelism to compensate. Passing the parallelism
+    // figure straight through now means what the old `+ 1` was for.
     //
     // Several corpus tests can run concurrently under nextest, each with
     // its own runner, so this nominally oversubscribes. Measured, it does
     // not cost anything: only DeepSpeech runs longer than ~1.2s, so the
     // overlap window is short, and the small corpora leave most of their
     // consumers parked on an empty queue.
-    // Written as `consumers + 1` so the fallback reads as a consumer count
-    // too: an unavailable parallelism figure keeps the previous hardcoded
-    // behaviour of 3 consumers rather than silently assuming 4 cores.
-    let num_jobs = std::thread::available_parallelism().map_or(3, NonZeroUsize::get) + 1;
+    let num_jobs = std::thread::available_parallelism().map_or(4, NonZeroUsize::get);
 
     let snapshotted = Arc::new(AtomicUsize::new(0));
     let cfg = Config {


### PR DESCRIPTION
Four CLI performance issues, plus the follow-up work each one turned up.

Fixes #1113
Fixes #1119
Fixes #1116
Fixes #1114

## Results

All measured with release binaries over `tests/repositories/DeepSpeech`
(12,732 analyzable files), median of three to five runs on a 16-core host.

| Change | Result |
|---|---|
| **#1113** `check` computes only thresholded metric families | 1.24–1.28× less user CPU on a one- or two-metric gate |
| **#1119** result channels lose their `Mutex` | No throughput change; −48 lines of unreachable error handling |
| **#1116** `diff --since` builds its sets in memory | wall 9.42 s → 7.62 s, sys 3.59 s → 2.34 s, output byte-identical |
| **#1114** parallel directory walk, no idle pool slot | walk 100.8 ms → 33.6 ms (3.0×); full `check` ~1.12× |

## Where the issues were wrong

Each issue's plan was checked rather than followed, and three premises did not
survive.

**#1113's proposed approach would have introduced a bug.** It suggested
deriving the metric selection from `threshold_metric_for_name`. That helper
answers a *suppression* question and returns `None` for `tokens` — but `tokens`
is a real configurable threshold, so selecting by it leaves `m.tokens` at zero
and `0 > limit` silently never fires. The family is instead declared per
`MetricExtractor` entry, making the registry the single source of truth.
`check_tokens_threshold_fires_under_narrowed_metric_selection` is the
regression test.

**#1113's other two claims are also wrong.** `Action::Exemptions` already
computed no metrics (`dispatch_exemptions` reads suppression markers off the
parse), so there was nothing to narrow. And the projected 5–7× came from
`bca metrics`, which serializes a document per file; `check` emits nothing per
file, so its ~22 s parse-and-walk floor bounds the saving. This repo's own
`bca.toml` thresholds nine of thirteen families, so `make self-scan` gains
nothing — contrary to the issue.

**#1114 is not the bottleneck it describes.** Warm, the serial walk was 0.09 s
of a 3.6 s `check` — 2.5%. The 3.0× speedup is real but it is 3× of a small
number. The cold-cache monorepo claim may well hold; it is not measurable
without root to drop the page cache.

**#1119's stated rationale is stale.** `std::sync::mpsc::Sender` has been
`Sync` since Rust 1.72 (MSRV is 1.94), so the mutex had been unnecessary for
years and crossbeam was never *required* — only consistent with the library's
existing channel. Corrected in the code comments and on the issue.

## Deliberately not done

**The streaming half of #1114.** It asks to feed the pool directly from the
walker with no intermediate `Vec`. Three reasons: it contradicts the same
issue's determinism requirement (you cannot sort a stream); `FilesData` is
published API, not `#[non_exhaustive]`, and constructed with struct literals,
so changing `run`'s parameter is a SemVer break needing an additive entry
point; and with the walk itself now 3× faster the remaining overlap is 33.6 ms
of a ~2 s run. Happy to file a follow-up against the next major.

## A regression this PR introduced and then fixed

Reviewing #1116 showed it had traded memory for time without saying so: peak
RSS went 437 MB → 831 MB, because the unbounded aggregate channel held a
`FuncSpace` for every file. A collector thread started before the walk, over a
per-job bounded channel, reduces each tree and drops it as it arrives:

| | sys | wall (min) | peak RSS |
|---|---|---|---|
| pre-#1116 (temp JSON) | 3.59 s | 9.42 s | 437 MB |
| #1116 as first written | 3.36 s | 12.42 s | 831 MB |
| final | 2.34 s | 7.62 s | 599 MB |

Memory falls 28% and wall time improves rather than paying for it. The residual
599 vs 437 MB is inherent — a side's `MetricSet` now accumulates *during* its
walk instead of in a pass afterwards, and that overlap is what buys the speed.
Called out in the CHANGELOG for anyone sizing a CI container.

## Public API

Additive: `ConcurrentRunner::without_path_verification`.

Behavioural, signature unchanged: `ConcurrentRunner::new`'s `num_jobs` is now
the consumer count rather than a budget shared with a producer thread, so a
caller passing `n` gets `n` consumers instead of `n - 1`.
`ConcurrentErrors::Producer` is no longer constructed and is retained until
3.0 so a downstream `match` still compiles. Both recorded in `STABILITY.md`
and `CHANGELOG.md`.

Two user-visible CLI changes, both in the CHANGELOG: per-file output order for
a directory walk is now sorted rather than readdir order (previously
unspecified and filesystem-dependent; the parallel walker would otherwise vary
it run to run), and a file that vanishes between the walk and its analysis is
now a tool error rather than a silent skip that exited 0.

## Tests

Twelve new tests, each verified to fail against the exact production line it
names. `audit-tests` caught three of them passing for the wrong reason and
they were fixed:

- `check_mi_value_is_identical…` widened with `tokens`/`abc`/`nom`, none of
  which are MI's dependencies, so deleting `Metric::Mi`'s dependency list drove
  *both* sides to `0` and they still matched.
- `report_body_…` and `exemptions_audit_…` guarded only against emptiness, so a
  deterministic drop removed the same record from both sides and still
  compared equal. They now assert the absolute counts their output carries.

One test is deliberately a unit test rather than end-to-end:
`walk_directory_seed_returns_sorted_paths`. The end-to-end version — five
`bca metrics` runs compared for identical order — stayed green with the sort
deleted, because the ordering bug is a race.

## Validation

`make pre-commit` cannot complete in a nested worktree (#1145 — `cargo fmt
--all` and `enums-check` resolve the workspace-excluded crates against the main
checkout's manifest). Every other stage was run individually and passes:
scoped fmt, clippy, test, test-doc, `cargo doc` with `-D warnings`, udeps,
`manpages-check`, both self-scan tiers, all lint families, and all four Python
stages. Baseline refreshed: 178 → 175 entries, four dropping out because
removing the unreachable poisoned-lock branches took `nexits` back under its
limit.

**The three `enums-*` stages are unverified here** and are untouched by this
branch; worth one `make pre-commit` from the main checkout before merge. I
added the findings to #1145, including that its planned five-manifest fix needs
to be six — `enums` is affected too.
