### PR TITLE
fix: batch 2026-08-05 (#1204, #1209, #1212)

### DIFF
--- a/.claude/rules/grammar-dispatch.md
+++ b/.claude/rules/grammar-dispatch.md
@@ -160,6 +160,48 @@ Minimum cross-walk when you edit one:
 - `is_string` ↔ `get_op_type` operand classification of string kinds
 - `is_call` ↔ `get_op_type` operator classification of call kinds
 - `is_func_space` ↔ each metric's body walker
+- `is_func_space` ↔ `get_space_kind` — the two halves of the space
+  tree, and the pair that fails *quietly*. The three above disagree
+  into a **wrong count**, which a snapshot diff shows you. This one
+  disagrees into an **absent key**: a node the walker promoted but the
+  getter left `Unknown` is not a member scope
+  (`SpaceKind::is_member_scope`), so its space serializes no `npm` /
+  `npa` block at all — which looks exactly like a language that
+  legitimately has no containers. Nothing diffs. §6's "gate all three
+  on the same predicate" is this bullet's fix.
+
+### Cross-walk the `_with_code` spelling, not the byte-less one
+
+When a predicate feeds anything the walker also consults, reach for the
+`_with_code` variant — that is what the walk actually calls.
+`spaces::compute` promotes a node with
+`Checker::promotes_to_func_space_with_code`, labels the resulting space
+with `Getter::get_space_kind_with_code` inside `open_func_space`, and
+`note_member_scope` hands that recorded kind to `npm` / `npa`.
+
+**The trap is silent because the defaults forward.**
+`Checker::is_func_space_with_code` and `Getter::get_space_kind_with_code`
+both discard `code` and `ancestors` and call the byte-less form, so the
+two spellings compile *and behave identically* everywhere except where a
+language overrides one — which is precisely where the answer matters. A
+byte-less call site therefore reads as correct against every language
+that has no override, and is wrong only on the one that does. You cannot
+recover this from the signatures; both look total.
+
+Elixir is that language, and currently the only one overriding either
+method. `defmodule` / `def` / `defp` are not distinct grammar
+productions — they parse as `Call` nodes told apart only by their target
+identifier text (#275) — so `ElixirCode::is_func_space` lists just
+`Source | AnonymousFunction` and `ElixirCode::get_space_kind` has no
+`defmodule` arm. The byte-less pair answers `(false, Unknown)` for every
+Elixir container.
+
+This has already landed once. `ops_inner` opened spaces on the byte-less
+`is_func || is_func_space`, so `bca ops` returned a bare file-level space
+for every Elixir input while `bca metrics` returned a full
+module/function tree — no error, no wrong number, just a missing tree
+(#1130). `tests/parity/ops_metrics_space_parity.rs` exists to keep the
+two walks agreeing.
 
 ## 8. Anchor a default/fallback exclusion to the construct
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -359,6 +359,19 @@ for historical reference.
   operators in the book's *Cognitive Complexity → Per-language
   deviations* list (#1150). No behaviour change.
 
+- Documented an upstream `tree-sitter-c` limitation on the book's
+  *Supported Languages* page (#1209). A pre-ANSI (K&R) function
+  definition whose return type wraps the declarator — `int *f(a) int a;
+  { … }`, and likewise `char **`, `struct S *` or a `static` pointer
+  return — opens no function space under `C` or `Objective-C`, so it is
+  absent from `nom.functions`, `nargs` and `bca functions` while the
+  orphaned body's decisions are charged to the file's unit space. The
+  parse produces no `ERROR` node, so nothing downstream can detect it.
+  `C/C++` supports no K&R form at all. No behaviour change; the paired
+  fixture in `tests/grammars/c_grammar_metrics.rs` is a drift marker, so
+  a grammar bump that fixes the parse fails the test rather than
+  shifting metrics silently.
+
 - `bca ops` opens the same function spaces as `bca metrics`, through the
   same source-aware promote-and-classify predicate (#1130). The two
   walks each carried their own copy of the decision and the `ops` copy

--- a/big-code-analysis-book/src/languages.md
+++ b/big-code-analysis-book/src/languages.md
@@ -57,6 +57,34 @@ variant's slug is
 its `LANG::name`, lowercase and punctuation-free so it round-trips
 through `FromStr`.
 
+## K&R definitions with a wrapped return type {#kr-wrapped-return-type}
+
+A pre-ANSI (K&R) function definition opens no function space under `C`
+or `Objective-C` when its return type wraps the declarator — `int *`,
+`char **`, `struct S *`, or a `static` pointer return all reproduce it:
+
+```c
+int *krptr(a, b) int a; int b; { if (a) { return 0; } return 1; }
+```
+
+`tree-sitter-c` 0.24.2 builds its old-style function definition from a
+declarator nested *inside* the old-style declarator, so an outer
+`pointer_declarator` is unreachable and the parser prefers a plain
+`declaration` that swallows the first parameter declaration, orphaning
+the body as a bare `compound_statement`. No `ERROR` node is produced —
+the parse silently succeeds wrongly, and there is no dispatch arm
+missing on our side.
+
+The consequence is that the body's decisions are charged to the file's
+unit space: the line above reports `cyclomatic.sum` 2 and
+`nom.functions` 0, a file-level count no function-level row accounts
+for. A K&R definition whose return type does not wrap the declarator
+(`int krplain(a, b) int a; int b; { … }`) is unaffected, as is any ANSI
+definition. `C/C++` and `Mozcpp` open no space for *either* K&R form,
+because `tree-sitter-cpp` has no rule for the syntax at all. This is an
+upstream grammar limitation, tracked here as
+[#1209](https://github.com/dekobon/big-code-analysis/issues/1209).
+
 ## Internal helper variants
 
 The following `LANG` variants are not user-facing languages — they

--- a/docs/development/benchmarking.md
+++ b/docs/development/benchmarking.md
@@ -330,14 +330,14 @@ The predicates are a rounding error; one scan was not. Python's
 instance-attribute walk in `metrics::npa::python` visits every node of
 every method body, and was 381 k of that language's 417 k child scans —
 92 % of them. The metric walk's other per-node `children` consumers are
-`Preorder` and the suppression DFS. Crate-wide there are three more —
-`Search::first_occurrence`, `Search::act_on_node`, and `output::dump`'s
-tree renderer — none of which a `metrics()` call runs, so they are
-absent from the figures above.
+`Preorder` and the suppression DFS. Crate-wide there are two more —
+`Search::act_on_node` and `output::dump`'s tree renderer — neither of
+which a `metrics()` call runs, so they are absent from the figures
+above.
 
-`Node::children_with` lets all six hoist one cursor out of their loop,
+`Node::children_with` lets all five hoist one cursor out of their loop,
 and the counter `child_scan_cursors` in `src/node.rs` is what keeps
-them there, since the change moves no metric value. All six are
+them there, since the change moves no metric value. All five are
 asserted: the walks reachable from `node.rs` in
 `the_converted_traversals_scan_a_tree_on_one_cursor`, and the renderer
 in `output::dump`'s own `dump_holds_one_cursor_for_the_whole_tree`.
@@ -345,8 +345,7 @@ The counter records in `Node::children` — the allocating form — so a
 hoisted cursor records **zero** and a per-node one records once per
 interior node; each assertion pins the exact zero, and each was
 verified by reverting its call site and watching that test alone fail
-(50 cursors over 50 nodes for the two `Search` walks, 12 over 34 for
-the dump).
+(50 cursors over 50 nodes for `act_on_node`, 12 over 34 for the dump).
 
 Measured on 400 Python corpus files (694 k nodes), interleaved
 best-of-nine: **414 620 cursor allocations down to 33 328 (−92 %), walk

--- a/src/metrics/container_scope_tests.rs
+++ b/src/metrics/container_scope_tests.rs
@@ -620,6 +620,15 @@ fn no_space_is_emitted_with_an_unknown_kind() {
     assert_fixtures_present(FIXTURES);
     for fixture in FIXTURES {
         let spaces = emitted_spaces(fixture.lang, fixture.source);
+        // The root is always emitted and is always `Unit`, so a fixture
+        // that opened no space below it would satisfy every assertion
+        // here without exercising a single classifier decision.
+        assert!(
+            spaces.len() > 1,
+            "{:?}: expected at least one space below the root, got {:?}",
+            fixture.lang,
+            summary(&spaces)
+        );
         for space in &spaces {
             // `assert!` rather than `assert_ne!`: the latter appends
             // "left: Unknown / right: Unknown" to a `!=` failure, which

--- a/src/metrics/container_scope_tests.rs
+++ b/src/metrics/container_scope_tests.rs
@@ -568,6 +568,75 @@ fn the_file_root_keeps_its_rollup() {
     }
 }
 
+/// No fixture emits a space the classifier left `Unknown`.
+///
+/// A space's kind comes from `Getter::get_space_kind_with_code`, called
+/// once per promoted node by `spaces::compute::open_func_space`. So a
+/// node the walker promoted — via
+/// `Checker::promotes_to_func_space_with_code` — whose classifier
+/// answered `Unknown` becomes a space that is not a
+/// [`SpaceKind::is_member_scope`], and `note_member_scope` then records
+/// a kind that suppresses `npm` / `npa` outright. That is an *absent
+/// key*, not a wrong count: it reads the same as a language with no
+/// containers, so no snapshot diff and no value assertion can see it.
+///
+/// Asserted here on the serialized kind rather than by walking nodes and
+/// checking `is_func_space_with_code(n) ⇒ get_space_kind_with_code(n) !=
+/// Unknown` directly. `Checker` / `Getter` methods are static and
+/// monomorphised per parser type; `AstInner` hands out a `root_node` but
+/// no LANG-generic way to invoke them against it, so the node-walk form
+/// would need a new `run_*` dispatch arm on the macro — production
+/// surface grown to host a test. The promoted-but-`Unknown` space *is*
+/// that implication one step downstream, and is already observable.
+///
+/// **Coverage is bounded by [`FIXTURES`].** This can only fail for a
+/// shape some fixture exercises. It establishes nothing about languages
+/// or constructs not represented there — a partial sweep cannot show
+/// absence.
+///
+/// **What it adds over the sweeps above** is not the Elixir case. That
+/// was measured, not assumed: reverting `open_func_space` to the
+/// byte-less `get_space_kind` fails 12 lib tests, every one of them
+/// failing on Elixir — the only language overriding either method — and
+/// both [`containers_emit_npm_and_npa`] (an `Unknown`
+/// container is not a container kind) and [`function_spaces_emit_neither`]
+/// are among them. So this sweep is not uniquely responsible for that
+/// perturbation and should not be read as if it were.
+///
+/// Its own contribution is a selector hole, and specifically the
+/// *partial* form of one. [`function_spaces_emit_neither`] filters
+/// `kind == SpaceKind::Function`, so a space that *should* be a function
+/// but classifies `Unknown` drops out of the filter rather than failing
+/// the assertion; what catches the revert there is its anti-vacuity
+/// guard, and only because that perturbation degrades **every** Elixir
+/// function space at once, leaving the fixture with none. A fixture
+/// keeping one genuine function space — an `AnonymousFunction`, which
+/// the Elixir fixture happens not to have — would satisfy that guard
+/// while the rest degraded silently. This sweep filters nothing, so
+/// there is no set for a space to fall out of. (`.claude/rules/testing.md`:
+/// "review the selector as carefully as the assertion".)
+#[test]
+fn no_space_is_emitted_with_an_unknown_kind() {
+    assert_fixtures_present(FIXTURES);
+    for fixture in FIXTURES {
+        let spaces = emitted_spaces(fixture.lang, fixture.source);
+        for space in &spaces {
+            // `assert!` rather than `assert_ne!`: the latter appends
+            // "left: Unknown / right: Unknown" to a `!=` failure, which
+            // reads as a contradiction next to the real message.
+            assert!(
+                space.kind != SpaceKind::Unknown,
+                "{:?}: space {:?} was promoted to a space but classified \
+                 Unknown, so it serializes no npm/npa block; every space \
+                 was {:?}",
+                fixture.lang,
+                space.name,
+                summary(&spaces)
+            );
+        }
+    }
+}
+
 /// Every #1184 construct opens a function space that emits neither
 /// block, while a plain method beside it does the same.
 ///

--- a/src/node.rs
+++ b/src/node.rs
@@ -43,12 +43,12 @@ crate::observation::counter!(node_resolved_sibling_lookups);
 // makes moving one back a test failure rather than a silent allocation
 // per node.
 //
-// All six consumers are guarded: `preorder`, `first_occurrence` and
-// `act_on_node` here, `metrics::npa::python` and the suppression DFS
-// through a `metrics()` / `suppression_markers` call, and
-// `output::dump`'s renderer from that module's own tests. The accessor
-// is `pub(crate)` (not `pub(super)`) precisely so the last one can be
-// asserted from where it lives — see `crate::observation`.
+// All five consumers are guarded: `preorder` and `act_on_node` here,
+// `metrics::npa::python` and the suppression DFS through a `metrics()`
+// / `suppression_markers` call, and `output::dump`'s renderer from that
+// module's own tests. The accessor is `pub(crate)` (not `pub(super)`)
+// precisely so the last one can be asserted from where it lives — see
+// `crate::observation`.
 crate::observation::counter!(child_scan_cursors);
 
 /// A parsed source tree wrapping a [`tree_sitter::Tree`].
@@ -832,27 +832,6 @@ impl<'a> Iterator for ChildrenWith<'_, 'a> {
 impl ExactSizeIterator for ChildrenWith<'_, '_> {}
 
 impl<'a> Search<'a> for Node<'a> {
-    fn first_occurrence(&self, pred: fn(u16) -> bool) -> Option<Node<'a>> {
-        let mut cursor = self.cursor();
-        let mut stack = Vec::new();
-
-        stack.push(*self);
-
-        while let Some(node) = stack.pop() {
-            if pred(node.kind_id()) {
-                return Some(node);
-            }
-            // Children go on in source order and the freshly-pushed tail
-            // is reversed in place, so the LIFO `stack` yields the
-            // leftmost child first — pre-order with no staging buffer.
-            let first_child = stack.len();
-            stack.extend(node.children_with(&mut cursor));
-            stack[first_child..].reverse();
-        }
-
-        None
-    }
-
     fn act_on_node(&self, action: &mut dyn FnMut(&Node<'a>, Ancestors<'a, '_>)) {
         let mut cursor = self.cursor();
         let mut stack = Vec::new();
@@ -1558,29 +1537,18 @@ mod tests {
             "the suppression scan built {scans} cursors over {nodes} nodes (#1112)"
         );
 
-        // The two `Search` walks. The counter records in `children()`,
-        // the allocating form, so a walk that hoists its cursor records
-        // nothing at all and a per-node one records once per interior
-        // node. Asserting the exact zero is what separates them; a bound
-        // like `< nodes / 2` would hold for either on a small fixture.
+        // The `Search` walk, `act_on_node`. The counter records in
+        // `children()`, the allocating form, so a walk that hoists its
+        // cursor records nothing at all and a per-node one records once
+        // per interior node. Asserting the exact zero is what tells a
+        // hoisted cursor from a per-node one; a bound like `< nodes / 2`
+        // would hold for either on a small fixture.
         let tree = Tree::new::<MozjsCode>(
             b"function f(a) { return { g: (b) => b + 1, h: [1, 2, 3] }; }\nf(2);\n",
         );
         let root = tree.get_root();
         let nodes = root.preorder().count();
         assert!(nodes > 30, "fixture is too small to prove much");
-
-        // A predicate nothing matches, so the walk runs to exhaustion
-        // and every node's children are scanned.
-        let before = child_scan_cursors::observed();
-        let missing = root.first_occurrence(|id| id == u16::MAX);
-        let scans = child_scan_cursors::observed() - before;
-        assert!(missing.is_none(), "the fixture has no such kind");
-        assert_eq!(
-            scans, 0,
-            "first_occurrence built {scans} cursors over {nodes} nodes; it holds \
-             one for the walk (#1112)"
-        );
 
         let before = child_scan_cursors::observed();
         let mut seen = 0_usize;
@@ -1634,76 +1602,6 @@ mod tests {
         // function that always returned `false`.
         assert!(grandchild.parent_grandparent_match(Ancestors::unknown(), yes, yes));
         assert!(grandchild.parent_grandparent_match(Ancestors::known(&[root, child]), yes, yes));
-    }
-
-    /// [`Search::first_occurrence`] must return `None` when nothing in
-    /// the subtree matches, rather than falling back to the root or the
-    /// last node it looked at.
-    ///
-    /// The four C-family getters that used to be its only callers each
-    /// looked for a declarator the surrounding grammar guaranteed was
-    /// there, so the whole suite only ever exercised the hit path. They
-    /// moved onto [`crate::c_declarator`] in #1208; this test and its
-    /// sibling below are what is left (#1212).
-    #[test]
-    fn first_occurrence_answers_none_when_nothing_matches() {
-        let tree = Tree::new::<crate::langs::CCode>(b"int main() { int a; }");
-        let root = tree.get_root();
-
-        // `u16::MAX` is not a grammar kind id, so nothing can match and
-        // the walk runs the whole subtree out before answering.
-        assert!(root.first_occurrence(|id| id == u16::MAX).is_none());
-        // The complementary predicate matches everything, so the `None`
-        // above is the absent match rather than a search that stopped
-        // looking. (The predicate is a `fn` pointer, so neither can
-        // capture a kind id from the fixture.)
-        let found = root
-            .first_occurrence(|id| id != u16::MAX)
-            .expect("a match-everything predicate must hit the root itself");
-        assert_eq!(found.id(), root.id(), "the search starts at the root");
-    }
-
-    /// [`Search::first_occurrence`] must answer in **pre-order** — the
-    /// leftmost match, not merely some match.
-    ///
-    /// Nothing pinned this. Deleting the `stack[first_child..].reverse()`
-    /// that maintains it failed zero of the suite's lib tests, while the
-    /// same deletion in the sibling [`Search::act_on_node`] failed one,
-    /// so only half the pair was guarded.
-    /// `first_occurrence_answers_none_when_nothing_matches` cannot cover
-    /// it: its match-everything predicate hits the root before any child
-    /// is pushed, so the child order never comes into play.
-    ///
-    /// The order was load-bearing while the C, C++, Objective-C and
-    /// mozcpp `get_func_space_name` declarator searches were
-    /// `first_occurrence` calls: a reversed sibling order changed
-    /// *which* declarator named a function space. Those four moved onto
-    /// [`crate::c_declarator`] in #1208 — which is also what fixed the
-    /// shapes where leftmost was the wrong answer — so no production
-    /// code depends on the order today, and #1212 asks whether the
-    /// method should survive at all. Until it is answered the contract
-    /// stays pinned, because an unpinned one is how it went unguarded
-    /// the first time.
-    ///
-    /// Measured on this fixture: `"main"` as written, `"b"` with the
-    /// reversal removed.
-    #[cfg(feature = "c")]
-    #[test]
-    fn first_occurrence_answers_the_leftmost_match() {
-        const SOURCE: &[u8] = b"int main() { int a; int b; }";
-
-        let tree = Tree::new::<crate::langs::CCode>(SOURCE);
-        let identifier = tree
-            .get_root()
-            .first_occurrence(|id| id == crate::languages::language_c::C::Identifier as u16)
-            .expect("the fixture declares identifiers");
-
-        assert_eq!(
-            identifier.utf8_text(SOURCE),
-            Some("main"),
-            "first_occurrence must return the leftmost identifier in source \
-             order, not the last child pushed"
-        );
     }
 
     /// [`Node::children_with`] must yield exactly what

--- a/src/spaces_tests.rs
+++ b/src/spaces_tests.rs
@@ -49,7 +49,6 @@ fn cpp_function_definition_is_classified_as_function() {
     use crate::checker::Checker;
     use crate::getter::Getter;
     use crate::langs::CppCode;
-    use crate::traits::Search;
 
     let source = "int the_func(int x) { return x; }\n";
     let path = std::path::PathBuf::from("fd.cc");
@@ -60,7 +59,9 @@ fn cpp_function_definition_is_classified_as_function() {
     // so the test stays valid if a future grammar bump starts
     // emitting one of the higher-numbered aliases.
     let fn_node = root
-        .first_occurrence(|id| {
+        .preorder()
+        .find(|node| {
+            let id = node.kind_id();
             Cpp::FunctionDefinition == id
                 || Cpp::FunctionDefinition2 == id
                 || Cpp::FunctionDefinition3 == id

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -76,16 +76,6 @@ pub(crate) trait ParserTrait {
 }
 
 pub(crate) trait Search<'a> {
-    /// Finds the first node of the subtree, in pre-order, whose
-    /// `kind_id` satisfies `pred`.
-    // Kept, and allowed, pending #1212: #1208 moved the four C-family
-    // `get_func_space_name` impls — its only production callers — onto
-    // the shared declarator walk in `crate::c_declarator`, and the tests
-    // in `src/node.rs` are all that reach it now. Whether to remove it
-    // or to state a reason for keeping it is a decision of its own, not
-    // a rider on a name-resolution bug fix.
-    #[allow(dead_code)]
-    fn first_occurrence(&self, pred: fn(u16) -> bool) -> Option<Node<'a>>;
     /// Visits every node of the subtree in source order, handing the
     /// action each node's ancestor chain alongside it so a predicate it
     /// applies stays off `Node::parent` (#1088).

--- a/tests/grammars/c_grammar_metrics.rs
+++ b/tests/grammars/c_grammar_metrics.rs
@@ -85,6 +85,51 @@ mod c_metrics {
         assert_eq!(m.cognitive.cognitive_sum(), 4, "cognitive");
     }
 
+    /// Upstream-grammar limitation, deliberately pinned (#1209): in
+    /// `tree-sitter-c` 0.24.2 the old-style (K&R) function definition
+    /// nests its declarator *inside* the old-style declarator, so an
+    /// outer `pointer_declarator` is unreachable. A K&R definition whose
+    /// return type wraps the declarator therefore parses as a plain
+    /// `declaration` that swallows the first parameter declaration, with
+    /// the body orphaned as a bare `compound_statement` sibling — no
+    /// `ERROR` node, no `function_definition`, so `is_func` never sees a
+    /// node to match. `LANG::Objc` shares the defect and `Cpp` / `Mozcpp`
+    /// open no space for either form (no K&R rule at all); both are
+    /// recorded in the book's Supported Languages page rather than here,
+    /// since this suite drives `LANG::C` only.
+    ///
+    /// The `krptr` values below are a bug-lock, not an endorsement: an
+    /// issue is open on this and the pinned numbers record only where
+    /// the decisions land *today* (on the file's unit space). A grammar
+    /// bump that parses the form correctly must fail this test rather
+    /// than shift metrics silently. `krplain` is the control — the
+    /// unwrapped K&R form works and must keep working, which is what
+    /// makes the contrast attributable to the wrapping declarator.
+    #[test]
+    fn c_knr_wrapped_return_type_opens_no_function_space() {
+        let plain = c_space("int krplain(a, b) int a; int b; { if (a) { return 0; } return 1; }");
+        assert_eq!(plain.spaces.len(), 1, "one space for the plain K&R form");
+        assert_eq!(plain.spaces[0].kind, SpaceKind::Function, "space kind");
+        assert_eq!(plain.spaces[0].name.as_deref(), Some("krplain"), "name");
+        assert_eq!(plain.metrics.nargs.function_args_sum(), 2, "K&R args");
+        // unit(1) + fn(1) + if(1) = 3.
+        assert_eq!(plain.metrics.cyclomatic.cyclomatic_sum(), 3, "cyclomatic");
+
+        let wrapped = c_space("int *krptr(a, b) int a; int b; { if (a) { return 0; } return 1; }");
+        assert!(
+            wrapped.spaces.is_empty(),
+            "#1209: the wrapped return type currently opens no space; a \
+             grammar fix makes this fail, which is the point"
+        );
+        assert_eq!(wrapped.metrics.nom.functions_sum(), 0, "no function");
+        // The orphaned body's `if` is charged to the unit: unit(1) + if(1).
+        assert_eq!(
+            wrapped.metrics.cyclomatic.cyclomatic_sum(),
+            2,
+            "the stray decision lands on the file's unit space"
+        );
+    }
+
     /// C has no classes/methods/attributes, so `npm` / `npa` / `wmc` are
     /// no-op impls (decision-log #9) and no `Class` space is ever produced
     /// — a `struct` is a data aggregate, not a function space.


### PR DESCRIPTION
Three low-priority follow-ups from #1197, #1200 and #1208, each closing a
gap where something was unguarded, undocumented, or dead. No metric value
moves and no public API changes, so there is no snapshot churn and no
`big-code-analysis-output` submodule bump.

## What's here

| Commit | Issue | Change |
|---|---|---|
| `8ab58c3d` | #1212 | Remove `Search::first_occurrence` and its `#[allow(dead_code)]` |
| `dd34b1c1` | #1209 | Document the K&R wrapped-return-type parse limitation, pinned by a drift-marker test |
| `1c18af87` | #1204 | Add §7's fourth cross-walk pair and a `_with_code` subsection to `grammar-dispatch.md`, with a fixture sweep |
| `303509f5` | #1204 | Guard that sweep against a bare root (found by `/audit-tests`) |
| `cb4945b0` | — | Consolidated CHANGELOG entry |

### #1212 — remove `Search::first_occurrence`

#1208 moved the four C-family `get_func_space_name` impls — its only
production callers — onto the shared declarator walk in
`src/c_declarator.rs`, leaving the method alive only under an
`#[allow(dead_code)]` and guarded by three tests that protected nothing
shipped. `Search` is `pub(crate)`, so there is no public API impact and
`STABILITY.md` needs no change.

The one remaining *utility* use in `src/spaces_tests.rs` located a nested
`function_definition`, so `first_child` was not a drop-in (it scans one
level). It now uses `root.preorder().find(…)`, which is the same
leftmost-first, root-inclusive walk — `Preorder` has its own order pin in
`preorder_matches_recursive_document_order`.

The `child_scan_cursors` consumer count drops six to five in both places
that state it. `docs/development/benchmarking.md`'s historical #1112
measurement is re-attributed to `act_on_node` rather than restated with an
invented number — and that re-attribution was checked by reverting
`act_on_node` to `children()`, which reproduces exactly the recorded
"50 cursors over 50 nodes".

### #1209 — K&R functions with a wrapped return type

A pre-ANSI K&R definition whose return type wraps the declarator opens no
function space under `C` or `Objective-C`:

```c
int  krplain(a, b) int a; int b; { if (a) { return 0; } return 1; }  /* space, nargs 2 */
int *krptr(a, b)   int a; int b; { if (a) { return 0; } return 1; }  /* no space at all */
```

The report's root-cause section was partly wrong and has been corrected on
the issue. The parse is **re-associated**, not merely reclassified, and
produces **no `ERROR` node**: the `declaration`'s wrapping declarator
swallows the first parameter declaration, `int b;` becomes a second
top-level `declaration`, and the body is orphaned as a bare
`compound_statement`. In `tree-sitter-c` 0.24.2 the old-style function
definition nests its declarator *inside* the old-style declarator, so an
outer `pointer_declarator` is unreachable.

The impact is not uniform invisibility — the orphaned body's decisions are
charged to the **file's unit space** (`cyclomatic.sum` 2 with
`nom.functions` 0), a file-level number no function-level row accounts for.

Two facts not in the original report: `LANG::Objc` shares the defect, and
`Cpp` / `Mozcpp` open no space for *either* K&R form, so `.h` / `.mm`
routing is not a mitigating factor.

Resolution is option 1 — document, do not work around. `src/checker/c.rs`
already enumerates both `function_definition` aliases correctly; the node
it would match is never produced, so there is no dispatch arm to add.
Re-implementing K&R declarator recognition would be a slice of the grammar
rewritten for a form C23 removed. The grammar pin is untouched, and
nothing was filed upstream.

The paired test is a **drift marker**: it pins `cyclomatic.sum == 2` —
where the decision currently lands — so a grammar bump that fixes the
parse fails loudly rather than shifting metrics silently. Its doc comment
says explicitly that the values are a bug-lock, not an endorsement.
A control fixture (`char **kr2`, same defect, no decision) measures 1,
proving the pinned 2 tracks the orphaned `if` rather than being a
parse-failure constant.

### #1204 — `grammar-dispatch` §7 and the `_with_code` spelling

§7 listed three predicate pairs and not `is_func_space` ↔
`get_space_kind`. That pair is worth its own entry because the three
existing ones disagree into a **wrong count**, which a snapshot diff
shows you, while this one disagrees into an **absent key** — a promoted
node the getter left `Unknown` is not a member scope, so its space
serializes no `npm` / `npa` block, which reads exactly like a language
with no containers.

The new subsection states why the `_with_code` trap is silent: the
defaults forward to the byte-less form, so both spellings compile *and
behave identically* everywhere except where a language overrides — which
is precisely where the answer matters. Elixir is that language, and this
has already landed once: `ops_inner` used the byte-less form and returned
a bare file-level space for every Elixir input (#1130).

**Note for reviewers:** the issue argued from `metrics::opens_member_scope`
(`src/metrics/mod.rs:106`), which #1203 deleted in `ac437bb1` the day
before. The hazard survived — it now runs through
`spaces::compute::open_func_space` — so this fixes it on a corrected
premise, and the issue body has been updated. The issue's prescribed test
shape was also not buildable: `Checker` / `Getter` methods are static and
monomorphised per parser, and `AstInner` offers no LANG-generic way to
invoke them against a node, so building it meant growing production macro
surface to host a test. The sweep asserts the same implication one step
downstream, on the serialized space kind.

## Verification

Every measured claim was checked by perturbation rather than assertion:

- Reverting `open_func_space` to the byte-less `get_space_kind` fails
  **exactly 12** lib tests, all Elixir. `containers_emit_npm_and_npa` and
  `function_spaces_emit_neither` are among them, so the new sweep is
  **not** uniquely responsible for that case — its independent value is a
  partial-degradation selector hole, and the doc comment says so rather
  than overclaiming.
- `/audit-tests` found the new sweep had the vacuity hole its three
  siblings already guard against: it iterated every emitted space without
  checking any existed below the always-`Unit` root. Neutering the Elixir
  fixture to `x = 1` made the unguarded sweep **pass**. Fixed in
  `303509f5`.
- Two independent `/code-review` passes returned no findings, each
  re-measuring the K&R claims against real parser output.

`make pre-commit` → `BCA_GATE: pass (gate=pre-commit)`.

Coverage: the batch adds 135 lines of Rust, of which 123 are in test-only
files `cargo llvm-cov` does not place in the denominator and 12 are
comment lines in `src/node.rs` (98.79%, above the 96.62% project figure),
with zero overlap against that file's uncovered set. No measured
production line ships, so patch coverage cannot sit below project
coverage.

Fixes #1204
Fixes #1209
Fixes #1212
