### PR TITLE
fix(nargs): count a macro-obscured declarator's own arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -784,8 +784,10 @@ for historical reference.
   legitimate function returning a function pointer,
   `int (*fp(int a, int b))(int c)`, interposes a
   `parenthesized_declarator` and does not move, nor does C++
-  `operator()` — the only construct across `DeepSpeech` and `pdf.js`
-  whose source text resembles the shape, at 179 occurrences.
+  `operator()` — the one construct whose source text resembles the
+  shape, at 1,546 function spaces across the corpora, none of which
+  nests: the grammar emits a single `operator_name` with the parameter
+  list as its sibling.
 
   The space keeps the **macro's** name, so the 44 names #1208 recovered
   are unaffected: after `##` pasting the real symbol is not in the
@@ -795,7 +797,7 @@ for historical reference.
   *function*, one walk.
 
   46 function spaces change across the corpora, all in files with no
-  snapshot coverage. 26 are macro shims, fixed. The other 20 are
+  snapshot coverage. 27 are macro shims, fixed. The other 19 are
   `TF_ASSIGN_OR_RETURN(…); if (…)` statements that tree-sitter recovers
   into this same shape, where the outer "parameter list" is the `if`
   condition; recovery trees have never been inside the walk's contract

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -766,6 +766,41 @@ for historical reference.
 
 ### Fixed
 
