### PR TITLE
fix(getter): name C-family functions with nested declarators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -766,6 +766,24 @@ for historical reference.
 
 ### Fixed
 
+- C, C++, Mozcpp and Objective-C function spaces whose declared name
+  sits under an extra declarator layer now carry that name instead of
+  `null` (#1208). Two spellings were affected: a function returning a
+  function pointer, `int (*fp(int a, int b))(int c)`, and the
+  macro-obscured declarator `RUN_STATS_METHOD(allocate)(JNIEnv *env)`
+  that JNI shims use. Both put a `function_declarator` in the slot
+  `get_func_space_name` expected an identifier in, so the name resolved
+  to nothing. The four getters now read the name off the same innermost
+  declarator `nargs` has read the arity from since #1200, so the two
+  answers about one function can no longer disagree.
+
+  Three surfaces change with it: `name` in the metric output, `bca
+  functions`, which had been rendering these as a red `error:` line, and
+  the `bca check` / `.bca-baseline.toml` offender key, which had been
+  the line-dependent `<anon@L…>`. A C-family baseline holding such an
+  entry needs one refresh, after which the key is stable across line
+  drift like any other named function.
+
 - C, C++, Mozcpp and Objective-C functions whose return type is a
   pointer or a reference now report their real arity instead of 0
   (#1200). C declarator syntax nests outward from the declared name, so

--- a/src/c_declarator.rs
+++ b/src/c_declarator.rs
@@ -130,6 +130,21 @@ pub(crate) fn innermost_declarator<'tree, T: Checker>(node: &Node<'tree>) -> Opt
     .last()
 }
 
+/// The node spelling a C-family function's name.
+///
+/// It is the `declarator` field of [`innermost_declarator`] — the same
+/// node whose `parameters` field gives the arity — and it is a separate
+/// function only so the four `get_func_space_name` impls state that
+/// pairing once instead of four times. Each caller still gates the
+/// result on its own grammar's identifier kinds: what counts as a name
+/// is where C, C++ and Objective-C differ (`destructor_name`,
+/// `qualified_identifier`, `operator_name`, `template_function`), and a
+/// kind this module accepted on their behalf would be a claim about
+/// four grammars made in a module that reads none of them.
+pub(crate) fn declarator_name<'tree, T: Checker>(node: &Node<'tree>) -> Option<Node<'tree>> {
+    innermost_declarator::<T>(node)?.child_by_field_name("declarator")
+}
+
 /// Compared by `kind()` string rather than `kind_id`, per
 /// `.claude/rules/grammar-dispatch.md` §1: both rules carry
 /// numeric-suffix aliases across the four C-family grammars, and a

--- a/src/c_declarator.rs
+++ b/src/c_declarator.rs
@@ -209,6 +209,19 @@ mod space_name_tests {
         ("int (*g(void))[4] { return 0; }", Some("g")),
         ("int plain(int a, int b) { return a; }", Some("plain")),
         ("FILE *ptr(int a) { return 0; }", Some("ptr")),
+        // Why the fallback may not simply require each link to be a
+        // `*_declarator`, which is the tidier-looking rule. Every
+        // grammar recovers this TensorFlow C-API signature into a
+        // `qualified_identifier` holding a **zero-width** `::` and the
+        // real `pointer_type_declarator`, so the chain has to descend
+        // through a link that is not a declarator at all to reach the
+        // name. Gating the fallback on the kind suffix loses this and
+        // two more names in the corpora: a non-declarator link is not
+        // always a name.
+        (
+            "TF_CAPI_EXPORT extern TF_ConcreteFunction* TF_GetFn(TF_SavedModel* m) { return 0; }",
+            Some("TF_GetFn"),
+        ),
         // The one row the gate must *reject*. Redundant parentheses
         // around the name are legal C and put a
         // `parenthesized_declarator` where every grammar's name kinds
@@ -319,6 +332,25 @@ mod space_name_tests {
         }
     }
 
+    /// Fail with every mismatched row, and fail *differently* when a
+    /// feature set left the loop empty.
+    ///
+    /// Shared so the failure formatting exists once: it is by
+    /// construction unreachable while the suite is green, so a second
+    /// copy is coverage the tests can never earn.
+    #[track_caller]
+    fn assert_all_matched(failures: &[String], checked: usize, what: &str) {
+        assert!(
+            failures.is_empty(),
+            "{}/{checked} {what}:\n{}",
+            failures.len(),
+            failures.join("\n")
+        );
+        // Non-vacuity: a feature set that disabled all four languages
+        // would otherwise leave every assertion above unrun.
+        assert!(checked > 0, "no C-family language was enabled");
+    }
+
     /// A C-family function's name comes off the same declarator its
     /// arity does (#1208).
     #[test]
@@ -336,15 +368,11 @@ mod space_name_tests {
                 checked += CPP_ONLY_SHAPES.len();
             }
         }
-        assert!(
-            failures.is_empty(),
-            "{}/{checked} declarator shapes named the wrong space:\n{}",
-            failures.len(),
-            failures.join("\n")
+        assert_all_matched(
+            &failures,
+            checked,
+            "declarator shapes named the wrong space",
         );
-        // Non-vacuity: a feature set that disabled all four languages
-        // would otherwise leave every assertion above unrun.
-        assert!(checked > 0, "no C-family language was enabled");
     }
 
     /// [`check`] must be *able* to fail.
@@ -381,6 +409,59 @@ mod space_name_tests {
         assert!(
             only.contains("deliberately_wrong") && only.contains("Some(\"plain\")"),
             "the failure must name both the expectation and the space found: {only}"
+        );
+    }
+
+    /// An unexpanded macro where a trailing attribute belongs, which is
+    /// the one input in this module that reaches
+    /// [`super::declarator_name`]'s `?` — the arm taken when *no* link
+    /// on the chain carries a `parameters` field, so there is no
+    /// declarator to read a name from at all. Every other row resolves
+    /// an owner and is answered by the identifier-kind gate instead.
+    ///
+    /// The grammars split two-two on it, which is the reason this is its
+    /// own test rather than a table row — and the split is not the one
+    /// the language families would suggest:
+    ///
+    /// | grammar | parse | name |
+    /// | --- | --- | --- |
+    /// | C, **mozcpp** | clean — `function_declarator` admits the trailing identifier | `f` |
+    /// | C++, Objective-C | `ERROR` around the declarator | none |
+    ///
+    /// Where the parse is clean the chain follows a real `declarator`
+    /// field and the name resolves. Where it is not, the declarator sits
+    /// inside an `ERROR` and the macro is left as the
+    /// `pointer_declarator`'s last named child, so the fallback follows
+    /// the macro into a dead end.
+    ///
+    /// mozcpp siding with C rather than with the upstream `tree-sitter-cpp`
+    /// it forked from is the finding worth keeping here: it owns no file
+    /// extension, so nothing routes to it and only a unit test can see
+    /// it at all (`.claude/rules/grammar-dispatch.md`, "when you fix one
+    /// language, sweep the rest").
+    ///
+    /// Recovery trees are outside the walk's contract — see
+    /// [`super::innermost_declarator`], which measured this exact shape
+    /// as one of the two corpus spaces #1208 un-named. This pins what
+    /// the walk does there, not a claim that it is the right answer.
+    #[test]
+    fn a_macro_where_an_attribute_belongs_divides_the_grammars() {
+        const SOURCE: &str = "int *f() TF_ATTRIBUTE_NOINLINE { return 0; }";
+
+        let mut failures = Vec::new();
+        let mut checked = 0;
+        for lang in [LANG::C, LANG::Cpp, LANG::Mozcpp, LANG::Objc]
+            .into_iter()
+            .filter(LANG::is_enabled)
+        {
+            let expected = matches!(lang, LANG::C | LANG::Mozcpp).then_some("f");
+            check(lang, &[(SOURCE, expected)], &mut failures);
+            checked += 1;
+        }
+        assert_all_matched(
+            &failures,
+            checked,
+            "grammars disagreed about the recovery shape",
         );
     }
 }

