### PR TITLE
refactor(diag): unify severity prefixes on one helper per crate

### DIFF
--- a/.bca-baseline.toml
+++ b/.bca-baseline.toml
@@ -792,12 +792,6 @@ metric = "halstead.effort"
 value = 64170.027458982564
 
 [[entry]]
-path = "src/getter/cpp.rs"
-qualified = "CppCode::get_func_space_name"
-metric = "cognitive"
-value = 15.0
-
-[[entry]]
 path = "src/getter/elixir.rs"
 qualified = "ElixirCode::get_op_type"
 metric = "halstead.effort"
@@ -808,12 +802,6 @@ path = "src/getter/irules.rs"
 qualified = "IrulesCode::get_op_type"
 metric = "halstead.effort"
 value = 53163.06867422894
-
-[[entry]]
-path = "src/getter/mozcpp.rs"
-qualified = "MozcppCode::get_func_space_name"
-metric = "cognitive"
-value = 15.0
 
 [[entry]]
 path = "src/getter/perl.rs"
@@ -1026,12 +1014,6 @@ metric = "nargs"
 value = 5.0
 
 [[entry]]
-path = "src/metrics/nargs.rs"
-qualified = "<file>"
-metric = "loc.ploc"
-value = 536.0
-
-[[entry]]
 path = "src/metrics/npa/python.rs"
 qualified = "python_self_attr_name_bytes"
 metric = "nexits"
@@ -1059,7 +1041,7 @@ value = 7.0
 path = "src/output/code_climate.rs"
 qualified = "write_code_climate"
 metric = "halstead.effort"
-value = 60471.77938561803
+value = 60596.13916454601
 
 [[entry]]
 path = "src/output/dump.rs"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -584,6 +584,16 @@ jobs:
       # it from the aggregate recipe.
       - name: check-manpage-assets (explicit)
         run: python3 utils/check-manpage-assets.py
+      # Defensive twin for the diagnostic-prefix gate (#1199): a
+      # capitalised `Warning:` / `Error:` / `Note:` baked into a string
+      # literal bypasses the one-helper-per-crate severity ladder and
+      # reads as correct in review. Its self-tests run as their own
+      # step because a source-scanning gate that stops matching
+      # reports a clean tree.
+      - name: check-diagnostic-prefix (explicit)
+        run: python3 utils/check-diagnostic-prefix.py
+      - name: check-diagnostic-prefix self-tests (explicit)
+        run: python3 -m unittest -q utils/check-diagnostic-prefix-test.py
       # Defensive twin for the grammar-marker-sync gate (#400): bumping
       # the notification-only marker in tree-sitter-{mozjs,mozcpp}/
       # Cargo.toml without re-running the matching generate-*.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -285,6 +285,30 @@ repos:
         entry: python3 utils/check-manpage-assets.py
         pass_filenames: false
 