+- C, C++, Mozcpp and Objective-C functions whose declarator is obscured
+  by an unexpanded function-like macro now report their own arity rather
+  than the macro's (#1213). `RUN_STATS_METHOD(allocate)(JNIEnv *env,
+  jclass clazz)` — the JNI shim idiom — nests one `function_declarator`
+  directly inside another, and since #1200 `nargs` read the innermost,
+  so the macro's `(allocate)` was the answer and the function's own
+  arguments were discarded. TensorFlow's four `run_stats_jni.cc` shims
+  all reported 1 while declaring 2, 3, 4 and 3; `bca check --threshold
+  nargs=1` found one violation in that file and now finds five. The
+  multi-argument spelling moved the other way, `void MACRO(a, b)(int x)`
+  having reported the macro's 2 rather than the function's 1.
+
+  Neither language permits a function to return a function type (C11
+  6.7.6.3p1, C++ `[dcl.fct]`), so the direct nesting is not a declarator
+  chain and the rule is structural rather than a guess about macros: a
+  legitimate function returning a function pointer,
+  `int (*fp(int a, int b))(int c)`, interposes a
+  `parenthesized_declarator` and does not move, nor does C++
+  `operator()` — the only construct across `DeepSpeech` and `pdf.js`
+  whose source text resembles the shape, at 179 occurrences.
+
+  The space keeps the **macro's** name, so the 44 names #1208 recovered
+  are unaffected: after `##` pasting the real symbol is not in the
+  source at all, and the macro is the token a reader greps for. Arity
+  now comes off the outer declarator and the name off the invocation it
+  wraps, which retires #1208's same-*node* pairing in favour of one
+  *function*, one walk.
+
+  46 function spaces change across the corpora, all in files with no
+  snapshot coverage. 26 are macro shims, fixed. The other 20 are
+  `TF_ASSIGN_OR_RETURN(…); if (…)` statements that tree-sitter recovers
+  into this same shape, where the outer "parameter list" is the `if`
+  condition; recovery trees have never been inside the walk's contract
+  and those numbers were not arities before the change either.
+
 - C, C++, Mozcpp and Objective-C function spaces whose declared name
   sits under an extra declarator layer now carry that name instead of
   `null` (#1208). Two spellings were affected: a function returning a
@@ -773,9 +808,12 @@ for historical reference.
   macro-obscured declarator `RUN_STATS_METHOD(allocate)(JNIEnv *env)`
   that JNI shims use. Both put a `function_declarator` in the slot
   `get_func_space_name` expected an identifier in, so the name resolved
-  to nothing. The four getters now read the name off the same innermost
-  declarator `nargs` has read the arity from since #1200, so the two
-  answers about one function can no longer disagree.
+  to nothing. The four getters now take the name from the same
+  declarator walk `nargs` has taken the arity from since #1200, so the
+  two answers about one function can no longer disagree. (#1213, above,
+  then moved the macro spelling's arity to the outer declarator while
+  leaving its name where it is, so for that one shape the two answers
+  come off two nodes of the same walk rather than one.)
 
   Three surfaces change with it: `name` in the metric output, `bca
   functions`, which had been rendering these as a red `error:` line, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -784,6 +784,18 @@ for historical reference.
   entry needs one refresh, after which the key is stable across line
   drift like any other named function.
 
+  Six spaces move the other way, all of them inside `ERROR`-recovery
+  subtrees, where no declarator rule holds and any strategy's answer is
+  arbitrary: two lose a name they had (one of which had been reporting
+  an `if` statement's callee as a function name) and four are renamed.
+  One of the renames is a regression to weigh when refreshing a
+  baseline: an annotation macro carrying an argument —
+  `T *f() TF_LOCKS_EXCLUDED(mu_)`, the TensorFlow / Abseil idiom — now
+  names the space after the macro, so two members of one class sharing
+  an annotation share one offender key. Measured over `DeepSpeech` and
+  `pdf.js` (14,269 files): 46 spaces named, 2 un-named, 4 renamed, for a
+  net 44 fewer nameless spaces.
+
 - C, C++, Mozcpp and Objective-C functions whose return type is a
   pointer or a reference now report their real arity instead of 0
   (#1200). C declarator syntax nests outward from the declared name, so

--- a/big-code-analysis-book/src/metrics.md
+++ b/big-code-analysis-book/src/metrics.md
@@ -746,6 +746,35 @@ language. Comments written inside the parameter list are not
 parameters, including the C++ idiom that puts one where an unused
 parameter's name would go — `void f(int /*unused*/)` is one argument.
 
+### Macro-obscured C-family declarators {#nargs-macro-declarators}
+
+C, C++, Mozcpp and Objective-C are parsed without running the
+preprocessor, so a function-like macro standing where the declared name
+belongs is still there in the tree. The idiom is the JNI shim:
+
+```c
+#define RUN_STATS_METHOD(name) JNICALL Java_org_tensorflow_RunStats_##name
+
+JNIEXPORT jlong RUN_STATS_METHOD(allocate)(JNIEnv *env, jclass clazz) { … }
+```
+
+Read as written, `RUN_STATS_METHOD(allocate)` is the declarator and
+`(JNIEnv *env, jclass clazz)` belongs to the return type — one argument.
+big-code-analysis reads it the other way and reports **two**, because
+neither language lets a function return a function type (C11 6.7.6.3p1,
+C++ `[dcl.fct]`): a declarator nested directly inside another one cannot
+be a declarator chain, so the outer list is the function's own. Every
+legitimate function-returning-a-function-pointer form —
+`int (*fp(int a, int b))(int c)` — puts parentheses in between and is
+unaffected, as is C++ `operator()`.
+
+The space is named for the **macro**, not the function. There is no
+other candidate: the real symbol is assembled by `##` token pasting and
+never appears in the source. So several shims in one file share a name,
+which `bca check` shows as several rows with the same label at different
+lines, and which `.bca-baseline.toml` disambiguates by body hash the way
+it does an overload set.
+
 ### What the threshold gate measures {#nargs-gate}
 
 `bca check --threshold nargs=N` gates each callable on **its own**

--- a/src/c_declarator.rs
+++ b/src/c_declarator.rs
@@ -142,7 +142,7 @@ use crate::node::Node;
 /// TensorFlow's `TF_ASSIGN_OR_RETURN(bool ok, Try(x)); if (ok) { … }` —
 /// recovers into a `function_declarator` whose `declarator` field is the
 /// macro call and whose `parameters` field is the `if` **condition**. So
-/// the rule changes the answer for 20 of the 46 corpus spaces it
+/// the rule changes the answer for 19 of the 46 corpus spaces it
 /// touches, from the macro's argument count to the condition's, neither
 /// of which is an arity. There is no fixture for it: whether the
 /// grammar recovers this way depends on where the line breaks fall,

--- a/src/c_declarator.rs
+++ b/src/c_declarator.rs
@@ -3,25 +3,33 @@
 //!
 //! C declarator syntax nests outward from the declared name, so neither
 //! a function's parameter list nor its name is reliably a child of the
-//! function node itself. Both live on the same node — the innermost
-//! `function_declarator` along the chain — which is what
-//! [`innermost_declarator`] finds:
+//! function node itself. Both are found from the one node
+//! [`innermost_declarator`] returns — the innermost link on the chain
+//! that is the function's own declarator rather than its return type's:
 //!
 //! - [`crate::metrics::nargs`] reads its `parameters` field (#1200).
 //! - The `Getter::get_func_space_name` impls for C, C++, mozcpp and
-//!   Objective-C read its `declarator` field (#1208).
+//!   Objective-C read its name side through [`declarator_name`] (#1208).
 //!
 //! Keeping one walk keeps the two answers about the same function from
 //! disagreeing, which is how #1208 arose: the arity came from this
 //! chain and the name came from a leftmost pre-order search that stopped
 //! one level too early.
+//!
+//! For most shapes those two answers come off the *same* node, the
+//! `parameters` and `declarator` fields of a single
+//! `function_declarator`. An unexpanded function-like macro is the
+//! exception: the arity is the macro's own outer list and the name is
+//! spelled inside the invocation it wraps (#1213). So the invariant is
+//! one *function*, one walk — not one node.
 
 use crate::checker::Checker;
 use crate::node::Node;
 
 /// The innermost declarator along a C-family function's declarator
 /// chain: the node whose `parameters` field holds the function's *own*
-/// formal arguments, and whose `declarator` field holds its name.
+/// formal arguments. [`declarator_name`] takes the name from the same
+/// node's `declarator` field.
 ///
 /// C declarator syntax nests outward from the declared name, so a
 /// function node's `declarator` field is only the function's parameter
@@ -34,6 +42,19 @@ use crate::node::Node;
 /// innermost is what makes both of those come out right (#1200), and
 /// the same node carries the name `f` that a leftmost search misses
 /// (#1208).
+///
+/// "Innermost" has one exception, and it is the one shape where the
+/// grammar's reading and the preprocessor's disagree. An unexpanded
+/// function-like macro — `RUN_STATS_METHOD(allocate)(JNIEnv *env,
+/// jclass clazz)`, which is what every JNI shim looks like — parses as
+/// a `function_declarator` sitting in another one's `declarator` field,
+/// so the innermost list is the macro's `(allocate)` and the function's
+/// own arguments are discarded. Neither language permits that chain: a
+/// function may not return a function type (C11 6.7.6.3p1, C++
+/// `[dcl.fct]`), so every legitimate function-returning-a-function-
+/// pointer form interposes a `parenthesized_declarator` and the direct
+/// nesting can only be a macro (or an `ERROR`, below). The walk stops
+/// at the outer link there and reports the function's arity (#1213).
 ///
 /// The walk is by field name, per `.claude/rules/grammar-dispatch.md`
 /// §3, which also sidesteps §1: `PointerDeclarator2`,
@@ -119,6 +140,19 @@ use crate::node::Node;
 /// `a_parenthesised_macro_takes_the_name_of_the_function_it_annotates`
 /// pins it.
 ///
+/// Recovery also manufactures the direct `function_declarator` nesting
+/// the macro rule keys on, from source containing no macro-obscured
+/// declarator at all. A *statement* macro followed by an `if` —
+/// TensorFlow's `TF_ASSIGN_OR_RETURN(bool ok, Try(x)); if (ok) { … }` —
+/// recovers into a `function_declarator` whose `declarator` field is the
+/// macro call and whose `parameters` field is the `if` **condition**. So
+/// the rule changes the answer for 20 of the 46 corpus spaces it
+/// touches, from the macro's argument count to the condition's, neither
+/// of which is an arity. There is no fixture for it: whether the
+/// grammar recovers this way depends on where the line breaks fall,
+/// tree-sitter costing a recovery by the extent it skips, so any pinned
+/// spelling would be a claim about whitespace (#1213).
+///
 /// Whatever any strategy returns there is arbitrary, and the walk does
 /// not try to be clever about it. Measured over `DeepSpeech` and
 /// `pdf.js` (14,269 files), moving the four getters onto this walk
@@ -135,6 +169,23 @@ pub(crate) fn innermost_declarator<'tree, T: Checker>(node: &Node<'tree>) -> Opt
     std::iter::successors(
         node.child_by_field_name("declarator"),
         |current| match current.child_by_field_name("declarator") {
+            // An unexpanded function-like macro standing in for the
+            // declarator, which is the shape JNI shims take. Neither C
+            // nor C++ lets a function return a function type (C11
+            // 6.7.6.3p1, C++ `[dcl.fct]`), so a `function_declarator`
+            // directly inside another one's `declarator` field is not a
+            // declarator chain at all: the outer list is the function's
+            // own and the inner one holds the macro's arguments. Both
+            // links have to be tested — a pointer return puts a
+            // `function_declarator` in a `pointer_declarator`'s
+            // `declarator` field, and stopping *there* would end the
+            // chain on a node carrying no `parameters` and report 0
+            // (#1213).
+            Some(inner)
+                if current.kind() == FUNCTION_DECLARATOR && inner.kind() == FUNCTION_DECLARATOR =>
+            {
+                None
+            }
             Some(declarator) => Some(declarator),
             None if current.child_by_field_name("parameters").is_some() => None,
             None => current
@@ -159,21 +210,40 @@ pub(crate) fn innermost_declarator<'tree, T: Checker>(node: &Node<'tree>) -> Opt
 
 /// The node spelling a C-family function's name.
 ///
-/// It is the `declarator` field of [`innermost_declarator`] — the same
-/// node whose `parameters` field gives the arity — and it is a separate
-/// function only so the four `get_func_space_name` impls state that
-/// pairing once instead of four times. Each caller still gates the
+/// It is the `declarator` field of [`innermost_declarator`], and it is a
+/// separate function only so the four `get_func_space_name` impls state
+/// that pairing once instead of four times. Each caller still gates the
 /// result on its own grammar's identifier kinds: what counts as a name
 /// is where C, C++ and Objective-C differ (`destructor_name`,
 /// `qualified_identifier`, `operator_name`, `template_function`), and a
 /// kind this module accepted on their behalf would be a claim about
 /// four grammars made in a module that reads none of them.
+///
+/// The macro shape [`innermost_declarator`] stops at is the one place
+/// the name and the arity come off different nodes. There that
+/// `declarator` field is the macro *invocation* — itself a
+/// `function_declarator`, which no getter's identifier gate accepts — so
+/// the walk descends through it to the identifier the macro spells.
+/// `RUN_STATS_METHOD` is the only name in the source: the real
+/// `Java_…_allocate` exists only after `##` pasting, and it is the token
+/// a reader greps for. This is why the module doc states the invariant
+/// per *function* rather than per node (#1213).
 pub(crate) fn declarator_name<'tree, T: Checker>(node: &Node<'tree>) -> Option<Node<'tree>> {
-    innermost_declarator::<T>(node)?.child_by_field_name("declarator")
+    // Descending past a *run* of them rather than one: `A(b)(c)(int x)`
+    // is two nested macro invocations and the name is still `A`.
+    std::iter::successors(
+        innermost_declarator::<T>(node)?.child_by_field_name("declarator"),
+        |link| {
+            (link.kind() == FUNCTION_DECLARATOR)
+                .then(|| link.child_by_field_name("declarator"))
+                .flatten()
+        },
+    )
+    .last()
 }
 
 /// Compared by `kind()` string rather than `kind_id`, per
-/// `.claude/rules/grammar-dispatch.md` §1: both rules carry
+/// `.claude/rules/grammar-dispatch.md` §1: every rule below carries
 /// numeric-suffix aliases across the four C-family grammars, and a
 /// `kind_id` match would have to enumerate every one of them and would
 /// regress silently on the next grammar bump. C and Objective-C simply
@@ -181,6 +251,10 @@ pub(crate) fn declarator_name<'tree, T: Checker>(node: &Node<'tree>) -> Option<N
 const CONVERSION_OPERATOR: &str = "operator_cast";
 const ATTRIBUTE: &str = "attribute_declaration";
 const TEMPLATE_ARGUMENTS: &str = "template_argument_list";