--- a/src/c_declarator.rs
+++ b/src/c_declarator.rs
@@ -1,0 +1,306 @@
+//! The C-family declarator-chain walk, shared by the two surfaces that
+//! need it.
+//!
+//! C declarator syntax nests outward from the declared name, so neither
+//! a function's parameter list nor its name is reliably a child of the
+//! function node itself. Both live on the same node — the innermost
+//! `function_declarator` along the chain — which is what
+//! [`innermost_declarator`] finds:
+//!
+//! - [`crate::metrics::nargs`] reads its `parameters` field (#1200).
+//! - The `Getter::get_func_space_name` impls for C, C++, mozcpp and
+//!   Objective-C read its `declarator` field (#1208).
+//!
+//! Keeping one walk keeps the two answers about the same function from
+//! disagreeing, which is how #1208 arose: the arity came from this
+//! chain and the name came from a leftmost pre-order search that stopped
+//! one level too early.
+
+use crate::checker::Checker;
+use crate::node::Node;
+
+/// The innermost declarator along a C-family function's declarator
+/// chain: the node whose `parameters` field holds the function's *own*
+/// formal arguments, and whose `declarator` field holds its name.
+///
+/// C declarator syntax nests outward from the declared name, so a
+/// function node's `declarator` field is only the function's parameter
+/// list when the return type is plain. Anything the return type
+/// contributes — a `*`, a `&`, a parenthesised group — wraps the
+/// `function_declarator` that owns the real list, and the outermost
+/// `parameters` a chain carries can belong to the *return type* rather
+/// than to the function (`int (*f(int a))(int b)` returns a pointer to a
+/// one-argument function and itself takes one argument). Taking the
+/// innermost is what makes both of those come out right (#1200), and
+/// the same node carries the name `f` that a leftmost search misses
+/// (#1208).
+///
+/// The walk is by field name, per `.claude/rules/grammar-dispatch.md`
+/// §3, which also sidesteps §1: `PointerDeclarator2`,
+/// `FunctionDeclarator2`/`3` and `ReferenceDeclarator2`/`3`/`4` are
+/// numeric-suffix aliases that a `kind_id` match would have to
+/// enumerate and would silently regress on the next grammar bump.
+///
+/// Three of the rules on the chain expose no field at all, which is why
+/// the field alone is not enough. Every entry below is from the pinned
+/// grammars' `node-types.json` (`tree-sitter-cpp` 0.23.4,
+/// `tree-sitter-c` 0.24.2, `tree-sitter-objc` 3.0.2, vendored
+/// `tree-sitter-mozcpp`), and the fieldless list is the complete set of
+/// `*_declarator` rules with no fields that a *function definition's*
+/// name side can reach — the rest (`variadic_declarator`,
+/// `structured_binding_declarator`, Objective-C's `keyword_declarator`
+/// and `struct_declarator`, and the `abstract_*` family) sit in
+/// parameter, binding or type position, never here.
+///
+/// | rule | `declarator` field |
+/// | --- | --- |
+/// | `pointer_declarator` | required |
+/// | `function_declarator` | required |
+/// | `abstract_function_declarator` | **optional** |
+/// | `reference_declarator` | **absent — no fields** |
+/// | `parenthesized_declarator` | **absent — no fields** |
+/// | `attributed_declarator` | **absent — no fields** |
+///
+/// In all three fieldless rules the inner declarator is the last
+/// *named* child once attributes are set aside, so that is the
+/// fallback:
+///
+/// - `reference_declarator` is `seq(choice('&', '&&'), _declarator)`.
+/// - `parenthesized_declarator` is `seq('(',
+///   optional(ms_call_modifier), _declarator, ')')` — last rather than
+///   sole, so `int (__cdecl *f(int a))(int b)` does not defeat it.
+/// - `attributed_declarator` is `seq(_declarator,
+///   repeat1(attribute_declaration))`, the one rule that puts the
+///   declarator **first**. Excluding `attribute_declaration` — its only
+///   non-declarator child type in all four grammars — restores "last"
+///   as the right answer, and without that exclusion
+///   `int f(int a, int b) [[deprecated]]` reports 0.
+///
+/// Comments are excluded for the same reason, tree-sitter admitting one
+/// anywhere.
+///
+/// The fallback stops at a node that already carries `parameters`,
+/// which is the C++ lambda: `abstract_function_declarator`'s
+/// `declarator` field is optional, so `[](int a, int (*cb)(int x))`
+/// would otherwise descend into the `parameter_list` and return `cb`'s
+/// `(int x)` — one argument instead of two.
+///
+/// Every step strictly descends a finite tree, so the walk terminates
+/// without a depth cap.
+///
+/// # ERROR-recovery trees are outside this contract
+///
+/// Every rule above is the grammar's, and none of them holds once
+/// tree-sitter starts recovering. An unexpanded macro in declarator
+/// position — `T *f() TF_ATTRIBUTE_NOINLINE { … }` — puts the real
+/// `function_declarator` inside an `ERROR` node and leaves the macro's
+/// `field_identifier` as the `pointer_declarator`'s last named child,
+/// so the fallback follows the macro and the walk answers `None`.
+/// Whatever any strategy returns there is arbitrary, and the walk does
+/// not try to be clever about it: measured over `DeepSpeech` and
+/// `pdf.js` (14,269 files), moving the four getters onto this walk
+/// named 44 previously-nameless function spaces and un-named 2, both of
+/// the latter inside recovery subtrees — one of which had been
+/// reporting an `if` statement's callee as a function name (#1208).
+pub(crate) fn innermost_declarator<'tree, T: Checker>(node: &Node<'tree>) -> Option<Node<'tree>> {
+    // The chain starts at the `declarator` field rather than at `node`
+    // so the last-named-child fallback can never fire on the function
+    // node itself and walk into its body. The walk runs outside-in, so
+    // the innermost qualifying link is the last one it yields.
+    std::iter::successors(
+        node.child_by_field_name("declarator"),
+        |current| match current.child_by_field_name("declarator") {
+            Some(declarator) => Some(declarator),
+            None if current.child_by_field_name("parameters").is_some() => None,
+            None => current
+                .children()
+                .filter(|child| {
+                    child.is_named() && !T::is_comment(child) && child.kind() != ATTRIBUTE
+                })
+                .last(),
+        },
+    )
+    // A conversion operator's `declarator` field is the type it converts
+    // *to*, not its name side: `operator int (*)(int x)` takes no
+    // arguments, and everything from here inward describes that
+    // function-pointer type. Cutting the chain restores the 0 the
+    // pre-#1200 code reported by never finding `parameters` at all.
+    .take_while(|link| link.kind() != CONVERSION_OPERATOR)
+    .filter(|link| link.child_by_field_name("parameters").is_some())
+    .last()
+}
+
+/// Compared by `kind()` string rather than `kind_id`, per
+/// `.claude/rules/grammar-dispatch.md` §1: both rules carry
+/// numeric-suffix aliases across the four C-family grammars, and a
+/// `kind_id` match would have to enumerate every one of them and would
+/// regress silently on the next grammar bump. C and Objective-C simply
+/// never emit `operator_cast`.
+const CONVERSION_OPERATOR: &str = "operator_cast";
+const ATTRIBUTE: &str = "attribute_declaration";
+
+#[cfg(test)]
+mod space_name_tests {
+    use crate::test_support::space_verbatim;
+    use crate::{FuncSpace, LANG, MetricsOptions, SpaceKind};
+
+    /// Declarator shapes all four C-family grammars parse alike, with
+    /// the name each one's function space must carry.
+    ///
+    /// The first three are #1208 itself: every one resolved to `None`
+    /// before the getters moved onto [`super::innermost_declarator`].
+    /// The macro spelling is the shape that dominates the corpora — 354
+    /// nameless C-family function spaces across `DeepSpeech` and
+    /// `pdf.js`, clustered in TensorFlow's JNI shims — and it carries no
+    /// `parenthesized_declarator` at all, so a fix keyed on that kind
+    /// would pass the first row and miss the population. `RUN_STATS_METHOD`
+    /// is the *syntactic* answer: the name the declarator chain spells,
+    /// which is the macro's rather than the function's, and which agrees
+    /// with the single argument `nargs` reads from the same node.
+    ///
+    /// The last three are controls. `g` in particular resolved
+    /// correctly *before* this change — its outer declarator is an
+    /// `array_declarator`, so the old leftmost pre-order search happened
+    /// to reach the right `function_declarator` — and would regress
+    /// silently if the walk stopped one link too early.
+    const SHARED_SHAPES: &[(&str, &str)] = &[
+        ("int (*fp(int a, int b))(int c) { return 0; }", "fp"),
+        ("int (__cdecl *w(int a, int b))(int c) { return 0; }", "w"),
+        (
+            "void RUN_STATS_METHOD(allocate)(int a) { }",
+            "RUN_STATS_METHOD",
+        ),
+        ("int (*g(void))[4] { return 0; }", "g"),
+        ("int plain(int a, int b) { return a; }", "plain"),
+        ("FILE *ptr(int a) { return 0; }", "ptr"),
+    ];
+
+    /// C++ name forms C and Objective-C have no syntax for. None of
+    /// these is a #1208 shape; they are here because the rewrite
+    /// replaced the `child(0)` the identifier-kind `match` used to read
+    /// with the `declarator` field, and each of these rows is a
+    /// different kind arriving in that slot — `destructor_name`,
+    /// `qualified_identifier`, `operator_name`, `template_function`.
+    /// The conversion operator additionally pins the `OperatorCast`
+    /// early return, which the shared walk cannot answer for: a
+    /// conversion operator's declarator field is the type it converts
+    /// *to*, so [`super::innermost_declarator`] deliberately cuts the
+    /// chain there and returns `None`.
+    const CPP_ONLY_SHAPES: &[(&str, &str)] = &[
+        ("struct S { ~S() { } };", "~S"),
+        ("void Foo::bar(int a) { }", "Foo::bar"),
+        (
+            "struct S { operator int() const { return 0; } };",
+            "operator int() const",
+        ),
+        (
+            "struct S { int operator+(int o) const { return o; } };",
+            "operator+",
+        ),
+        (
+            "Foo &Bar::get(int a) { static Foo f; return f; }",
+            "Bar::get",
+        ),
+        ("template <typename T> T tfree(T a) { return a; }", "tfree"),
+    ];
+
+    /// Each fixture is padded with a leading and a trailing comment
+    /// line, so the asserted span is `(2, 2)` — a value a
+    /// default-constructed or off-by-one span does not also satisfy,
+    /// unlike the `(1, 1)` a bare one-line fixture would produce.
+    const FIXTURE_LINE: usize = 2;
+
+    fn pad(source: &str) -> String {
+        format!("// leading\n{source}\n// trailing\n")
+    }
+
+    /// Every `Function` space in the tree, in source order.
+    ///
+    /// The C++ rows nest their function inside a `struct` space, so the
+    /// assertion cannot read `root.spaces[0]`; collecting the whole
+    /// subtree also lets each row assert that the fixture opened
+    /// *exactly one* function space, which is `get_space_kind` and
+    /// `is_func_space` agreeing with the name — `.claude/rules/
+    /// grammar-dispatch.md` §6.
+    fn function_spaces(space: &FuncSpace, found: &mut Vec<(Option<String>, usize, usize)>) {
+        if space.kind == SpaceKind::Function {
+            found.push((space.name.clone(), space.start_line, space.end_line));
+        }
+        for child in &space.spaces {
+            function_spaces(child, found);
+        }
+    }
+
+    fn check(lang: LANG, shapes: &[(&str, &str)], failures: &mut Vec<String>) {
+        for (source, expected) in shapes {
+            let root = space_verbatim(lang, pad(source).as_bytes(), MetricsOptions::default());
+            let mut found = Vec::new();
+            function_spaces(&root, &mut found);
+            let want = vec![(Some((*expected).to_owned()), FIXTURE_LINE, FIXTURE_LINE)];
+            if found != want {
+                failures.push(format!(
+                    "{lang:?}: {source:?}\n  want {want:?}\n  got  {found:?}"
+                ));
+            }
+        }
+    }
+
+    /// A C-family function's name comes off the same declarator its
+    /// arity does (#1208).
+    #[test]
+    fn the_innermost_declarator_names_the_function_space() {
+        let mut failures = Vec::new();
+        let mut checked = 0;
+        for lang in [LANG::C, LANG::Cpp, LANG::Mozcpp, LANG::Objc]
+            .into_iter()
+            .filter(LANG::is_enabled)
+        {
+            check(lang, SHARED_SHAPES, &mut failures);
+            checked += SHARED_SHAPES.len();
+            if matches!(lang, LANG::Cpp | LANG::Mozcpp) {
+                check(lang, CPP_ONLY_SHAPES, &mut failures);
+                checked += CPP_ONLY_SHAPES.len();
+            }
+        }
+        assert!(
+            failures.is_empty(),
+            "{}/{checked} declarator shapes named the wrong space:\n{}",
+            failures.len(),
+            failures.join("\n")
+        );
+        // Non-vacuity: a feature set that disabled all four languages
+        // would otherwise leave every assertion above unrun.
+        assert!(checked > 0, "no C-family language was enabled");
+    }
+
+    /// [`check`] must be *able* to fail.
+    ///
+    /// It collects rather than asserts, so nothing in the table above
+    /// would notice if `function_spaces` selected no space at all — the
+    /// comparison would just find two empty expectations equal, and
+    /// every row would pass vacuously
+    /// (`.claude/rules/testing.md`, "Review the selector as carefully as
+    /// the assertion"). Feeding it a name that is deliberately wrong is
+    /// the cheapest proof that the selector reaches a real space and the
+    /// comparison discriminates.
+    #[cfg(feature = "c")]
+    #[test]
+    fn the_table_reports_a_name_that_does_not_match() {
+        let mut failures = Vec::new();
+        check(
+            LANG::C,
+            &[(
+                "int plain(int a, int b) { return a; }",
+                "deliberately_wrong",
+            )],
+            &mut failures,
+        );
+        let [only] = failures.as_slice() else {
+            panic!("one wrong expectation must produce one failure, got {failures:?}");
+        };
+        assert!(
+            only.contains("deliberately_wrong") && only.contains("plain"),
+            "the failure must name both the expectation and what was found: {only}"
+        );
+    }
+}

