### PR TITLE
perf(node): stop re-deriving parents in debug builds, reuse child-scan cursors

### DIFF
--- a/.bca-baseline.toml
+++ b/.bca-baseline.toml
@@ -812,7 +812,7 @@ value = 10.0
 [[entry]]
 path = "src/metrics/npa/python.rs"
 qualified = "python_self_attr_name_bytes"
-start_line = 302
+start_line = 305
 metric = "nexits"
 value = 6.0
 
@@ -833,9 +833,9 @@ value = 10.0
 [[entry]]
 path = "src/node.rs"
 qualified = "Node<'a>"
-start_line = 82
+start_line = 93
 metric = "nom"
-value = 34.0
+value = 35.0
 
 [[entry]]
 path = "src/ops.rs"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,7 +282,10 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: cargo test --lib with --cfg chain_audit
         env:
-          # Appends to the workflow-level `-D warnings`.
+          # Replaces the workflow-level RUSTFLAGS rather than extending
+          # it — a step `env` key shadows the workflow one — so `-D
+          # warnings` is repeated here deliberately. Keep the two in
+          # step if the workflow-level value ever gains a flag.
           RUSTFLAGS: "-D warnings --cfg chain_audit"
         run: cargo test -p big-code-analysis --lib --all-features --locked
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,35 @@ jobs:
           include_passed: false
           fail_on_failure: false
 
+  # The exact ancestor-chain assertion (#1122). `Ancestors::checked` keeps
+  # only an O(1) approximation on by default, because the exact
+  # `chain.last() == node.parent()` form costs Node::parent's O(depth) per
+  # node and makes every debug-build walk quadratic. This lane restores it
+  # so a walker whose truncate/push bookkeeping desynchronises still fails
+  # a build rather than silently feeding predicates a wrong ancestor.
+  #
+  # ubuntu-only and lib-scoped: the assertion lives in the library's walks,
+  # so the per-OS matrix and the CLI / web / integration tiers would re-pay
+  # the quadratic cost without covering anything the lib tests do not.
+  chain-audit:
+    name: chain audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          submodules: false
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable tip
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: cargo test --lib with --cfg chain_audit
+        env:
+          # Appends to the workflow-level `-D warnings`.
+          RUSTFLAGS: "-D warnings --cfg chain_audit"
+        run: cargo test -p big-code-analysis --lib --all-features --locked
+
   coverage:
     name: coverage
     runs-on: ubuntu-latest
@@ -887,6 +916,7 @@ jobs:
       - clippy
       - docs
       - test
+      - chain-audit
       - coverage
       - msrv
       - feature-matrix

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,6 +293,18 @@ If `pre-commit` is installed, also run `pre-commit run --all-files`. The
 project's `.pre-commit-config.yaml` runs clippy, `cargo +nightly udeps`,
 and the test suite.
 