+/// Carries the most aliases of the four — `FunctionDeclarator2` through
+/// `FunctionDeclarator5` in `tree-sitter-c` alone — so it is the one the
+/// `kind()`-string rule above most needs to cover.
+const FUNCTION_DECLARATOR: &str = "function_declarator";
 
 #[cfg(test)]
 mod space_name_tests {
@@ -196,10 +270,15 @@ mod space_name_tests {
     /// nameless C-family function spaces across `DeepSpeech` and
     /// `pdf.js`, clustered in TensorFlow's JNI shims — and it carries no
     /// `parenthesized_declarator` at all, so a fix keyed on that kind
-    /// would pass the first row and miss the population. `RUN_STATS_METHOD`
-    /// is the *syntactic* answer: the name the declarator chain spells,
-    /// which is the macro's rather than the function's, and which agrees
-    /// with the single argument `nargs` reads from the same node.
+    /// would pass the first row and miss the population.
+    /// `RUN_STATS_METHOD` is the macro's name, not the function's, which
+    /// after `##` pasting is not in the source at all; it is kept
+    /// because it is the token a reader greps for (#1213).
+    ///
+    /// The two macro rows after it are #1213: the arity moved to the
+    /// outer declarator there, so the name is the only thing still read
+    /// from inside the invocation, and `A` additionally pins the descent
+    /// through a *run* of nested invocations.
     ///
     /// The next three are controls. `g` in particular resolved
     /// correctly *before* this change — its outer declarator is an
@@ -218,6 +297,8 @@ mod space_name_tests {
             "void RUN_STATS_METHOD(allocate)(int a) { }",
             Some("RUN_STATS_METHOD"),
         ),
+        ("void MACRO(a, b)(int x) { }", Some("MACRO")),
+        ("void A(b, c)(d)(int x, int y, int z) { }", Some("A")),
         ("int (*g(void))[4] { return 0; }", Some("g")),
         ("int plain(int a, int b) { return a; }", Some("plain")),
         ("FILE *ptr(int a) { return 0; }", Some("ptr")),

--- a/src/c_declarator.rs
+++ b/src/c_declarator.rs
@@ -109,12 +109,24 @@ use crate::node::Node;
 /// `function_declarator` inside an `ERROR` node and leaves the macro's
 /// `field_identifier` as the `pointer_declarator`'s last named child,
 /// so the fallback follows the macro and the walk answers `None`.
+///
+/// Give that macro an argument — `T *f() TF_LOCKS_EXCLUDED(mu_) { … }`,
+/// which is the spelling the TensorFlow / Abseil annotations actually
+/// take — and it is a `function_declarator` carrying `parameters`, so
+/// the walk answers with the *macro's* name rather than with nothing.
+/// That is the one shape this change made worse: the leftmost pre-order
+/// search it replaced descended into the `ERROR` and got `f` right.
+/// `a_parenthesised_macro_takes_the_name_of_the_function_it_annotates`
+/// pins it.
+///
 /// Whatever any strategy returns there is arbitrary, and the walk does
-/// not try to be clever about it: measured over `DeepSpeech` and
+/// not try to be clever about it. Measured over `DeepSpeech` and
 /// `pdf.js` (14,269 files), moving the four getters onto this walk
-/// named 44 previously-nameless function spaces and un-named 2, both of
-/// the latter inside recovery subtrees — one of which had been
-/// reporting an `if` statement's callee as a function name (#1208).
+/// named 46 previously-nameless function spaces, un-named 2 and renamed
+/// 4 — 354 nameless spaces down to 310, a net 44. All six of the latter
+/// sit inside recovery subtrees: one of the un-named had been reporting
+/// an `if` statement's callee as a function name, and one of the renamed
+/// is the `TF_LOCKS_EXCLUDED` case above (#1208).
 pub(crate) fn innermost_declarator<'tree, T: Checker>(node: &Node<'tree>) -> Option<Node<'tree>> {
     // The chain starts at the `declarator` field rather than at `node`
     // so the last-named-child fallback can never fire on the function
@@ -462,6 +474,60 @@ mod space_name_tests {
             &failures,
             checked,
             "grammars disagreed about the recovery shape",
+        );
+    }
+
+    /// The same macro carrying an argument, which is the spelling the
+    /// annotation idiom actually takes — `TF_LOCKS_EXCLUDED(mu_)`,
+    /// `TF_GUARDED_BY(mu_)`, `ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_)`.
+    ///
+    /// Where the grammar recovers, it is worse than the parameterless
+    /// spelling above rather than the same. A bare trailing identifier
+    /// carries no `parameters`, so the chain dead-ends and the space
+    /// merely goes nameless; a parenthesised one is a
+    /// `function_declarator` that *does*, so it becomes the walk's
+    /// answer and the space is named after the macro. `nargs` reads the
+    /// macro's argument off the same node, and two members of one class
+    /// sharing an annotation collapse onto a single `bca check` offender
+    /// key (`K::TF_LOCKS_EXCLUDED` twice).
+    ///
+    /// This is the one shape #1208 made worse: the leftmost pre-order
+    /// search it replaced descended into the `ERROR` and got `f` right.
+    /// One corpus space is affected — `resource()` in TensorFlow's
+    /// `resource_op_kernel_test.cc`, which #1208 renamed to
+    /// `TF_LOCKS_EXCLUDED`. Pinned rather than fixed, like its sibling
+    /// above: reaching into a recovery subtree is a strategy decision of
+    /// its own, and every rule the walk follows is void inside an
+    /// `ERROR`. Teach the walk to unwrap one and this is a row to
+    /// update, not a row to delete.
+    #[test]
+    fn a_parenthesised_macro_takes_the_name_of_the_function_it_annotates() {
+        const SOURCE: &str = "int *f() TF_LOCKS_EXCLUDED(mu_) { return 0; }";
+
+        let mut failures = Vec::new();
+        let mut checked = 0;
+        for lang in [LANG::C, LANG::Cpp, LANG::Mozcpp, LANG::Objc]
+            .into_iter()
+            .filter(LANG::is_enabled)
+        {
+            // Only C parses this cleanly, and there the chain follows a
+            // real `declarator` field past the macro to `f`. The split
+            // is *not* the two-two of the parameterless spelling:
+            // mozcpp sides with C there and with C++ here, so a fixture
+            // in either spelling alone would misreport what the other
+            // does.
+            let expected = if lang == LANG::C {
+                "f"
+            } else {
+                "TF_LOCKS_EXCLUDED"
+            };
+            check(lang, &[(SOURCE, Some(expected))], &mut failures);
+            checked += 1;
+        }
+        assert_all_matched(
+            &failures,
+            checked,
+            "grammars disagreed about the annotated recovery shape",
         );
     }
 }