+      # Diagnostic-prefix gate — every severity prefix the workspace
+      # prints is lowercase and written by one `diag.rs` helper per
+      # crate, so no string literal may start with `Warning:` /
+      # `Error:` / `Note:`. Guards the #1199 bug class: six such sites
+      # accumulated across two crates because each reads as correct
+      # in isolation. See #609, #1199.
+      - id: check-diagnostic-prefix
+        name: check-diagnostic-prefix
+        language: system
+        files: '^(.*\.rs|utils/check-diagnostic-prefix\.py)$'
+        entry: python3 utils/check-diagnostic-prefix.py
+        pass_filenames: false
+
+      # Self-tests for the diagnostic-prefix gate. A source-scanning
+      # gate that stops matching reports a clean tree, so its own
+      # tests are the only thing standing between a broken regex and
+      # a silently disabled check.
+      - id: check-diagnostic-prefix-test
+        name: check-diagnostic-prefix-test
+        language: system
+        files: '^utils/check-diagnostic-prefix(-test)?\.py$'
+        entry: python3 -m unittest -q utils/check-diagnostic-prefix-test.py
+        pass_filenames: false
+
       # The `enums/` crate is workspace-excluded, so the workspace
       # clippy/test hooks above never touch it. Add a dedicated check
       # so warnings here cannot drift (see #164).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,7 +221,11 @@ and `cargo run -p big-code-analysis-web --`.
   literal — including in a `Display` impl, whose renderings are prefixed
   by whichever layer presents them (#609, #1199).
   `make check-diagnostic-prefix` blocks the capitalised spellings; the
-  lowercase ones are convention, not gated.
+  lowercase ones are convention, not gated — so `bca: warning:` and a
+  hand-rolled `warning:` are on you to catch in review. Informational
+  `bca: …` lines (`bca: wrote N baseline entries`) are a separate,
+  severity-free family and stay as they are; a severity word after that
+  namespace is the redundant double prefix #609 removed.
 - Edition is 2024 — `let-else`, let-chains, and other 2024 features are
   available.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ and `cargo run -p big-code-analysis-web --`.
 - `utils/` — repo-maintenance helper scripts, including the gates run
   by `make pre-commit` / `make ci`: `check-versions.py`,
   `check-snapshot-anchors.py`, `check-rustfmt-bail.py`,
-  `check-manpage-assets.py`,
+  `check-manpage-assets.py`, `check-diagnostic-prefix.py`,
   `check-grammar-marker-sync.py`, `check-enums-codegen-drift.sh`,
   `check-grammar-crate.py`, `check-grammars-crates.sh`,
   `check-excluded-manifests.py`, `verify-name-only-churn.py`, and each
@@ -214,6 +214,14 @@ and `cargo run -p big-code-analysis-web --`.
 - Never use `to_string_lossy()` on paths used as identifiers (map keys,
   JSON output, error correlation). Use `to_str()` with explicit error
   handling. `path.display()` is fine for log output only.
+- Stderr diagnostics carry a **lowercase** severity prefix, written in
+  one place per crate: `warn` / `die` / `note` in
+  `big-code-analysis-cli/src/diag.rs`, `warn` in `src/diag.rs`. Pass the
+  bare message and never spell `warning:` / `error:` / `Warning:` in a
+  literal — including in a `Display` impl, whose renderings are prefixed
+  by whichever layer presents them (#609, #1199).
+  `make check-diagnostic-prefix` blocks the capitalised spellings; the
+  lowercase ones are convention, not gated.
 - Edition is 2024 — `let-else`, let-chains, and other 2024 features are
   available.
 
@@ -242,7 +250,10 @@ cannot run), `cargo doc --no-deps --workspace
 `cargo +nightly udeps`, the markdown /
 TOML / shell / Makefile / GitHub Actions lint families, the man-page
 drift gate (`cargo xtask` + `git diff --exit-code -- man/`, mirroring
-the `manpage` CI job), the bca self-scan threshold gate at both
+the `manpage` CI job), the diagnostic-prefix gate
+(`make check-diagnostic-prefix`, which blocks a capitalised
+`Warning:` / `Error:` / `Note:` string literal — see "Rust
+conventions"), the bca self-scan threshold gate at both
 tiers (`make self-scan` mirroring the `Threshold gate` step in
 `.github/workflows/pages.yml`, plus `make self-scan-headroom`
 which scales every limit by `BCA_HEADROOM` — default `0.95` — so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,36 +184,32 @@ for historical reference.
 ### Changed
 
 - Severity prefixes moved off the message producers and onto the layer
-  that presents them (#1199). `PreprocDiagnostic`'s `Display` now
-  renders the bare message: `bca preproc` prints it through the CLI's
-  `warn` helper instead of a bare `eprintln!`, so `warning:` is written
-  in one place rather than baked into five variants. Per
-  `STABILITY.md`, `Display` impls are stable but their exact wording is
-  not. Two user-visible consequences, both intended: the `IncludeCycle`
-  block no longer ends in a newline, so it is no longer followed by a
-  blank line; and the CSV writer's non-UTF-8 path warning now reads
+  that presents them (#609, #1199). `PreprocDiagnostic`'s `Display` now
+  renders the **bare message, with no severity prefix at all**: `bca
+  preproc` prints it through the CLI's `warn` helper instead of a bare
+  `eprintln!`, so `warning:` is written in one place rather than baked
+  into five variants. Embedders that captured these and printed them
+  verbatim must add their own prefix. (Previously the five variants
+  disagreed among themselves: `SelfInclusion`, `IncludeCycle` and
+  `NotPreprocessed` capitalised `Warning:` while the two non-UTF-8
+  variants did not, and neither spelling matched any other CLI
+  diagnostic, since `warn()` has printed lowercase `warning:` since
+  #609.) Per `STABILITY.md`, `Display` impls are stable but their exact
+  wording is not, so this is not a breaking change. Two further
+  user-visible consequences, both intended: the `IncludeCycle` block no
+  longer ends in a newline, so it is no longer followed by a blank
+  line; and the CSV writer's non-UTF-8 path warning now reads
   `warning: skipping non-UTF-8 path in CSV output: …`, having moved
   onto the shared helper that already words the other five formats'
   (dropping its capitalised prefix and its lone use of "source path").
   The remaining capitalised warnings in the library — the code-climate
   empty-path skip and the walker's non-regular-file skip — are
-  lowercase for the same reason. `make check-diagnostic-prefix`
+  lowercase for the same reason, as are the walk seam's two
+  explicit-path notices, which shed the redundant `bca: warning:`
+  double prefix #609 removed elsewhere. `make check-diagnostic-prefix`
   (`utils/check-diagnostic-prefix.py`, wired into `make lint`,
-  `make pre-commit`, `make ci` and pre-commit) blocks a seventh site
+  `make pre-commit`, `make ci` and pre-commit) blocks a further site
   from reappearing.
-
-- `PreprocDiagnostic`'s `Display` output now uses a lowercase
-  `warning:` prefix for all five variants. `SelfInclusion`,
-  `IncludeCycle` and `NotPreprocessed` previously capitalised it while
-  the two non-UTF-8 variants did not, so `bca preproc` emitted both
-  spellings — and the capitalised three matched no other CLI
-  diagnostic, since `warn()` has printed lowercase `warning:` since
-  #609. Per `STABILITY.md`, `Display` impls are stable but their exact
-  wording is not, so this is not a breaking change. It is also
-  deliberately byte-compatible with routing these through `warn()`
-  later: `warn(msg)` renders `warning: {msg}`, so moving the prefix out
-  of `Display` will produce identical output rather than a second
-  user-visible change.
 
 - This project's own `nargs` limit converges from 7 to the shipped
   default of 5 (#1183). Repository configuration only — no library or CLI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,25 @@ for historical reference.
 
 ### Changed
 
+- Severity prefixes moved off the message producers and onto the layer
+  that presents them (#1199). `PreprocDiagnostic`'s `Display` now
+  renders the bare message: `bca preproc` prints it through the CLI's
+  `warn` helper instead of a bare `eprintln!`, so `warning:` is written
+  in one place rather than baked into five variants. Per
+  `STABILITY.md`, `Display` impls are stable but their exact wording is
+  not. Two user-visible consequences, both intended: the `IncludeCycle`
+  block no longer ends in a newline, so it is no longer followed by a
+  blank line; and the CSV writer's non-UTF-8 path warning now reads
+  `warning: skipping non-UTF-8 path in CSV output: …`, having moved
+  onto the shared helper that already words the other five formats'
+  (dropping its capitalised prefix and its lone use of "source path").
+  The remaining capitalised warnings in the library — the code-climate
+  empty-path skip and the walker's non-regular-file skip — are
+  lowercase for the same reason. `make check-diagnostic-prefix`
+  (`utils/check-diagnostic-prefix.py`, wired into `make lint`,
+  `make pre-commit`, `make ci` and pre-commit) blocks a seventh site
+  from reappearing.
+
 - `PreprocDiagnostic`'s `Display` output now uses a lowercase
   `warning:` prefix for all five variants. `SelfInclusion`,
   `IncludeCycle` and `NotPreprocessed` previously capitalised it while

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ find-by-ext = $(if $(FD),$(FD) --extension $(1) $(FD_EXCLUDE) $(2),find . -name 
 NEXTEST        := $(shell command -v cargo-nextest 2>/dev/null)
 TEST_CMD       = $(if $(NEXTEST),$(NEXTEST) nextest run --workspace --all-features,cargo test --workspace --all-features --lib --bins --tests)
 
-.PHONY: help check-tools worktree-setup worktree-setup-test build build-release check test test-doc chain-audit fmt fmt-check markdown-fmt markdown-lint shellcheck sh-fmt sh-fmt-check toml-fmt toml-fmt-check toml-lint makefile-check actionlint snapshot-anchors snapshot-anchors-test rustfmt-bail rustfmt-bail-test grammar-marker-sync grammar-marker-sync-test check-versions check-excluded-manifests check-excluded-manifests-test check-manpage-assets gate-status-test enums-check enums-codegen-drift enums-codegen-drift-test self-scan self-scan-headroom self-scan-write-baseline self-scan-write-baseline-headroom vcs lint clippy udeps insta-review insta-accept clean distclean install install-cli install-web doc doc-open doc-check doc-check-docsrs book book-serve book-pot book-po-update book-ja book-deploy all pre-commit ci release-check verify-changelog pkg-deb-local pkg-rpm-local dev-env-build dev-env-run dev-env-shell dev-env-rm py-bootstrap py-sync py-relock py-clean py-fmt py-fmt-check py-lint py-typecheck py-test py-stubtest smoke smoke-cli smoke-lib bench bench-scaling bench-walk _check-find _pc-all _pc-fmt _pc-clippy _pc-test _pc-doc-check _pc-udeps _pc-shellcheck _pc-markdown-lint _pc-toml-lint _pc-makefile-check _pc-actionlint _pc-snapshot-anchors _pc-snapshot-anchors-test _pc-rustfmt-bail _pc-rustfmt-bail-test _pc-grammar-marker-sync _pc-grammar-marker-sync-test _pc-check-versions _pc-check-versions-test _pc-check-grammar-crate-test _pc-check-excluded-manifests _pc-check-excluded-manifests-test _pc-check-manpage-assets _pc-worktree-setup-test _pc-gate-status-test _pc-enums-check _pc-enums-codegen-drift _pc-enums-codegen-drift-test _pc-self-scan _pc-self-scan-headroom _pc-py-fmt _pc-py-typecheck _pc-py-test _pc-py-stubtest _ci-all _ci-fmt-check _ci-clippy _ci-test _ci-doc-check _ci-build _ci-udeps _ci-shellcheck _ci-markdown-lint _ci-toml-lint _ci-makefile-check _ci-actionlint _ci-snapshot-anchors _ci-snapshot-anchors-test _ci-rustfmt-bail _ci-rustfmt-bail-test _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-versions-test _ci-check-grammar-crate-test _ci-check-excluded-manifests _ci-check-excluded-manifests-test _ci-check-manpage-assets _ci-worktree-setup-test _ci-gate-status-test _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test _ci-enums-codegen-drift-test _ci-self-scan _ci-self-scan-headroom _ci-cargo-pipeline _ci-py-fmt-check _ci-py-lint _ci-py-typecheck _ci-py-test _ci-py-stubtest
+.PHONY: help check-tools worktree-setup worktree-setup-test build build-release check test test-doc chain-audit fmt fmt-check markdown-fmt markdown-lint shellcheck sh-fmt sh-fmt-check toml-fmt toml-fmt-check toml-lint makefile-check actionlint snapshot-anchors snapshot-anchors-test rustfmt-bail rustfmt-bail-test grammar-marker-sync grammar-marker-sync-test check-versions check-excluded-manifests check-excluded-manifests-test check-manpage-assets check-diagnostic-prefix check-diagnostic-prefix-test gate-status-test enums-check enums-codegen-drift enums-codegen-drift-test self-scan self-scan-headroom self-scan-write-baseline self-scan-write-baseline-headroom vcs lint clippy udeps insta-review insta-accept clean distclean install install-cli install-web doc doc-open doc-check doc-check-docsrs book book-serve book-pot book-po-update book-ja book-deploy all pre-commit ci release-check verify-changelog pkg-deb-local pkg-rpm-local dev-env-build dev-env-run dev-env-shell dev-env-rm py-bootstrap py-sync py-relock py-clean py-fmt py-fmt-check py-lint py-typecheck py-test py-stubtest smoke smoke-cli smoke-lib bench bench-scaling bench-walk _check-find _pc-all _pc-fmt _pc-clippy _pc-test _pc-doc-check _pc-udeps _pc-shellcheck _pc-markdown-lint _pc-toml-lint _pc-makefile-check _pc-actionlint _pc-snapshot-anchors _pc-snapshot-anchors-test _pc-rustfmt-bail _pc-rustfmt-bail-test _pc-grammar-marker-sync _pc-grammar-marker-sync-test _pc-check-versions _pc-check-versions-test _pc-check-grammar-crate-test _pc-check-excluded-manifests _pc-check-excluded-manifests-test _pc-check-manpage-assets _pc-check-diagnostic-prefix _pc-check-diagnostic-prefix-test _pc-worktree-setup-test _pc-gate-status-test _pc-enums-check _pc-enums-codegen-drift _pc-enums-codegen-drift-test _pc-self-scan _pc-self-scan-headroom _pc-py-fmt _pc-py-typecheck _pc-py-test _pc-py-stubtest _ci-all _ci-fmt-check _ci-clippy _ci-test _ci-doc-check _ci-build _ci-udeps _ci-shellcheck _ci-markdown-lint _ci-toml-lint _ci-makefile-check _ci-actionlint _ci-snapshot-anchors _ci-snapshot-anchors-test _ci-rustfmt-bail _ci-rustfmt-bail-test _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-versions-test _ci-check-grammar-crate-test _ci-check-excluded-manifests _ci-check-excluded-manifests-test _ci-check-manpage-assets _ci-check-diagnostic-prefix _ci-check-diagnostic-prefix-test _ci-worktree-setup-test _ci-gate-status-test _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test _ci-enums-codegen-drift-test _ci-self-scan _ci-self-scan-headroom _ci-cargo-pipeline _ci-py-fmt-check _ci-py-lint _ci-py-typecheck _ci-py-test _ci-py-stubtest
 
 # Default target
 help:
@@ -139,6 +139,8 @@ help:
 	@echo "  check-excluded-manifests             Assert excluded crates root a workspace and grammars are =-pinned"
 	@echo "  check-excluded-manifests-test        Self-tests for the check-excluded-manifests gate"
 	@echo "  check-manpage-assets                 Assert every bca-*.1 man page is in deb+rpm asset lists"
+	@echo "  check-diagnostic-prefix              Block capitalised Warning:/Error:/Note: literals"
+	@echo "  check-diagnostic-prefix-test         Self-tests for the diagnostic-prefix gate"
 	@echo "  worktree-setup-test                  Self-tests for the worktree-setup submodule classifier"
 	@echo "  gate-status-test                     Self-tests for the pre-commit/ci BCA_GATE verdict line"
 	@echo "  enums-check                          cargo clippy + cargo test on workspace-excluded enums crate"
@@ -533,6 +535,22 @@ check-excluded-manifests-test:
 check-manpage-assets:
 	@echo "Checking man-page packaging asset lists..."
 	@python3 $(BASE_DIR)utils/check-manpage-assets.py
+
+# Diagnostic-prefix gate (#1199). Every severity prefix this workspace
+# prints is lowercase and written by one helper per crate (`diag.rs`);
+# a fresh `eprintln!("Warning: ...")` reads as correct in review and
+# nothing else notices. Static lint — no network, no cargo.
+check-diagnostic-prefix:
+	@echo "Checking diagnostic severity prefixes..."
+	@python3 $(BASE_DIR)utils/check-diagnostic-prefix.py
+
+# Self-tests for the diagnostic-prefix gate. Separate target for the
+# same reason as the other gate self-tests: a source-scanning gate that
+# stops matching reports a clean tree, so its own tests have to fail
+# loudly and on their own parallel arm.
+check-diagnostic-prefix-test:
+	@echo "Running check-diagnostic-prefix self-tests..."
+	@(cd $(BASE_DIR) && python3 -m unittest -q utils/check-diagnostic-prefix-test.py)
 
 # Sync gate for check-grammar-crate.py's EXTENSIONS table. Re-derives
 # the grammar -> extension mapping from src/langs.rs `mk_langs!` and
@@ -983,7 +1001,7 @@ lint:
 	$(MAKE) -j --output-sync=target \
 	  _ci-clippy \
 	  _ci-shellcheck _ci-markdown-lint _ci-toml-lint _ci-makefile-check \
-	  _ci-actionlint _ci-snapshot-anchors _ci-snapshot-anchors-test _ci-rustfmt-bail _ci-rustfmt-bail-test _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-versions-test _ci-check-grammar-crate-test _ci-check-excluded-manifests _ci-check-excluded-manifests-test _ci-check-manpage-assets _ci-worktree-setup-test _ci-gate-status-test _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test
+	  _ci-actionlint _ci-snapshot-anchors _ci-snapshot-anchors-test _ci-rustfmt-bail _ci-rustfmt-bail-test _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-versions-test _ci-check-grammar-crate-test _ci-check-excluded-manifests _ci-check-excluded-manifests-test _ci-check-manpage-assets _ci-check-diagnostic-prefix _ci-check-diagnostic-prefix-test _ci-worktree-setup-test _ci-gate-status-test _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test
 
 # ---------------------------------------------------------------------------
 # Maintenance
@@ -1148,7 +1166,7 @@ _pc-all:
 	$(MAKE) -j --output-sync=target \
 	  _pc-test \
 	  _pc-shellcheck _pc-markdown-lint _pc-toml-lint _pc-makefile-check \
-	  _pc-actionlint _pc-snapshot-anchors _pc-snapshot-anchors-test _pc-rustfmt-bail _pc-rustfmt-bail-test _pc-grammar-marker-sync _pc-grammar-marker-sync-test _pc-check-versions _pc-check-versions-test _pc-check-grammar-crate-test _pc-check-excluded-manifests _pc-check-excluded-manifests-test _pc-check-manpage-assets _pc-worktree-setup-test _pc-gate-status-test _pc-enums-check _pc-enums-codegen-drift _pc-enums-codegen-drift-test \
+	  _pc-actionlint _pc-snapshot-anchors _pc-snapshot-anchors-test _pc-rustfmt-bail _pc-rustfmt-bail-test _pc-grammar-marker-sync _pc-grammar-marker-sync-test _pc-check-versions _pc-check-versions-test _pc-check-grammar-crate-test _pc-check-excluded-manifests _pc-check-excluded-manifests-test _pc-check-manpage-assets _pc-check-diagnostic-prefix _pc-check-diagnostic-prefix-test _pc-worktree-setup-test _pc-gate-status-test _pc-enums-check _pc-enums-codegen-drift _pc-enums-codegen-drift-test \
 	  _pc-manpages \
 	  _pc-self-scan _pc-self-scan-headroom \
 	  _pc-py-fmt _pc-py-typecheck _pc-py-test _pc-py-stubtest
@@ -1158,7 +1176,7 @@ _ci-all:
 	$(MAKE) -j --output-sync=target \
 	  _ci-cargo-pipeline \
 	  _ci-shellcheck _ci-markdown-lint _ci-toml-lint _ci-makefile-check \
-	  _ci-actionlint _ci-snapshot-anchors _ci-snapshot-anchors-test _ci-rustfmt-bail _ci-rustfmt-bail-test _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-versions-test _ci-check-grammar-crate-test _ci-check-excluded-manifests _ci-check-excluded-manifests-test _ci-check-manpage-assets _ci-worktree-setup-test _ci-gate-status-test _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test \
+	  _ci-actionlint _ci-snapshot-anchors _ci-snapshot-anchors-test _ci-rustfmt-bail _ci-rustfmt-bail-test _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-versions-test _ci-check-grammar-crate-test _ci-check-excluded-manifests _ci-check-excluded-manifests-test _ci-check-manpage-assets _ci-check-diagnostic-prefix _ci-check-diagnostic-prefix-test _ci-worktree-setup-test _ci-gate-status-test _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test \
 	  _ci-py-fmt-check _ci-py-lint _ci-py-typecheck _ci-py-test _ci-py-stubtest
 
 # ---------------------------------------------------------------------------
@@ -1192,6 +1210,8 @@ _ci-all:
 #    ├── _pc-grammar-marker-sync
 #    ├── _pc-grammar-marker-sync-test
 #    ├── _pc-check-versions
+#    ├── _pc-check-diagnostic-prefix
+#    ├── _pc-check-diagnostic-prefix-test
 #    ├── _pc-worktree-setup-test
 #    ├── _pc-gate-status-test
 #    ├── _pc-enums-check
@@ -1292,6 +1312,12 @@ _pc-check-excluded-manifests-test: _pc-fmt
 
 _pc-check-manpage-assets: _pc-fmt
 	$(MAKE) check-manpage-assets
+
+_pc-check-diagnostic-prefix: _pc-fmt
+	$(MAKE) check-diagnostic-prefix
+
+_pc-check-diagnostic-prefix-test: _pc-fmt
+	$(MAKE) check-diagnostic-prefix-test
 
 _pc-worktree-setup-test: _pc-fmt
 	$(MAKE) worktree-setup-test
@@ -1465,6 +1491,12 @@ _ci-check-excluded-manifests-test:
 
 _ci-check-manpage-assets:
 	$(MAKE) check-manpage-assets
+
+_ci-check-diagnostic-prefix:
+	$(MAKE) check-diagnostic-prefix
+
+_ci-check-diagnostic-prefix-test:
+	$(MAKE) check-diagnostic-prefix-test
 
 _ci-worktree-setup-test:
 	$(MAKE) worktree-setup-test

--- a/big-code-analysis-cli/src/commands/preproc.rs
+++ b/big-code-analysis-cli/src/commands/preproc.rs
@@ -78,9 +78,13 @@ pub(crate) fn run_command_preproc(globals: GlobalOpts, args: PreprocArgs) {
     let mut data = into_preproc_data(preproc_lock);
     // Include-resolution diagnostics (self-inclusion, cycles, non-UTF-8
     // paths, un-preprocessed files) are returned rather than written to
-    // stderr by the library, so the CLI surfaces them here.
+    // stderr by the library, so the CLI surfaces them here — through
+    // `warn` rather than a bare `eprintln!`, so the `warning:` prefix
+    // comes from the severity ladder like every other CLI diagnostic
+    // (#1199). The multi-line `IncludeCycle` variant is prefixed on its
+    // header line only, leaving its member list indented beneath.
     for diagnostic in fix_includes(&mut data.files, &all_files) {
-        eprintln!("{diagnostic}");
+        warn(diagnostic);
     }
 
     let serialized = serde_json::to_string(&data)

--- a/big-code-analysis-cli/src/walk.rs
+++ b/big-code-analysis-cli/src/walk.rs
@@ -197,11 +197,11 @@ impl WalkFilters<'_> {
         // for every caller standing anywhere but the project root, which
         // is exactly when the override it announces happens (#1164).
         if let Some(glob) = self.excludes.first_match(seed, cwd_form) {
-            eprintln!(
-                "bca: warning: {} matches an exclude pattern ({glob}) \
+            warn(format_args!(
+                "{} matches an exclude pattern ({glob}) \
                  but was named explicitly; analyzing anyway",
                 seed.display()
-            );
+            ));
         }
     }
 }
@@ -454,10 +454,10 @@ fn visit_walk_entry(
     let entry = match entry {
         Ok(entry) => entry,
         Err(e) => {
-            eprintln!(
-                "bca: warning: skipping walk entry in {}: {e}",
+            warn(format_args!(
+                "skipping walk entry in {}: {e}",
                 seed.display()
-            );
+            ));
             // Every variant warns; only an I/O-backed one is tallied, because
             // only that one means the walk lost files it should have seen
             // (#1131). See [`WalkErrors`] for why the rest stay non-fatal.

--- a/big-code-analysis-cli/tests/check/check_thresholds.rs
+++ b/big-code-analysis-cli/tests/check/check_thresholds.rs
@@ -369,6 +369,8 @@ fn check_with_no_matching_files_exits_one() {
         // `error:` prefix (matching clap's own usage errors), never the
         // old capitalized `Error:`.
         .stderr(predicate::str::contains("error: no input files matched"))
+        // diag-prefix-ok: the capitalised spelling is the thing asserted
+        // absent here, not a prefix this test emits (#1199).
         .stderr(predicate::str::contains("Error:").not());
 }
 

--- a/big-code-analysis-cli/tests/cli_ux/cli_smoke.rs
+++ b/big-code-analysis-cli/tests/cli_ux/cli_smoke.rs
@@ -377,6 +377,77 @@ fn preproc_resolves_cross_file_include_across_directory() {
     );
 }
 
+/// The presentation half of the diagnostic-prefix contract (#1199): the
+/// library's `PreprocDiagnostic::Display` renders a bare message, and
+/// the CLI is what adds `warning:` — via `diag::warn`, the same helper
+/// every other CLI diagnostic goes through. `src/preproc_tests.rs` pins
+/// the bare messages; only an end-to-end run can pin what a user reads,
+/// and without this half the prefix is guarded nowhere.
+///
+/// The fixture produces two of the five variants: a header-only
+/// `SelfInclusion` and the multi-line `IncludeCycle`, which is the one
+/// with a shape to get wrong. `warn` prefixes its header line only and
+/// leaves the member lines indented beneath, and — since #1199 dropped
+/// the `writeln!` that terminated the last member — the block is no
+/// longer followed by a blank line.
+#[test]
+fn preproc_diagnostics_render_under_the_warning_prefix() {
+    let dir = TempDir::new().unwrap();
+    let self_h = dir.path().join("self.h");
+    let a_h = dir.path().join("a.h");
+    let b_h = dir.path().join("b.h");
+    std::fs::write(&self_h, "#include \"self.h\"\nint s;\n").unwrap();
+    std::fs::write(&a_h, "#include \"b.h\"\nint a;\n").unwrap();
+    std::fs::write(&b_h, "#include \"a.h\"\nint b;\n").unwrap();
+
+    let output = cli()
+        .args(["preproc", "--paths", dir.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "preproc should succeed");
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    let lines: Vec<&str> = stderr.lines().collect();
+
+    // Diagnostics are emitted in `PreprocResults::files` (a `HashMap`)
+    // order, so assert per-line rather than pinning the whole block.
+    let self_line = format!("warning: possible self inclusion {}", self_h.display());
+    assert!(
+        lines.contains(&self_line.as_str()),
+        "expected {self_line:?} among {lines:?}"
+    );
+
+    let header = lines
+        .iter()
+        .position(|l| *l == "warning: possible include cycle:")
+        .unwrap_or_else(|| panic!("no cycle header in {lines:?}"));
+    let mut members = lines
+        .get(header + 1..header + 3)
+        .unwrap_or_else(|| panic!("cycle header not followed by two members: {lines:?}"))
+        .to_vec();
+    members.sort_unstable();
+    assert_eq!(
+        members,
+        vec![
+            format!("  - \"{}\"", a_h.display()),
+            format!("  - \"{}\"", b_h.display()),
+        ],
+        "the cycle members are indented under the prefixed header, unprefixed"
+    );
+
+    // A `Display` ending in a newline would stack with `warn`'s own and
+    // leave a blank line after the block — the pre-#1199 output.
+    assert!(
+        !stderr.contains("\n\n"),
+        "no diagnostic block is followed by a blank line: {stderr:?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .all(|l| l.starts_with("warning: ") || l.starts_with("  - \"")),
+        "every stderr line is either a prefixed diagnostic or a cycle member: {lines:?}"
+    );
+}
+
 /// Recursively yield files under `dir` whose extension equals `ext`.
 fn walkdir_entries(dir: &std::path::Path, ext: &str) -> impl Iterator<Item = std::path::PathBuf> {
     fn visit(dir: &std::path::Path, ext: &str, found: &mut Vec<std::path::PathBuf>) {

--- a/big-code-analysis-cli/tests/discovery/explicit_path_excludes.rs
+++ b/big-code-analysis-cli/tests/discovery/explicit_path_excludes.rs
@@ -82,9 +82,14 @@ fn explicit_path_overrides_manifest_exclude_and_warns_naming_the_glob() {
         .code(2)
         .stdout(predicate::str::contains("skipme_offender"))
         .stderr(predicate::str::contains(
-            "bca: warning: skipme/a.rs matches an exclude pattern (./skipme/**) \
+            "warning: skipme/a.rs matches an exclude pattern (./skipme/**) \
              but was named explicitly; analyzing anyway",
-        ));
+        ))
+        // #609/#1199: the notice goes through `diag::warn` like every
+        // other CLI diagnostic, so it carries the bare lowercase prefix
+        // — not the redundant `bca: warning:` double prefix this seam
+        // kept after #609 unified the rest.
+        .stderr(predicate::str::contains("bca: warning:").not());
 }
 
 /// The counterpart: the same manifest, reached through the *walk*,
@@ -320,7 +325,7 @@ fn override_warning_survives_a_mixed_case_extension() {
         // the unannounced override was a live one.
         .stdout(predicate::str::contains("upper_offender"))
         .stderr(predicate::str::contains(
-            "bca: warning: skipme/B.RS matches an exclude pattern (./skipme/**) \
+            "warning: skipme/B.RS matches an exclude pattern (./skipme/**) \
              but was named explicitly; analyzing anyway",
         ))
         .stderr(predicate::str::contains("skipme/a.rs matches an exclude"));
@@ -547,7 +552,7 @@ fn override_warning_fires_from_a_subdirectory() {
         .code(2)
         .stdout(predicate::str::contains("skipme_offender"))
         .stderr(predicate::str::contains(
-            "bca: warning: a.rs matches an exclude pattern (./skipme/**) \
+            "warning: a.rs matches an exclude pattern (./skipme/**) \
              but was named explicitly; analyzing anyway",
         ));
 }

--- a/src/concurrent_files.rs
+++ b/src/concurrent_files.rs
@@ -20,6 +20,8 @@ type BoxedCause = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 use crossbeam::channel::{Receiver, Sender, unbounded};
 
+use crate::diag::warn;
+
 type ProcFilesFunction<Config> = dyn Fn(PathBuf, &Config) -> std::io::Result<()> + Send + Sync;
 
 #[derive(Debug)]
@@ -224,7 +226,10 @@ fn explore<Config: 'static + Send + Sync>(
         // classified every entry (#1114) — see
         // [`ConcurrentRunner::without_path_verification`].
         if verify_paths && !path.is_file() {
-            eprintln!("Warning: not a regular file, skipping: {}", path.display());
+            warn(format_args!(
+                "not a regular file, skipping: {}",
+                path.display()
+            ));
             continue;
         }
         send_file(path, cfg, sender)?;

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -1,0 +1,30 @@
+//! Severity-prefixed stderr diagnostics for the library.
+//!
+//! The library counterpart to `big-code-analysis-cli/src/diag.rs`: one
+//! helper per severity so the lowercase `warning:` prefix — matching
+//! clap's own usage-error formatter, and therefore the rustc/cargo/git
+//! diagnostic family (#609) — is written in exactly one place per crate
+//! rather than re-spelled at each call site (#1199).
+//!
+//! Only `warning` exists here. The library never exits the process, so
+//! it has no `error:`/`die` counterpart: fatal conditions are returned
+//! as [`MetricsError`](crate::MetricsError) or [`std::io::Error`] and
+//! the CLI decides how to present them. The few diagnostics that *are*
+//! printed rather than returned are all best-effort skips — a path that
+//! is not valid UTF-8, an entry that is not a regular file — where the
+//! run continues with that item omitted.
+//!
+//! `utils/check-diagnostic-prefix.py` (`make lint`) blocks a capitalised
+//! `Warning:` / `Error:` / `Note:` literal from reappearing at a call
+//! site that bypasses these helpers.
+
+use std::fmt::Display;
+
+/// Print a `warning:`-prefixed diagnostic to stderr (non-fatal).
+///
+/// A multi-line `msg` is prefixed on its first line only; the remaining
+/// lines are emitted verbatim, so a message whose continuation lines are
+/// already indented reads as one block under the header.
+pub(crate) fn warn(msg: impl Display) {
+    eprintln!("warning: {msg}");
+}

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -9,10 +9,19 @@
 //! Only `warning` exists here. The library never exits the process, so
 //! it has no `error:`/`die` counterpart: fatal conditions are returned
 //! as [`MetricsError`](crate::MetricsError) or [`std::io::Error`] and
-//! the CLI decides how to present them. The few diagnostics that *are*
-//! printed rather than returned are all best-effort skips — a path that
-//! is not valid UTF-8, an entry that is not a regular file — where the
-//! run continues with that item omitted.
+//! the CLI decides how to present them. What is printed rather than
+//! returned is a best-effort skip — a path that is not valid UTF-8, an
+//! entry that is not a regular file — or a malformed in-source
+//! suppression marker, in every case leaving the run to continue with
+//! that item omitted.
+//!
+//! One library diagnostic deliberately stays outside this helper:
+//! [`crate::ConcurrentRunner`]'s per-file failure line
+//! (`error processing <path>: <err>`, `src/concurrent_files.rs`). It is
+//! error-severity text emitted by a *callback* the embedder supplied,
+//! so prefixing it here would claim a severity ladder the library has
+//! no `error:` half of. Worth revisiting alongside a library `error`
+//! helper, not before.
 //!
 //! `utils/check-diagnostic-prefix.py` (`make lint`) blocks a capitalised
 //! `Warning:` / `Error:` / `Note:` literal from reappearing at a call

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,6 +246,12 @@ pub mod wire;
 #[cfg_attr(docsrs, doc(cfg(feature = "vcs-git")))]
 pub mod vcs;
 
+// --- Diagnostics ---
+//
+// The single place the library writes a `warning:` prefix; the CLI has
+// its own severity ladder in `big-code-analysis-cli/src/diag.rs`.
+mod diag;
+
 // --- Errors ---
 mod error;
 pub use crate::error::{FromPathError, MetricsError};

--- a/src/output/code_climate.rs
+++ b/src/output/code_climate.rs
@@ -742,6 +742,23 @@ mod tests {
     }
 
     #[test]
+    fn offender_whose_path_normalises_to_empty_is_dropped_from_the_report() {
+        // The unit test above pins `normalize_path`; this pins what the
+        // *writer* does with its `None` — skip that finding and carry
+        // on, rather than abandoning the document or emitting a finding
+        // with an empty `location.path` (which Code Climate consumers
+        // key on). Only a second, well-formed offender can tell those
+        // apart, so the good record is what makes the assertion sharp.
+        let v = render_value(&[
+            rec("./", "cyclomatic", 17.0, 15.0),
+            rec("src/good.rs", "cognitive", 20.0, 15.0),
+        ]);
+        let findings = v.as_array().expect("an array of findings");
+        assert_eq!(findings.len(), 1, "the empty-path offender is skipped: {v}");
+        assert_eq!(findings[0]["location"]["path"], "src/good.rs");
+    }
+
+    #[test]
     fn start_line_zero_is_clamped_to_one() {
         let mut r = rec("a.rs", "cyclomatic", 17.0, 15.0);
         r.start_line = 0;

--- a/src/output/code_climate.rs
+++ b/src/output/code_climate.rs
@@ -44,6 +44,7 @@ use std::io::{self, Write};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 
+use crate::diag::warn;
 use crate::metric_catalog::lookup;
 use crate::output::offenders::{OffenderRecord, Severity, TOOL_ID, warn_non_utf8_path};
 
@@ -90,10 +91,10 @@ pub fn write_code_climate<W: Write>(offenders: &[OffenderRecord], mut writer: W)
             continue;
         };
         let Some(path) = normalize_path(path_raw) else {
-            eprintln!(
-                "Warning: skipping empty repo-relative path in code-climate output: {}",
+            warn(format_args!(
+                "skipping empty repo-relative path in code-climate output: {}",
                 record.path.display()
-            );
+            ));
             continue;
         };
         let start_line = record.start_line.max(1);

--- a/src/output/csv.rs
+++ b/src/output/csv.rs
@@ -25,6 +25,7 @@ use std::path::Path;
 
 use crate::output::funcspace_row::{IDENTITY_COLUMNS, METRIC_COUNT, metric_values};
 use crate::output::numfmt::CellMetric;
+use crate::output::offenders::warn_non_utf8_path;
 use crate::spaces::FuncSpace;
 
 // Compile-time guarantee that the metric tuple matches CSV_HEADER —
@@ -189,11 +190,7 @@ pub fn write_csv<W: Write>(space: &FuncSpace, source_path: &Path, writer: W) -> 
 
     wtr.write_record(CSV_HEADER).map_err(csv_err)?;
 
-    let Some(path_str) = source_path.to_str() else {
-        eprintln!(
-            "Warning: skipping non-UTF-8 source path in CSV output: {}",
-            source_path.display()
-        );
+    let Some(path_str) = warn_non_utf8_path("CSV", source_path) else {
         return wtr.flush();
     };
 
@@ -224,11 +221,7 @@ where
         .from_writer(writer);
     wtr.write_record(CSV_HEADER).map_err(csv_err)?;
     for (space, source_path) in spaces {
-        let Some(path_str) = source_path.to_str() else {
-            eprintln!(
-                "Warning: skipping non-UTF-8 source path in CSV output: {}",
-                source_path.display()
-            );
+        let Some(path_str) = warn_non_utf8_path("CSV", source_path) else {
             continue;
         };
         write_space_rows(&mut wtr, path_str, space)?;
@@ -653,23 +646,54 @@ d""#
         assert_eq!(defang_formula("café"), "café");
     }
 
-    #[test]
-    fn non_utf8_path_skips_data_rows() {
-        #[cfg(unix)]
-        {
-            use std::ffi::OsStr;
-            use std::os::unix::ffi::OsStrExt;
-            use std::path::PathBuf;
+    /// A path with no UTF-8 rendering, constructible only on Unix.
+    ///
+    /// `#[cfg]` sits on the callers' `fn`, not around a test body: an
+    /// empty `#[test]` body is a *passing* test, so the inner-block form
+    /// reports green on Windows having asserted nothing
+    /// (`.claude/rules/testing.md`).
+    #[cfg(unix)]
+    fn non_utf8_path() -> std::path::PathBuf {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
 
-            let bad = PathBuf::from(OsStr::from_bytes(b"\xff\xfe.rs"));
-            let space = empty_space("root", SpaceKind::Unit, 1, 1);
-            let out = render(&space, &bad);
-            assert_eq!(
-                out.lines().count(),
-                1,
-                "header should be the only line, got:\n{out}"
-            );
-        }
+        std::path::PathBuf::from(OsStr::from_bytes(b"\xff\xfe.rs"))
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn non_utf8_path_skips_data_rows() {
+        let space = empty_space("root", SpaceKind::Unit, 1, 1);
+        let out = render(&space, &non_utf8_path());
+        assert_eq!(
+            out.lines().count(),
+            1,
+            "header should be the only line, got:\n{out}"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn aggregate_skips_only_the_non_utf8_file() {
+        // The aggregate path `continue`s past an undecodable path rather
+        // than abandoning the document, so the *other* files' rows must
+        // still be there — a check `non_utf8_path_skips_data_rows`
+        // cannot make, since a single-file document that skips its only
+        // file and one that bails outright are the same bytes.
+        let bad = non_utf8_path();
+        let good = empty_space("good", SpaceKind::Unit, 1, 1);
+        let skipped = empty_space("skipped", SpaceKind::Unit, 1, 1);
+        let spaces: Vec<(FuncSpace, &Path)> =
+            vec![(skipped, bad.as_path()), (good, Path::new("good.rs"))];
+
+        let mut buf = Vec::new();
+        write_csv_aggregate(spaces.iter().map(|(s, p)| (s, *p)), &mut buf)
+            .expect("writing to Vec is infallible");
+        let out = String::from_utf8(buf).expect("output is UTF-8");
+
+        assert_eq!(out.lines().count(), 2, "header + the one good row:\n{out}");
+        let row = out.lines().nth(1).expect("data row");
+        assert!(row.starts_with("good.rs,"), "row was: {row}");
     }
 
     #[test]

--- a/src/output/offenders.rs
+++ b/src/output/offenders.rs
@@ -13,6 +13,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+use crate::diag::warn;
 use crate::metric_catalog::{Direction, lookup};
 use crate::output::numfmt::MessageMetric;
 
@@ -23,18 +24,20 @@ use crate::output::numfmt::MessageMetric;
 pub const TOOL_ID: &str = "big-code-analysis";
 
 /// `path.to_str()`, or emit a stderr warning and return `None`. Used
-/// by every output format that turns offender paths into UTF-8
-/// identifiers (Checkstyle attribute, SARIF URI, warning-line column,
-/// HTML / CSV cell). Centralizing the warning text keeps the
-/// `format` label consistent across formats.
+/// by every output format that turns paths into UTF-8 identifiers
+/// (Checkstyle attribute, SARIF URI, Code Climate path, clang/MSVC
+/// warning-line column, CSV cell). Centralizing the warning text keeps
+/// the `format` label consistent across formats, and routing the prefix
+/// through [`crate::diag::warn`] keeps `warning:` written in one place
+/// (#1199).
 pub(crate) fn warn_non_utf8_path<'a>(format: &str, path: &'a Path) -> Option<&'a str> {
     if let Some(s) = path.to_str() {
         Some(s)
     } else {
-        eprintln!(
-            "Warning: skipping non-UTF-8 path in {format} output: {}",
+        warn(format_args!(
+            "skipping non-UTF-8 path in {format} output: {}",
             path.display()
-        );
+        ));
         None
     }
 }

--- a/src/preproc.rs
+++ b/src/preproc.rs
@@ -38,7 +38,13 @@ use crate::traits::*;
 /// that cannot be decoded as UTF-8, and files referenced but never
 /// preprocessed are all reported here rather than written to `stderr`,
 /// so an embedder (e.g. `bca-web`) can capture, suppress, or surface
-/// them as it sees fit. The CLI prints them to `stderr`.
+/// them as it sees fit. The CLI prints them to `stderr` through its
+/// `warning:` helper.
+///
+/// [`Display`](std::fmt::Display) renders the bare message with no
+/// severity prefix and no trailing newline; prefixing is the presenting
+/// layer's job, so the prefix is written in exactly one place per crate
+/// (#1199).
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub enum PreprocDiagnostic {
     /// A file's `#include` resolved back to the file itself; the
@@ -77,31 +83,33 @@ impl std::fmt::Display for PreprocDiagnostic {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::SelfInclusion { file } => {
-                write!(f, "warning: possible self inclusion {}", file.display())
+                write!(f, "possible self inclusion {}", file.display())
             }
             Self::IncludeCycle { members } => {
-                writeln!(f, "warning: possible include cycle:")?;
+                write!(f, "possible include cycle:")?;
                 for member in members {
                     // Explicit quotes preserve whitespace visibility for
                     // paths that contain spaces — important when the cycle
                     // warning is the only signal a user gets.
-                    writeln!(f, "  - \"{member}\"")?;
+                    //
+                    // The newline leads rather than trails so the rendered
+                    // block carries no trailing newline of its own: a
+                    // `Display` that ends in one stacks with the caller's
+                    // `println!`/`warn` and prints a stray blank line
+                    // (#1199).
+                    write!(f, "\n  - \"{member}\"")?;
                 }
                 Ok(())
             }
             Self::NonUtf8CyclePath { path } => {
-                write!(
-                    f,
-                    "warning: skipping non-UTF-8 path in include cycle: {path}"
-                )
+                write!(f, "skipping non-UTF-8 path in include cycle: {path}")
             }
-            Self::NonUtf8IndirectInclude { path } => write!(
-                f,
-                "warning: skipping non-UTF-8 indirect include path: {path}"
-            ),
+            Self::NonUtf8IndirectInclude { path } => {
+                write!(f, "skipping non-UTF-8 indirect include path: {path}")
+            }
             Self::NotPreprocessed { file } => write!(
                 f,
-                "warning: included file which has not been preprocessed: {}",
+                "included file which has not been preprocessed: {}",
                 file.display()
             ),
         }

--- a/src/preproc_tests.rs
+++ b/src/preproc_tests.rs
@@ -859,14 +859,15 @@ fn preprocess_truncated_include_does_not_panic() {
 /// `preproc_diagnostic_display_lists_every_cycle_member` below, which
 /// needs a different assertion shape.
 ///
-/// All five variants use the lowercase `warning:` prefix, matching the
-/// CLI's own severity ladder in `big-code-analysis-cli/src/diag.rs`
-/// (#609). That is load-bearing rather than cosmetic: `warn(msg)` is
-/// `eprintln!("warning: {msg}")`, and `bca preproc` currently emits
-/// these through a bare `eprintln!("{diagnostic}")`, so the two
-/// spellings now produce identical bytes. Moving the prefix out of
-/// `Display` and onto `warn()` is therefore a pure refactor — these
-/// assertions are what will prove it emitted nothing new.
+/// No variant carries a severity prefix: `warning:` is written once, by
+/// the presenting layer's `warn` helper (#1199 —
+/// `big-code-analysis-cli/src/diag.rs` for the CLI,
+/// `src/diag.rs` for the library). These assertions are the half of that
+/// contract that pins the *message*; the rendered stderr line is pinned
+/// by `preproc_diagnostics_render_under_the_warning_prefix` in the
+/// CLI's `cli_ux` suite. Neither half is sufficient alone — without the
+/// CLI test nothing guards the prefix, and without this one nothing
+/// guards the wording.
 #[test]
 fn preproc_diagnostic_display_renders_each_single_line_variant() {
     assert_eq!(
@@ -874,7 +875,7 @@ fn preproc_diagnostic_display_renders_each_single_line_variant() {
             file: PathBuf::from("inc/self ref.h"),
         }
         .to_string(),
-        "warning: possible self inclusion inc/self ref.h",
+        "possible self inclusion inc/self ref.h",
     );
 
     assert_eq!(
@@ -882,7 +883,7 @@ fn preproc_diagnostic_display_renders_each_single_line_variant() {
             path: "bad/\u{fffd}.h".to_owned(),
         }
         .to_string(),
-        "warning: skipping non-UTF-8 path in include cycle: bad/\u{fffd}.h",
+        "skipping non-UTF-8 path in include cycle: bad/\u{fffd}.h",
     );
 
     assert_eq!(
@@ -890,7 +891,7 @@ fn preproc_diagnostic_display_renders_each_single_line_variant() {
             path: "bad/\u{fffd}.h".to_owned(),
         }
         .to_string(),
-        "warning: skipping non-UTF-8 indirect include path: bad/\u{fffd}.h",
+        "skipping non-UTF-8 indirect include path: bad/\u{fffd}.h",
     );
 
     assert_eq!(
@@ -898,16 +899,22 @@ fn preproc_diagnostic_display_renders_each_single_line_variant() {
             file: PathBuf::from("vendor/unseen.h"),
         }
         .to_string(),
-        "warning: included file which has not been preprocessed: vendor/unseen.h",
+        "included file which has not been preprocessed: vendor/unseen.h",
     );
 }
 
 /// `IncludeCycle` is the only multi-line variant: a header line plus one
-/// quoted line per member, each newline-terminated. The member list here
-/// is deliberately unsorted and contains a path with a space — the
-/// quoting exists precisely so that whitespace stays visible, and a
-/// member set of one could not distinguish "prints every member" from
-/// "prints the first".
+/// quoted line per member, newline-*separated*. The member list here is
+/// deliberately unsorted and contains a path with a space — the quoting
+/// exists precisely so that whitespace stays visible, and a member set
+/// of one could not distinguish "prints every member" from "prints the
+/// first".
+///
+/// The expected string ends at the last member's closing quote, and
+/// that is load-bearing: before #1199 each member line was
+/// `writeln!`-terminated, so `warn`/`println!` added a second newline
+/// and every cycle block printed followed by a blank line. Restoring
+/// the `writeln!` fails this assertion (verified by perturbation).
 #[test]
 fn preproc_diagnostic_display_lists_every_cycle_member() {
     let rendered = PreprocDiagnostic::IncludeCycle {
@@ -917,15 +924,14 @@ fn preproc_diagnostic_display_lists_every_cycle_member() {
 
     assert_eq!(
         rendered,
-        "warning: possible include cycle:\n  - \"z.h\"\n  - \"a b.h\"\n  - \"m.h\"\n",
+        "possible include cycle:\n  - \"z.h\"\n  - \"a b.h\"\n  - \"m.h\"",
     );
-
     let empty = PreprocDiagnostic::IncludeCycle {
         members: Vec::new(),
     }
     .to_string();
     assert_eq!(
-        empty, "warning: possible include cycle:\n",
+        empty, "possible include cycle:",
         "an empty member list still renders the header and nothing else"
     );
 }

--- a/src/preproc_tests.rs
+++ b/src/preproc_tests.rs
@@ -935,3 +935,60 @@ fn preproc_diagnostic_display_lists_every_cycle_member() {
         "an empty member list still renders the header and nothing else"
     );
 }
+
+/// A [`std::fmt::Write`] sink that accepts `budget` writes and then
+/// fails, so a `Display` impl can be driven to its error path at any
+/// point in its output.
+struct FailingSink {
+    budget: usize,
+    writes: usize,
+}
+
+impl std::fmt::Write for FailingSink {
+    fn write_str(&mut self, _s: &str) -> std::fmt::Result {
+        if self.budget == 0 {
+            return Err(std::fmt::Error);
+        }
+        self.budget -= 1;
+        self.writes += 1;
+        Ok(())
+    }
+}
+
+/// `IncludeCycle` is the only variant that writes more than once, so it
+/// is the only one that can swallow a formatter error: a `let _ =` in
+/// place of either `?` leaves the header (or an earlier member) on the
+/// wire and reports success. `to_string()` cannot catch that — a
+/// `String` sink never fails — which is why this drives the impl
+/// through a sink that does.
+///
+/// The write count is *measured* rather than hardcoded, so the loop
+/// still asserts exactly "no write error is swallowed" if the impl is
+/// later rewritten to emit a different number of writes.
+#[test]
+fn preproc_diagnostic_display_propagates_every_formatter_error() {
+    use std::fmt::Write as _;
+
+    let cycle = PreprocDiagnostic::IncludeCycle {
+        members: vec!["a.h".to_owned(), "b.h".to_owned()],
+    };
+
+    let mut counter = FailingSink {
+        budget: usize::MAX,
+        writes: 0,
+    };
+    write!(counter, "{cycle}").expect("an unlimited sink never fails");
+    let total = counter.writes;
+    assert!(
+        total > 1,
+        "a single-write rendering could not test propagation"
+    );
+
+    for budget in 0..total {
+        let mut sink = FailingSink { budget, writes: 0 };
+        assert!(
+            write!(sink, "{cycle}").is_err(),
+            "a sink failing on write {budget} must surface as an error"
+        );
+    }
+}

--- a/src/spaces/compute.rs
+++ b/src/spaces/compute.rs
@@ -9,6 +9,7 @@
 use std::hash::BuildHasherDefault;
 
 use super::*;
+use crate::diag::warn;
 
 /// Derives the two metrics that read from a space's *complete* state:
 /// Halstead's `Stats` from the accumulated occurrence maps, and MI from
@@ -426,11 +427,11 @@ fn apply_comment_suppression(
             // The `+ 1` converts tree-sitter's 0-based rows to the
             // 1-based line numbers `FuncSpace::start_line` and the
             // rest of this module report.
-            eprintln!(
-                "warning: {}:{}: {diagnostic}",
+            warn(format_args!(
+                "{}:{}: {diagnostic}",
                 diagnostic_path,
                 node.start_row() + 1
-            );
+            ));
         }
         if let Some(suppression) = &scan.suppression {
             apply_suppression(state_stack, suppression);

--- a/src/vcs/git/cached.rs
+++ b/src/vcs/git/cached.rs
@@ -20,6 +20,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use super::{OBJECT_CACHE_BYTES, current_unix_seconds, history, repo, walk_err};
+use crate::diag::warn;
 use crate::vcs::HistoryIndex;
 use crate::vcs::cache::{self, CacheConfig, CommitEvent, HistoryCache};
 use crate::vcs::error::Error;
@@ -281,6 +282,6 @@ fn persist(
         events: events.to_vec(),
     };
     if let Err(e) = cache::write_atomic(path, &entry) {
-        eprintln!("warning: failed to write VCS history cache: {e}");
+        warn(format_args!("failed to write VCS history cache: {e}"));
     }
 }

--- a/utils/check-diagnostic-prefix-test.py
+++ b/utils/check-diagnostic-prefix-test.py
@@ -94,6 +94,28 @@ class ScanTextOffenders(unittest.TestCase):
         text = 'let a = "Warning: one";\nlet b = "Error: two";\n'
         self.assertEqual([(1, "Warning"), (2, "Error")], [(n, w) for n, w, _ in GATE.scan_text(text)])
 
+    def test_both_offenders_on_one_line_are_reported(self) -> None:
+        # `re.search` stops at the first match, so the author fixes the
+        # one named, re-runs the gate, and it fails again on the same
+        # line — with a header that had undercounted.
+        text = 'let a = "Warning: one"; let b = "Error: two";\n'
+        self.assertEqual(
+            [(1, "Warning"), (1, "Error")], [(n, w) for n, w, _ in GATE.scan_text(text)]
+        )
+
+    def test_a_single_line_raw_string_is_still_scanned(self) -> None:
+        # Only the *interior* of a multi-line raw string is skipped: a
+        # one-line `r#"…"#` is as plausible a diagnostic as any other
+        # literal, so the fixture carve-out must not swallow it.
+        self.assertEqual(
+            [(1, "Error")],
+            [(n, w) for n, w, _ in GATE.scan_text('die(r#"Error: x"#);\n')],
+        )
+
+    def test_scanning_resumes_after_a_raw_string_closes(self) -> None:
+        text = 'let f = r#"\n  int x;\n"#; eprintln!("Error: real");\n'
+        self.assertEqual([(3, "Error")], [(n, w) for n, w, _ in GATE.scan_text(text)])
+
 
 class ScanTextNonOffenders(unittest.TestCase):
     """Shapes that must not be reported."""
@@ -108,6 +130,40 @@ class ScanTextNonOffenders(unittest.TestCase):
 
     def test_word_without_colon_is_not_a_prefix(self) -> None:
         self.assertEqual(GATE.scan_text('let m = "Warning about x";\n'), [])
+
+    def test_escaped_inner_quote_is_prose_not_a_prefix(self) -> None:
+        # An escaped quote never *starts* a literal, so what follows it
+        # is prose. Anchoring on any `"` reported this as an offender
+        # with no correct remediation.
+        self.assertEqual(GATE.scan_text('let m = "he said \\"Error: no\\"";\n'), [])
+
+    def test_multiline_raw_string_fixture_is_skipped(self) -> None:
+        # The embedded-source-fixture shape this workspace is built on.
+        # Neither opt-out position is reachable inside a raw string — both
+        # would land in the fixture and change what the metric test
+        # measures — so flagging it left no correct remediation.
+        text = 'let src = r#"\n    std::cerr << "Warning: low memory";\n"#;\n'
+        self.assertEqual(GATE.scan_text(text), [])
+
+    def test_an_escaped_cr_does_not_open_a_raw_string(self) -> None:
+        # `\r"` and `"r"` both end in the raw-string opener's characters
+        # without being one. Reading either as an open skips every line
+        # until the next quote, and the offender hiding in there is a
+        # false *clean* — the one outcome this gate exists to prevent.
+        # Both shapes are live in this tree (`src/tools.rs:409`,
+        # `src/languages/language_ruby.rs:481`).
+        text = 'let l = s.strip_suffix(b"\\r").unwrap_or(s);\neprintln!("Error: x");\n'
+        self.assertEqual([(2, "Error")], [(n, w) for n, w, _ in GATE.scan_text(text)])
+
+    def test_a_string_holding_only_r_does_not_open_a_raw_string(self) -> None:
+        text = 'Ruby::R => "r",\neprintln!("Error: x");\n'
+        self.assertEqual([(2, "Error")], [(n, w) for n, w, _ in GATE.scan_text(text)])
+
+    def test_hash_count_must_match_to_close_a_raw_string(self) -> None:
+        # A bare `"#` inside an `r##"…"##` fixture does not terminate it,
+        # so the lines after it are still fixture data.
+        text = 'let src = r##"\n  let a = "#;\n  eprintln!("Warning: fixture");\n"##;\n'
+        self.assertEqual(GATE.scan_text(text), [])
 
     def test_comment_lines_are_skipped(self) -> None:
         # This gate's own explanatory comments quote the banned shape;

--- a/utils/check-diagnostic-prefix-test.py
+++ b/utils/check-diagnostic-prefix-test.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Tests for check-diagnostic-prefix.py.
+
+Three kinds of test, matching the check-excluded-manifests-test.py
+pattern:
+
+* Unit tests over synthetic Rust snippets, weighted toward the two ways
+  a source-scanning gate goes wrong: a hit it should have reported
+  (every emitting shape, every spelling, raw and hash-delimited
+  literals) and a hit it should not (prose containing the word, a
+  comment explaining the rule, an opted-out fixture).
+* ``main()`` tests over a synthetic repository root, covering the clean
+  and the offending branch plus the remediation text each prints.
+* A smoke test running the real gate against the real repository,
+  asserting a clean tree reports OK.
+
+The false-clean direction is the one that matters: a gate that reports
+"OK" over a tree it failed to read is indistinguishable from a tree with
+nothing to find, which is precisely the outcome the gate exists to
+prevent (see `.claude/rules/tool-output.md`).
+
+Run with:
+    python3 -m unittest -q utils/check-diagnostic-prefix-test.py
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+UTILS_DIR = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = UTILS_DIR.parent
+SCRIPT_SRC = UTILS_DIR / "check-diagnostic-prefix.py"
+
+
+def _load_module():  # type: ignore[no-untyped-def]
+    spec = importlib.util.spec_from_file_location("check_diagnostic_prefix", SCRIPT_SRC)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+GATE = _load_module()
+
+
+class ScanTextOffenders(unittest.TestCase):
+    """Shapes that must be reported."""
+
+    def test_capitalised_eprintln_is_reported(self) -> None:
+        found = GATE.scan_text('    eprintln!("Warning: skipping {p}");\n')
+        self.assertEqual(len(found), 1)
+        line_no, word, line = found[0]
+        self.assertEqual(line_no, 1)
+        self.assertEqual(word, "Warning")
+        self.assertTrue(line.startswith("eprintln!"))
+
+    def test_literal_on_its_own_line_is_reported(self) -> None:
+        # The wrapped shape every offender #1199 collected was written
+        # in: the macro on one line, the literal on the next. A gate
+        # matching `eprintln!` and the literal on the *same* line would
+        # have reported the whole tree clean.
+        text = 'eprintln!(\n    "Warning: not a regular file: {}",\n    p\n);\n'
+        found = GATE.scan_text(text)
+        self.assertEqual([(2, "Warning")], [(n, w) for n, w, _ in found])
+
+    def test_every_severity_and_case_is_reported(self) -> None:
+        for word in ("Warning", "WARNING", "Error", "ERROR", "Note", "NOTE"):
+            with self.subTest(word=word):
+                found = GATE.scan_text(f'let m = "{word}: bad";\n')
+                self.assertEqual([w for _, w, _ in found], [word])
+
+    def test_raw_and_hash_delimited_literals_are_reported(self) -> None:
+        for literal in ('r"Error: x"', 'r#"Error: x"#', 'r##"Error: x"##'):
+            with self.subTest(literal=literal):
+                self.assertEqual(len(GATE.scan_text(f"let m = {literal};\n")), 1)
+
+    def test_line_numbers_survive_an_exotic_separator_in_a_literal(self) -> None:
+        # `str.splitlines()` breaks on U+2028 and the vertical-tab
+        # family; rustc does not. One inside a string literal would
+        # shift every reported line number after it by one, sending the
+        # reader to the wrong line.
+        text = 'let sep = " ";\neprintln!("Error: x");\n'
+        self.assertEqual([(2, "Error")], [(n, w) for n, w, _ in GATE.scan_text(text)])
+
+    def test_every_offending_line_is_reported_not_just_the_first(self) -> None:
+        text = 'let a = "Warning: one";\nlet b = "Error: two";\n'
+        self.assertEqual([(1, "Warning"), (2, "Error")], [(n, w) for n, w, _ in GATE.scan_text(text)])
+
+
+class ScanTextNonOffenders(unittest.TestCase):
+    """Shapes that must not be reported."""
+
+    def test_lowercase_prefix_is_the_house_style(self) -> None:
+        self.assertEqual(GATE.scan_text('eprintln!("warning: {msg}");\n'), [])
+
+    def test_word_inside_prose_is_not_a_prefix(self) -> None:
+        # Anchoring at the literal's start is what keeps ordinary prose
+        # out: the gate is about a prefix, not about the word.
+        self.assertEqual(GATE.scan_text('let m = "retry on Error: yes";\n'), [])
+
+    def test_word_without_colon_is_not_a_prefix(self) -> None:
+        self.assertEqual(GATE.scan_text('let m = "Warning about x";\n'), [])
+
+    def test_comment_lines_are_skipped(self) -> None:
+        # This gate's own explanatory comments quote the banned shape;
+        # so does the CHANGELOG entry pasted into a doc comment.
+        text = '// never write "Warning: x"\n/// Renders "Error: y" historically.\n'
+        self.assertEqual(GATE.scan_text(text), [])
+
+    def test_marker_on_the_same_line_opts_out(self) -> None:
+        text = 'assert!(!out.contains("Error:")); // diag-prefix-ok: asserted absent\n'
+        self.assertEqual(GATE.scan_text(text), [])
+
+    def test_marker_anywhere_in_the_comment_block_above_opts_out(self) -> None:
+        # The live opt-out in `check_thresholds.rs` is a two-line block
+        # with the marker on the first line; a rule that only looked at
+        # the immediately preceding line would miss it.
+        text = (
+            "        // diag-prefix-ok: the capitalised spelling is the\n"
+            "        // thing asserted absent here (#1199).\n"
+            '        .stderr(predicate::str::contains("Error:").not());\n'
+        )
+        self.assertEqual(GATE.scan_text(text), [])
+
+    def test_marker_below_the_line_does_not_opt_out(self) -> None:
+        # Only the line itself and the block above count, so a marker
+        # attached to the *next* statement cannot silently cover this
+        # one.
+        text = 'eprintln!("Error: x");\n// diag-prefix-ok\n'
+        self.assertEqual(len(GATE.scan_text(text)), 1)
+
+    def test_blank_line_breaks_the_comment_block(self) -> None:
+        text = "// diag-prefix-ok\n\neprintln!(\"Error: x\");\n"
+        self.assertEqual(len(GATE.scan_text(text)), 1)
+
+
+class MainOverSyntheticRoot(unittest.TestCase):
+    """``main()`` end-to-end over a temporary tree."""
+
+    @contextlib.contextmanager
+    def _root_with(self, files: dict[str, str]):  # type: ignore[no-untyped-def]
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            for rel, text in files.items():
+                path = root / rel
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(text, encoding="utf-8")
+            with mock.patch.object(GATE, "REPO_ROOT", root):
+                yield root
+
+    def _run_main(self) -> tuple[int, str, str]:
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            code = GATE.main()
+        return code, out.getvalue(), err.getvalue()
+
+    def test_clean_tree_passes_and_reports_the_file_count(self) -> None:
+        with self._root_with({"src/a.rs": 'eprintln!("warning: ok");\n'}):
+            code, out, _ = self._run_main()
+        self.assertEqual(code, 0)
+        # The count is part of the contract: "OK (0 files checked)" is a
+        # gate that found nothing because it read nothing.
+        self.assertIn("1 Rust files checked", out)
+
+    def test_offending_tree_fails_and_names_file_line_and_remedy(self) -> None:
+        with self._root_with(
+            {
+                "src/a.rs": 'fn f() {\n    eprintln!("Warning: bad");\n}\n',
+                "src/ok.rs": 'eprintln!("warning: fine");\n',
+            }
+        ):
+            code, _, err = self._run_main()
+        self.assertEqual(code, 1)
+        self.assertIn("src/a.rs:2", err)
+        self.assertIn("Warning:", err)
+        self.assertIn("diag.rs", err)
+        self.assertNotIn("src/ok.rs", err)
+
+    def test_non_rust_files_are_not_scanned(self) -> None:
+        with self._root_with({"utils/x.py": 'print("Warning: bad")\n'}):
+            code, out, _ = self._run_main()
+        self.assertEqual(code, 0)
+        self.assertIn("0 Rust files checked", out)
+
+
+class RealRepositorySmoke(unittest.TestCase):
+    def test_gate_passes_on_this_repository(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_SRC)],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"gate failed on a clean tree:\n{result.stdout}\n{result.stderr}",
+        )
+        self.assertIn("Diagnostic prefixes OK", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/check-diagnostic-prefix.py
+++ b/utils/check-diagnostic-prefix.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""check-diagnostic-prefix
+
+Block a capitalised ``Warning:`` / ``Error:`` / ``Note:`` severity prefix
+from being baked into a Rust string literal.
+
+Every diagnostic this workspace prints carries a *lowercase* prefix,
+matching clap's own usage-error formatter and therefore the
+rustc/cargo/git diagnostic family (#609). Each crate writes that prefix
+in exactly one place — ``big-code-analysis-cli/src/diag.rs`` for the CLI,
+``src/diag.rs`` for the library — so a call site passes the bare message
+and never spells a severity itself.
+
+The failure mode this gate exists for (#1199): a new
+``eprintln!("Warning: …")`` reads as perfectly correct in review, and
+nothing else in the workspace notices. Six such sites had accumulated
+across two crates before anyone tallied them, in three different
+spellings.
+
+Remediation is always the same — drop the prefix from the literal and
+emit through the crate's ``warn`` helper::
+
+    -    eprintln!("Warning: skipping {path}");
+    +    warn(format_args!("skipping {path}"));
+
+Scope and limits:
+
+* Rust sources only (``git ls-files '*.rs'``, falling back to a
+  filesystem walk outside a git checkout). Python and shell helpers
+  print to their own conventions.
+* The match is anchored at the *start* of a string literal, so prose
+  that merely contains the word ("… on Error: retry" in a doc comment)
+  is not a hit.
+* Whole-line comments are skipped, so a ``//`` explaining this rule —
+  including the examples above — does not trip it.
+* An embedded fixture that legitimately contains such a literal (a C
+  string in a test corpus, say) opts out with ``// diag-prefix-ok`` on
+  the same line or in the comment block above it. One site uses it
+  today: the #609 regression test that asserts the capitalised spelling
+  is *absent* from `bca check` stderr.
+
+See AGENTS.md "Validation gates" for the policy this enforces.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+import sys
+
+# `parents[1]`, not `parent`: these gates live in `utils/` but every
+# path they read is anchored at the repository root.
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+SKIP_DIRS = {".git", "target", "node_modules", ".venv", "__pycache__"}
+
+# A string literal — plain, raw, or hash-delimited raw — whose first
+# characters are a capitalised severity word followed by a colon.
+SEVERITY_LITERAL = re.compile(
+    r'(?:\br)?#*"(?P<word>Warning|WARNING|Error|ERROR|Note|NOTE):'
+)
+
+# Opt-out marker for a literal that is data rather than a diagnostic.
+ALLOW_MARKER = "diag-prefix-ok"
+
+
+def discover_targets(root: pathlib.Path) -> list[pathlib.Path]:
+    """Every tracked Rust file in the tree.
+
+    Workspace-wide on purpose: the sites #1199 collected sat in the
+    library, in the CLI, and in output writers, and a gate scoped to one
+    of those directories would have reported the other two clean.
+    """
+    listed = subprocess.run(
+        ["git", "ls-files", "-z", "*.rs"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if listed.returncode == 0 and listed.stdout:
+        return sorted(root / rel for rel in listed.stdout.split("\0") if rel)
+    return sorted(
+        p
+        for p in root.rglob("*.rs")
+        if p.is_file() and not SKIP_DIRS.intersection(p.relative_to(root).parts)
+    )
+
+
+def _is_allowed(lines: list[str], index: int) -> bool:
+    """True when line ``index`` carries an opt-out marker.
+
+    The marker may sit on the line itself or anywhere in the comment
+    block immediately above it. Scanning the whole block rather than one
+    line matters because the rationale a marker requires rarely fits on
+    one line, and a marker that silently stops applying when its own
+    comment grows is worse than no escape hatch.
+    """
+    if ALLOW_MARKER in lines[index]:
+        return True
+    above = index - 1
+    while above >= 0 and lines[above].lstrip().startswith("//"):
+        if ALLOW_MARKER in lines[above]:
+            return True
+        above -= 1
+    return False
+
+
+def scan_text(text: str) -> list[tuple[int, str, str]]:
+    """Offending ``(line number, severity word, line)`` triples.
+
+    Line numbers are 1-based so they paste straight into an editor.
+    """
+    offenders: list[tuple[int, str, str]] = []
+    # `split("\n")`, not `splitlines()`: the latter also breaks on U+2028
+    # and the vertical-tab family, which rustc does not treat as line
+    # terminators, so one inside a string literal would shift every
+    # reported line number past it.
+    lines = text.split("\n")
+    for index, line in enumerate(lines):
+        stripped = line.lstrip()
+        if stripped.startswith("//"):
+            continue
+        match = SEVERITY_LITERAL.search(line)
+        if match and not _is_allowed(lines, index):
+            offenders.append((index + 1, match.group("word"), stripped))
+    return offenders
+
+
+def _report(offenders: list[tuple[pathlib.Path, int, str, str]]) -> None:
+    print(
+        f"Capitalised severity prefix in {len(offenders)} string "
+        "literal(s):\n",
+        file=sys.stderr,
+    )
+    for path, line_no, word, line in offenders:
+        print(f"  {path}:{line_no}: {word}: -> {line}", file=sys.stderr)
+    print(
+        "\nDiagnostics carry a lowercase prefix written in one place per\n"
+        "crate: `warn` / `die` / `note` in\n"
+        "`big-code-analysis-cli/src/diag.rs` (CLI) and `warn` in\n"
+        "`src/diag.rs` (library). Drop the prefix from the literal and\n"
+        "emit through the helper (#609, #1199). A literal that is data\n"
+        "rather than a diagnostic opts out with a `diag-prefix-ok`\n"
+        "comment on the same line or in the comment block above it.",
+        file=sys.stderr,
+    )
+
+
+def main() -> int:
+    targets = discover_targets(REPO_ROOT)
+    offenders = [
+        (path.relative_to(REPO_ROOT), line_no, word, line)
+        for path in targets
+        for line_no, word, line in scan_text(path.read_text(encoding="utf-8"))
+    ]
+    if offenders:
+        _report(offenders)
+        return 1
+
+    print(f"Diagnostic prefixes OK ({len(targets)} Rust files checked).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utils/check-diagnostic-prefix.py
+++ b/utils/check-diagnostic-prefix.py
@@ -29,15 +29,19 @@ Scope and limits:
   filesystem walk outside a git checkout). Python and shell helpers
   print to their own conventions.
 * The match is anchored at the *start* of a string literal, so prose
-  that merely contains the word ("… on Error: retry" in a doc comment)
-  is not a hit.
+  that merely contains the word — in a doc comment, or as an escaped
+  inner quotation (``"he said \\"Error: no\\""``) — is not a hit.
 * Whole-line comments are skipped, so a ``//`` explaining this rule —
   including the examples above — does not trip it.
-* An embedded fixture that legitimately contains such a literal (a C
-  string in a test corpus, say) opts out with ``// diag-prefix-ok`` on
-  the same line or in the comment block above it. One site uses it
-  today: the #609 regression test that asserts the capitalised spelling
-  is *absent* from `bca check` stderr.
+* The interior of a *multi-line* raw string is skipped. That is where
+  this workspace's embedded source fixtures live, real foreign code
+  says ``std::cerr << "Warning: …"``, and neither opt-out position is
+  reachable: both sit inside the fixture, so writing a marker would
+  change the text the metric test measures.
+* Anything else that legitimately contains such a literal opts out with
+  ``// diag-prefix-ok`` on the same line or in the comment block above
+  it. One site uses it today: the #609 regression test that asserts the
+  capitalised spelling is *absent* from `bca check` stderr.
 
 See AGENTS.md "Validation gates" for the policy this enforces.
 """
@@ -57,9 +61,25 @@ SKIP_DIRS = {".git", "target", "node_modules", ".venv", "__pycache__"}
 
 # A string literal — plain, raw, or hash-delimited raw — whose first
 # characters are a capitalised severity word followed by a colon.
+#
+# The `(?<!\\)` rejects an *escaped* quote, so a quotation embedded in a
+# message (`"he said \"Error: no\""`) is prose rather than a prefix. The
+# gate is about what a literal starts with; an inner quote never starts
+# one.
 SEVERITY_LITERAL = re.compile(
-    r'(?:\br)?#*"(?P<word>Warning|WARNING|Error|ERROR|Note|NOTE):'
+    r'(?:\br)?#*(?<!\\)"(?P<word>Warning|WARNING|Error|ERROR|Note|NOTE):'
 )
+
+# The opening delimiter of a raw (or raw byte) string literal, capturing
+# its hash count so the matching terminator can be searched for.
+#
+# The lookbehind excludes `"` and `\` as well as word characters, because
+# without them an ordinary string is read as opening a raw one and every
+# line until the next quote is skipped. Both shapes are live in this
+# tree: `line.strip_suffix(b"\r")` ends in `\r"`, and `Ruby::R => "r",`
+# ends in `"r"`. Measured across 559 files, dropping the two characters
+# turns 99 candidate multi-line opens into 27.
+RAW_STRING_OPEN = re.compile(r'(?<![A-Za-z0-9_"\\])b?r(?P<hashes>#*)"')
 
 # Opt-out marker for a literal that is data rather than a diagnostic.
 ALLOW_MARKER = "diag-prefix-ok"
@@ -107,10 +127,36 @@ def _is_allowed(lines: list[str], index: int) -> bool:
     return False
 
 
+def _unterminated_raw_open(segment: str) -> int | None:
+    """Hash count of a raw string ``segment`` opens and does not close.
+
+    ``None`` when every raw string opened here also closes here, which is
+    the ordinary case — a one-line ``r"…"`` stays in scope for the scan.
+    """
+    pos = 0
+    while (opening := RAW_STRING_OPEN.search(segment, pos)) is not None:
+        terminator = '"' + "#" * len(opening.group("hashes"))
+        close = segment.find(terminator, opening.end())
+        if close < 0:
+            return len(opening.group("hashes"))
+        pos = close + len(terminator)
+    return None
+
+
 def scan_text(text: str) -> list[tuple[int, str, str]]:
     """Offending ``(line number, severity word, line)`` triples.
 
     Line numbers are 1-based so they paste straight into an editor.
+
+    The interior of a *multi-line* raw string is skipped: those hold the
+    embedded source fixtures this workspace tests against, and real
+    foreign code says ``std::cerr << "Warning: …"``. Neither opt-out
+    position works in there — the marker would have to sit on the
+    offending line or in a ``//`` block above it, and both are inside the
+    fixture, so writing one changes the very text the metric test
+    measures. A raw string that opens and closes on one line is still
+    scanned; a diagnostic is never emitted from inside a fixture, so the
+    skip costs no coverage.
     """
     offenders: list[tuple[int, str, str]] = []
     # `split("\n")`, not `splitlines()`: the latter also breaks on U+2028
@@ -118,13 +164,27 @@ def scan_text(text: str) -> list[tuple[int, str, str]]:
     # terminators, so one inside a string literal would shift every
     # reported line number past it.
     lines = text.split("\n")
+    open_hashes: int | None = None
     for index, line in enumerate(lines):
-        stripped = line.lstrip()
-        if stripped.startswith("//"):
+        if open_hashes is not None:
+            terminator = '"' + "#" * open_hashes
+            close = line.find(terminator)
+            if close < 0:
+                continue
+            segment = line[close + len(terminator) :]
+            open_hashes = None
+        else:
+            segment = line
+        # A `//` line cannot open a raw string either, so this returns
+        # before the open-tracking below.
+        if segment.lstrip().startswith("//"):
             continue
-        match = SEVERITY_LITERAL.search(line)
-        if match and not _is_allowed(lines, index):
-            offenders.append((index + 1, match.group("word"), stripped))
+        if not _is_allowed(lines, index):
+            offenders.extend(
+                (index + 1, match.group("word"), line.lstrip())
+                for match in SEVERITY_LITERAL.finditer(segment)
+            )
+        open_hashes = _unterminated_raw_open(segment)
     return offenders
 
 


### PR DESCRIPTION
Closes #1199.

Severity prefixes moved off the message producers and onto the layer
that presents them, so `warning:` is written in exactly one place per
crate: `diag::warn` in the CLI (the #609 ladder) and a new
`src/diag.rs` in the library.

## What changed

- `PreprocDiagnostic::Display` renders the bare message; `bca preproc`
  routes it through `diag::warn`.
- The library gets `src/diag.rs` (`pub(crate) fn warn`), and every
  library stderr warning goes through it — including the two that were
  already lowercase, which had been correct by coincidence.
- CSV joins the other five output formats on `warn_non_utf8_path`,
  dropping its duplicated wording. `write_csv` / `write_csv_aggregate`
  keep their signatures, so nothing is deferred to 3.0.
- `walk.rs`'s two explicit-path notices shed the `bca: warning:` double
  prefix that #609 removed elsewhere.
- New gate `utils/check-diagnostic-prefix.py` (+ 26 self-tests), wired
  into `make lint` / `pre-commit` / `ci`, the pre-commit hooks, and an
  explicit CI step.

## The issue undercounted

It names three capitalised library sites; a workspace sweep found five.
`src/output/code_climate.rs` (empty repo-relative path) and
`src/concurrent_files.rs` (not a regular file) were missing, as was
`walk.rs`'s double prefix in the CLI. That is precisely the failure
mode the gate exists to stop, already realised.

## User-visible output changes

Three, all intended and all in the changelog:

1. The `IncludeCycle` block no longer ends in a newline, so it is no
   longer followed by a blank line. It was an artifact of `writeln!` in
   a `Display` impl stacking with the caller's own newline.
2. The CSV non-UTF-8 warning takes the shared helper's wording.
3. `walk.rs`'s two notices read `warning:` instead of `bca: warning:`.

`PreprocDiagnostic` is a public export, and `STABILITY.md:158` — "the
exact wording of `Display` output is not [stable]" — is what clears
this. **Embedders that captured these and printed them verbatim must
now add their own prefix.**

Everything else is byte-identical: `bca preproc` stderr was captured on
a fixture before and after, and the only line that differs is the blank
one above.

## Verification

Every new or changed test was proven to fail against the pre-fix code
by perturbing production, not by reading:

- Reverting the CLI call site to `eprintln!` trips the prefix assertion;
  restoring the `writeln!` trips the blank-line assertion —
  independently.
- Turning the aggregate CSV `continue` into a `return` fails the new
  `aggregate_skips_only_the_non_utf8_file`. That branch had no test, and
  a single-file document that skips its only file is byte-identical to
  one that bails, so the existing test structurally could not cover it.
- With `splitlines()` the gate reports a line number one too high past a
  U+2028 in a literal.

Two gate bugs found and fixed in review, both of the false-*clean* kind
this gate exists to prevent: a naive raw-string opener read
`strip_suffix(b"\r")` and `Ruby::R => "r",` as opening a raw string and
skipped to the next quote, and `re.search` reported only the first
offender per line. Measured across all 559 tracked files, the
multi-line-fixture skip now hides zero would-be hits.

`non_utf8_path_skips_data_rows` also had its `#[cfg(unix)]` moved from
an inner block onto the `fn`: the old form compiled to an empty — and
therefore passing — body on Windows (`.claude/rules/testing.md`).

## Baseline

`write_code_climate`'s `halstead.effort` moved +0.2% past its recorded
value, so `.bca-baseline.toml` is refreshed in the same commit. The
refresh also dropped three entries that had gone stale on `main`.

`make pre-commit`: `BCA_GATE: pass`.