+**The ancestor-chain audit** (`make chain-audit`) re-runs the library
+tests with `--cfg chain_audit`, which restores the exact
+`chain.last() == node.parent()` assertion in `Ancestors::checked`. The
+default build keeps only an `O(1)` approximation of it, because the
+exact form is `Node::parent`'s `O(depth)` per node and made every
+debug-build walk quadratic (#1122). The approximation misses a chain
+that is short by exactly one, so run this around any change to a walk's
+truncate/push bookkeeping — `src/spaces/compute.rs`, `src/ops.rs`,
+`src/comment_rm.rs`, `src/suppression.rs`, `Search::act_on_node`. It is
+not part of `make pre-commit`; the `chain-audit` CI job runs it per PR.
+See [Benchmarking](docs/development/benchmarking.md#chain-audit).
+
 **Mutation testing** runs out-of-band on a quarterly cron via
 `.github/workflows/mutation-test.yml` against `src/metrics/`,
 `src/checker.rs`, and `src/getter.rs`. It is intentionally not part of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,15 @@ for historical reference.
   short by exactly one. The library test suite falls from ~5.0 s to
   ~1.7 s, `cognitive_nesting_is_inherited_at_depth` from ~1.6 s to
   ~0.02 s. No shipped behaviour changes.
+- Traversals that enumerate every node's children reuse one
+  `TreeCursor` instead of building and freeing one per node, through
+  the new internal `Node::children_with` (#1112). `Node::preorder`, the
+  suppression-marker DFS, and Python's instance-attribute scan in
+  `metrics::npa::python` were the only per-node consumers; the last was
+  92 % of the Python metric walk's child scans. Over 400 Python corpus
+  files that is 414,620 cursor allocations down to 33,328 (−92 %) and
+  −2.4 % walk time. Other languages reach `children` on 3-6 % of nodes,
+  where the effect is under 1 %. Metric values are unchanged.
 - Every file destination and terminal dump writes through an
   explicitly-flushed 64 KiB buffer, replacing the raw `File` and
   `LineWriter` handles the incremental serializers wrote through one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,8 +248,9 @@ for historical reference.
   `metrics::npa::python` were the only per-node consumers; the last was
   92 % of the Python metric walk's child scans. Over 400 Python corpus
   files that is 414,620 cursor allocations down to 33,328 (−92 %) and
-  −2.4 % walk time. Other languages reach `children` on 3-6 % of nodes,
-  where the effect is under 1 %. Metric values are unchanged.
+  −2.4 % walk time. Other languages reach `children` on 3-6 % of nodes
+  (16 % for C#), where the effect is under 1 %. Metric values are
+  unchanged.
 - Every file destination and terminal dump writes through an
   explicitly-flushed 64 KiB buffer, replacing the raw `File` and
   `LineWriter` handles the incremental serializers wrote through one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,6 +228,19 @@ for historical reference.
   or `--jobs 64` on a 16-core host; the lock was taken once per file,
   never per record. The change removes a global serialization point and
   four unreachable poisoned-lock branches.
+- The debug-build ancestor-chain check no longer re-derives every
+  parent, so an unoptimised metric walk is linear like the shipped one
+  (#1122). `Ancestors::checked` verified `chain.last() == node.parent()`
+  per node on all five walks that thread a chain, and `Node::parent`
+  costs `O(depth)` — which made every `cargo test` walk `O(nodes ×
+  depth)` and hit the deep-nesting regression tests hardest. The exact
+  assertion moved behind `--cfg chain_audit` (`make chain-audit`, plus a
+  `chain-audit` CI lane); a plain debug build keeps an `O(1)`
+  consequence of the same invariant, which catches a `push` moved ahead
+  of the per-node computes and a dropped `truncate` but not a chain
+  short by exactly one. The library test suite falls from ~5.0 s to
+  ~1.7 s, `cognitive_nesting_is_inherited_at_depth` from ~1.6 s to
+  ~0.02 s. No shipped behaviour changes.
 - Every file destination and terminal dump writes through an
   explicitly-flushed 64 KiB buffer, replacing the raw `File` and
   `LineWriter` handles the incremental serializers wrote through one

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,12 @@ tempfile = "^3.0"
 # workspace.
 [workspace.lints.rust]
 missing_docs = "warn"
+# `chain_audit` turns `Ancestors::checked` back into the exact
+# parent-identity assertion it was before #1122. Off by default because
+# that assertion costs `Node::parent`'s `O(depth)` per node on all five
+# checked walks; `make chain-audit` and the CI lane of the same name set
+# it. Declared here so `-D warnings` does not reject the `#[cfg]`.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(chain_audit)'] }
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ find-by-ext = $(if $(FD),$(FD) --extension $(1) $(FD_EXCLUDE) $(2),find . -name 
 NEXTEST        := $(shell command -v cargo-nextest 2>/dev/null)
 TEST_CMD       = $(if $(NEXTEST),$(NEXTEST) nextest run --workspace --all-features,cargo test --workspace --all-features --lib --bins --tests)
 
-.PHONY: help check-tools build build-release check test test-doc fmt fmt-check markdown-fmt markdown-lint shellcheck sh-fmt sh-fmt-check toml-fmt toml-fmt-check toml-lint makefile-check actionlint snapshot-anchors grammar-marker-sync grammar-marker-sync-test check-versions check-manpage-assets enums-check enums-codegen-drift enums-codegen-drift-test self-scan self-scan-headroom self-scan-write-baseline self-scan-write-baseline-headroom vcs lint clippy udeps insta-review insta-accept clean distclean install install-cli install-web doc doc-open doc-check doc-check-docsrs book book-serve book-pot book-po-update book-ja book-deploy all pre-commit ci release-check verify-changelog pkg-deb-local pkg-rpm-local dev-env-build dev-env-run dev-env-shell dev-env-rm py-bootstrap py-sync py-relock py-clean py-fmt py-fmt-check py-lint py-typecheck py-test py-stubtest smoke smoke-cli smoke-lib bench bench-scaling bench-walk _check-find _pc-fmt _pc-clippy _pc-test _pc-doc-check _pc-udeps _pc-shellcheck _pc-markdown-lint _pc-toml-lint _pc-makefile-check _pc-actionlint _pc-snapshot-anchors _pc-grammar-marker-sync _pc-grammar-marker-sync-test _pc-check-versions _pc-check-versions-test _pc-check-grammar-crate-test _pc-check-manpage-assets _pc-enums-check _pc-enums-codegen-drift _pc-enums-codegen-drift-test _pc-self-scan _pc-self-scan-headroom _pc-py-fmt _pc-py-typecheck _pc-py-test _pc-py-stubtest _ci-fmt-check _ci-clippy _ci-test _ci-doc-check _ci-build _ci-udeps _ci-shellcheck _ci-markdown-lint _ci-toml-lint _ci-makefile-check _ci-actionlint _ci-snapshot-anchors _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-versions-test _ci-check-grammar-crate-test _ci-check-manpage-assets _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test _ci-enums-codegen-drift-test _ci-self-scan _ci-self-scan-headroom _ci-cargo-pipeline _ci-py-fmt-check _ci-py-lint _ci-py-typecheck _ci-py-test _ci-py-stubtest
+.PHONY: help check-tools build build-release check test test-doc chain-audit fmt fmt-check markdown-fmt markdown-lint shellcheck sh-fmt sh-fmt-check toml-fmt toml-fmt-check toml-lint makefile-check actionlint snapshot-anchors grammar-marker-sync grammar-marker-sync-test check-versions check-manpage-assets enums-check enums-codegen-drift enums-codegen-drift-test self-scan self-scan-headroom self-scan-write-baseline self-scan-write-baseline-headroom vcs lint clippy udeps insta-review insta-accept clean distclean install install-cli install-web doc doc-open doc-check doc-check-docsrs book book-serve book-pot book-po-update book-ja book-deploy all pre-commit ci release-check verify-changelog pkg-deb-local pkg-rpm-local dev-env-build dev-env-run dev-env-shell dev-env-rm py-bootstrap py-sync py-relock py-clean py-fmt py-fmt-check py-lint py-typecheck py-test py-stubtest smoke smoke-cli smoke-lib bench bench-scaling bench-walk _check-find _pc-fmt _pc-clippy _pc-test _pc-doc-check _pc-udeps _pc-shellcheck _pc-markdown-lint _pc-toml-lint _pc-makefile-check _pc-actionlint _pc-snapshot-anchors _pc-grammar-marker-sync _pc-grammar-marker-sync-test _pc-check-versions _pc-check-versions-test _pc-check-grammar-crate-test _pc-check-manpage-assets _pc-enums-check _pc-enums-codegen-drift _pc-enums-codegen-drift-test _pc-self-scan _pc-self-scan-headroom _pc-py-fmt _pc-py-typecheck _pc-py-test _pc-py-stubtest _ci-fmt-check _ci-clippy _ci-test _ci-doc-check _ci-build _ci-udeps _ci-shellcheck _ci-markdown-lint _ci-toml-lint _ci-makefile-check _ci-actionlint _ci-snapshot-anchors _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-versions-test _ci-check-grammar-crate-test _ci-check-manpage-assets _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test _ci-enums-codegen-drift-test _ci-self-scan _ci-self-scan-headroom _ci-cargo-pipeline _ci-py-fmt-check _ci-py-lint _ci-py-typecheck _ci-py-test _ci-py-stubtest
 
 # Default target
 help:
@@ -107,6 +107,7 @@ help:
 	@echo "Test targets:"
 	@echo "  test                                 Run unit and integration tests (nextest if present)"
 	@echo "  test-doc                             Run cargo doc tests"
+	@echo "  chain-audit                          Re-run the suite with the exact ancestor-chain assertion (out-of-band)"
 	@echo "  insta-review                         Review pending insta snapshot diffs"
 	@echo "  insta-accept                         Accept all pending insta snapshots"
 	@echo ""
@@ -228,6 +229,28 @@ test:
 # is a separate target rather than an oversight (see .config/nextest.toml).
 test-doc:
 	cargo test --workspace --all-features --doc
+
+# The ancestor-chain audit (#1122). `--cfg chain_audit` restores the
+# exact `chain.last() == node.parent()` assertion in `Ancestors::checked`
+# that the default build trades for an O(1) approximation, so every walk
+# that threads a chain is verified node-by-node against the tree.
+#
+# Out of band because that assertion is `Node::parent`'s O(depth) lookup
+# per node, which turns the linear shipped walk quadratic and roughly
+# triples the lib suite's wall time. Runs in the `chain-audit` CI lane;
+# run it locally around any change to a walk's truncate/push bookkeeping.
+#
+# Library-scoped, matching that lane: all five walks that thread a chain
+# live in the root crate, so the CLI / web / integration tiers would
+# re-pay the quadratic cost without reaching an assertion the lib tests
+# do not already reach.
+#
+# RUSTFLAGS rather than a Cargo feature on purpose: `make test` passes
+# `--all-features`, so a feature would switch the audit back on in the
+# very inner loop this target exists to keep fast.
+chain-audit:
+	RUSTFLAGS="$${RUSTFLAGS:-} --cfg chain_audit" \
+	  cargo test -p big-code-analysis --lib --all-features
 
 # `cargo insta test` shells out to `cargo test`, not $(TEST_CMD): insta's
 # nextest integration needs `--test-runner nextest`, and under it insta

--- a/docs/development/benchmarking.md
+++ b/docs/development/benchmarking.md
@@ -243,6 +243,42 @@ is the guard.
 Treat the linear bounds above as covering the walk's ancestor *chain*
 threading, not every `O(depth)` lookup in the crate.
 
+### Child scans, and where the allocation actually was {#child-scans}
+
+`Node::children` builds a `tree_sitter::TreeCursor`, which heap-allocates
+its stack and frees it on drop — so a traversal that calls it per node
+pays a `malloc`/`free` pair per node. [#1112][child-cursor] expected that
+cost to be spread across the walk's predicates, on the strength of ~137
+call sites. Counting it says otherwise. Per-language, over the corpus
+slice, a full `metrics()` walk reaches `children` on:
+
+| Language | calls / node |
+|---|---|
+| C++ (`.cc`) | 0.031 |
+| Rust, JavaScript | 0.040 |
+| Java | 0.058 |
+| C# | 0.164 |
+| **Python** | **0.600** |
+
+The predicates are a rounding error; one scan was not. Python's
+instance-attribute walk in `metrics::npa::python` visits every node of
+every method body, and was 381 k of that language's 417 k child scans —
+92 %, and the only per-node `children` consumer in the crate outside
+`Preorder` and the suppression DFS. `Node::children_with` lets those
+three hoist one cursor out of their loop; the counter
+`child_scan_cursors` in `src/node.rs` is what keeps them there, since
+the change moves no metric value.
+
+Measured on 400 Python corpus files (694 k nodes), interleaved
+best-of-nine: **414 620 cursor allocations down to 33 328 (−92 %), walk
+time 159.0 ms to 155.2 ms (−2.4 %)**. Every other language is under 1 %,
+which is the useful part of the result — the remaining call sites are
+predicates holding a bare `&Node`, and threading a cursor to them would
+cross the `Checker` / `Getter` trait surface to save roughly 17 ns per
+call on 3-6 % of nodes. Not worth it; measure before widening this.
+
+[child-cursor]: https://github.com/dekobon/big-code-analysis/issues/1112
+
 ### The chain audit {#chain-audit}
 
 The chain those bounds depend on is only as good as the walker's

--- a/docs/development/benchmarking.md
+++ b/docs/development/benchmarking.md
@@ -243,6 +243,42 @@ is the guard.
 Treat the linear bounds above as covering the walk's ancestor *chain*
 threading, not every `O(depth)` lookup in the crate.
 
+### The chain audit {#chain-audit}
+
+The chain those bounds depend on is only as good as the walker's
+truncate/push bookkeeping, and `Ancestors::parent` reads `chain.last()`
+without checking it — so a slip feeds every predicate a wrong ancestor
+silently rather than failing. `Ancestors::checked` is the guard, and
+until [#1122][chain-audit-issue] it asked the exact question:
+`chain.last() == node.parent()`. That is `Node::parent` again, per node,
+on all five walks that build a chain — which made every *debug* walk
+quadratic while the shipped one stayed linear, and put the cost in every
+`cargo test`. The deep-nesting regression tests paid it worst, which is
+to say the tests that exist to pin the walk's linearity were the slowest
+thing about not shipping it.
+
+The exact assertion now lives behind `--cfg chain_audit`:
+
+```bash
+make chain-audit
+```
+
+Removing it from the default build took the lib suite from ~5.0 s to
+~1.7 s, `cognitive_nesting_is_inherited_at_depth` from ~1.6 s to ~0.02 s,
+and `deeply_nested_spaces_convert_to_wire_without_stack_overflow` from
+~1.8 s to ~0.02 s.
+
+What a plain debug build keeps is an `O(1)` consequence of the same
+invariant — a parent's byte span contains its child's, and no node is
+its own parent — which catches a `push` moved ahead of the per-node
+computes and a dropped `truncate`, but not a chain that is short by
+exactly one (a grandparent contains the node too). That gap is the
+lane's whole justification: run `make chain-audit` around any change to
+a walk's chain bookkeeping, not just around a change to its cost. The
+`chain-audit` CI job runs it per PR over the library's tests.
+
+[chain-audit-issue]: https://github.com/dekobon/big-code-analysis/issues/1122
+
 [parent-walk]: https://github.com/dekobon/big-code-analysis/issues/1084
 [cognitive-parent]: https://github.com/dekobon/big-code-analysis/issues/1062
 [remaining-climbs]: https://github.com/dekobon/big-code-analysis/issues/1088

--- a/docs/development/benchmarking.md
+++ b/docs/development/benchmarking.md
@@ -275,7 +275,8 @@ time 159.0 ms to 155.2 ms (−2.4 %)**. Every other language is under 1 %,
 which is the useful part of the result — the remaining call sites are
 predicates holding a bare `&Node`, and threading a cursor to them would
 cross the `Checker` / `Getter` trait surface to save roughly 17 ns per
-call on 3-6 % of nodes. Not worth it; measure before widening this.
+call on the 3-6 % of nodes above (16 % in C#). Not worth it; measure
+before widening this.
 
 [child-cursor]: https://github.com/dekobon/big-code-analysis/issues/1112
 

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -591,7 +591,8 @@ fn rust_attribute_run_under(parent: &Node, node: &Node, code: &[u8]) -> bool {
     // runs to the end of `parent`'s children, so the answer depends on
     // whether those end in an attribute run and is meaningless either
     // way. The walker constructs its chain through `Ancestors::checked`,
-    // which catches the mismatch in debug builds.
+    // which catches a mismatch that shows in the spans in any debug build
+    // and every mismatch under `make chain-audit` (#1122).
     let Some(run_start) = run_start else {
         return false;
     };

--- a/src/function_tests.rs
+++ b/src/function_tests.rs
@@ -191,8 +191,9 @@ fn dump_span_ansi_layout_error_branch() {
 /// / `pair`, which #1088 moved onto the walk's ancestor chain. This is
 /// also the only lib-level exercise of that chain — `act_on_node`
 /// constructs it through `Ancestors::checked`, so a bookkeeping slip
-/// trips the debug assertion here rather than only in the web crate's
-/// endpoint tests.
+/// trips its assertion here rather than only in the web crate's
+/// endpoint tests (fully under `make chain-audit`; in a plain debug
+/// build, for the slips the `O(1)` guard sees — see #1122).
 #[test]
 fn js_function_spans_name_expressions_from_their_binding() {
     use crate::langs::JavascriptParser;

--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -9792,11 +9792,13 @@ end",
         let expected = |n: u64| n * (n + 1) / 2;
 
         assert_eq!(cognitive_of(&nested_fns(3)), expected(3), "1 + 2 + 3");
-        // Half the depth of `cognitive_nesting_is_inherited_at_depth`:
-        // each level here also opens a `FuncSpace`, and the debug-build
-        // `Ancestors::checked` assertion re-derives every parent with
-        // `Node::parent`, so the unoptimised walk is quadratic even
-        // though the release one is not.
+        // Half the depth of `cognitive_nesting_is_inherited_at_depth`
+        // because each level here also opens a `FuncSpace`. The debug
+        // build is no longer the reason: #1122 took the `Node::parent`
+        // re-derivation out of `Ancestors::checked`, so an unoptimised
+        // walk is linear like the release one and this case dropped from
+        // ~1.0 s to ~0.02 s. `make chain-audit` puts the quadratic
+        // assertion back deliberately.
         assert_eq!(cognitive_of(&nested_fns(1_000)), expected(1_000));
     }
 

--- a/src/metrics/npa/python.rs
+++ b/src/metrics/npa/python.rs
@@ -221,10 +221,13 @@ fn python_collect_self_attrs_in_subtree<'a>(
 ) {
     use Python::*;
 
+    // One cursor for the whole subtree, not one per node: this is the
+    // crate's heaviest `children` consumer by a wide margin — 92 % of
+    // the Python metric walk's child scans — and each would otherwise
+    // build and free a `TreeCursor` (#1112, `Node::children_with`).
+    let mut cursor = root.cursor();
     let mut stack: Vec<Node<'a>> = Vec::with_capacity(32);
-    for child in root.children() {
-        stack.push(child);
-    }
+    stack.extend(root.children_with(&mut cursor));
     while let Some(node) = stack.pop() {
         // Boundary: do not descend into nested classes, functions, or
         // lambdas. Their attributes belong to their inner scope.
@@ -239,9 +242,7 @@ fn python_collect_self_attrs_in_subtree<'a>(
             python_collect_self_attrs_from_target(&node, code, seen);
         }
 
-        for child in node.children() {
-            stack.push(child);
-        }
+        stack.extend(node.children_with(&mut cursor));
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -33,6 +33,17 @@ use parser_cache::parse_on_scratch_parser;
 // test failure rather than a silent quadratic.
 crate::observation::counter!(node_resolved_sibling_lookups);
 
+// Child scans that built their own `TreeCursor`, on this thread.
+//
+// [`Node::children_with`] yields exactly what [`Node::children`] yields
+// — it exists to reuse one cursor across a traversal instead of
+// heap-allocating and freeing one per visited node, and no assertion on
+// a metric value can tell the two apart. #1112 moved the three
+// per-node traversals that could hoist a cursor onto it; the counter is
+// what makes moving one back a test failure rather than a silent
+// allocation per node.
+crate::observation::counter!(child_scan_cursors);
+
 /// A parsed source tree wrapping a [`tree_sitter::Tree`].
 ///
 /// The "open parse seam" (see issue #251) is reached by external
@@ -306,27 +317,43 @@ impl<'a> Node<'a> {
         self.0.field_name_for_child(child_index)
     }
 
+    /// Iterator over this node's direct children.
+    ///
+    /// Builds a [`Cursor`], which heap-allocates. A loop that visits
+    /// many nodes should hoist one cursor and use [`children_with`]
+    /// instead; see its note for when the difference is worth the
+    /// plumbing.
+    ///
+    /// [`children_with`]: Self::children_with
     pub(crate) fn children(&self) -> Children<'a> {
+        child_scan_cursors::record();
         let mut cursor = self.cursor();
-        // `goto_first_child` returns false when the node has no
-        // children, in which case the iterator is empty from the
-        // outset. Termination is then driven entirely by the cursor
-        // (see `Children::next`), so the iterator stops exactly when
-        // the tree reports no further siblings — it can never pad the
-        // sequence with duplicate nodes if `child_count` and the
-        // cursor walk ever disagree.
-        let done = !cursor.goto_first_child();
-        Children {
-            cursor,
-            done,
-            // `child_count` is the authoritative length for the
-            // `ExactSizeIterator` contract; for well-formed trees it
-            // equals the cursor sibling walk, so the reported length
-            // and the emitted data agree. A childless node (`done`
-            // already set) reports `0` so the empty iterator's length
-            // matches its (lack of) data.
-            remaining: if done { 0 } else { self.child_count() },
-        }
+        let scan = ChildScan::seed(self, &mut cursor);
+        Children { cursor, scan }
+    }
+
+    /// [`children`], over a cursor the caller owns.
+    ///
+    /// `tree_sitter::TreeCursor` heap-allocates its stack when built and
+    /// frees it when dropped, so a traversal that calls [`children`]
+    /// once per visited node pays a `malloc`/`free` pair per node.
+    /// `ts_tree_cursor_reset` keeps the allocation, so a loop that can
+    /// hoist one cursor pays for it once however many nodes it visits
+    /// (#1112).
+    ///
+    /// Worth the plumbing only where a loop visits many nodes. Measured
+    /// on the corpus slice, a full metric walk reaches [`children`] on
+    /// 3-6 % of nodes in every language except Python, where one scan —
+    /// the instance-attribute walk in `metrics::npa::python` — took it
+    /// to 60 %. Predicates that hold a bare `&Node` and scan one node's
+    /// children keep [`children`]: threading a cursor to them would
+    /// cross the `Checker` / `Getter` trait surface to save a single
+    /// allocation per call.
+    ///
+    /// [`children`]: Self::children
+    pub(crate) fn children_with<'c>(&self, cursor: &'c mut Cursor<'a>) -> ChildrenWith<'c, 'a> {
+        let scan = ChildScan::seed(self, cursor);
+        ChildrenWith { cursor, scan }
     }
 
     pub(crate) fn cursor(&self) -> Cursor<'a> {
@@ -406,17 +433,23 @@ impl<'a> Node<'a> {
     /// descendants (this node first, then each child subtree left to
     /// right).
     ///
-    /// The traversal is allocation-light: it reuses one work stack and
-    /// visits each node exactly once, so a full walk is O(n) in the
-    /// subtree size. Every yielded [`Node`] carries the underlying tree
-    /// lifetime `'a`, so callers may collect or retain the handles.
+    /// The traversal is allocation-light: it reuses one work stack *and
+    /// one cursor*, and visits each node exactly once, so a full walk is
+    /// O(n) in the subtree size and allocates only the stack's growth.
+    /// Building a fresh cursor per visited node instead would cost a
+    /// `malloc`/`free` pair per node (#1112). Every yielded [`Node`]
+    /// carries the underlying tree lifetime `'a`, so callers may collect
+    /// or retain the handles.
     ///
     /// This is the Rust counterpart of the Python `Node.walk()` binding
     /// (issue #728): the binding wraps each yielded node, so Rust and
     /// Python share one traversal order.
     #[must_use]
     pub fn preorder(&self) -> Preorder<'a> {
-        Preorder { stack: vec![*self] }
+        Preorder {
+            stack: vec![*self],
+            cursor: self.cursor(),
+        }
     }
 
     /// Collects every node in this subtree (this node included) whose
@@ -608,14 +641,17 @@ impl<'tree, 'chain> Iterator for AncestorIter<'tree, 'chain> {
 /// Pre-order iterator over a node and its descendants, returned by
 /// [`Node::preorder`].
 ///
-/// Holds a single work stack of not-yet-visited nodes. Each step pops the
+/// Holds a single work stack of not-yet-visited nodes, and a single
+/// cursor to enumerate each node's children with. Each step pops the
 /// next node, pushes its children so the leftmost is visited first, and
 /// yields the popped node — so the sequence is the node, then each child
-/// subtree in order. The stack is reused across steps (children are pushed
+/// subtree in order. Both are reused across steps (children are pushed
 /// then the freshly-pushed slice is reversed in place), so the walk
-/// allocates only the stack's growth, not a fresh buffer per node.
+/// allocates only the stack's growth: no fresh buffer per node, and no
+/// fresh `TreeCursor` either (#1112).
 pub struct Preorder<'a> {
     stack: Vec<Node<'a>>,
+    cursor: Cursor<'a>,
 }
 
 impl<'a> Iterator for Preorder<'a> {
@@ -627,8 +663,11 @@ impl<'a> Iterator for Preorder<'a> {
         // appended so the leftmost child ends up on top of the stack and
         // is visited next — pre-order without a per-node temporary.
         let first_child = self.stack.len();
-        self.stack.extend(node.children());
-        self.stack[first_child..].reverse();
+        // Destructured so the stack and the cursor are borrowed as the
+        // disjoint fields they are.
+        let Self { stack, cursor } = self;
+        stack.extend(node.children_with(cursor));
+        stack[first_child..].reverse();
         Some(node)
     }
 }
@@ -655,36 +694,52 @@ impl<'a> Cursor<'a> {
     }
 }
 
-/// Iterator over a node's direct children, returned by
-/// [`Node::children`].
+/// Position of a child scan, independent of who owns the cursor driving
+/// it.
 ///
-/// Termination is driven by the cursor alone: each step yields the
-/// cursor's current node, then advances with `goto_next_sibling`,
-/// stopping the moment that returns false. This makes the cursor the
-/// single source of truth for both the emitted data and when to stop, so
-/// the sequence can never be padded with duplicates if `child_count` and
-/// the actual sibling walk disagree.
-///
-/// The `ExactSizeIterator` length is reported from `child_count` (tracked
-/// in `remaining`). For well-formed trees the cursor walk and
-/// `child_count` agree, so the advertised length matches the data.
-pub(crate) struct Children<'a> {
-    cursor: Cursor<'a>,
+/// [`Children`] and [`ChildrenWith`] differ only in that — one owns its
+/// cursor, the other borrows the caller's — and `children_with` exists
+/// to save an allocation, not to answer differently. Keeping the
+/// termination rule here rather than in each iterator is what stops the
+/// two from drifting.
+struct ChildScan {
     done: bool,
     remaining: usize,
 }
 
-impl<'a> Iterator for Children<'a> {
-    type Item = Node<'a>;
+impl ChildScan {
+    /// Seats `cursor` on `node`'s first child.
+    ///
+    /// `goto_first_child` returns false when the node has no children,
+    /// in which case the scan is exhausted from the outset. Termination
+    /// is then driven entirely by the cursor (see [`ChildScan::step`]),
+    /// so the iterator stops exactly when the tree reports no further
+    /// siblings — it can never pad the sequence with duplicate nodes if
+    /// `child_count` and the cursor walk ever disagree.
+    ///
+    /// `child_count` is the authoritative length for the
+    /// `ExactSizeIterator` contract; for well-formed trees it equals the
+    /// cursor sibling walk, so the reported length and the emitted data
+    /// agree. A childless node reports `0` so the empty iterator's
+    /// length matches its (lack of) data.
+    fn seed<'a>(node: &Node<'a>, cursor: &mut Cursor<'a>) -> Self {
+        cursor.reset(node);
+        let done = !cursor.goto_first_child();
+        Self {
+            done,
+            remaining: if done { 0 } else { node.child_count() },
+        }
+    }
 
-    fn next(&mut self) -> Option<Self::Item> {
+    /// Yields the cursor's current child and advances past it.
+    fn step<'a>(&mut self, cursor: &mut Cursor<'a>) -> Option<Node<'a>> {
         if self.done {
             return None;
         }
-        let result = self.cursor.node();
+        let result = cursor.node();
         // The cursor is the single source of truth for termination:
         // once there is no next sibling this yield is the last one.
-        self.done = !self.cursor.goto_next_sibling();
+        self.done = !cursor.goto_next_sibling();
         // Keep the advertised length consistent with termination: when
         // the cursor stops, nothing remains. For well-formed trees this
         // equals `child_count - emitted`; if the cursor walk and
@@ -704,7 +759,60 @@ impl<'a> Iterator for Children<'a> {
     }
 }
 
+/// Iterator over a node's direct children, returned by
+/// [`Node::children`]. Owns the cursor it walks with.
+///
+/// Termination is driven by the cursor alone: each step yields the
+/// cursor's current node, then advances with `goto_next_sibling`,
+/// stopping the moment that returns false. This makes the cursor the
+/// single source of truth for both the emitted data and when to stop, so
+/// the sequence can never be padded with duplicates if `child_count` and
+/// the actual sibling walk disagree.
+///
+/// The `ExactSizeIterator` length is reported from `child_count` (tracked
+/// in [`ChildScan`]). For well-formed trees the cursor walk and
+/// `child_count` agree, so the advertised length matches the data.
+pub(crate) struct Children<'a> {
+    cursor: Cursor<'a>,
+    scan: ChildScan,
+}
+
+impl<'a> Iterator for Children<'a> {
+    type Item = Node<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.scan.step(&mut self.cursor)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.scan.size_hint()
+    }
+}
+
 impl ExactSizeIterator for Children<'_> {}
+
+/// Iterator over a node's direct children, returned by
+/// [`Node::children_with`]. Borrows the caller's cursor rather than
+/// building one, which is the whole of the difference: it yields exactly
+/// what [`Children`] yields, through the same [`ChildScan`].
+pub(crate) struct ChildrenWith<'c, 'a> {
+    cursor: &'c mut Cursor<'a>,
+    scan: ChildScan,
+}
+
+impl<'a> Iterator for ChildrenWith<'_, 'a> {
+    type Item = Node<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.scan.step(self.cursor)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.scan.size_hint()
+    }
+}
+
+impl ExactSizeIterator for ChildrenWith<'_, '_> {}
 
 impl<'a> Search<'a> for Node<'a> {
     fn first_occurrence(&self, pred: fn(u16) -> bool) -> Option<Node<'a>> {
@@ -996,29 +1104,8 @@ mod tests {
                 .map(|c| (c.id(), c.kind_id()))
                 .collect();
 
-            let mut iter = wrapped.children();
-            // ExactSizeIterator length must equal the child count up
-            // front and stay exact as the iterator is consumed.
-            assert_eq!(
-                iter.len(),
-                expected.len(),
-                "children().len() disagreed with child_count at kind {}",
-                n.kind(),
-            );
-
-            let mut actual = Vec::new();
-            let mut remaining = expected.len();
-            while let Some(child) = iter.next() {
-                remaining -= 1;
-                assert_eq!(
-                    iter.len(),
-                    remaining,
-                    "size_hint drifted mid-iteration at kind {}",
-                    n.kind(),
-                );
-                actual.push((child.id(), child.kind_id()));
-            }
-            assert_eq!(iter.len(), 0, "iterator not drained to zero len");
+            let actual =
+                drain_checking_exact_size(wrapped.children(), expected.len(), "children", n.kind());
             assert_eq!(
                 actual,
                 expected,
@@ -1216,6 +1303,44 @@ mod tests {
         );
     }
 
+    /// Drains `iter`, holding it to the `ExactSizeIterator` contract at
+    /// every step, and returns the `(id, kind_id)` of each child yielded.
+    ///
+    /// `len()` must equal the node's `child_count` before the first step,
+    /// fall by exactly one per yield, and be zero at exhaustion. Both
+    /// child iterators are checked against it, so the contract is stated
+    /// once — `children_with` exists to save an allocation, and a
+    /// separate copy of this is how the two would come to disagree.
+    fn drain_checking_exact_size<'a>(
+        mut iter: impl ExactSizeIterator<Item = Node<'a>>,
+        child_count: usize,
+        what: &str,
+        kind: &str,
+    ) -> Vec<(usize, u16)> {
+        assert_eq!(
+            iter.len(),
+            child_count,
+            "{what}().len() disagreed with child_count at kind {kind}"
+        );
+        let mut remaining = child_count;
+        let mut drained = Vec::with_capacity(remaining);
+        while let Some(child) = iter.next() {
+            remaining -= 1;
+            assert_eq!(
+                iter.len(),
+                remaining,
+                "{what}() size_hint drifted mid-iteration at kind {kind}"
+            );
+            drained.push((child.id(), child.kind_id()));
+        }
+        assert_eq!(
+            iter.len(),
+            0,
+            "{what}() was not drained to zero len at kind {kind}"
+        );
+        drained
+    }
+
     /// Ancestor ids yielded by `ancestors`, nearest first.
     fn ancestor_ids(ancestors: Ancestors<'_, '_>, node: &Node<'_>) -> Vec<usize> {
         ancestors.iter(node).map(|(a, _)| a.id()).collect()
@@ -1343,6 +1468,133 @@ mod tests {
             b"const f = a => { a => { g(() => 1); }; };\nconst o = { m: function () { return 1; } };\n",
             &["arrow_function"],
         );
+    }
+
+    /// The traversals #1112 moved onto [`Node::children_with`] must scan
+    /// a whole tree on one cursor, not one per node.
+    ///
+    /// Nothing in the output says so: `children_with` yields exactly
+    /// what `children` yields, so every metric, marker, and pre-order
+    /// assertion in the suite holds just as well with a fresh
+    /// `TreeCursor` built and freed per visited node. The counter is the
+    /// only observable, which is why reverting one of these loops has to
+    /// be a test failure rather than a silent allocation per node.
+    ///
+    /// Seeding a real scan first is what makes it falsifiable: compared
+    /// against zero these assertions would also pass with `record()`
+    /// never wired up at all.
+    #[cfg(all(feature = "c", feature = "mozjs", feature = "python", feature = "rust"))]
+    #[test]
+    fn the_converted_traversals_scan_a_tree_on_one_cursor() {
+        use crate::traits::ParserTrait;
+
+        let seed_tree = Tree::new::<crate::langs::CCode>(b"int main() { int a; }");
+        let _ = seed_tree.get_root().children().count();
+        assert!(
+            child_scan_cursors::observed() > 0,
+            "the seed scan must be counted"
+        );
+
+        // `preorder` over a tree far larger than any per-call constant,
+        // so "one per node" and "one per walk" cannot be confused.
+        let tree = Tree::new::<MozjsCode>(
+            b"const o = { m: (a) => a + 1, n: function () { return [1, 2, 3]; } };\nfoo(o);\n",
+        );
+        let before = child_scan_cursors::observed();
+        let visited = tree.get_root().preorder().count();
+        assert!(visited > 40, "fixture is too small to prove much");
+        assert_eq!(
+            child_scan_cursors::observed(),
+            before,
+            "preorder built a cursor per node; it holds one for the walk (#1112)"
+        );
+
+        // The Python instance-attribute scan walks every method body of
+        // a class. Before #1112 it was 92 % of the metric walk's child
+        // scans on the Python corpus slice — one per node under the
+        // class. It is not the only scan a `metrics()` call makes, so
+        // the bound is a fraction of the node count rather than zero.
+        // Measured on this fixture: 18 scans over 81 nodes with the
+        // cursor hoisted, 91 without, so the bound separates the two
+        // with room on both sides.
+        let source = "class C:\n    def a(self):\n        self.x = 1\n        self.y = [1, 2]\n\
+                      \n    def b(self):\n        self.z, self.w = 1, 2\n        \
+                      if self.x:\n            self.v = self.y\n";
+        let ast = crate::test_support::parse_named(crate::LANG::Python, "c.py", source);
+        let nodes = ast.root_node().preorder().count();
+        let before = child_scan_cursors::observed();
+        ast.metrics(crate::MetricsOptions::default())
+            .expect("the walk must yield a top-level space");
+        let scans = child_scan_cursors::observed() - before;
+        assert!(nodes > 60, "fixture is too small to prove much");
+        assert!(
+            scans < nodes / 2,
+            "the Python metric walk built {scans} cursors over {nodes} nodes; the \
+             instance-attribute scan is meant to hold one for the subtree (#1112)"
+        );
+
+        // The suppression scan is a full-tree DFS of its own: 0 scans
+        // over this fixture's 29 nodes with the cursor hoisted, 29
+        // without.
+        let parser = crate::langs::RustParser::new(
+            b"// bca: suppress(cognitive)\nfn f() { if a { g(1, 2); } }\n".to_vec(),
+            std::path::Path::new("lib.rs"),
+            None,
+        );
+        let nodes = parser.root().preorder().count();
+        let before = child_scan_cursors::observed();
+        let markers = crate::suppression::suppression_markers(&parser);
+        let scans = child_scan_cursors::observed() - before;
+        assert_eq!(markers.len(), 1, "fixture carries one marker");
+        assert!(nodes > 20, "fixture is too small to prove much");
+        assert!(
+            scans < nodes / 2,
+            "the suppression scan built {scans} cursors over {nodes} nodes (#1112)"
+        );
+    }
+
+    /// [`Node::children_with`] must yield exactly what
+    /// [`Node::children`] yields — same nodes, same order, same
+    /// `ExactSizeIterator` length at every step — for every node of a
+    /// real tree.
+    ///
+    /// The two share `seed_child_scan` / `step_child_scan` precisely so
+    /// they cannot diverge, and this is what says the sharing is wired
+    /// up. It also covers the reuse itself: one cursor drives every
+    /// node's scan here, so a `reset` that failed to rewind would show
+    /// as the second node inheriting the first's position.
+    #[test]
+    fn children_with_yields_exactly_what_children_does() {
+        let code = b"const o = { m: (a) => a + 1, n: function () {} }; foo(); ;";
+        let tree = Tree::new::<MozjsCode>(code);
+        let root = tree.get_root();
+
+        let mut cursor = root.cursor();
+        let mut leaves = 0;
+        let mut widest = 0;
+        for node in root.preorder() {
+            let expected: Vec<_> = node.children().map(|c| (c.id(), c.kind_id())).collect();
+
+            let actual = drain_checking_exact_size(
+                node.children_with(&mut cursor),
+                expected.len(),
+                "children_with",
+                node.kind(),
+            );
+            assert_eq!(
+                actual,
+                expected,
+                "children_with diverged from children at kind {}",
+                node.kind()
+            );
+
+            leaves += usize::from(expected.is_empty());
+            widest = widest.max(expected.len());
+        }
+        // Both ends of the arity range, else the comparison could hold
+        // over nothing but one-child wrappers.
+        assert!(leaves > 0, "fixture must contain childless nodes");
+        assert!(widest > 2, "fixture must contain a multi-child node");
     }
 
     /// The `O(1)` guard [`Ancestors::checked`] keeps on by default must

--- a/src/node.rs
+++ b/src/node.rs
@@ -363,18 +363,6 @@ impl<'a> Node<'a> {
         Cursor(self.0.walk())
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn get_parent(&self, level: usize) -> Option<Node<'a>> {
-        let mut level = level;
-        let mut node = *self;
-        while level != 0 {
-            node = node.parent()?;
-            level -= 1;
-        }
-
-        Some(node)
-    }
-
     /// Counts this node's ancestors satisfying `check`, walking upward
     /// from the parent and stopping at (and excluding) the first
     /// ancestor satisfying `stop`. An ancestor that is the `if` of an
@@ -1563,6 +1551,74 @@ mod tests {
             scans < nodes / 2,
             "the suppression scan built {scans} cursors over {nodes} nodes (#1112)"
         );
+    }
+
+    /// [`Node::parent_grandparent_match`] must answer `false` when
+    /// either link is missing, rather than degrading to a
+    /// single-predicate check.
+    ///
+    /// Its doc states that invariant and Python's `Cyclomatic` `else`
+    /// arm depends on it, but nothing exercised either absent-link
+    /// return: every call in the suite runs on a node that has both a
+    /// parent and a grandparent. Both predicates answer `true` here, so
+    /// a `false` result can only come from the missing link — an
+    /// implementation that skipped the second `climb.next()` and
+    /// returned `parent_pred`'s answer would pass every other test and
+    /// fail this one.
+    ///
+    /// Checked through both `Ancestors` constructors: the chain and the
+    /// climb reach the end by different code paths (`split_last` on an
+    /// empty slice, versus `Node::parent` returning `None`).
+    #[test]
+    fn parent_grandparent_match_is_false_when_either_link_is_absent() {
+        let tree = Tree::new::<crate::langs::CCode>(b"int main() { int a; }");
+        let root = tree.get_root();
+        let child = root.children().next().expect("the file has an item");
+        let grandchild = child
+            .children()
+            .next()
+            .expect("the function definition has children");
+        let yes: fn(&Node) -> bool = |_| true;
+
+        // No parent at all: the root, reached either way.
+        assert!(!root.parent_grandparent_match(Ancestors::unknown(), yes, yes));
+        assert!(!root.parent_grandparent_match(Ancestors::known(&[]), yes, yes));
+
+        // A parent but no grandparent: a direct child of the root.
+        assert!(!child.parent_grandparent_match(Ancestors::unknown(), yes, yes));
+        assert!(!child.parent_grandparent_match(Ancestors::known(&[root]), yes, yes));
+
+        // Both links present, so the same predicates now answer `true`.
+        // Without this the assertions above would also hold for a
+        // function that always returned `false`.
+        assert!(grandchild.parent_grandparent_match(Ancestors::unknown(), yes, yes));
+        assert!(grandchild.parent_grandparent_match(Ancestors::known(&[root, child]), yes, yes));
+    }
+
+    /// [`Search::first_occurrence`] must return `None` when nothing in
+    /// the subtree matches, rather than falling back to the root or the
+    /// last node it looked at.
+    ///
+    /// Every caller in the crate — the C / C++ / Objective-C / Mozcpp
+    /// getters — uses it to find a declarator that the surrounding
+    /// grammar guarantees is there, so the whole suite only ever
+    /// exercised the hit path.
+    #[test]
+    fn first_occurrence_answers_none_when_nothing_matches() {
+        let tree = Tree::new::<crate::langs::CCode>(b"int main() { int a; }");
+        let root = tree.get_root();
+
+        // `u16::MAX` is not a grammar kind id, so nothing can match and
+        // the walk runs the whole subtree out before answering.
+        assert!(root.first_occurrence(|id| id == u16::MAX).is_none());
+        // The complementary predicate matches everything, so the `None`
+        // above is the absent match rather than a search that stopped
+        // looking. (The predicate is a `fn` pointer, so neither can
+        // capture a kind id from the fixture.)
+        let found = root
+            .first_occurrence(|id| id != u16::MAX)
+            .expect("a match-everything predicate must hit the root itself");
+        assert_eq!(found.id(), root.id(), "the search starts at the root");
     }
 
     /// [`Node::children_with`] must yield exactly what

--- a/src/node.rs
+++ b/src/node.rs
@@ -1558,11 +1558,12 @@ mod tests {
     /// `ExactSizeIterator` length at every step — for every node of a
     /// real tree.
     ///
-    /// The two share `seed_child_scan` / `step_child_scan` precisely so
-    /// they cannot diverge, and this is what says the sharing is wired
-    /// up. It also covers the reuse itself: one cursor drives every
-    /// node's scan here, so a `reset` that failed to rewind would show
-    /// as the second node inheriting the first's position.
+    /// Checked against the raw `child(i)` walk rather than against
+    /// `children()`: the two iterators share [`ChildScan`], so a
+    /// comparison between them would pass just as happily if the shared
+    /// step were wrong. It also covers the reuse itself — one cursor
+    /// drives every node's scan here, so a `reset` that failed to rewind
+    /// would show as the second node inheriting the first's position.
     #[test]
     fn children_with_yields_exactly_what_children_does() {
         let code = b"const o = { m: (a) => a + 1, n: function () {} }; foo(); ;";
@@ -1573,7 +1574,15 @@ mod tests {
         let mut leaves = 0;
         let mut widest = 0;
         for node in root.preorder() {
-            let expected: Vec<_> = node.children().map(|c| (c.id(), c.kind_id())).collect();
+            // Ground truth is the raw `child(i)` walk, not `children()`.
+            // The two iterators share `ChildScan`, so checking one
+            // against the other would pass just as happily if the shared
+            // step were wrong.
+            let raw = node.as_tree_sitter();
+            let expected: Vec<_> = (0..raw.child_count() as u32)
+                .filter_map(|i| raw.child(i))
+                .map(|c| (c.id(), c.kind_id()))
+                .collect();
 
             let actual = drain_checking_exact_size(
                 node.children_with(&mut cursor),
@@ -1584,7 +1593,7 @@ mod tests {
             assert_eq!(
                 actual,
                 expected,
-                "children_with diverged from children at kind {}",
+                "children_with diverged from the child(i) walk at kind {}",
                 node.kind()
             );
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -327,8 +327,10 @@ impl<'a> Node<'a> {
     /// [`children_with`]: Self::children_with
     pub(crate) fn children(&self) -> Children<'a> {
         child_scan_cursors::record();
+        // `descend`, not `seed`: `ts_node_walk` already ran the
+        // `ts_tree_cursor_init` that `Cursor::reset` would run again.
         let mut cursor = self.cursor();
-        let scan = ChildScan::seed(self, &mut cursor);
+        let scan = ChildScan::descend(self, &mut cursor);
         Children { cursor, scan }
     }
 
@@ -343,12 +345,13 @@ impl<'a> Node<'a> {
     ///
     /// Worth the plumbing only where a loop visits many nodes. Measured
     /// on the corpus slice, a full metric walk reaches [`children`] on
-    /// 3-6 % of nodes in every language except Python, where one scan —
-    /// the instance-attribute walk in `metrics::npa::python` — took it
-    /// to 60 %. Predicates that hold a bare `&Node` and scan one node's
-    /// children keep [`children`]: threading a cursor to them would
-    /// cross the `Checker` / `Getter` trait surface to save a single
-    /// allocation per call.
+    /// 3-6 % of nodes in C++, Rust, JavaScript, and Java, 16 % in C#,
+    /// and 60 % in Python, where one scan — the instance-attribute walk
+    /// in `metrics::npa::python` — was 92 % of the total. Predicates
+    /// that hold a bare `&Node` and scan one node's children keep
+    /// [`children`]: threading a cursor to them would cross the
+    /// `Checker` / `Getter` trait surface to save a single allocation
+    /// per call.
     ///
     /// [`children`]: Self::children
     pub(crate) fn children_with<'c>(&self, cursor: &'c mut Cursor<'a>) -> ChildrenWith<'c, 'a> {
@@ -724,6 +727,15 @@ impl ChildScan {
     /// length matches its (lack of) data.
     fn seed<'a>(node: &Node<'a>, cursor: &mut Cursor<'a>) -> Self {
         cursor.reset(node);
+        Self::descend(node, cursor)
+    }
+
+    /// [`ChildScan::seed`], for a cursor already seated on `node` —
+    /// which is what [`Node::cursor`] hands back, and `ts_node_walk` and
+    /// `ts_tree_cursor_reset` run the same `ts_tree_cursor_init`. Only
+    /// [`Node::children`] may skip the reset; every other caller reuses
+    /// a cursor left wherever the previous scan ended.
+    fn descend<'a>(node: &Node<'a>, cursor: &mut Cursor<'a>) -> Self {
         let done = !cursor.goto_first_child();
         Self {
             done,

--- a/src/node.rs
+++ b/src/node.rs
@@ -465,8 +465,8 @@ impl<'tree, 'chain> Ancestors<'tree, 'chain> {
         Self(Some(chain))
     }
 
-    /// [`Ancestors::known`], but in debug builds first checks that
-    /// `chain` really is `node`'s ancestry.
+    /// [`Ancestors::known`], but first checks that `chain` really is
+    /// `node`'s ancestry.
     ///
     /// The parity test below proves the walker's truncate/push rule on a
     /// *replica* walker, so it cannot see `metrics_inner` itself
@@ -478,13 +478,46 @@ impl<'tree, 'chain> Ancestors<'tree, 'chain> {
     /// here; [`Ancestors::known`] stays unchecked for the callers that
     /// deliberately pair a chain with a foreign node.
     ///
-    /// Debug-only, because [`Node::parent`] is the `O(depth)` lookup
-    /// #1084 exists to remove and must never run in a release build.
+    /// # Two checks, because the exact one is not affordable by default
+    ///
+    /// The invariant is "`chain.last()` **is** `node.parent()`", and
+    /// asking that outright costs [`Node::parent`]'s `O(depth)` — the
+    /// very lookup #1084 exists to remove. Per node, on all five walks
+    /// that construct a checked chain, it made every debug-build walk
+    /// `O(nodes × depth)` while the shipped walk is `O(nodes)`: a tax on
+    /// every `cargo test`, worst on the deep-nesting regression tests
+    /// that exist to pin the shipped walk's linearity (#1122). It now
+    /// runs only under `--cfg chain_audit`, which `make chain-audit` and
+    /// the CI lane of the same name set — and there as a plain
+    /// `assert_eq!`, so the audit has teeth in a release profile too.
+    ///
+    /// What stays on in every debug build is an `O(1)` *consequence* of
+    /// that invariant: a parent's byte span contains its child's, and no
+    /// node is its own parent. Strictly weaker — a grandparent contains
+    /// the node as well — but it is shaped to the two ways a walker
+    /// desynchronises. A `push` moved ahead of the per-node computes
+    /// leaves `chain.last() == node`; a dropped `truncate` leaves the
+    /// previous subtree's path, whose last entry is disjoint from the
+    /// node that follows it. Both trip here, on the first node that
+    /// shows them, at four integer comparisons.
     pub(crate) fn checked(chain: &'chain [Node<'tree>], node: &Node<'tree>) -> Self {
-        debug_assert_eq!(
+        // Opt-in only: `Node::parent` restarts at the root, so this is
+        // the `O(nodes × depth)` walk described above.
+        #[cfg(chain_audit)]
+        assert_eq!(
             chain.last().map(Node::id),
             node.parent().map(|parent| parent.id()),
             "ancestor chain desynchronised on a {} node",
+            node.kind()
+        );
+        debug_assert!(
+            chain.last().is_none_or(|parent| {
+                parent.id() != node.id()
+                    && parent.start_byte() <= node.start_byte()
+                    && node.end_byte() <= parent.end_byte()
+            }),
+            "ancestor chain desynchronised on a {} node: chain.last() neither \
+             contains it nor differs from it",
             node.kind()
         );
         Self::known(chain)
@@ -1310,6 +1343,88 @@ mod tests {
             b"const f = a => { a => { g(() => 1); }; };\nconst o = { m: function () { return 1; } };\n",
             &["arrow_function"],
         );
+    }
+
+    /// The `O(1)` guard [`Ancestors::checked`] keeps on by default must
+    /// accept every chain a walker really builds — over several grammar
+    /// families, not just the one fixture a failure would surface in.
+    ///
+    /// The assertion that an equal-span pair was seen is what makes the
+    /// containment non-strict on purpose rather than by luck: a
+    /// single-child wrapper (`expression_statement` over its expression,
+    /// say) spans exactly what its child spans, so tightening either
+    /// bound to `<` would reject a correct chain on most real input.
+    #[test]
+    fn checked_accepts_the_chains_the_walkers_build() {
+        let mut equal_span_pairs = 0;
+        let mut check = |node: &Node<'_>, chain: &[Node<'_>]| {
+            let _ = Ancestors::checked(chain, node);
+            if let Some(parent) = chain.last()
+                && parent.start_byte() == node.start_byte()
+                && parent.end_byte() == node.end_byte()
+            {
+                equal_span_pairs += 1;
+            }
+        };
+        let visited = for_each_node_with_chain::<crate::langs::CCode>(
+            b"int main() { if (a) { int x; } else { f(a, b); } }",
+            &mut check,
+        ) + for_each_node_with_chain::<crate::langs::JavascriptCode>(
+            b"const o = { m: (a) => a + 1 };\nfoo.bar();\n",
+            &mut check,
+        ) + for_each_node_with_chain::<crate::langs::PythonCode>(
+            b"def f(a):\n    if a:\n        return [x for x in a]\n",
+            &mut check,
+        );
+
+        assert!(visited > 60, "fixtures are too small to prove much");
+        assert!(
+            equal_span_pairs > 0,
+            "no parent spans exactly what its child does, so this fixture set \
+             cannot tell non-strict containment from strict"
+        );
+    }
+
+    /// A `push` moved ahead of the per-node computes leaves the node
+    /// itself as `chain.last()`. Spans alone cannot see that — a node
+    /// contains itself — so the identity half of the guard is what
+    /// catches it.
+    ///
+    /// Debug-gated because `debug_assert!` compiles out under
+    /// `--release`, where `checked` degrades to `known` by design.
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "ancestor chain desynchronised")]
+    fn checked_rejects_a_chain_ending_in_the_node_itself() {
+        let tree = Tree::new::<crate::langs::CCode>(b"int main() { int a; }");
+        let body = tree
+            .get_root()
+            .preorder()
+            .find(|n| n.kind() == "compound_statement")
+            .expect("fixture has a function body");
+        let _ = Ancestors::checked(std::slice::from_ref(&body), &body);
+    }
+
+    /// A dropped `truncate` leaves the previous subtree's path in place,
+    /// so the next node up gets a `chain.last()` from a sibling subtree —
+    /// disjoint from it in bytes. That is the containment half.
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "ancestor chain desynchronised")]
+    fn checked_rejects_a_chain_from_a_disjoint_subtree() {
+        let tree = Tree::new::<crate::langs::CCode>(b"int main() { int a; int b; }");
+        let body = tree
+            .get_root()
+            .preorder()
+            .find(|n| n.kind() == "compound_statement")
+            .expect("fixture has a function body");
+        let declarations: Vec<Node<'_>> = body
+            .children()
+            .filter(|n| n.kind() == "declaration")
+            .collect();
+        assert_eq!(declarations.len(), 2, "fixture has two declarations");
+        // `int a;` neither contains nor equals `int b;`.
+        let _ = Ancestors::checked(&declarations[..1], &declarations[1]);
     }
 
     /// [`Node::has_sibling`] must answer the same whether its parent

--- a/src/suppression.rs
+++ b/src/suppression.rs
@@ -582,7 +582,12 @@ pub(crate) fn suppression_markers<T: ParserTrait>(parser: &T) -> Vec<Suppression
     // enclosing function name, borrowed from `code`, so child nodes
     // inherit it without re-deriving, plus the node's depth, which
     // indexes `chain`.
-    let mut stack: Vec<(Node<'_>, Option<&str>, usize)> = vec![(parser.root(), None, 0)];
+    let root = parser.root();
+    let mut stack: Vec<(Node<'_>, Option<&str>, usize)> = vec![(root, None, 0)];
+    // One cursor for the whole walk, not one per node: this visits every
+    // node in the file, and `Node::children` would build and free a
+    // `TreeCursor` at each (#1112, `Node::children_with`).
+    let mut cursor = root.cursor();
     while let Some((node, enclosing, depth)) = stack.pop() {
         chain.truncate(depth);
 
@@ -602,9 +607,10 @@ pub(crate) fn suppression_markers<T: ParserTrait>(parser: &T) -> Vec<Suppression
             enclosing
         };
         chain.push(node);
-        for child in node.children() {
-            stack.push((child, child_enclosing, depth + 1));
-        }
+        stack.extend(
+            node.children_with(&mut cursor)
+                .map(|child| (child, child_enclosing, depth + 1)),
+        );
     }
     markers.sort_by_key(|m| m.line);
     markers


### PR DESCRIPTION
Fixes #1122 and #1112 — two allocation/assertion costs in the AST walk.
Neither changes a metric value; there is no snapshot drift.

Both issues rested on premises that did not survive measurement, so the
headline result differs from what they predicted. Details below.

## #1122 — the debug-build walk was quadratic

`Ancestors::checked` asked the exact question — `chain.last() ==
node.parent()` — on every node of all five walks that thread an ancestor
chain. `Node::parent` is the `O(depth)` lookup #1084 exists to remove,
so every debug-build walk was `O(nodes × depth)` while the shipped walk
is `O(nodes)`. The tests that exist to pin the shipped walk's linearity
were the slowest thing about not shipping it.

The exact assertion now runs only under `--cfg chain_audit`, which
`make chain-audit` and a new `chain-audit` CI lane set. A **custom cfg,
not a Cargo feature**: `make test` passes `--all-features`, so a feature
would have switched the audit back on in exactly the inner loop this
exists to keep fast.

A plain debug build keeps an `O(1)` *consequence* of the same
invariant — a parent's byte span contains its child's, and no node is
its own parent. That catches a `push` moved ahead of the per-node
computes and a dropped `truncate`, but **not** a chain short by exactly
one, since a grandparent contains the node too. That gap is the audit
lane's justification, and it is demonstrated rather than asserted:
truncating one level short in `spaces/compute.rs` passes the default
build and fails the lane.

| | before | after |
|---|---|---|
| whole library suite | ~5.0 s | ~1.7 s |
| `cognitive_nesting_is_inherited_at_depth` | 1.60 s | 0.02 s |
| `cognitive_function_depth_is_inherited_at_depth` | 1.00 s | 0.02 s |
| `deeply_nested_spaces_convert_to_wire…` | 1.83 s | 0.02 s |
| `deeply_nested_ops_convert_and_serialize…` | 3.14 s | 1.31 s |

`make chain-audit` restores the old cost, which confirms the attribution.

## #1112 — the cursor allocation was in one place, not 137

The issue attributes the cost to per-node predicates across the walk
("roughly ~137 call sites"). Counting actual calls during a full
`metrics()` walk over the corpus slice says otherwise:

| Language | `children()` calls / node |
|---|---|
| C++ (`.cc`) | 0.031 |
| Rust, JavaScript | 0.040 |
| Java | 0.058 |
| C# | 0.164 |
| **Python** | **0.600** |

The predicates are a rounding error. One scan was not:
`python_collect_self_attrs_in_subtree` walks every node of every method
body and was **381 k of Python's 417 k child scans — 92 %**. Attributed
with `#[track_caller]`, so that is the measured call site rather than an
inference.

`Node::children_with` lets a loop hoist one cursor and reset it per
node, applied to the three genuine per-node consumers: that Python scan,
`Preorder`, and the suppression-marker DFS.

**Plan steps 1 and 2 were deliberately not done.** No cursor threading
into the `Checker` / `Getter` predicates and no `thread_local!` pool:
after the three loops above, the remaining call sites hold a bare
`&Node`, and threading a cursor to them would cross the trait surface
across 25 language modules to save ~17 ns per call on a small minority
of nodes (JavaScript: ~1.0 ms over a 6.25 MB walk, ~0.25 %).

Measured on 400 Python corpus files (694 k nodes), interleaved
best-of-nine in a single binary — this host is loaded, so a two-run
comparison would not be trustworthy:

- cursor allocations: **414,620 → 33,328 (−92 %)**
- walk time: **159.0 ms → 155.2 ms (−2.4 %)**

The allocation removal is unambiguous; the wall-clock win is real but
modest, and outside Python it is under 1 %. Stating that plainly because
the issue's framing implied more.

## Testing

Both changes are invisible in output — every metric assertion holds
either way — so each gets an `observation::counter!` and each new test
was verified by perturbation, not just by passing:

- `Ancestors::checked`: fails if containment is tightened to strict;
  two `#[should_panic]` tests for the self-push and disjoint-subtree
  shapes both fail if the `debug_assert!` is deleted.
- `child_scan_cursors`: `the_converted_traversals_scan_a_tree_on_one_cursor`
  fails if **any one** of the three loops is reverted, verified
  individually.
- `children_with` parity is checked against the raw `child(i)` ground
  truth, not against `children()` — they share `ChildScan`, so that
  comparison would have passed on a wrong shared step.

Coverage rose against `main`: **+158 lines, +18 functions, +273 regions
covered** (missed lines −1), compared by covered counts rather than the
percentage column.

## Corrections to the issues

- #1122 step 5 asks to update `benchmarking.md`'s "note that the
  unoptimised walk is quadratic". No such note exists there — the only
  "unoptimised" mention concerns the bench harness's smoke mode. The
  stale cost claim was in `src/metrics/cognitive.rs`, and that is what
  was corrected.
- #1112's per-node framing is corrected above, and recorded in
  `benchmarking.md#child-scans` so the next person does not re-derive it.

## Validation

`cargo fmt`, `clippy --all-targets --all-features -D warnings`, the full
`--all-features` workspace suite, doctests, `doc-check`, both `self-scan`
tiers, `snapshot-anchors`, `markdown-lint`, `actionlint`, the
`no-default-features` and `rust,typescript` feature-matrix legs, the
Python `ruff` / `mypy` / `pytest` / `stubtest` stages, and
`make chain-audit`.

`.bca-baseline.toml` is refreshed with the headroom variant: `impl Node`
`nom` 34 → 35 for `children_with`.

One caveat: `make pre-commit` cannot run to completion from a git
worktree under `.claude/worktrees/`. `cargo fmt --all` and `enums-check`
fail with "current package believes it's in a workspace when it's not",
because cargo walks up from the workspace-*excluded* vendored crates and
finds the parent repo's manifest. This is pre-existing and purely
location-caused. Every stage was run individually instead, with
`cargo fmt` covered by the per-package equivalent. Worth fixing
separately, since the repo's own `batch-fix` skill uses these worktrees.