--- a/src/c_declarator.rs
+++ b/src/c_declarator.rs
@@ -438,10 +438,14 @@ mod space_name_tests {
         assert!(checked > 0, "no C-family language was enabled");
     }
 
-    /// A C-family function's name comes off the same declarator its
-    /// arity does (#1208).
+    /// A C-family function's name comes off the declarator walk its
+    /// arity comes off (#1208) — from the innermost declarator itself
+    /// for most shapes, and from inside the macro invocation that
+    /// declarator wraps for the three macro rows (#1213). "Same walk"
+    /// rather than "same node" is why this is not named for the
+    /// innermost declarator alone.
     #[test]
-    fn the_innermost_declarator_names_the_function_space() {
+    fn the_declarator_walk_names_the_function_space() {
         let mut failures = Vec::new();
         let mut checked = 0;
         for lang in [LANG::C, LANG::Cpp, LANG::Mozcpp, LANG::Objc]

--- a/src/c_declarator.rs
+++ b/src/c_declarator.rs
@@ -14,14 +14,10 @@
 //! Keeping one walk keeps the two answers about the same function from
 //! disagreeing, which is how #1208 arose: the arity came from this
 //! chain and the name came from a leftmost pre-order search that stopped
-//! one level too early.
-//!
-//! For most shapes those two answers come off the *same* node, the
-//! `parameters` and `declarator` fields of a single
-//! `function_declarator`. An unexpanded function-like macro is the
-//! exception: the arity is the macro's own outer list and the name is
-//! spelled inside the invocation it wraps (#1213). So the invariant is
-//! one *function*, one walk — not one node.
+//! one level too early. The invariant is one *function*, one walk —
+//! not one node: an unexpanded function-like macro puts the arity and
+//! the name on two links of the chain, which each function's own doc
+//! below explains (#1213).
 
 use crate::checker::Checker;
 use crate::node::Node;
@@ -51,8 +47,8 @@ use crate::node::Node;
 /// so the innermost list is the macro's `(allocate)` and the function's
 /// own arguments are discarded. Neither language permits that chain: a
 /// function may not return a function type (C11 6.7.6.3p1, C++
-/// `[dcl.fct]`), so every legitimate function-returning-a-function-
-/// pointer form interposes a `parenthesized_declarator` and the direct
+/// `[dcl.fct]`), so a legitimate function returning a function pointer
+/// always interposes a `parenthesized_declarator`, and the direct
 /// nesting can only be a macro (or an `ERROR`, below). The walk stops
 /// at the outer link there and reports the function's arity (#1213).
 ///
@@ -229,17 +225,15 @@ pub(crate) fn innermost_declarator<'tree, T: Checker>(node: &Node<'tree>) -> Opt
 /// a reader greps for. This is why the module doc states the invariant
 /// per *function* rather than per node (#1213).
 pub(crate) fn declarator_name<'tree, T: Checker>(node: &Node<'tree>) -> Option<Node<'tree>> {
