### PR TITLE
fix(nargs): count args on the innermost C declarator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -778,11 +778,35 @@ for historical reference.
   is fixed in the same walk: it had been reporting `(int c)`, the
   return type's list, rather than its own.
 
+  A C++11 `[[…]]` attribute on a function no longer hides its
+  parameters either. `attributed_declarator` is the one declarator rule
+  that puts its declarator *first*, so
+  `int f(int a, int b) [[deprecated]]` had always reported 0. The GNU
+  `__attribute__((…))` spelling was never affected — every one of the
+  four grammars absorbs it into the `function_declarator` instead of
+  wrapping it.
+
+  A C++ conversion operator is explicitly *excluded* from the walk:
+  `operator int (*)(int x)` takes no arguments however many its target
+  type has.
+
   **Metric drift.** Serialized `nargs` rises wherever such a function
   appears — 3,336 recorded values across 276 files of the `DeepSpeech`
   corpus, and nothing falls. Since #1196 made the gate read a
   callable's own parameter count, these functions were invisible to
   `bca check --threshold nargs=N` and can now trip it.
+
+- C's `(void)` marker is no longer counted as a parameter. `int f(void)`
+  declares nothing, but the grammar emits a real `parameter_declaration`
+  for the `void` and every `nargs` filter counted it, so `f(void)` and
+  `f(int)` both reported 1. Fixed for C, C++, Mozcpp and Objective-C.
+  The distinction needs the source bytes rather than the tree — an
+  unnamed parameter is the same shape and really is one argument — so
+  `Checker` gained an `is_empty_param_marker` hook that defaults to
+  `false` and reads them.
+
+  **Metric drift.** 24 recorded values fall to 0 in the `DeepSpeech`
+  corpus, all in `pywrapfst.cc`, its only `(void)` definitions.
 
 - A comment written inside a parameter list is no longer counted as a
   parameter (#1201). tree-sitter attaches such a comment as a direct

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -766,6 +766,24 @@ for historical reference.
 
 ### Fixed
 
+- C, C++, Mozcpp and Objective-C functions whose return type is a
+  pointer or a reference now report their real arity instead of 0
+  (#1200). C declarator syntax nests outward from the declared name, so
+  `FILE *f(int a, int b, int c)` puts the parameter list on a
+  `function_declarator` wrapped by the `pointer_declarator` the return
+  type contributed; `nargs` read the wrapper, found no parameters and
+  reported nothing. `int **`, `int &`, `Foo &&`, `static int *` and a
+  member function returning a reference were all affected. A function
+  returning a *function pointer* — `int (*fp(int a, int b))(int c)` —
+  is fixed in the same walk: it had been reporting `(int c)`, the
+  return type's list, rather than its own.
+
+  **Metric drift.** Serialized `nargs` rises wherever such a function
+  appears — 3,336 recorded values across 276 files of the `DeepSpeech`
+  corpus, and nothing falls. Since #1196 made the gate read a
+  callable's own parameter count, these functions were invisible to
+  `bca check --threshold nargs=N` and can now trip it.
+
 - A comment written inside a parameter list is no longer counted as a
   parameter (#1201). tree-sitter attaches such a comment as a direct
   child of the parameter-*list* node rather than inside the parameter it

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -362,6 +362,24 @@ pub(crate) trait Checker {
     fn is_non_arg(_: &Node) -> bool {
         false
     }
+    /// Whether `param` is a language's way of spelling *"this function
+    /// takes nothing"* inside an otherwise ordinary parameter list.
+    ///
+    /// C's `int f(void)` declares zero parameters, but the grammar
+    /// emits a real `parameter_declaration` for the `void`, so the
+    /// negative filters in [`crate::nargs`] counted it as one — `f` and
+    /// `int f(int)` both reported 1 despite one of them taking no
+    /// argument at all.
+    ///
+    /// It takes `code` because the question is not structural: a
+    /// `parameter_declaration` holding a bare `primitive_type` and no
+    /// declarator is *also* how an unnamed parameter is spelled, and
+    /// `void f(int)` really does take one. Only the bytes tell them
+    /// apart — `.claude/rules/grammar-dispatch.md` §10.
+    #[inline]
+    fn is_empty_param_marker(_param: &Node, _code: &[u8]) -> bool {
+        false
+    }
     /// Whether `node` — the value of a function's `parameters` field —
     /// is itself a *single formal parameter* rather than a parameter
     /// *list*.
@@ -546,6 +564,25 @@ pub(crate) fn csharp_accessor_count(node: &Node) -> usize {
 /// accessor-less expression-bodied form (#464 indexer, #472 property).
 pub(crate) fn csharp_member_has_accessors(node: &Node) -> bool {
     csharp_accessor_count(node) > 0
+}
+
+/// Whether `param` is C's `(void)` marker — the spelling for an empty
+/// parameter list — rather than a parameter.
+///
+/// Shared by C, C++, Mozcpp and Objective-C, which all inherit the
+/// idiom and all emit a real `parameter_declaration` for it.
+///
+/// The declarator check is what separates the marker from `void *p`,
+/// which is an ordinary parameter of type `void *`, and the byte
+/// comparison is what separates it from an unnamed parameter of any
+/// other type: `f(int)` and `f(void)` are the same shape and different
+/// arities.
+pub(crate) fn c_family_void_parameter(param: &Node, code: &[u8]) -> bool {
+    param.child_by_field_name("declarator").is_none()
+        && param
+            .child_by_field_name("type")
+            .and_then(|ty| code.get(ty.start_byte()..ty.end_byte()))
+            == Some(b"void".as_slice())
 }
 
 /// Strip the `#` / `#!` marker plus the `[...]` brackets from a

--- a/src/checker/c.rs
+++ b/src/checker/c.rs
@@ -44,6 +44,11 @@ impl Checker for CCode {
         node.kind_id() == C::CallExpression
     }
 
+    // C's `(void)` marker, shared with C++, Mozcpp and Objective-C.
+    fn is_empty_param_marker(param: &Node, code: &[u8]) -> bool {
+        c_family_void_parameter(param, code)
+    }
+
     fn is_non_arg(node: &Node) -> bool {
         matches!(node.kind_id().into(), C::LPAREN | C::COMMA | C::RPAREN)
     }

--- a/src/checker/cpp.rs
+++ b/src/checker/cpp.rs
@@ -55,6 +55,11 @@ impl Checker for CppCode {
         node.kind_id() == Cpp::CallExpression
     }
 
+    // C's `(void)` marker, shared with C++, Mozcpp and Objective-C.
+    fn is_empty_param_marker(param: &Node, code: &[u8]) -> bool {
+        c_family_void_parameter(param, code)
+    }
+
     fn is_non_arg(node: &Node) -> bool {
         matches!(
             node.kind_id().into(),

--- a/src/checker/mozcpp.rs
+++ b/src/checker/mozcpp.rs
@@ -55,6 +55,11 @@ impl Checker for MozcppCode {
         node.kind_id() == Mozcpp::CallExpression
     }
 
+    // C's `(void)` marker, shared with C++, Mozcpp and Objective-C.
+    fn is_empty_param_marker(param: &Node, code: &[u8]) -> bool {
+        c_family_void_parameter(param, code)
+    }
+
     fn is_non_arg(node: &Node) -> bool {
         matches!(
             node.kind_id().into(),

--- a/src/checker/objc.rs
+++ b/src/checker/objc.rs
@@ -60,6 +60,11 @@ impl Checker for ObjcCode {
         )
     }
 
+    // C's `(void)` marker, shared with C++, Mozcpp and Objective-C.
+    fn is_empty_param_marker(param: &Node, code: &[u8]) -> bool {
+        c_family_void_parameter(param, code)
+    }
+
     fn is_non_arg(node: &Node) -> bool {
         matches!(
             node.kind_id().into(),

--- a/src/metrics/nargs.rs
+++ b/src/metrics/nargs.rs
@@ -4629,16 +4629,12 @@ mod c_family_return_type_declarators {
         // fixtures assert about the struct and pass with the defect
         // reinstated.
         let mut space = &root;
-        loop {
-            let [only] = space.spaces.as_slice() else {
-                break;
-            };
+        let mut depth = 0;
+        while let [only] = space.spaces.as_slice() {
             space = only;
+            depth += 1;
         }
-        assert!(
-            !std::ptr::eq(space, &root),
-            "{lang:?}: fixture opened no space at all"
-        );
+        assert!(depth > 0, "{lang:?}: fixture opened no space at all");
         (
             space.metrics.nargs.closure_args(),
             space.metrics.nargs.function_args(),

--- a/src/metrics/nargs.rs
+++ b/src/metrics/nargs.rs
@@ -303,28 +303,23 @@ fn compute_args<T: Checker>(node: &Node, nargs: &mut usize) {
 /// Every step strictly descends a finite tree, so the walk terminates
 /// without a depth cap.
 fn declarator_params_owner<'tree, T: Checker>(node: &Node<'tree>) -> Option<Node<'tree>> {
-    // The chain starts at the field rather than at `node` so the
-    // last-named-child fallback can never fire on the function node
-    // itself and walk into its body.
-    let mut current = node.child_by_field_name("declarator")?;
-    let mut owner = None;
-    loop {
-        let carries_params = current.child_by_field_name("parameters").is_some();
-        if carries_params {
-            owner = Some(current);
-        }
-        let next = match current.child_by_field_name("declarator") {
+    // The chain starts at the `declarator` field rather than at `node`
+    // so the last-named-child fallback can never fire on the function
+    // node itself and walk into its body. The walk runs outside-in, so
+    // the innermost qualifying link is the last one it yields.
+    std::iter::successors(
+        node.child_by_field_name("declarator"),
+        |current| match current.child_by_field_name("declarator") {
             Some(declarator) => Some(declarator),
-            None if carries_params => None,
+            None if current.child_by_field_name("parameters").is_some() => None,
             None => current
                 .children()
                 .filter(|child| child.is_named() && !T::is_comment(child))
                 .last(),
-        };
-        let Some(next) = next else { break };
-        current = next;
-    }
-    owner
+        },
+    )
+    .filter(|link| link.child_by_field_name("parameters").is_some())
+    .last()
 }
 
 #[doc(hidden)]

--- a/src/metrics/nargs.rs
+++ b/src/metrics/nargs.rs
@@ -4618,12 +4618,24 @@ mod c_family_return_type_declarators {
     #[track_caller]
     fn sole_space_args(lang: LANG, source: &str) -> (u64, u64) {
         let root = space_verbatim(lang, source.as_bytes(), MetricsOptions::default());
-        let [space] = root.spaces.as_slice() else {
-            panic!(
-                "{lang:?}: fixture must open exactly one space, opened {}",
-                root.spaces.len()
-            );
-        };
+        // Descend to the *innermost* sole space, not the first one.
+        // A free function is one level down, but a conversion operator
+        // is two — its `struct` opens a container space in between,
+        // whose own counters stay at zero however badly the operator is
+        // counted. Stopping at the first level made both `operator_cast`
+        // fixtures assert about the struct and pass with the defect
+        // reinstated.
+        let mut space = &root;
+        loop {
+            let [only] = space.spaces.as_slice() else {
+                break;
+            };
+            space = only;
+        }
+        assert!(
+            !std::ptr::eq(space, &root),
+            "{lang:?}: fixture opened no space at all"
+        );
         (
             space.metrics.nargs.closure_args(),
             space.metrics.nargs.function_args(),

--- a/src/metrics/nargs.rs
+++ b/src/metrics/nargs.rs
@@ -4681,6 +4681,23 @@ mod c_family_return_type_declarators {
                     "int g(int a, int b) { auto f = []{ return 1; }; return f(); }",
                     (0, 2),
                 ),
+                // …and the shape that makes that first step *matter*.
+                // The row above executes the early return but cannot
+                // discriminate it — perturbing the walk to begin at the
+                // last named child instead of the `declarator` field
+                // fails none of the suite, because a parameterless
+                // lambda's body has nothing carrying `parameters` down
+                // its last-child spine.
+                //
+                // A local *function declaration* does. `declaration`
+                // has a `declarator` field of its own, so a walk that
+                // starts outside the declarator chain lands on `q`'s
+                // `function_declarator` and bills its two parameters to
+                // the enclosing lambda, which declares none.
+                (
+                    "int g(int a, int b) { auto f = []{ int q(int x, int y); }; f(); return a + b; }",
+                    (0, 2),
+                ),
                 // The guard for the walk's stop condition. A lambda's
                 // `abstract_function_declarator` carries `parameters`
                 // but its `declarator` field is *optional* and absent

--- a/src/metrics/nargs.rs
+++ b/src/metrics/nargs.rs
@@ -227,15 +227,17 @@ impl Stats {
 /// Elixir and Kotlin lambdas reach their parameter list by three routes
 /// `compute_args` cannot express, so they call this directly.
 #[inline]
-fn count_args<T: Checker>(params: &Node) -> usize {
+fn count_args<T: Checker>(params: &Node, code: &[u8]) -> usize {
     params
         .children()
-        .filter(|child| !T::is_non_arg(child) && !T::is_comment(child))
+        .filter(|child| {
+            !T::is_non_arg(child) && !T::is_comment(child) && !T::is_empty_param_marker(child, code)
+        })
         .count()
 }
 
 #[inline]
-fn compute_args<T: Checker>(node: &Node, nargs: &mut usize) {
+fn compute_args<T: Checker>(node: &Node, code: &[u8], nargs: &mut usize) {
     if let Some(params) = node.child_by_field_name("parameters") {
         // The field can hold a lone parameter rather than a list, in
         // which case there are no children to walk and `count_args`
@@ -244,7 +246,7 @@ fn compute_args<T: Checker>(node: &Node, nargs: &mut usize) {
             *nargs += 1;
             return;
         }
-        *nargs += count_args::<T>(&params);
+        *nargs += count_args::<T>(&params, code);
     } else if node.child_by_field_name("parameter").is_some() {
         // JS/TS/TSX/MozJS arrow functions with a bare identifier parameter
         // (`x => …`) use the singular `parameter` field instead of the plural
@@ -375,13 +377,18 @@ where
     /// silently report 0 here (#1142).
     fn compute<'a>(node: &Node<'a>, code: &[u8], ancestors: Ancestors<'a, '_>, stats: &mut Stats) {
         if Self::is_func_with_code(node, code, ancestors) {
-            compute_args::<Self>(&Self::params_owner(node, ancestors), &mut stats.fn_nargs);
+            compute_args::<Self>(
+                &Self::params_owner(node, ancestors),
+                code,
+                &mut stats.fn_nargs,
+            );
             return;
         }
 
         if Self::is_closure(node, ancestors) {
             compute_args::<Self>(
                 &Self::params_owner(node, ancestors),
+                code,
                 &mut stats.closure_nargs,
             );
         }
@@ -451,19 +458,14 @@ impl NArgs for MozcppCode {
 //   * a block `^(int x){ … }` holds its params in a `parameter_list`
 //     child rather than under a `parameters` field.
 impl NArgs for ObjcCode {
-    fn compute<'a>(
-        node: &Node<'a>,
-        _code: &[u8],
-        _ancestors: Ancestors<'a, '_>,
-        stats: &mut Stats,
-    ) {
+    fn compute<'a>(node: &Node<'a>, code: &[u8], _ancestors: Ancestors<'a, '_>, stats: &mut Stats) {
         match node.kind_id().into() {
             Objc::FunctionDefinition | Objc::FunctionDefinition2 => {
                 // The same declarator walk C and C++ use: Objective-C
                 // inherits C's declarator syntax, so `FILE *f(int a)`
                 // buries the parameter list one level down (#1200).
                 if let Some(owner) = declarator_params_owner::<Self>(node) {
-                    compute_args::<Self>(&owner, &mut stats.fn_nargs);
+                    compute_args::<Self>(&owner, code, &mut stats.fn_nargs);
                 }
             }
             Objc::MethodDefinition => {
@@ -546,7 +548,7 @@ fn compute_kotlin_func_args(node: &Node, nargs: &mut usize) {
     }
 }
 
-fn compute_kotlin_lambda_args(node: &Node, nargs: &mut usize) {
+fn compute_kotlin_lambda_args(node: &Node, code: &[u8], nargs: &mut usize) {
     // Lambda parameters are plain identifiers or destructuring patterns separated
     // by commas; there is no typed `Parameter` wrapper node (unlike function
     // value parameters), so a negative filter is the correct predicate here — the
@@ -559,12 +561,12 @@ fn compute_kotlin_lambda_args(node: &Node, nargs: &mut usize) {
         .children()
         .find(|c| c.kind_id() == Kotlin::LambdaParameters)
     {
-        *nargs += count_args::<KotlinCode>(&params);
+        *nargs += count_args::<KotlinCode>(&params, code);
     }
 }
 
 impl NArgs for KotlinCode {
-    fn compute<'a>(node: &Node<'a>, _code: &[u8], ancestors: Ancestors<'a, '_>, stats: &mut Stats) {
+    fn compute<'a>(node: &Node<'a>, code: &[u8], ancestors: Ancestors<'a, '_>, stats: &mut Stats) {
         if Self::is_func(node, ancestors) {
             compute_kotlin_func_args(node, &mut stats.fn_nargs);
             return;
@@ -572,7 +574,7 @@ impl NArgs for KotlinCode {
 
         if Self::is_closure(node, ancestors) {
             if node.kind_id() == Kotlin::LambdaLiteral {
-                compute_kotlin_lambda_args(node, &mut stats.closure_nargs);
+                compute_kotlin_lambda_args(node, code, &mut stats.closure_nargs);
             } else {
                 compute_kotlin_func_args(node, &mut stats.closure_nargs);
             }
@@ -681,17 +683,17 @@ fn perl_signature<'a>(node: &Node<'a>) -> Option<Node<'a>> {
 // `function_signature`. Perl carried that exclusion inline for years
 // before #1201 found the same hole in every other language and moved it
 // into the shared predicate.
-fn compute_perl_args(node: &Node, nargs: &mut usize) {
+fn compute_perl_args(node: &Node, code: &[u8], nargs: &mut usize) {
     let Some(signature) = perl_signature(node) else {
         return;
     };
-    *nargs += count_args::<PerlCode>(&signature);
+    *nargs += count_args::<PerlCode>(&signature, code);
 }
 
 impl NArgs for PerlCode {
-    fn compute<'a>(node: &Node<'a>, _code: &[u8], ancestors: Ancestors<'a, '_>, stats: &mut Stats) {
+    fn compute<'a>(node: &Node<'a>, code: &[u8], ancestors: Ancestors<'a, '_>, stats: &mut Stats) {
         if Self::is_func(node, ancestors) {
-            compute_perl_args(node, &mut stats.fn_nargs);
+            compute_perl_args(node, code, &mut stats.fn_nargs);
             return;
         }
 
@@ -705,7 +707,7 @@ impl NArgs for PerlCode {
         // `perl_anonymous_sub_signature_is_zero`) rather than passing
         // silently; revisit at the next `recreate-grammars.sh` bump.
         if Self::is_closure(node, ancestors) {
-            compute_perl_args(node, &mut stats.closure_nargs);
+            compute_perl_args(node, code, &mut stats.closure_nargs);
         }
     }
 }
@@ -737,7 +739,7 @@ fn elixir_declared_args(node: &Node, code: &[u8]) -> usize {
     };
     let head = elixir_unwrap_guard(&head, code);
     match head.kind_id().into() {
-        Elixir::Call => elixir_arguments(&head).map_or(0, |p| count_args::<ElixirCode>(&p)),
+        Elixir::Call => elixir_arguments(&head).map_or(0, |p| count_args::<ElixirCode>(&p, code)),
         Elixir::BinaryOperator => 2,
         Elixir::UnaryOperator => 1,
         _ => 0,
@@ -789,7 +791,8 @@ impl NArgs for ElixirCode {
             && let Some(clause) = node.first_child(|id| id == Elixir::StabClause)
             && let Some(params) = clause.child_by_field_name("left")
         {
-            stats.closure_nargs += count_args::<ElixirCode>(&elixir_unwrap_guard(&params, code));
+            stats.closure_nargs +=
+                count_args::<ElixirCode>(&elixir_unwrap_guard(&params, code), code);
         }
     }
 }
@@ -854,11 +857,11 @@ impl NArgs for JavaCode {
 // for a `parameters` field) misses them. Match the closure_parameters
 // child directly and count its `closure_parameter` grand-children.
 impl NArgs for GroovyCode {
-    fn compute<'a>(node: &Node<'a>, _code: &[u8], ancestors: Ancestors<'a, '_>, stats: &mut Stats) {
+    fn compute<'a>(node: &Node<'a>, code: &[u8], ancestors: Ancestors<'a, '_>, stats: &mut Stats) {
         use crate::languages::language_groovy::Groovy;
 
         if Self::is_func(node, ancestors) {
-            compute_args::<Self>(node, &mut stats.fn_nargs);
+            compute_args::<Self>(node, code, &mut stats.fn_nargs);
             return;
         }
 
@@ -4695,6 +4698,17 @@ mod c_family_return_type_declarators {
                 "int gdef(int a, int b) __attribute__((deprecated)) { return a; }",
                 (0, 2),
             ),
+            // C's `(void)` marker declares *no* parameters, but the
+            // grammar emits a real `parameter_declaration` for it, so
+            // every negative filter counted it as one.
+            ("int none(void) { return 0; }", (0, 0)),
+            // The two shapes `(void)` must not be confused with. An
+            // unnamed parameter is structurally identical — a bare type
+            // with no declarator — and really is one argument, so only
+            // the bytes separate them. `void *` carries a declarator
+            // and is likewise a real parameter.
+            ("int unnamed(int) { return 0; }", (0, 1)),
+            ("int ptr(void *p, int a) { return 0; }", (0, 2)),
             // The unwrapped control: its `declarator` field already is
             // the `function_declarator`, so it passed before the fix
             // and must keep passing after it.

--- a/src/metrics/nargs.rs
+++ b/src/metrics/nargs.rs
@@ -273,10 +273,16 @@ fn compute_args<T: Checker>(node: &Node, nargs: &mut usize) {
 /// numeric-suffix aliases that a `kind_id` match would have to
 /// enumerate and would silently regress on the next grammar bump.
 ///
-/// Two of the rules in the chain expose no field at all, which is why
-/// the field alone is not enough. From the pinned grammars'
-/// `node-types.json` (`tree-sitter-cpp` 0.23.4, `tree-sitter-c` 0.24.2,
-/// `tree-sitter-objc` 3.0.2, vendored `tree-sitter-mozcpp`):
+/// Three of the rules on the chain expose no field at all, which is why
+/// the field alone is not enough. Every entry below is from the pinned
+/// grammars' `node-types.json` (`tree-sitter-cpp` 0.23.4,
+/// `tree-sitter-c` 0.24.2, `tree-sitter-objc` 3.0.2, vendored
+/// `tree-sitter-mozcpp`), and the fieldless list is the complete set of
+/// `*_declarator` rules with no fields that a *function definition's*
+/// name side can reach — the rest (`variadic_declarator`,
+/// `structured_binding_declarator`, Objective-C's `keyword_declarator`
+/// and `struct_declarator`, and the `abstract_*` family) sit in
+/// parameter, binding or type position, never here.
 ///
 /// | rule | `declarator` field |
 /// | --- | --- |
@@ -285,13 +291,24 @@ fn compute_args<T: Checker>(node: &Node, nargs: &mut usize) {
 /// | `abstract_function_declarator` | **optional** |
 /// | `reference_declarator` | **absent — no fields** |
 /// | `parenthesized_declarator` | **absent — no fields** |
+/// | `attributed_declarator` | **absent — no fields** |
 ///
-/// `reference_declarator` is `seq(choice('&', '&&'), _declarator)` and
-/// `parenthesized_declarator` is `seq('(', optional(ms_call_modifier),
-/// _declarator, ')')`: in both the inner declarator is the last *named*
-/// child, so that is the fallback. Last rather than sole, so a leading
-/// `ms_call_modifier` (`int (__cdecl *f(int a))(int b)`) does not defeat
-/// it, and comment-filtered because tree-sitter admits a comment
+/// In all three fieldless rules the inner declarator is the last
+/// *named* child once attributes are set aside, so that is the
+/// fallback:
+///
+/// - `reference_declarator` is `seq(choice('&', '&&'), _declarator)`.
+/// - `parenthesized_declarator` is `seq('(',
+///   optional(ms_call_modifier), _declarator, ')')` — last rather than
+///   sole, so `int (__cdecl *f(int a))(int b)` does not defeat it.
+/// - `attributed_declarator` is `seq(_declarator,
+///   repeat1(attribute_declaration))`, the one rule that puts the
+///   declarator **first**. Excluding `attribute_declaration` — its only
+///   non-declarator child type in all four grammars — restores "last"
+///   as the right answer, and without that exclusion
+///   `int f(int a, int b) [[deprecated]]` reports 0.
+///
+/// Comments are excluded for the same reason, tree-sitter admitting one
 /// anywhere.
 ///
 /// The fallback stops at a node that already carries `parameters`,
@@ -314,13 +331,30 @@ fn declarator_params_owner<'tree, T: Checker>(node: &Node<'tree>) -> Option<Node
             None if current.child_by_field_name("parameters").is_some() => None,
             None => current
                 .children()
-                .filter(|child| child.is_named() && !T::is_comment(child))
+                .filter(|child| {
+                    child.is_named() && !T::is_comment(child) && child.kind() != ATTRIBUTE
+                })
                 .last(),
         },
     )
+    // A conversion operator's `declarator` field is the type it converts
+    // *to*, not its name side: `operator int (*)(int x)` takes no
+    // arguments, and everything from here inward describes that
+    // function-pointer type. Cutting the chain restores the 0 the
+    // pre-#1200 code reported by never finding `parameters` at all.
+    .take_while(|link| link.kind() != CONVERSION_OPERATOR)
     .filter(|link| link.child_by_field_name("parameters").is_some())
     .last()
 }
+
+/// Compared by `kind()` string rather than `kind_id`, per
+/// `.claude/rules/grammar-dispatch.md` §1: both rules carry
+/// numeric-suffix aliases across the four C-family grammars, and a
+/// `kind_id` match would have to enumerate every one of them and would
+/// regress silently on the next grammar bump. C and Objective-C simply
+/// never emit `operator_cast`.
+const CONVERSION_OPERATOR: &str = "operator_cast";
+const ATTRIBUTE: &str = "attribute_declaration";
 
 #[doc(hidden)]
 /// Per-language counting of function arguments.
@@ -4639,11 +4673,38 @@ mod c_family_return_type_declarators {
                 "int (__cdecl *w(int a, int b))(int c) { return 0; }",
                 (0, 2),
             ),
+            // The GNU attribute spelling, which all four grammars
+            // absorb *into* the `function_declarator` rather than
+            // wrapping it — so it never builds an
+            // `attributed_declarator` and was never miscounted. It is
+            // the control for the C++11 spelling below, a different
+            // tree for the same source-level idea.
+            (
+                "int gdef(int a, int b) __attribute__((deprecated)) { return a; }",
+                (0, 2),
+            ),
             // The unwrapped control: its `declarator` field already is
             // the `function_declarator`, so it passed before the fix
             // and must keep passing after it.
             ("int plain(int a, int b) { return a; }", (0, 2)),
         ])
+    }
+
+    /// The C++11 `[[…]]` attribute, which is the only spelling that
+    /// builds an `attributed_declarator` — the one fieldless rule
+    /// putting its declarator *first*, so the last-named-child fallback
+    /// lands on the attribute unless `attribute_declaration` is
+    /// excluded. Reported 0 both before #1200 and after its first cut.
+    ///
+    /// Objective-C is absent because its grammar parses `[[…]]` on a
+    /// *definition* as a `declaration` — no `function_definition`, so no
+    /// space and nothing to count. That is upstream, not a miscount of
+    /// ours; the GNU spelling above covers Objective-C's attribute path.
+    fn cpp11_attribute_shapes(lang: LANG) -> Option<&'static [(&'static str, (u64, u64))]> {
+        matches!(lang, LANG::C | LANG::Cpp | LANG::Mozcpp).then_some(&[(
+            "int attr(int a, int b) [[deprecated]] { return a; }",
+            (0, 2),
+        )])
     }
 
     /// The shapes only C++ has: `reference_declarator`, which — unlike
@@ -4665,6 +4726,23 @@ mod c_family_return_type_declarators {
                 // ends at a `qualified_identifier` rather than a bare
                 // one, which has named children of its own.
                 ("Foo &Bar::get(int a) { static Foo f; return f; }", (0, 1)),
+                // A conversion operator takes no arguments, however
+                // many its target *type* has. `operator_cast` is the
+                // one link whose `declarator` field leaves the name
+                // side, and following it billed the converted-to
+                // function-pointer type's `(int x)` to the operator —
+                // a regression the first cut of #1200 introduced and
+                // no fixture then covered.
+                (
+                    "struct S { operator int (*)(int x) { return nullptr; } };",
+                    (0, 0),
+                ),
+                // The same shape through a reference, so the fix cannot
+                // be keyed on the pointer spelling alone.
+                (
+                    "struct S { operator int (&)(int x, int y) { static int *p; return *reinterpret_cast<int (*)(int, int)>(p); } };",
+                    (0, 0),
+                ),
                 (
                     "int g() { auto f = [](int a, int b){ return a + b; }; return f(1, 2); }",
                     (2, 0),
@@ -4715,12 +4793,13 @@ mod c_family_return_type_declarators {
 
     #[test]
     fn a_wrapped_return_type_does_not_hide_the_parameter_list() {
-        let (mut shared, mut cpp_only) = (0, 0);
+        let (mut shared, mut cpp_only, mut attributed) = (0, 0, 0);
         let mut failures = Vec::new();
         for lang in LANG::into_enum_iter().filter(LANG::is_enabled) {
             for (table, counter) in [
                 (c_declarator_shapes(lang), &mut shared),
                 (cpp_only_shapes(lang), &mut cpp_only),
+                (cpp11_attribute_shapes(lang), &mut attributed),
             ] {
                 for (source, expected) in table.unwrap_or_default() {
                     *counter += 1;
@@ -4736,17 +4815,18 @@ mod c_family_return_type_declarators {
                 }
             }
         }
-        let (failed, checked) = (failures.len(), shared + cpp_only);
+        let (failed, checked) = (failures.len(), shared + cpp_only + attributed);
         assert!(
             failures.is_empty(),
             "{failed}/{checked} return-type shapes lost their parameter list: {failures:#?}"
         );
-        // Both tallies, so a renamed `LANG` variant or a feature that
+        // Every tally, so a renamed `LANG` variant or a feature that
         // stopped being enabled fails here rather than passing
         // vacuously.
         assert!(
-            shared > 0 && cpp_only > 0,
-            "no fixture ran (shared={shared}, cpp_only={cpp_only}); this test asserted nothing"
+            shared > 0 && cpp_only > 0 && attributed > 0,
+            "no fixture ran (shared={shared}, cpp_only={cpp_only}, \
+             attributed={attributed}); this test asserted nothing"
         );
     }
 

--- a/src/metrics/nargs.rs
+++ b/src/metrics/nargs.rs
@@ -4678,6 +4678,18 @@ mod c_family_return_type_declarators {
                     "int g() { auto f = [](int a, int b){ return a + b; }; return f(1, 2); }",
                     (2, 0),
                 ),
+                // The one shape with no declarator to walk: a
+                // parameterless lambda has no
+                // `abstract_function_declarator` at all, so the walk
+                // returns `None` on its first step and `params_owner`
+                // falls back to the node. `g` carries parameters of its
+                // own so the expected pair is not all-zero — an
+                // all-default expectation would hold however badly the
+                // fallback behaved.
+                (
+                    "int g(int a, int b) { auto f = []{ return 1; }; return f(); }",
+                    (0, 2),
+                ),
                 // The guard for the walk's stop condition. A lambda's
                 // `abstract_function_declarator` carries `parameters`
                 // but its `declarator` field is *optional* and absent

--- a/src/metrics/nargs.rs
+++ b/src/metrics/nargs.rs
@@ -4729,4 +4729,49 @@ mod c_family_return_type_declarators {
             "no fixture ran (shared={shared}, cpp_only={cpp_only}); this test asserted nothing"
         );
     }
+
+    /// FIXME(#1208): the arity of a function returning a function
+    /// pointer is right after #1200; its **name** is not.
+    ///
+    /// `get_func_space_name` reaches the declarator through
+    /// `first_occurrence`, which stops at the *outer*
+    /// `function_declarator` — the return type's — whose `child(0)` is a
+    /// `parenthesized_declarator` and matches none of the identifier
+    /// kinds, so the arm falls through to `None`. That is a getter bug
+    /// in a different metric surface, tracked separately.
+    ///
+    /// Pinned here rather than left in the tracker so the gap fails in
+    /// CI the day it is fixed, per `.claude/rules/grammar-dispatch.md`.
+    /// When #1208 lands, this test inverts: assert `Some("fp")`.
+    #[test]
+    fn a_parenthesised_declarator_still_loses_its_space_name() {
+        for lang in [LANG::C, LANG::Cpp, LANG::Mozcpp, LANG::Objc]
+            .into_iter()
+            .filter(LANG::is_enabled)
+        {
+            let root = space_verbatim(
+                lang,
+                b"int (*fp(int a, int b))(int c) { return 0; }",
+                MetricsOptions::default(),
+            );
+            let [space] = root.spaces.as_slice() else {
+                panic!("{lang:?}: fixture must open exactly one space");
+            };
+            assert_eq!(
+                space.name, None,
+                "{lang:?}: #1208 appears to be fixed — invert this test to assert Some(\"fp\")"
+            );
+            // The control, so a regression that lost *every* space name
+            // would not read as #1208 merely still being open.
+            let named = space_verbatim(
+                lang,
+                b"int plain(int a, int b) { return a; }",
+                MetricsOptions::default(),
+            );
+            let [space] = named.spaces.as_slice() else {
+                panic!("{lang:?}: control must open exactly one space");
+            };
+            assert_eq!(space.name.as_deref(), Some("plain"), "{lang:?}");
+        }
+    }
 }

--- a/src/metrics/nargs.rs
+++ b/src/metrics/nargs.rs
@@ -254,6 +254,83 @@ fn compute_args<T: Checker>(node: &Node, nargs: &mut usize) {
     }
 }
 
+/// The node whose `parameters` field holds a C-family function's *own*
+/// formal arguments: the **innermost** one along the declarator chain.
+///
+/// C declarator syntax nests outward from the declared name, so a
+/// function node's `declarator` field is only the function's parameter
+/// list when the return type is plain. Anything the return type
+/// contributes — a `*`, a `&`, a parenthesised group — wraps the
+/// `function_declarator` that owns the real list, and the outermost
+/// `parameters` a chain carries can belong to the *return type* rather
+/// than to the function (`int (*f(int a))(int b)` returns a pointer to a
+/// one-argument function and itself takes one argument). Taking the
+/// innermost is what makes both of those come out right (#1200).
+///
+/// The walk is by field name, per `.claude/rules/grammar-dispatch.md`
+/// §3, which also sidesteps §1: `PointerDeclarator2`,
+/// `FunctionDeclarator2`/`3` and `ReferenceDeclarator2`/`3`/`4` are
+/// numeric-suffix aliases that a `kind_id` match would have to
+/// enumerate and would silently regress on the next grammar bump.
+///
+/// Two of the rules in the chain expose no field at all, which is why
+/// the field alone is not enough. From the pinned grammars'
+/// `node-types.json` (`tree-sitter-cpp` 0.23.4, `tree-sitter-c` 0.24.2,
+/// `tree-sitter-objc` 3.0.2, vendored `tree-sitter-mozcpp`):
+///
+/// | rule | `declarator` field |
+/// | --- | --- |
+/// | `pointer_declarator` | required |
+/// | `function_declarator` | required |
+/// | `abstract_function_declarator` | **optional** |
+/// | `reference_declarator` | **absent — no fields** |
+/// | `parenthesized_declarator` | **absent — no fields** |
+///
+/// `reference_declarator` is `seq(choice('&', '&&'), _declarator)` and
+/// `parenthesized_declarator` is `seq('(', optional(ms_call_modifier),
+/// _declarator, ')')`: in both the inner declarator is the last *named*
+/// child, so that is the fallback. Last rather than sole, so a leading
+/// `ms_call_modifier` (`int (__cdecl *f(int a))(int b)`) does not defeat
+/// it, and comment-filtered because tree-sitter admits a comment
+/// anywhere.
+///
+/// The fallback stops at a node that already carries `parameters`,
+/// which is the C++ lambda: `abstract_function_declarator`'s
+/// `declarator` field is optional, so `[](int a, int (*cb)(int x))`
+/// would otherwise descend into the `parameter_list` and return `cb`'s
+/// `(int x)` — one argument instead of two.
+///
+/// Every step strictly descends a finite tree, so the walk terminates
+/// without a depth cap.
+fn declarator_params_owner<'tree, T: Checker>(node: &Node<'tree>) -> Option<Node<'tree>> {
+    // The chain starts at the field rather than at `node` so the
+    // last-named-child fallback can never fire on the function node
+    // itself and walk into its body.
+    let mut current = node.child_by_field_name("declarator")?;
+    let mut owner = None;
+    loop {
+        let carries_params = current.child_by_field_name("parameters").is_some();
+        if carries_params {
+            owner = Some(current);
+        }
+        current = match current.child_by_field_name("declarator") {
+            Some(declarator) => declarator,
+            None if carries_params => break,
+            None => {
+                let Some(last) = current
+                    .children()
+                    .filter(|child| child.is_named() && !T::is_comment(child))
+                    .last()
+                else {
+                    break;
+                };
+                last
+            }
+        };
+    }
+    owner
+}
+
 #[doc(hidden)]
 /// Per-language counting of function arguments.
 pub(crate) trait NArgs
@@ -278,12 +355,15 @@ where
         }
 
         if Self::is_closure(node, ancestors) {
-            compute_args::<Self>(node, &mut stats.closure_nargs);
+            compute_args::<Self>(
+                &Self::params_owner(node, ancestors),
+                &mut stats.closure_nargs,
+            );
         }
     }
 
-    /// The node whose `parameters` field holds this function's formal
-    /// arguments. Defaults to the function node itself.
+    /// The node whose `parameters` field holds this callable's formal
+    /// arguments. Defaults to the callable's own node.
     ///
     /// Exists so a language that spells its parameters somewhere other
     /// than on the function node can say *that* and inherit everything
@@ -293,70 +373,46 @@ where
     /// pick up a later correction — which is the drift #1142 and #1162
     /// were both filed about.
     ///
+    /// It answers for both channels — a closure reaches its parameters
+    /// through this too, which is what lets the C family express a C++
+    /// lambda and a pointer-returning function as one rule (#1200).
+    ///
     /// The two are mutually exclusive: only the default `compute` calls
-    /// this, so a language that overrides `compute` (the C family, Objc,
-    /// Go, Kotlin, Lua, Tcl, iRules, Perl, Elixir, Groovy) would define
-    /// a `params_owner` that is never consulted. Override one or the
+    /// this, so a language that overrides `compute` (Objc, Go, Kotlin,
+    /// Lua, Tcl, iRules, Perl, Elixir, Groovy) would define a
+    /// `params_owner` that is never consulted. Override one or the
     /// other, not both.
     fn params_owner<'tree>(node: &Node<'tree>, _ancestors: Ancestors<'tree, '_>) -> Node<'tree> {
         *node
     }
 }
 
+// The C family spells a function's parameters on the
+// `function_declarator` buried under whatever the *return type*
+// contributed, so all three point `params_owner` at the innermost
+// declarator carrying a `parameters` field. Falling back to the node
+// keeps the pre-#1200 answer for a shape with no declarator at all — a
+// parameterless C++ lambda, `[]{ … }`, which has none.
+//
+// C++ and Mozcpp reach this for their lambdas as well as their
+// functions; C has no closure form at all (`CCode::is_closure` is a
+// constant `false`), so its closure channel is unreachable rather than
+// merely unused.
 impl NArgs for CppCode {
-    fn compute<'a>(node: &Node<'a>, _code: &[u8], ancestors: Ancestors<'a, '_>, stats: &mut Stats) {
-        if Self::is_func(node, ancestors) {
-            if let Some(declarator) = node.child_by_field_name("declarator") {
-                let new_node = declarator;
-                compute_args::<Self>(&new_node, &mut stats.fn_nargs);
-            }
-            return;
-        }
-
-        if Self::is_closure(node, ancestors)
-            && let Some(declarator) = node.child_by_field_name("declarator")
-        {
-            let new_node = declarator;
-            compute_args::<Self>(&new_node, &mut stats.closure_nargs);
-        }
+    fn params_owner<'tree>(node: &Node<'tree>, _ancestors: Ancestors<'tree, '_>) -> Node<'tree> {
+        declarator_params_owner::<Self>(node).unwrap_or(*node)
     }
 }
 
 impl NArgs for CCode {
-    fn compute<'a>(node: &Node<'a>, _code: &[u8], ancestors: Ancestors<'a, '_>, stats: &mut Stats) {
-        if Self::is_func(node, ancestors) {
-            if let Some(declarator) = node.child_by_field_name("declarator") {
-                let new_node = declarator;
-                compute_args::<Self>(&new_node, &mut stats.fn_nargs);
-            }
-            return;
-        }
-
-        if Self::is_closure(node, ancestors)
-            && let Some(declarator) = node.child_by_field_name("declarator")
-        {
-            let new_node = declarator;
-            compute_args::<Self>(&new_node, &mut stats.closure_nargs);
-        }
+    fn params_owner<'tree>(node: &Node<'tree>, _ancestors: Ancestors<'tree, '_>) -> Node<'tree> {
+        declarator_params_owner::<Self>(node).unwrap_or(*node)
     }
 }
 
 impl NArgs for MozcppCode {
-    fn compute<'a>(node: &Node<'a>, _code: &[u8], ancestors: Ancestors<'a, '_>, stats: &mut Stats) {
-        if Self::is_func(node, ancestors) {
-            if let Some(declarator) = node.child_by_field_name("declarator") {
-                let new_node = declarator;
-                compute_args::<Self>(&new_node, &mut stats.fn_nargs);
-            }
-            return;
-        }
-
-        if Self::is_closure(node, ancestors)
-            && let Some(declarator) = node.child_by_field_name("declarator")
-        {
-            let new_node = declarator;
-            compute_args::<Self>(&new_node, &mut stats.closure_nargs);
-        }
+    fn params_owner<'tree>(node: &Node<'tree>, _ancestors: Ancestors<'tree, '_>) -> Node<'tree> {
+        declarator_params_owner::<Self>(node).unwrap_or(*node)
     }
 }
 
@@ -378,8 +434,11 @@ impl NArgs for ObjcCode {
     ) {
         match node.kind_id().into() {
             Objc::FunctionDefinition | Objc::FunctionDefinition2 => {
-                if let Some(declarator) = node.child_by_field_name("declarator") {
-                    compute_args::<Self>(&declarator, &mut stats.fn_nargs);
+                // The same declarator walk C and C++ use: Objective-C
+                // inherits C's declarator syntax, so `FILE *f(int a)`
+                // buries the parameter list one level down (#1200).
+                if let Some(owner) = declarator_params_owner::<Self>(node) {
+                    compute_args::<Self>(&owner, &mut stats.fn_nargs);
                 }
             }
             Objc::MethodDefinition => {
@@ -4514,5 +4573,160 @@ mod comments_in_parameter_lists {
                 "{lang:?}: a bare lambda parameter is one closure argument"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod c_family_return_type_declarators {
+    use crate::test_support::space_verbatim;
+    use crate::{LANG, MetricsOptions};
+
+    /// `(closure_args, function_args)` read from the fixture's sole
+    /// nested space.
+    ///
+    /// The space rather than the file roll-up, because since #1196 the
+    /// `nargs` gate reads a callable's *own* parameter count: a fix that
+    /// repaired only the roll-up would leave the gate exactly as blind
+    /// as #1200 found it. The pair rather than the total, so a
+    /// regression that merely moved a count between the function and
+    /// closure channels cannot read as a pass.
+    #[track_caller]
+    fn sole_space_args(lang: LANG, source: &str) -> (u64, u64) {
+        let root = space_verbatim(lang, source.as_bytes(), MetricsOptions::default());
+        let [space] = root.spaces.as_slice() else {
+            panic!(
+                "{lang:?}: fixture must open exactly one space, opened {}",
+                root.spaces.len()
+            );
+        };
+        (
+            space.metrics.nargs.closure_args(),
+            space.metrics.nargs.function_args(),
+        )
+    }
+
+    /// The return shapes every C-derived grammar here shares, plus the
+    /// unwrapped control that keeps the fix honest.
+    ///
+    /// Every pointer row reported **0** before #1200 and the nested rows
+    /// reported the *return type's* arity; the plain row already passed
+    /// and is here so a helper that returned nothing at all could not
+    /// look like a fix.
+    ///
+    /// Each nested row deliberately gives the inner and outer parameter
+    /// lists **different** lengths. An earlier draft of the `__cdecl`
+    /// row spelled both as one argument, which made it agree with the
+    /// answer it was written to reject.
+    fn c_declarator_shapes(lang: LANG) -> Option<&'static [(&'static str, (u64, u64))]> {
+        if !matches!(lang, LANG::C | LANG::Cpp | LANG::Mozcpp | LANG::Objc) {
+            return None;
+        }
+        // C declarator syntax, shared by all four grammars. `Foo` is
+        // deliberately an undeclared type: tree-sitter resolves the
+        // shape syntactically, and a fixture that leaned on a typedef
+        // would be testing the fixture.
+        Some(&[
+            // A pointer return: the reported symptom in #1200.
+            ("FILE *f(int a, int b, int c) { return 0; }", (0, 3)),
+            // Two levels of `pointer_declarator`, so a walk that steps
+            // exactly once still fails.
+            ("int **g(int a, int b) { return 0; }", (0, 2)),
+            // A storage-class specifier ahead of the pointer, which
+            // sits outside the declarator entirely.
+            ("static int *h(int a) { return 0; }", (0, 1)),
+            // A function returning a pointer to a one-argument
+            // function. The *outer* `function_declarator` owns
+            // `(int c)` — the return type's list — so taking the first
+            // `parameters` found reports 1. `fp` takes two.
+            ("int (*fp(int a, int b))(int c) { return 0; }", (0, 2)),
+            // The same shape with an MSVC calling convention, which
+            // parses as a real `ms_call_modifier` node *preceding* the
+            // declarator inside the `parenthesized_declarator`. This is
+            // what makes the fallback take the last named child rather
+            // than the first.
+            (
+                "int (__cdecl *w(int a, int b))(int c) { return 0; }",
+                (0, 2),
+            ),
+            // The unwrapped control: its `declarator` field already is
+            // the `function_declarator`, so it passed before the fix
+            // and must keep passing after it.
+            ("int plain(int a, int b) { return a; }", (0, 2)),
+        ])
+    }
+
+    /// The shapes only C++ has: `reference_declarator`, which — unlike
+    /// `pointer_declarator` — exposes no `declarator` field at all, and
+    /// the lambda, which reaches `params_owner` through the closure
+    /// channel rather than the function one.
+    fn cpp_only_shapes(lang: LANG) -> Option<&'static [(&'static str, (u64, u64))]> {
+        Some(match lang {
+            LANG::Cpp | LANG::Mozcpp => &[
+                ("int &r(int a, int b) { static int x; return x; }", (0, 2)),
+                // The rule's other spelling: `&&` is a distinct token
+                // in the same `reference_declarator`, so a fix keyed on
+                // the `&` token alone would pass the row above.
+                (
+                    "Foo &&m(int a) { static Foo f; return static_cast<Foo &&>(f); }",
+                    (0, 1),
+                ),
+                // A member function returning a reference: the chain
+                // ends at a `qualified_identifier` rather than a bare
+                // one, which has named children of its own.
+                ("Foo &Bar::get(int a) { static Foo f; return f; }", (0, 1)),
+                (
+                    "int g() { auto f = [](int a, int b){ return a + b; }; return f(1, 2); }",
+                    (2, 0),
+                ),
+                // The guard for the walk's stop condition. A lambda's
+                // `abstract_function_declarator` carries `parameters`
+                // but its `declarator` field is *optional* and absent
+                // here, so a walk that falls through to the last named
+                // child descends into the parameter list and reports
+                // `cb`'s own `(int x)` — one argument instead of two.
+                (
+                    "int g() { auto f = [](int a, int (*cb)(int x)){ return cb(a); }; return 0; }",
+                    (2, 0),
+                ),
+            ],
+            _ => return None,
+        })
+    }
+
+    #[test]
+    fn a_wrapped_return_type_does_not_hide_the_parameter_list() {
+        let (mut shared, mut cpp_only) = (0, 0);
+        let mut failures = Vec::new();
+        for lang in LANG::into_enum_iter().filter(LANG::is_enabled) {
+            for (table, counter) in [
+                (c_declarator_shapes(lang), &mut shared),
+                (cpp_only_shapes(lang), &mut cpp_only),
+            ] {
+                for (source, expected) in table.unwrap_or_default() {
+                    *counter += 1;
+                    let got = sole_space_args(lang, source);
+                    // Collected rather than asserted inline so a
+                    // regression shows every language and shape it
+                    // broke, not just the first. The branch carries no
+                    // formatting — a line that runs only on failure can
+                    // never be covered.
+                    if got != *expected {
+                        failures.push((lang, source, *expected, got));
+                    }
+                }
+            }
+        }
+        let (failed, checked) = (failures.len(), shared + cpp_only);
+        assert!(
+            failures.is_empty(),
+            "{failed}/{checked} return-type shapes lost their parameter list: {failures:#?}"
+        );
+        // Both tallies, so a renamed `LANG` variant or a feature that
+        // stopped being enabled fails here rather than passing
+        // vacuously.
+        assert!(
+            shared > 0 && cpp_only > 0,
+            "no fixture ran (shared={shared}, cpp_only={cpp_only}); this test asserted nothing"
+        );
     }
 }

--- a/src/metrics/nargs.rs
+++ b/src/metrics/nargs.rs
@@ -313,20 +313,16 @@ fn declarator_params_owner<'tree, T: Checker>(node: &Node<'tree>) -> Option<Node
         if carries_params {
             owner = Some(current);
         }
-        current = match current.child_by_field_name("declarator") {
-            Some(declarator) => declarator,
-            None if carries_params => break,
-            None => {
-                let Some(last) = current
-                    .children()
-                    .filter(|child| child.is_named() && !T::is_comment(child))
-                    .last()
-                else {
-                    break;
-                };
-                last
-            }
+        let next = match current.child_by_field_name("declarator") {
+            Some(declarator) => Some(declarator),
+            None if carries_params => None,
+            None => current
+                .children()
+                .filter(|child| child.is_named() && !T::is_comment(child))
+                .last(),
         };
+        let Some(next) = next else { break };
+        current = next;
     }
     owner
 }


### PR DESCRIPTION
Fixes #1200
Fixes #1210

C, C++, Mozcpp and Objective-C functions whose return type is a pointer or a reference reported `nargs.function_args = 0` regardless of their real arity — 7.9% of the matched functions in the DeepSpeech/kenlm C++ corpus. Since #1196 made the `nargs` gate read a callable's own parameter count, every one of them was also invisible to `bca check --threshold nargs=N`.

## The issue's prescribed fix would have shipped half the bug

Both the issue body and its resolution plan specify walking the `declarator` **field** down to a node carrying `parameters`. Read against the pinned grammars' `node-types.json`, that repairs the pointer cases and **leaves every reference case at 0** — one of the shapes the issue itself lists and demands fixtures for:

| rule | `declarator` field |
| --- | --- |
| `pointer_declarator` | required |
| `function_declarator` | required |
| `abstract_function_declarator` | **optional** |
| `reference_declarator` | **absent — no fields at all** |
| `parenthesized_declarator` | **absent — no fields at all** |
| `attributed_declarator` | **absent — no fields at all** |

In `reference_declarator` and `parenthesized_declarator` the inner declarator is a plain named child with no field name, so a field-only descent stops dead.

## The rule that shipped

Walk the declarator chain and take the **innermost** node carrying a `parameters` field:

```
step(n):
    n.child_by_field_name("declarator")   -> that child
    else if n has a "parameters" field    -> None   (chain ends)
    else                                  -> last named non-comment non-attribute child
```

…cut at any `operator_cast`, and seeded from the `declarator` field rather than the function node.

Every clause is load-bearing:

- **Field first**, per grammar-dispatch §3, which also sidesteps §1 — `PointerDeclarator2`, `FunctionDeclarator2`/`3`, `ReferenceDeclarator2`/`3`/`4` are aliases a `kind_id` match would have to enumerate.
- **Stop on a `parameters`-bearing node with no `declarator` field** — the C++ lambda. `abstract_function_declarator.declarator` is *optional*, so `[](int a, int (*cb)(int x))` would otherwise return `cb`'s `(int x)`: 1 instead of 2.
- **Last, not sole or first, named child** — `int (__cdecl *w(int a, int b))(int c)` puts a real `ms_call_modifier` ahead of the declarator.
- **Excluding `attribute_declaration`** — `attributed_declarator` is the one fieldless rule putting its declarator *first*, so without this `int f(int a, int b) [[deprecated]]` reports 0. The GNU `__attribute__((…))` spelling was never affected: all four grammars absorb it into the `function_declarator` instead of wrapping it.
- **Cutting at `operator_cast`** — its `declarator` field is the type the operator converts *to*. A conversion operator takes no arguments however many its target type has.

**Innermost, not first**, is what also fixes a function returning a function pointer. `int (*fp(int a, int b))(int c)` had reported 1 — the return type's list — where `fp` takes 2. The issue's plan proposed a `FIXME` for this; the rule gets it for free.

## Consolidated rather than patched in place

`CppCode`, `CCode` and `MozcppCode` carried three byte-identical `NArgs::compute` overrides — which is why one bug existed in triplicate. All three are gone, replaced by a one-line `params_owner`, the hook whose own doc comment says re-stating `compute` is the drift #1142 and #1162 were filed about. The default `compute` now routes closures through it too (a no-op elsewhere: only `JavaCode` overrides it, and only for record compact constructors). This also removed `CCode`'s dead closure branch — `CCode::is_closure` is a constant `false`.

`ObjcCode` keeps its own `compute` (three unrelated parameter shapes) with only the `FunctionDefinition` arm rerouted.

## Also fixed: C's `(void)` marker (#1210)

`int f(void)` declares no parameters, but the grammar emits a real `parameter_declaration` for the `void` and every filter counted it, so `f(void)` and `f(int)` both reported 1. The distinction needs the source bytes — an unnamed parameter is the same shape and really *is* one argument — so `count_args` now threads `&[u8]` to a new `Checker::is_empty_param_marker`, defaulting to `false` and overridden by the four C-family grammars through one shared helper. `void *p` keeps counting: it carries a declarator.

This is an independent behaviour change in its own commit (`7253f144`), reviewable and revertable apart from the rest.

## Verification

Seven perturbations, each applied to one clause alone and run against the whole lib suite, each producing a disjoint failure set:

| perturbation | failures |
| --- | --- |
| field-only descent (the plan's fix) | 22/30 — every pointer, reference and nested row |
| first instead of innermost | the 4 nested `fp` rows |
| drop the lambda stop clause | the 2 lambda-guard rows |
| first instead of last named child | the 4 `__cdecl` rows |
| start off the declarator chain | the 2 local-declaration rows |
| drop the `operator_cast` cut | the 4 conversion-operator rows |
| drop the `attribute_declaration` exclusion | the 3 `[[deprecated]]` rows |
| drop the `(void)` exclusion | the 4 `(void)` rows |
| structural-only `(void)` check | the 4 `unnamed` rows instead |

Two of those fixtures only became real after the *selector* was fixed, and both times the selector was the weak point rather than the assertion:

- The parameterless-lambda row I added to close a coverage gap gave 100% region coverage of the walk's entry guard and failed **0 of 3,322 tests** when that guard was perturbed. Two further candidate fixtures also failed to fail — the `declarator` fields keep pulling the walk back onto declarator-shaped nodes, which is precisely why the guard is safe. The row that discriminates puts a local function *declaration* last in the lambda body.
- Both `operator_cast` fixtures passed with the regression reinstated, because `sole_space_args` read the *first* nested space and a conversion operator sits two levels down, behind its `struct`'s container space. The helper now descends to the innermost sole space.

Also probed as paired plain/pointer variants: constructors, destructors, `operator=`, templates, `[[nodiscard]]`, trailing return types, variadics, `const`-qualified pointer returns, 2000-level pointer nesting (0.00 s — the walk is an iterative `successors` unfold, not recursion), and malformed input.

## Drift

- **#1200**: 3,336 `nargs` values rise across 276 `DeepSpeech` snapshot files. Nothing falls; no other metric key moves.
- **#1210**: 24 values fall to 0, all in `pywrapfst.cc`, the corpus's only `(void)` definitions.

Submodule accepted, committed and pushed (`1b032d7c`), with the SHA recorded in the parent commits alongside each fix.

## Follow-ups filed

- **#1208** — the same nested shape resolves its space name to `null`. A getter bug in a different metric surface; pinned in CI here by `a_parenthesised_declarator_still_loses_its_space_name`, which fails the day it is fixed.
- **#1209** — a K&R function with a pointer return opens no function space at all. Upstream: `tree-sitter-c` parses it as a `declaration`, so there is no `function_definition` for `is_func` to match and nothing in our wrapper to fix.

## Gates

`make pre-commit` → `BCA_GATE: pass`. `make bench-scaling` → all 26 probes within their complexity bound. No public-API change (`NArgs` is `pub(crate)` + `#[doc(hidden)]`), so no `STABILITY.md` cross-reference is needed.