--- a/src/c_declarator.rs
+++ b/src/c_declarator.rs
@@ -173,21 +173,39 @@ mod space_name_tests {
     /// which is the macro's rather than the function's, and which agrees
     /// with the single argument `nargs` reads from the same node.
     ///
-    /// The last three are controls. `g` in particular resolved
+    /// The next three are controls. `g` in particular resolved
     /// correctly *before* this change — its outer declarator is an
     /// `array_declarator`, so the old leftmost pre-order search happened
     /// to reach the right `function_declarator` — and would regress
     /// silently if the walk stopped one link too early.
-    const SHARED_SHAPES: &[(&str, &str)] = &[
-        ("int (*fp(int a, int b))(int c) { return 0; }", "fp"),
-        ("int (__cdecl *w(int a, int b))(int c) { return 0; }", "w"),
+    ///
+    /// The last row expects no name at all; its comment says why.
+    const SHARED_SHAPES: &[(&str, Option<&str>)] = &[
+        ("int (*fp(int a, int b))(int c) { return 0; }", Some("fp")),
+        (
+            "int (__cdecl *w(int a, int b))(int c) { return 0; }",
+            Some("w"),
+        ),
         (
             "void RUN_STATS_METHOD(allocate)(int a) { }",
-            "RUN_STATS_METHOD",
+            Some("RUN_STATS_METHOD"),
         ),
-        ("int (*g(void))[4] { return 0; }", "g"),
-        ("int plain(int a, int b) { return a; }", "plain"),
-        ("FILE *ptr(int a) { return 0; }", "ptr"),
+        ("int (*g(void))[4] { return 0; }", Some("g")),
+        ("int plain(int a, int b) { return a; }", Some("plain")),
+        ("FILE *ptr(int a) { return 0; }", Some("ptr")),
+        // The one row the gate must *reject*. Redundant parentheses
+        // around the name are legal C and put a
+        // `parenthesized_declarator` where every grammar's name kinds
+        // would be, so each getter's `matches!` falls through and the
+        // space stays nameless — emitting no name rather than whatever
+        // text happens to sit there is what that gate is for, and no
+        // other row reaches its `false` branch.
+        //
+        // A boundary, not a bug-lock: the shape has zero occurrences
+        // across `DeepSpeech` and `pdf.js`, so there is nothing to fix
+        // and no issue to open. Teach the walk to unwrap the
+        // parentheses and this is the row to update.
+        ("int (fp)(int a) { return a; }", None),
     ];
 
     /// C++ name forms C and Objective-C have no syntax for. None of
@@ -201,22 +219,25 @@ mod space_name_tests {
     /// conversion operator's declarator field is the type it converts
     /// *to*, so [`super::innermost_declarator`] deliberately cuts the
     /// chain there and returns `None`.
-    const CPP_ONLY_SHAPES: &[(&str, &str)] = &[
-        ("struct S { ~S() { } };", "~S"),
-        ("void Foo::bar(int a) { }", "Foo::bar"),
+    const CPP_ONLY_SHAPES: &[(&str, Option<&str>)] = &[
+        ("struct S { ~S() { } };", Some("~S")),
+        ("void Foo::bar(int a) { }", Some("Foo::bar")),
         (
             "struct S { operator int() const { return 0; } };",
-            "operator int() const",
+            Some("operator int() const"),
         ),
         (
             "struct S { int operator+(int o) const { return o; } };",
-            "operator+",
+            Some("operator+"),
         ),
         (
             "Foo &Bar::get(int a) { static Foo f; return f; }",
-            "Bar::get",
+            Some("Bar::get"),
         ),
-        ("template <typename T> T tfree(T a) { return a; }", "tfree"),
+        (
+            "template <typename T> T tfree(T a) { return a; }",
+            Some("tfree"),
+        ),
     ];
 
     /// Each fixture is padded with a leading and a trailing comment
@@ -246,12 +267,12 @@ mod space_name_tests {
         }
     }
 
-    fn check(lang: LANG, shapes: &[(&str, &str)], failures: &mut Vec<String>) {
+    fn check(lang: LANG, shapes: &[(&str, Option<&str>)], failures: &mut Vec<String>) {
         for (source, expected) in shapes {
             let root = space_verbatim(lang, pad(source).as_bytes(), MetricsOptions::default());
             let mut found = Vec::new();
             function_spaces(&root, &mut found);
-            let want = vec![(Some((*expected).to_owned()), FIXTURE_LINE, FIXTURE_LINE)];
+            let want = vec![(expected.map(str::to_owned), FIXTURE_LINE, FIXTURE_LINE)];
             if found != want {
                 failures.push(format!(
                     "{lang:?}: {source:?}\n  want {want:?}\n  got  {found:?}"
@@ -306,7 +327,7 @@ mod space_name_tests {
             LANG::C,
             &[(
                 "int plain(int a, int b) { return a; }",
-                "deliberately_wrong",
+                Some("deliberately_wrong"),
             )],
             &mut failures,
         );

--- a/src/c_declarator.rs
+++ b/src/c_declarator.rs
@@ -313,9 +313,15 @@ mod space_name_tests {
         let [only] = failures.as_slice() else {
             panic!("one wrong expectation must produce one failure, got {failures:?}");
         };
+        // `Some("plain")` rather than a bare `plain`: the message echoes
+        // the fixture source, which contains the word too, so the bare
+        // substring passes even when the selector found *nothing* —
+        // measured, by filtering `function_spaces` on `SpaceKind::Class`.
+        // Matching the rendered `Option` is what ties the assertion to
+        // the space rather than to the input.
         assert!(
-            only.contains("deliberately_wrong") && only.contains("plain"),
-            "the failure must name both the expectation and what was found: {only}"
+            only.contains("deliberately_wrong") && only.contains("Some(\"plain\")"),
+            "the failure must name both the expectation and the space found: {only}"
         );
     }
 }

--- a/src/c_declarator.rs
+++ b/src/c_declarator.rs
@@ -76,6 +76,19 @@ use crate::node::Node;
 ///   as the right answer, and without that exclusion
 ///   `int f(int a, int b) [[deprecated]]` reports 0.
 ///
+/// `template_argument_list` is excluded for the same reason as
+/// `attribute_declaration`, and it is the one exclusion the fallback
+/// needs beyond the three rules above. The fallback also runs on the
+/// *name* forms, which have no `declarator` field either, and two of
+/// them — `template_function` and `template_method` — put their argument
+/// list last: `void f<int (*)(int x, int y)>(int a)`. A type argument
+/// spelling a function type carries a `parameters` field of its own, so
+/// descending into it made that function read as taking two arguments
+/// and made its name resolve to nothing at all, the abstract declarator
+/// the chain landed on spelling no identifier. Excluding the argument
+/// list leaves the name itself as the last named child, which terminates
+/// the chain where it should.
+///
 /// Comments are excluded for the same reason, tree-sitter admitting one
 /// anywhere.
 ///
@@ -115,7 +128,9 @@ pub(crate) fn innermost_declarator<'tree, T: Checker>(node: &Node<'tree>) -> Opt
             None => current
                 .children()
                 .filter(|child| {
-                    child.is_named() && !T::is_comment(child) && child.kind() != ATTRIBUTE
+                    child.is_named()
+                        && !T::is_comment(child)
+                        && !matches!(child.kind(), ATTRIBUTE | TEMPLATE_ARGUMENTS)
                 })
                 .last(),
         },
@@ -153,6 +168,7 @@ pub(crate) fn declarator_name<'tree, T: Checker>(node: &Node<'tree>) -> Option<N
 /// never emit `operator_cast`.
 const CONVERSION_OPERATOR: &str = "operator_cast";
 const ATTRIBUTE: &str = "attribute_declaration";
+const TEMPLATE_ARGUMENTS: &str = "template_argument_list";
 
 #[cfg(test)]
 mod space_name_tests {
@@ -237,6 +253,28 @@ mod space_name_tests {
         (
             "template <typename T> T tfree(T a) { return a; }",
             Some("tfree"),
+        ),
+        // The two shapes the fallback's `template_argument_list`
+        // exclusion exists for. Both spell an explicit template argument
+        // of function type, so the chain would otherwise leave the name
+        // side entirely — down `template_function` into its
+        // `template_argument_list` — and settle on the argument's own
+        // `abstract_function_declarator`. That node spells no
+        // identifier, so the name came back `None`, and `nargs` read the
+        // argument's two parameters instead of the function's one.
+        //
+        // Both parse without an `ERROR` node, so neither is covered by
+        // the recovery caveat on [`super::innermost_declarator`]. The
+        // second is the more reachable of the two: an out-of-line
+        // member with explicit template arguments needs no `template <>`
+        // preamble.
+        (
+            "template <> void tspec<int (*)(int x, int y)>(int a) { }",
+            Some("tspec<int (*)(int x, int y)>"),
+        ),
+        (
+            "void Foo::tmem<int (*)(int x, int y)>(int a) { }",
+            Some("Foo::tmem<int (*)(int x, int y)>"),
         ),
     ];
 

--- a/src/getter/c.rs
+++ b/src/getter/c.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::wildcard_imports, clippy::enum_glob_use)]
 
 use super::*;
-use crate::c_declarator::innermost_declarator;
+use crate::c_declarator::declarator_name;
 
 impl Getter for CCode {
     fn get_func_space_name<'a, 'tree>(
@@ -17,13 +17,9 @@ impl Getter for CCode {
         // / template names), so the declarator name is a plain identifier.
         match node.kind_id().into() {
             C::FunctionDefinition | C::FunctionDefinition2 => {
-                // The name sits on the *innermost* declarator, which is
-                // the one whose `parameters` field the arity metric
-                // reads — see `crate::c_declarator` for why neither is
-                // a child of the function node (#1208).
-                if let Some(owner) = innermost_declarator::<Self>(node)
-                    && let Some(name) = owner.child_by_field_name("declarator")
-                {
+                // The name is not a child of the function node — see
+                // `crate::c_declarator` (#1208).
+                if let Some(name) = declarator_name::<Self>(node) {
                     match name.kind_id().into() {
                         C::TypeIdentifier | C::Identifier | C::FieldIdentifier => {
                             return node_text(code, &name);

--- a/src/getter/c.rs
+++ b/src/getter/c.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::wildcard_imports, clippy::enum_glob_use)]
 
 use super::*;
+use crate::c_declarator::innermost_declarator;
 
 impl Getter for CCode {
     fn get_func_space_name<'a, 'tree>(
@@ -16,21 +17,18 @@ impl Getter for CCode {
         // / template names), so the declarator name is a plain identifier.
         match node.kind_id().into() {
             C::FunctionDefinition | C::FunctionDefinition2 => {
-                // we're in a function_definition so need to get the declarator
-                if let Some(declarator) = node.child_by_field_name("declarator") {
-                    let declarator_node = declarator;
-                    if let Some(fd) = declarator_node.first_occurrence(|id| {
-                        C::FunctionDeclarator == id
-                            || C::FunctionDeclarator2 == id
-                            || C::FunctionDeclarator3 == id
-                    }) && let Some(first) = fd.child(0)
-                    {
-                        match first.kind_id().into() {
-                            C::TypeIdentifier | C::Identifier | C::FieldIdentifier => {
-                                return node_text(code, &first);
-                            }
-                            _ => {}
+                // The name sits on the *innermost* declarator, which is
+                // the one whose `parameters` field the arity metric
+                // reads — see `crate::c_declarator` for why neither is
+                // a child of the function node (#1208).
+                if let Some(owner) = innermost_declarator::<Self>(node)
+                    && let Some(name) = owner.child_by_field_name("declarator")
+                {
+                    match name.kind_id().into() {
+                        C::TypeIdentifier | C::Identifier | C::FieldIdentifier => {
+                            return node_text(code, &name);
                         }
+                        _ => {}
                     }
                 }
             }

--- a/src/getter/c.rs
+++ b/src/getter/c.rs
@@ -19,13 +19,13 @@ impl Getter for CCode {
             C::FunctionDefinition | C::FunctionDefinition2 => {
                 // The name is not a child of the function node — see
                 // `crate::c_declarator` (#1208).
-                if let Some(name) = declarator_name::<Self>(node) {
-                    match name.kind_id().into() {
-                        C::TypeIdentifier | C::Identifier | C::FieldIdentifier => {
-                            return node_text(code, &name);
-                        }
-                        _ => {}
-                    }
+                if let Some(name) = declarator_name::<Self>(node)
+                    && matches!(
+                        name.kind_id().into(),
+                        C::TypeIdentifier | C::Identifier | C::FieldIdentifier
+                    )
+                {
+                    return node_text(code, &name);
                 }
             }
             _ => {

--- a/src/getter/cpp.rs
+++ b/src/getter/cpp.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::wildcard_imports, clippy::enum_glob_use)]
 
 use super::*;
-use crate::c_declarator::innermost_declarator;
+use crate::c_declarator::declarator_name;
 
 impl Getter for CppCode {
     fn get_func_space_name<'a, 'tree>(
@@ -25,13 +25,9 @@ impl Getter for CppCode {
                 if let Some(op_cast) = node.first_child(|id| Cpp::OperatorCast == id) {
                     return node_text(code, &op_cast);
                 }
-                // The name sits on the *innermost* declarator, which
-                // is the one whose `parameters` field the arity metric
-                // reads — see `crate::c_declarator` for why neither is
-                // a child of the function node (#1208).
-                if let Some(owner) = innermost_declarator::<Self>(node)
-                    && let Some(name) = owner.child_by_field_name("declarator")
-                {
+                // The name is not a child of the function node — see
+                // `crate::c_declarator` (#1208).
+                if let Some(name) = declarator_name::<Self>(node) {
                     match name.kind_id().into() {
                         Cpp::TypeIdentifier
                         | Cpp::Identifier

--- a/src/getter/cpp.rs
+++ b/src/getter/cpp.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::wildcard_imports, clippy::enum_glob_use)]
 
 use super::*;
+use crate::c_declarator::innermost_declarator;
 
 impl Getter for CppCode {
     fn get_func_space_name<'a, 'tree>(
@@ -24,31 +25,28 @@ impl Getter for CppCode {
                 if let Some(op_cast) = node.first_child(|id| Cpp::OperatorCast == id) {
                     return node_text(code, &op_cast);
                 }
-                // we're in a function_definition so need to get the declarator
-                if let Some(declarator) = node.child_by_field_name("declarator") {
-                    let declarator_node = declarator;
-                    if let Some(fd) = declarator_node.first_occurrence(|id| {
-                        Cpp::FunctionDeclarator == id
-                            || Cpp::FunctionDeclarator2 == id
-                            || Cpp::FunctionDeclarator3 == id
-                    }) && let Some(first) = fd.child(0)
-                    {
-                        match first.kind_id().into() {
-                            Cpp::TypeIdentifier
-                            | Cpp::Identifier
-                            | Cpp::FieldIdentifier
-                            | Cpp::DestructorName
-                            | Cpp::OperatorName
-                            | Cpp::QualifiedIdentifier
-                            | Cpp::QualifiedIdentifier2
-                            | Cpp::QualifiedIdentifier3
-                            | Cpp::QualifiedIdentifier4
-                            | Cpp::TemplateFunction
-                            | Cpp::TemplateMethod => {
-                                return node_text(code, &first);
-                            }
-                            _ => {}
+                // The name sits on the *innermost* declarator, which
+                // is the one whose `parameters` field the arity metric
+                // reads — see `crate::c_declarator` for why neither is
+                // a child of the function node (#1208).
+                if let Some(owner) = innermost_declarator::<Self>(node)
+                    && let Some(name) = owner.child_by_field_name("declarator")
+                {
+                    match name.kind_id().into() {
+                        Cpp::TypeIdentifier
+                        | Cpp::Identifier
+                        | Cpp::FieldIdentifier
+                        | Cpp::DestructorName
+                        | Cpp::OperatorName
+                        | Cpp::QualifiedIdentifier
+                        | Cpp::QualifiedIdentifier2
+                        | Cpp::QualifiedIdentifier3
+                        | Cpp::QualifiedIdentifier4
+                        | Cpp::TemplateFunction
+                        | Cpp::TemplateMethod => {
+                            return node_text(code, &name);
                         }
+                        _ => {}
                     }
                 }
             }

--- a/src/getter/cpp.rs
+++ b/src/getter/cpp.rs
@@ -27,23 +27,23 @@ impl Getter for CppCode {
                 }
                 // The name is not a child of the function node — see
                 // `crate::c_declarator` (#1208).
-                if let Some(name) = declarator_name::<Self>(node) {
-                    match name.kind_id().into() {
+                if let Some(name) = declarator_name::<Self>(node)
+                    && matches!(
+                        name.kind_id().into(),
                         Cpp::TypeIdentifier
-                        | Cpp::Identifier
-                        | Cpp::FieldIdentifier
-                        | Cpp::DestructorName
-                        | Cpp::OperatorName
-                        | Cpp::QualifiedIdentifier
-                        | Cpp::QualifiedIdentifier2
-                        | Cpp::QualifiedIdentifier3
-                        | Cpp::QualifiedIdentifier4
-                        | Cpp::TemplateFunction
-                        | Cpp::TemplateMethod => {
-                            return node_text(code, &name);
-                        }
-                        _ => {}
-                    }
+                            | Cpp::Identifier
+                            | Cpp::FieldIdentifier
+                            | Cpp::DestructorName
+                            | Cpp::OperatorName
+                            | Cpp::QualifiedIdentifier
+                            | Cpp::QualifiedIdentifier2
+                            | Cpp::QualifiedIdentifier3
+                            | Cpp::QualifiedIdentifier4
+                            | Cpp::TemplateFunction
+                            | Cpp::TemplateMethod
+                    )
+                {
+                    return node_text(code, &name);
                 }
             }
             _ => {

--- a/src/getter/mozcpp.rs
+++ b/src/getter/mozcpp.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::wildcard_imports, clippy::enum_glob_use)]
 
 use super::*;
-use crate::c_declarator::innermost_declarator;
+use crate::c_declarator::declarator_name;
 
 impl Getter for MozcppCode {
     fn get_func_space_name<'a, 'tree>(
@@ -25,13 +25,9 @@ impl Getter for MozcppCode {
                 if let Some(op_cast) = node.first_child(|id| Mozcpp::OperatorCast == id) {
                     return node_text(code, &op_cast);
                 }
-                // The name sits on the *innermost* declarator, which
-                // is the one whose `parameters` field the arity metric
-                // reads — see `crate::c_declarator` for why neither is
-                // a child of the function node (#1208).
-                if let Some(owner) = innermost_declarator::<Self>(node)
-                    && let Some(name) = owner.child_by_field_name("declarator")
-                {
+                // The name is not a child of the function node — see
+                // `crate::c_declarator` (#1208).
+                if let Some(name) = declarator_name::<Self>(node) {
                     match name.kind_id().into() {
                         Mozcpp::TypeIdentifier
                         | Mozcpp::Identifier

--- a/src/getter/mozcpp.rs
+++ b/src/getter/mozcpp.rs
@@ -27,23 +27,23 @@ impl Getter for MozcppCode {
                 }
                 // The name is not a child of the function node — see
                 // `crate::c_declarator` (#1208).
-                if let Some(name) = declarator_name::<Self>(node) {
-                    match name.kind_id().into() {
+                if let Some(name) = declarator_name::<Self>(node)
+                    && matches!(
+                        name.kind_id().into(),
                         Mozcpp::TypeIdentifier
-                        | Mozcpp::Identifier
-                        | Mozcpp::FieldIdentifier
-                        | Mozcpp::DestructorName
-                        | Mozcpp::OperatorName
-                        | Mozcpp::QualifiedIdentifier
-                        | Mozcpp::QualifiedIdentifier2
-                        | Mozcpp::QualifiedIdentifier3
-                        | Mozcpp::QualifiedIdentifier4
-                        | Mozcpp::TemplateFunction
-                        | Mozcpp::TemplateMethod => {
-                            return node_text(code, &name);
-                        }
-                        _ => {}
-                    }
+                            | Mozcpp::Identifier
+                            | Mozcpp::FieldIdentifier
+                            | Mozcpp::DestructorName
+                            | Mozcpp::OperatorName
+                            | Mozcpp::QualifiedIdentifier
+                            | Mozcpp::QualifiedIdentifier2
+                            | Mozcpp::QualifiedIdentifier3
+                            | Mozcpp::QualifiedIdentifier4
+                            | Mozcpp::TemplateFunction
+                            | Mozcpp::TemplateMethod
+                    )
+                {
+                    return node_text(code, &name);
                 }
             }
             _ => {

--- a/src/getter/mozcpp.rs
+++ b/src/getter/mozcpp.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::wildcard_imports, clippy::enum_glob_use)]
 
 use super::*;
+use crate::c_declarator::innermost_declarator;
 
 impl Getter for MozcppCode {
     fn get_func_space_name<'a, 'tree>(
@@ -24,31 +25,28 @@ impl Getter for MozcppCode {
                 if let Some(op_cast) = node.first_child(|id| Mozcpp::OperatorCast == id) {
                     return node_text(code, &op_cast);
                 }
-                // we're in a function_definition so need to get the declarator
-                if let Some(declarator) = node.child_by_field_name("declarator") {
-                    let declarator_node = declarator;
-                    if let Some(fd) = declarator_node.first_occurrence(|id| {
-                        Mozcpp::FunctionDeclarator == id
-                            || Mozcpp::FunctionDeclarator2 == id
-                            || Mozcpp::FunctionDeclarator3 == id
-                    }) && let Some(first) = fd.child(0)
-                    {
-                        match first.kind_id().into() {
-                            Mozcpp::TypeIdentifier
-                            | Mozcpp::Identifier
-                            | Mozcpp::FieldIdentifier
-                            | Mozcpp::DestructorName
-                            | Mozcpp::OperatorName
-                            | Mozcpp::QualifiedIdentifier
-                            | Mozcpp::QualifiedIdentifier2
-                            | Mozcpp::QualifiedIdentifier3
-                            | Mozcpp::QualifiedIdentifier4
-                            | Mozcpp::TemplateFunction
-                            | Mozcpp::TemplateMethod => {
-                                return node_text(code, &first);
-                            }
-                            _ => {}
+                // The name sits on the *innermost* declarator, which
+                // is the one whose `parameters` field the arity metric
+                // reads — see `crate::c_declarator` for why neither is
+                // a child of the function node (#1208).
+                if let Some(owner) = innermost_declarator::<Self>(node)
+                    && let Some(name) = owner.child_by_field_name("declarator")
+                {
+                    match name.kind_id().into() {
+                        Mozcpp::TypeIdentifier
+                        | Mozcpp::Identifier
+                        | Mozcpp::FieldIdentifier
+                        | Mozcpp::DestructorName
+                        | Mozcpp::OperatorName
+                        | Mozcpp::QualifiedIdentifier
+                        | Mozcpp::QualifiedIdentifier2
+                        | Mozcpp::QualifiedIdentifier3
+                        | Mozcpp::QualifiedIdentifier4
+                        | Mozcpp::TemplateFunction
+                        | Mozcpp::TemplateMethod => {
+                            return node_text(code, &name);
                         }
+                        _ => {}
                     }
                 }
             }

--- a/src/getter/objc.rs
+++ b/src/getter/objc.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::wildcard_imports, clippy::enum_glob_use)]
 
 use super::*;
-use crate::c_declarator::innermost_declarator;
+use crate::c_declarator::declarator_name;
 
 impl Getter for ObjcCode {
     fn get_func_space_name<'a, 'tree>(
@@ -20,13 +20,9 @@ impl Getter for ObjcCode {
         // class / protocol name, or a method's first selector keyword.
         match node.kind_id().into() {
             Objc::FunctionDefinition | Objc::FunctionDefinition2 => {
-                // The name sits on the *innermost* declarator, which is
-                // the one whose `parameters` field the arity metric
-                // reads — see `crate::c_declarator` for why neither is a
-                // child of the function node (#1208).
-                if let Some(owner) = innermost_declarator::<Self>(node)
-                    && let Some(name) = owner.child_by_field_name("declarator")
-                {
+                // The name is not a child of the function node — see
+                // `crate::c_declarator` (#1208).
+                if let Some(name) = declarator_name::<Self>(node) {
                     match name.kind_id().into() {
                         Objc::TypeIdentifier | Objc::Identifier | Objc::FieldIdentifier => {
                             return node_text(code, &name);

--- a/src/getter/objc.rs
+++ b/src/getter/objc.rs
@@ -22,13 +22,13 @@ impl Getter for ObjcCode {
             Objc::FunctionDefinition | Objc::FunctionDefinition2 => {
                 // The name is not a child of the function node — see
                 // `crate::c_declarator` (#1208).
-                if let Some(name) = declarator_name::<Self>(node) {
-                    match name.kind_id().into() {
-                        Objc::TypeIdentifier | Objc::Identifier | Objc::FieldIdentifier => {
-                            return node_text(code, &name);
-                        }
-                        _ => {}
-                    }
+                if let Some(name) = declarator_name::<Self>(node)
+                    && matches!(
+                        name.kind_id().into(),
+                        Objc::TypeIdentifier | Objc::Identifier | Objc::FieldIdentifier
+                    )
+                {
+                    return node_text(code, &name);
                 }
             }
             Objc::MethodDefinition

--- a/src/getter/objc.rs
+++ b/src/getter/objc.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::wildcard_imports, clippy::enum_glob_use)]
 
 use super::*;
+use crate::c_declarator::innermost_declarator;
 
 impl Getter for ObjcCode {
     fn get_func_space_name<'a, 'tree>(
@@ -19,18 +20,16 @@ impl Getter for ObjcCode {
         // class / protocol name, or a method's first selector keyword.
         match node.kind_id().into() {
             Objc::FunctionDefinition | Objc::FunctionDefinition2 => {
-                if let Some(declarator) = node.child_by_field_name("declarator")
-                    && let Some(fd) = declarator.first_occurrence(|id| {
-                        Objc::FunctionDeclarator == id
-                            || Objc::FunctionDeclarator2 == id
-                            || Objc::FunctionDeclarator3 == id
-                            || Objc::FunctionDeclarator4 == id
-                    })
-                    && let Some(first) = fd.child(0)
+                // The name sits on the *innermost* declarator, which is
+                // the one whose `parameters` field the arity metric
+                // reads — see `crate::c_declarator` for why neither is a
+                // child of the function node (#1208).
+                if let Some(owner) = innermost_declarator::<Self>(node)
+                    && let Some(name) = owner.child_by_field_name("declarator")
                 {
-                    match first.kind_id().into() {
+                    match name.kind_id().into() {
                         Objc::TypeIdentifier | Objc::Identifier | Objc::FieldIdentifier => {
-                            return node_text(code, &first);
+                            return node_text(code, &name);
                         }
                         _ => {}
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,7 @@
 #![allow(clippy::upper_case_acronyms)]
 
 // Internal-only modules. Nothing is re-exported from these.
+mod c_declarator;
 mod c_langs_macros;
 mod c_macro;
 mod cfg_predicate;

--- a/src/metrics/nargs.rs
+++ b/src/metrics/nargs.rs
@@ -19,6 +19,7 @@
 
 use std::fmt;
 
+use crate::c_declarator::innermost_declarator;
 use crate::checker::Checker;
 use crate::macros::implement_metric_trait;
 use crate::*;
@@ -256,108 +257,6 @@ fn compute_args<T: Checker>(node: &Node, code: &[u8], nargs: &mut usize) {
     }
 }
 
-/// The node whose `parameters` field holds a C-family function's *own*
-/// formal arguments: the **innermost** one along the declarator chain.
-///
-/// C declarator syntax nests outward from the declared name, so a
-/// function node's `declarator` field is only the function's parameter
-/// list when the return type is plain. Anything the return type
-/// contributes — a `*`, a `&`, a parenthesised group — wraps the
-/// `function_declarator` that owns the real list, and the outermost
-/// `parameters` a chain carries can belong to the *return type* rather
-/// than to the function (`int (*f(int a))(int b)` returns a pointer to a
-/// one-argument function and itself takes one argument). Taking the
-/// innermost is what makes both of those come out right (#1200).
-///
-/// The walk is by field name, per `.claude/rules/grammar-dispatch.md`
-/// §3, which also sidesteps §1: `PointerDeclarator2`,
-/// `FunctionDeclarator2`/`3` and `ReferenceDeclarator2`/`3`/`4` are
-/// numeric-suffix aliases that a `kind_id` match would have to
-/// enumerate and would silently regress on the next grammar bump.
-///
-/// Three of the rules on the chain expose no field at all, which is why
-/// the field alone is not enough. Every entry below is from the pinned
-/// grammars' `node-types.json` (`tree-sitter-cpp` 0.23.4,
-/// `tree-sitter-c` 0.24.2, `tree-sitter-objc` 3.0.2, vendored
-/// `tree-sitter-mozcpp`), and the fieldless list is the complete set of
-/// `*_declarator` rules with no fields that a *function definition's*
-/// name side can reach — the rest (`variadic_declarator`,
-/// `structured_binding_declarator`, Objective-C's `keyword_declarator`
-/// and `struct_declarator`, and the `abstract_*` family) sit in
-/// parameter, binding or type position, never here.
-///
-/// | rule | `declarator` field |
-/// | --- | --- |
-/// | `pointer_declarator` | required |
-/// | `function_declarator` | required |
-/// | `abstract_function_declarator` | **optional** |
-/// | `reference_declarator` | **absent — no fields** |
-/// | `parenthesized_declarator` | **absent — no fields** |
-/// | `attributed_declarator` | **absent — no fields** |
-///
-/// In all three fieldless rules the inner declarator is the last
-/// *named* child once attributes are set aside, so that is the
-/// fallback:
-///
-/// - `reference_declarator` is `seq(choice('&', '&&'), _declarator)`.
-/// - `parenthesized_declarator` is `seq('(',
-///   optional(ms_call_modifier), _declarator, ')')` — last rather than
-///   sole, so `int (__cdecl *f(int a))(int b)` does not defeat it.
-/// - `attributed_declarator` is `seq(_declarator,
-///   repeat1(attribute_declaration))`, the one rule that puts the
-///   declarator **first**. Excluding `attribute_declaration` — its only
-///   non-declarator child type in all four grammars — restores "last"
-///   as the right answer, and without that exclusion
-///   `int f(int a, int b) [[deprecated]]` reports 0.
-///
-/// Comments are excluded for the same reason, tree-sitter admitting one
-/// anywhere.
-///
-/// The fallback stops at a node that already carries `parameters`,
-/// which is the C++ lambda: `abstract_function_declarator`'s
-/// `declarator` field is optional, so `[](int a, int (*cb)(int x))`
-/// would otherwise descend into the `parameter_list` and return `cb`'s
-/// `(int x)` — one argument instead of two.
-///
-/// Every step strictly descends a finite tree, so the walk terminates
-/// without a depth cap.
-fn declarator_params_owner<'tree, T: Checker>(node: &Node<'tree>) -> Option<Node<'tree>> {
-    // The chain starts at the `declarator` field rather than at `node`
-    // so the last-named-child fallback can never fire on the function
-    // node itself and walk into its body. The walk runs outside-in, so
-    // the innermost qualifying link is the last one it yields.
-    std::iter::successors(
-        node.child_by_field_name("declarator"),
-        |current| match current.child_by_field_name("declarator") {
-            Some(declarator) => Some(declarator),
-            None if current.child_by_field_name("parameters").is_some() => None,
-            None => current
-                .children()
-                .filter(|child| {
-                    child.is_named() && !T::is_comment(child) && child.kind() != ATTRIBUTE
-                })
-                .last(),
-        },
-    )
-    // A conversion operator's `declarator` field is the type it converts
-    // *to*, not its name side: `operator int (*)(int x)` takes no
-    // arguments, and everything from here inward describes that
-    // function-pointer type. Cutting the chain restores the 0 the
-    // pre-#1200 code reported by never finding `parameters` at all.
-    .take_while(|link| link.kind() != CONVERSION_OPERATOR)
-    .filter(|link| link.child_by_field_name("parameters").is_some())
-    .last()
-}
-
-/// Compared by `kind()` string rather than `kind_id`, per
-/// `.claude/rules/grammar-dispatch.md` §1: both rules carry
-/// numeric-suffix aliases across the four C-family grammars, and a
-/// `kind_id` match would have to enumerate every one of them and would
-/// regress silently on the next grammar bump. C and Objective-C simply
-/// never emit `operator_cast`.
-const CONVERSION_OPERATOR: &str = "operator_cast";
-const ATTRIBUTE: &str = "attribute_declaration";
-
 #[doc(hidden)]
 /// Per-language counting of function arguments.
 pub(crate) trait NArgs
@@ -432,19 +331,19 @@ where
 // merely unused.
 impl NArgs for CppCode {
     fn params_owner<'tree>(node: &Node<'tree>, _ancestors: Ancestors<'tree, '_>) -> Node<'tree> {
-        declarator_params_owner::<Self>(node).unwrap_or(*node)
+        innermost_declarator::<Self>(node).unwrap_or(*node)
     }
 }
 
 impl NArgs for CCode {
     fn params_owner<'tree>(node: &Node<'tree>, _ancestors: Ancestors<'tree, '_>) -> Node<'tree> {
-        declarator_params_owner::<Self>(node).unwrap_or(*node)
+        innermost_declarator::<Self>(node).unwrap_or(*node)
     }
 }
 
 impl NArgs for MozcppCode {
     fn params_owner<'tree>(node: &Node<'tree>, _ancestors: Ancestors<'tree, '_>) -> Node<'tree> {
-        declarator_params_owner::<Self>(node).unwrap_or(*node)
+        innermost_declarator::<Self>(node).unwrap_or(*node)
     }
 }
 
@@ -464,7 +363,7 @@ impl NArgs for ObjcCode {
                 // The same declarator walk C and C++ use: Objective-C
                 // inherits C's declarator syntax, so `FILE *f(int a)`
                 // buries the parameter list one level down (#1200).
-                if let Some(owner) = declarator_params_owner::<Self>(node) {
+                if let Some(owner) = innermost_declarator::<Self>(node) {
                     compute_args::<Self>(&owner, code, &mut stats.fn_nargs);
                 }
             }
@@ -4852,48 +4751,8 @@ mod c_family_return_type_declarators {
         );
     }
 
-    /// FIXME(#1208): the arity of a function returning a function
-    /// pointer is right after #1200; its **name** is not.
-    ///
-    /// `get_func_space_name` reaches the declarator through
-    /// `first_occurrence`, which stops at the *outer*
-    /// `function_declarator` — the return type's — whose `child(0)` is a
-    /// `parenthesized_declarator` and matches none of the identifier
-    /// kinds, so the arm falls through to `None`. That is a getter bug
-    /// in a different metric surface, tracked separately.
-    ///
-    /// Pinned here rather than left in the tracker so the gap fails in
-    /// CI the day it is fixed, per `.claude/rules/grammar-dispatch.md`.
-    /// When #1208 lands, this test inverts: assert `Some("fp")`.
-    #[test]
-    fn a_parenthesised_declarator_still_loses_its_space_name() {
-        for lang in [LANG::C, LANG::Cpp, LANG::Mozcpp, LANG::Objc]
-            .into_iter()
-            .filter(LANG::is_enabled)
-        {
-            let root = space_verbatim(
-                lang,
-                b"int (*fp(int a, int b))(int c) { return 0; }",
-                MetricsOptions::default(),
-            );
-            let [space] = root.spaces.as_slice() else {
-                panic!("{lang:?}: fixture must open exactly one space");
-            };
-            assert_eq!(
-                space.name, None,
-                "{lang:?}: #1208 appears to be fixed — invert this test to assert Some(\"fp\")"
-            );
-            // The control, so a regression that lost *every* space name
-            // would not read as #1208 merely still being open.
-            let named = space_verbatim(
-                lang,
-                b"int plain(int a, int b) { return a; }",
-                MetricsOptions::default(),
-            );
-            let [space] = named.spaces.as_slice() else {
-                panic!("{lang:?}: control must open exactly one space");
-            };
-            assert_eq!(space.name.as_deref(), Some("plain"), "{lang:?}");
-        }
-    }
+    // The #1208 bug-lock that stood here — asserting these shapes lost
+    // their space *name* while keeping their arity — was retired when
+    // #1208 landed. The name half now lives beside the walk it shares
+    // with this module, in `crate::c_declarator`.
 }

--- a/src/metrics/nargs.rs
+++ b/src/metrics/nargs.rs
@@ -4647,6 +4647,19 @@ mod c_family_return_type_declarators {
                 // ends at a `qualified_identifier` rather than a bare
                 // one, which has named children of its own.
                 ("Foo &Bar::get(int a) { static Foo f; return f; }", (0, 1)),
+                // An explicit template argument spelling a function
+                // type. `template_function` is another name form with
+                // named children, and its last one is the argument
+                // list — so the last-named-child fallback walks off the
+                // name side into `int (*)(int x, int y)` and bills that
+                // type's two parameters to a one-argument function
+                // unless `template_argument_list` is excluded. The two
+                // lists are deliberately different lengths, so the row
+                // cannot agree with the answer it rejects.
+                (
+                    "template <> void tspec<int (*)(int x, int y)>(int a) { }",
+                    (0, 1),
+                ),
                 // A conversion operator takes no arguments, however
                 // many its target *type* has. `operator_cast` is the
                 // one link whose `declarator` field leaves the name

--- a/src/node.rs
+++ b/src/node.rs
@@ -1640,10 +1640,11 @@ mod tests {
     /// the subtree matches, rather than falling back to the root or the
     /// last node it looked at.
     ///
-    /// Every caller in the crate — the C / C++ / Objective-C / Mozcpp
-    /// getters — uses it to find a declarator that the surrounding
-    /// grammar guarantees is there, so the whole suite only ever
-    /// exercised the hit path.
+    /// The four C-family getters that used to be its only callers each
+    /// looked for a declarator the surrounding grammar guaranteed was
+    /// there, so the whole suite only ever exercised the hit path. They
+    /// moved onto [`crate::c_declarator`] in #1208; this test and its
+    /// sibling below are what is left (#1212).
     #[test]
     fn first_occurrence_answers_none_when_nothing_matches() {
         let tree = Tree::new::<crate::langs::CCode>(b"int main() { int a; }");
@@ -1673,10 +1674,16 @@ mod tests {
     /// it: its match-everything predicate hits the root before any child
     /// is pushed, so the child order never comes into play.
     ///
-    /// The order is load-bearing rather than incidental — the C, C++,
-    /// Objective-C and mozcpp `get_func_space_name` declarator searches
-    /// are `first_occurrence` calls, and a reversed sibling order
-    /// changes *which* declarator names a function space.
+    /// The order was load-bearing while the C, C++, Objective-C and
+    /// mozcpp `get_func_space_name` declarator searches were
+    /// `first_occurrence` calls: a reversed sibling order changed
+    /// *which* declarator named a function space. Those four moved onto
+    /// [`crate::c_declarator`] in #1208 — which is also what fixed the
+    /// shapes where leftmost was the wrong answer — so no production
+    /// code depends on the order today, and #1212 asks whether the
+    /// method should survive at all. Until it is answered the contract
+    /// stays pinned, because an unpinned one is how it went unguarded
+    /// the first time.
     ///
     /// Measured on this fixture: `"main"` as written, `"b"` with the
     /// reversal removed.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -76,12 +76,14 @@ pub(crate) trait ParserTrait {
 }
 
 pub(crate) trait Search<'a> {
-    /// Kept, and allowed, pending #1212: #1208 moved the four C-family
-    /// `get_func_space_name` impls — its only production callers — onto
-    /// the shared declarator walk in [`crate::c_declarator`], and the
-    /// tests in `src/node.rs` are all that reach it now. Whether to
-    /// remove it or to state a reason for keeping it is a decision of
-    /// its own, not a rider on a name-resolution bug fix.
+    /// Finds the first node of the subtree, in pre-order, whose
+    /// `kind_id` satisfies `pred`.
+    // Kept, and allowed, pending #1212: #1208 moved the four C-family
+    // `get_func_space_name` impls — its only production callers — onto
+    // the shared declarator walk in `crate::c_declarator`, and the tests
+    // in `src/node.rs` are all that reach it now. Whether to remove it
+    // or to state a reason for keeping it is a decision of its own, not
+    // a rider on a name-resolution bug fix.
     #[allow(dead_code)]
     fn first_occurrence(&self, pred: fn(u16) -> bool) -> Option<Node<'a>>;
     /// Visits every node of the subtree in source order, handing the

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -76,6 +76,13 @@ pub(crate) trait ParserTrait {
 }
 
 pub(crate) trait Search<'a> {
+    /// Kept, and allowed, pending #1212: #1208 moved the four C-family
+    /// `get_func_space_name` impls — its only production callers — onto
+    /// the shared declarator walk in [`crate::c_declarator`], and the
+    /// tests in `src/node.rs` are all that reach it now. Whether to
+    /// remove it or to state a reason for keeping it is a decision of
+    /// its own, not a rider on a name-resolution bug fix.
+    #[allow(dead_code)]
     fn first_occurrence(&self, pred: fn(u16) -> bool) -> Option<Node<'a>>;
     /// Visits every node of the subtree in source order, handing the
     /// action each node's ancestor chain alongside it so a predicate it


### PR DESCRIPTION
Fixes #1208

A C/C++/Objective-C function whose declared name sits under an extra
declarator layer resolved its `FuncSpace::name` to `null`. Two spellings
were affected:

```c
int (*fp(int a, int b))(int c) { return 0; }        // a function returning a function pointer
void RUN_STATS_METHOD(allocate)(JNIEnv *env) { }    // a macro-obscured declarator (JNI shims)
```

`get_func_space_name` reached the declarator with `first_occurrence`, a
leftmost pre-order search. When the function node's own `declarator`
field is *already* a `function_declarator` — the return type's — the
search stops there, and its `child(0)` is a `parenthesized_declarator`
or an inner `function_declarator`, neither of which is an identifier
kind, so the arm fell through to `None`.

`nargs` has walked this chain correctly since #1200. That walk moves to
`src/c_declarator.rs`, and the four getters now read the name off the
same innermost declarator, so the arity and the name can no longer
describe two different nodes.

## What changed

- **`src/c_declarator.rs`** (new) — `innermost_declarator`, moved out of
  `src/metrics/nargs.rs` with its `node-types.json` table doc intact,
  plus `declarator_name`, which is that node's `declarator` field. The
  three `NArgs::params_owner` impls and the Objective-C `compute`
  override point at the new path; no arity moved.
- **The four getters** read `declarator_name::<Self>(node)` and gate the
  result with `matches!` on their own identifier kinds. The
  `FunctionDeclarator`/`2`/`3`/`4` enumerations are gone
  (`grammar-dispatch.md` §1) and the name comes off the `declarator`
  field rather than `child(0)` (§3). C++/mozcpp keep the `OperatorCast`
  early return: the shared walk deliberately cuts the chain at a
  conversion operator, so removing it would return `None`.
- **A regression found during review** — the fallback also runs on the
  C++ *name* forms, and `template_function` / `template_method` put
  their `template_argument_list` last, so a type argument spelling a
  function type pulled the chain off the name side.
  `template <> void tspec<int (*)(int x, int y)>(int a)` lost its name
  on this branch and had been misreading its arity since #1200.
  `template_argument_list` is now excluded alongside
  `attribute_declaration`.
- **`Search::first_occurrence`** loses its last production caller and
  trips `dead_code` on the lib target, so it sits behind a scoped
  `#[allow]` naming #1212. Both `src/node.rs` test docs that justified
  the pre-order contract *by naming these four getters* were rewritten —
  that claim is now false.

## Measurements

Same method both sides (`bca metrics --no-config` over `DeepSpeech` +
`pdf.js`, 14,269 files, 232,198 spaces):

| | nameless `kind: function` spaces |
|---|---|
| before | 354 |
| after | 310 |

**The issue's 354 is the nameless-function population, not this
defect's.** This fixes 44 (46 gained a name, 2 lost one). The residual
310 is ERROR-recovery on input the grammars cannot parse:
`schema_generated.h` (115, a macro between a struct name and its base
clause), two SWIG `.i` files (56), `gpu_device.cc` (32). The clusters
the issue named as this defect — the JNI shims — are all fixed:
`object_tracker_jni.cc` (18), `imageutils_jni.cc` (5),
`run_stats_jni.cc` (4), plus 17 XLA files.

The 2 losses are both inside recovery subtrees, where no strategy has a
defensible answer; one had been reporting the callee of a misparsed `if`
statement as a function name. The boundary is documented on
`innermost_declarator`.

## Snapshots

Two openfst `union-weight.h` snapshots move, where the issue predicted
none. Not a nameless space — a name→name change. tree-sitter-cpp cannot
parse `friend bool operator== <>(const UnionWeight<W, O> &, …)` and
folds the following comments and constructor into a
`reference_declarator` holding two sibling `function_declarator`s; the
old name came from the leftmost, the new one from the last. That space's
`function_args` has read `1` since #1200 — the arity of
`first_(W::NoWeight())`, not of `UnionWeight()` — so the name and the
arity had been describing two different nodes and now describe one.
Submodule bumped in the same parent commit and pushed.

## Tests

A table in `src/c_declarator.rs` over C / C++ / Mozcpp / Objective-C
asserting name **and** `kind: function` **and** span in one pass
(discharging `grammar-dispatch.md` §6): the three #1208 shapes, three
controls including the array-return `int (*g(void))[4]` that resolved
correctly *before* the fix, one row expecting no name, and eight C++
name forms. Mozcpp owns no file extension, so it reaches all of this
only through `space_verbatim`.

Reverting the getters fails 12 of 36 rows — exactly the three #1208
shapes × four languages. Removing the `template_argument_list`
exclusion fails exactly the two rows added for it.

`a_parenthesised_declarator_still_loses_its_space_name`, the #1200
bug-lock, is deleted: its `fp` fixture and `plain` control are rows in
the new table, in the module that now owns the behaviour.

## Downstream note

Affected C-family functions re-key in `.bca-baseline.toml` from the
line-dependent `<anon@L…>` to their real qualified name, so a baseline
holding such an entry needs one refresh — after which the key is stable
across line drift like any other named function. `bca functions` stops
rendering these as a red `error:` line.

## Follow-ups

- #1212 — `Search::first_occurrence` has no production caller.
- #1213 — the macro-declarator arity question. `nargs` reads
  `RUN_STATS_METHOD(allocate)(env, clazz)` as one argument; this makes
  the name agree with it, so the two surfaces are consistent. Whether
  they are consistent about the *right* node is open.

`make pre-commit` → `BCA_GATE: pass`.