-    // Descending past a *run* of them rather than one: `A(b)(c)(int x)`
-    // is two nested macro invocations and the name is still `A`.
-    std::iter::successors(
-        innermost_declarator::<T>(node)?.child_by_field_name("declarator"),
-        |link| {
-            (link.kind() == FUNCTION_DECLARATOR)
-                .then(|| link.child_by_field_name("declarator"))
-                .flatten()
-        },
-    )
-    .last()
+    // A run of them rather than one: `A(b)(c)(int x)` is two nested
+    // invocations and the name is still `A`. Each step descends a finite
+    // tree, so the loop terminates for the same reason the walk above
+    // does.
+    let mut name = innermost_declarator::<T>(node)?.child_by_field_name("declarator")?;
+    while name.kind() == FUNCTION_DECLARATOR {
+        name = name.child_by_field_name("declarator")?;
+    }
+    Some(name)
 }
 
 /// Compared by `kind()` string rather than `kind_id`, per

--- a/src/c_declarator.rs
+++ b/src/c_declarator.rs
@@ -227,13 +227,24 @@ pub(crate) fn innermost_declarator<'tree, T: Checker>(node: &Node<'tree>) -> Opt
 pub(crate) fn declarator_name<'tree, T: Checker>(node: &Node<'tree>) -> Option<Node<'tree>> {
     // A run of them rather than one: `A(b)(c)(int x)` is two nested
     // invocations and the name is still `A`. Each step descends a finite
-    // tree, so the loop terminates for the same reason the walk above
-    // does.
-    let mut name = innermost_declarator::<T>(node)?.child_by_field_name("declarator")?;
-    while name.kind() == FUNCTION_DECLARATOR {
-        name = name.child_by_field_name("declarator")?;
-    }
-    Some(name)
+    // tree, so this terminates for the same reason the walk above does.
+    //
+    // Written as a chain rather than a `while` with `?` inside it
+    // deliberately. The loop form needs an early return for "this
+    // `function_declarator` has no `declarator` field", which the
+    // grammars declare required and only an `ERROR` could violate — two
+    // arms no test can reach, and coverage counts them.
+    std::iter::successors(
+        innermost_declarator::<T>(node)?.child_by_field_name("declarator"),
+        |link| {
+            if link.kind() == FUNCTION_DECLARATOR {
+                link.child_by_field_name("declarator")
+            } else {
+                None
+            }
+        },
+    )
+    .last()
 }
 
 /// Compared by `kind()` string rather than `kind_id`, per

--- a/src/metrics/nargs.rs
+++ b/src/metrics/nargs.rs
@@ -4683,12 +4683,14 @@ mod c_family_return_type_declarators {
                 // ends at a `qualified_identifier` rather than a bare
                 // one, which has named children of its own.
                 ("Foo &Bar::get(int a) { static Foo f; return f; }", (0, 1)),
-                // `operator()` is the only construct in `DeepSpeech`
-                // and `pdf.js` whose *source text* looks like the
-                // macro nesting #1213 gates on — 179 occurrences. It
-                // does not nest: the grammar emits one `operator_name`
-                // with the parameter list as its sibling, so the gate
-                // never fires and the arity is the operator's own.
+                // `operator()` is the one construct whose *source text*
+                // looks like the macro nesting #1213 gates on, and it is
+                // not rare: 1,546 function spaces across `DeepSpeech`,
+                // against 46 direct nestings not one of which is an
+                // operator. It does not nest — the grammar emits a
+                // single `operator_name` with the parameter list as its
+                // sibling — so the gate never fires and the arity is the
+                // operator's own.
                 (
                     "struct S { int operator()(int a, int b) const { return a; } };",
                     (0, 2),

--- a/src/metrics/nargs.rs
+++ b/src/metrics/nargs.rs
@@ -4640,10 +4640,16 @@ mod c_family_return_type_declarators {
             // prove nothing.
             ("void A(b, c)(d)(int x, int y, int z) { }", (0, 3)),
             // A return type that nests without being a
-            // `function_declarator` at all: the outer link here is an
+            // `function_declarator` at all: the outer link is an
             // `array_declarator`, so the macro gate has nothing to fire
-            // on and `(void)` must still read 0.
-            ("int (*g(void))[4] { return 0; }", (0, 0)),
+            // on and the chain must still reach `arr`'s own list. Two
+            // arguments rather than the `(void)` this row first
+            // carried — `(0, 0)` is what a walk returning `None` for
+            // *everything* reports, so the row passed with the whole
+            // chain dead while 28 others failed
+            // (`.claude/rules/testing.md`, "Seed the state you claim to
+            // assert on").
+            ("int (*arr(int a, int b))[4] { return 0; }", (0, 2)),
         ])
     }
 
@@ -4687,10 +4693,17 @@ mod c_family_return_type_declarators {
                 // looks like the macro nesting #1213 gates on, and it is
                 // not rare: 1,546 function spaces across `DeepSpeech`,
                 // against 46 direct nestings not one of which is an
-                // operator. It does not nest — the grammar emits a
-                // single `operator_name` with the parameter list as its
-                // sibling — so the gate never fires and the arity is the
-                // operator's own.
+                // operator. The grammar emits a single `operator_name`
+                // with the parameter list as its sibling, so the gate is
+                // unreachable from here rather than merely inactive.
+                //
+                // Which is what this row guards, and it is worth being
+                // precise: no widening of the gate can fail it, because
+                // the chain already stops at this declarator. It fails
+                // if a future `tree-sitter-cpp` starts spelling
+                // `operator()` as a nested `function_declarator` — at
+                // which point the gate would silently halve the reported
+                // arity of that whole population.
                 (
                     "struct S { int operator()(int a, int b) const { return a; } };",
                     (0, 2),

--- a/src/metrics/nargs.rs
+++ b/src/metrics/nargs.rs
@@ -4608,6 +4608,42 @@ mod c_family_return_type_declarators {
             // the `function_declarator`, so it passed before the fix
             // and must keep passing after it.
             ("int plain(int a, int b) { return a; }", (0, 2)),
+            // An unexpanded function-like macro in declarator position,
+            // the shape every JNI shim takes (#1213). The macro's
+            // `(name)` is the innermost list, so #1200's walk read 1
+            // where the function declares 2.
+            ("void MACRO(name)(int a, int b) { }", (0, 2)),
+            // The multi-argument spelling. A gate keyed on the inner
+            // list holding a single bare `type_identifier` — the
+            // heuristic form the report proposed — passes the row above
+            // and misses this one, which read the macro's 2 rather than
+            // the function's 1. The two lists are deliberately
+            // different lengths and in the opposite direction to the
+            // row above, so neither row can agree with the other's
+            // wrong answer.
+            ("void MACRO(a, b)(int x) { }", (0, 1)),
+            // The row that prices the *second* half of the gate. A
+            // pointer return puts the outer `function_declarator` in a
+            // `pointer_declarator`'s `declarator` field, so a gate that
+            // tested only the inner link would cut the chain at the
+            // pointer — a node carrying no `parameters` at all — and
+            // report 0.
+            ("char *MACRO(n)(int a, int b) { return 0; }", (0, 2)),
+            // Two nested invocations, so a gate that stopped one link
+            // in still reads a macro's list. Three distinct lengths
+            // because the single-nesting spelling `A(b)(c)(int x)`
+            // reads 1 both before the fix and after it, and would
+            // prove nothing.
+            ("void A(b, c)(d)(int x, int y, int z) { }", (0, 3)),
+            // The control that shape must not be confused with, and
+            // the one textual near-miss over `DeepSpeech` and `pdf.js`
+            // (179 occurrences of the C++ spelling below). A function
+            // may not return a function type (C11 6.7.6.3p1), so a
+            // legitimate function-returning-a-function-pointer always
+            // interposes a `parenthesized_declarator` — which is why
+            // the gate can key on the direct nesting rather than on
+            // the absence of a type in the inner list.
+            ("int (*g(void))[4] { return 0; }", (0, 0)),
         ])
     }
 
@@ -4647,6 +4683,16 @@ mod c_family_return_type_declarators {
                 // ends at a `qualified_identifier` rather than a bare
                 // one, which has named children of its own.
                 ("Foo &Bar::get(int a) { static Foo f; return f; }", (0, 1)),
+                // `operator()` is the only construct in `DeepSpeech`
+                // and `pdf.js` whose *source text* looks like the
+                // macro nesting #1213 gates on — 179 occurrences. It
+                // does not nest: the grammar emits one `operator_name`
+                // with the parameter list as its sibling, so the gate
+                // never fires and the arity is the operator's own.
+                (
+                    "struct S { int operator()(int a, int b) const { return a; } };",
+                    (0, 2),
+                ),
                 // An explicit template argument spelling a function
                 // type. `template_function` is another name form with
                 // named children, and its last one is the argument

--- a/src/metrics/nargs.rs
+++ b/src/metrics/nargs.rs
@@ -4622,12 +4622,16 @@ mod c_family_return_type_declarators {
             // row above, so neither row can agree with the other's
             // wrong answer.
             ("void MACRO(a, b)(int x) { }", (0, 1)),
-            // The row that prices the *second* half of the gate. A
-            // pointer return puts the outer `function_declarator` in a
-            // `pointer_declarator`'s `declarator` field, so a gate that
-            // tested only the inner link would cut the chain at the
-            // pointer — a node carrying no `parameters` at all — and
-            // report 0.
+            // The two mechanisms composed: a return type to step
+            // through *and* a macro to stop at, so this is the only row
+            // where the gate fires at a link the chain reached rather
+            // than at the one it started from. It is also why the gate
+            // tests `current`'s kind and not just the inner link's — a
+            // `pointer_declarator`'s `declarator` field is a
+            // `function_declarator` too, and stopping there lands on a
+            // node with no `parameters`. That half is not exclusively
+            // this row's to guard, though: dropping it also regresses
+            // #1200's own `FILE *f(…)` and `int **g(…)` rows to 0.
             ("char *MACRO(n)(int a, int b) { return 0; }", (0, 2)),
             // Two nested invocations, so a gate that stopped one link
             // in still reads a macro's list. Three distinct lengths
@@ -4635,14 +4639,10 @@ mod c_family_return_type_declarators {
             // reads 1 both before the fix and after it, and would
             // prove nothing.
             ("void A(b, c)(d)(int x, int y, int z) { }", (0, 3)),
-            // The control that shape must not be confused with, and
-            // the one textual near-miss over `DeepSpeech` and `pdf.js`
-            // (179 occurrences of the C++ spelling below). A function
-            // may not return a function type (C11 6.7.6.3p1), so a
-            // legitimate function-returning-a-function-pointer always
-            // interposes a `parenthesized_declarator` — which is why
-            // the gate can key on the direct nesting rather than on
-            // the absence of a type in the inner list.
+            // A return type that nests without being a
+            // `function_declarator` at all: the outer link here is an
+            // `array_declarator`, so the macro gate has nothing to fire
+            // on and `(void)` must still read 0.
             ("int (*g(void))[4] { return 0; }", (0, 0)),
         ])
     }


### PR DESCRIPTION
Fixes #1213

An unexpanded function-like macro standing where the declared name
belongs — `RUN_STATS_METHOD(allocate)(JNIEnv *env, jclass clazz)`, the
JNI shim idiom — nests one `function_declarator` directly inside
another. Since #1200 `nargs` read the innermost, so the macro's
`(allocate)` was the answer and the function's own parameters were
discarded.

TensorFlow's four `run_stats_jni.cc` shims each reported **1** while
declaring 2, 3, 4 and 3, so `bca check --threshold nargs=1` found one
violation in that file where five belong.

## The rule is structural, not a guess about macros

Neither language lets a function return a function type (C11 6.7.6.3p1,
C++ [dcl.fct]), so a `function_declarator` nested *directly* inside
another cannot be a declarator chain — a legitimate function returning a
function pointer interposes a `parenthesized_declarator`, which is
exactly the #1208 shape. Both links have to be tested: a pointer return
puts the outer declarator inside a `pointer_declarator`'s `declarator`
field, and stopping at the first link reports 0.

## What this changes about #1208

#1208 landed on "the name and the arity come off the same node." That
was too strong. The invariant is **one function, one walk** — not one
node: for a macro-obscured declarator the arity belongs to the outer
link and the name to the invocation it wraps. The 44 names #1208
recovered are unaffected, and the space keeps the macro's name
deliberately — after `##` pasting the real symbol is not in the source
at all, and the macro is the token a reader greps for.

## Measurements

46 corpus spaces change arity, none of them snapshotted:

| | |
|---|---|
| 27 | macro shims — fixed |
| 19 | `TF_ASSIGN_OR_RETURN(...); if (...)` statements that tree-sitter recovers into the same shape, which was never inside a function's contract |

Not one of the 46 is an `operator()` — the near-miss worth ruling out,
since `bca functions` reports 1,546 such spaces across the corpora and a
rule that caught them would halve their arity.

## Also in this branch

Four corrections that came out of reviewing the above, each its own
commit:

- **`test(c_declarator)`** — pins `T *f() TF_LOCKS_EXCLUDED(mu_)`, the
  annotated-macro spelling. It carries an argument, so it is a
  `function_declarator` with `parameters` and the walk names the space
  after the macro. It splits the grammars differently from the
  parameterless spelling (C gets `f`; C++, mozcpp and Objective-C
  recover into an `ERROR` and get the macro), so a fixture in either
  alone misreports the other. Recovery trees are outside the walk's
  contract, so this pins the behaviour rather than claiming it is right.
- **`docs`** — #1208's changelog entry and the walk's doc both quoted
  the *net* corpus figure. Re-measured: **46 named, 2 un-named, 4
  renamed**, for a net 44. One of those renames (`resource` →
  `TF_LOCKS_EXCLUDED`) is a name regression against the pre-#1208
  leftmost search, now named in the changelog with its baseline-key
  consequence.
- **`test(nargs)`** — the `int (*g(void))[4]` row expected `(0, 0)`,
  which is also what the table reports when `innermost_declarator`
  returns `None` for *every* input: it passed with the whole walk dead
  while 28 sibling rows failed. It now takes two arguments.
- **`refactor` + follow-up** — the name walk was rewritten as a `while`
  loop, which needed a `?` for a state all four grammars declare
  impossible; coverage counts arms no test can reach, so
  `c_declarator.rs` went from 6 uncovered regions to 8. Reverted to a
  `successors` chain with a plain `if`, back to the original six.

`make pre-commit` → `BCA_GATE: pass`. No `.snap.new` under the output
submodule; the submodule pointer is unchanged.
