### PR TITLE
fix: release gates, enums lint set, and ruff version lockstep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -633,6 +633,19 @@ jobs:
       # gate without surfacing the regression in CI.
       - name: check-excluded-manifests self-tests (explicit)
         run: python3 -m unittest -q utils/check-excluded-manifests-test.py
+      # Defensive twin for the ruff-lockstep gate (#1230): the
+      # ruff-pre-commit `rev:`, `uv.lock`, and the hash-pinned
+      # `requirements/dev.txt` export CI installs from must name one
+      # version. They had already drifted once, silently, because a
+      # comment was the whole mechanism — so this gate in particular
+      # must not be able to disappear from the aggregate unnoticed.
+      - name: check-ruff-lockstep (explicit)
+        run: python3 utils/check-ruff-lockstep.py
+      # Run the gate's own unittests as their own explicit step
+      # so a refactor that breaks the script can't disable the
+      # gate without surfacing the regression in CI.
+      - name: check-ruff-lockstep self-tests (explicit)
+        run: python3 -m unittest -q utils/check-ruff-lockstep-test.py
       # Defensive twin for the enums-codegen-drift gate (#405):
       # running any grammar regen previously regenerated
       # `src/c_langs_macros/*.rs` to a pre-optimization form
@@ -722,8 +735,10 @@ jobs:
       # installs the exact resolved set `make py-bootstrap` uses
       # locally — no floor-vs-lockfile drift — and `--require-hashes`
       # pins the supply chain (OpenSSF Scorecard Pinned-Dependencies).
-      # Keep the ruff-pre-commit `rev:` in .pre-commit-config.yaml in
-      # lockstep with the ruff version resolved there.
+      # The ruff-pre-commit `rev:` in .pre-commit-config.yaml is held in
+      # lockstep with the ruff version resolved there by the
+      # `check-ruff-lockstep` gate in the `lint` job (#1230), so this is
+      # no longer something a reviewer has to remember.
       - name: Create venv + install Python toolchain
         working-directory: big-code-analysis-py
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,40 +141,32 @@ jobs:
             cargo publish --dry-run --locked --manifest-path "$d/Cargo.toml"
           done
 
-      # The parent's `=<leaf-version>` deps cannot resolve until the
-      # five `bca-tree-sitter-*` leaves are on crates.io. On the very
-      # first release tag this dry-run will fail by design — the
-      # release workflow's `publish-crates` job will then upload the
-      # leaves first and the parent second. We skip the parent dry-run
-      # in that bootstrap state by querying the sparse index for the
-      # ccomment leaf at the workspace-pinned version (probing one
-      # leaf is enough because every owned crate in this repo shares
-      # one version per the Lockstep version policy in RELEASING.md,
-      # enforced by ./utils/check-versions.py in `make pre-commit`).
-      # Once that leaf is on crates.io the bootstrap has happened and
-      # the parent dry-run becomes a hard gate again.
-      - name: Dry-run cargo publish for big-code-analysis
-        if: vars.ENABLE_CRATES_PUBLISH == 'true'
-        run: |
-          set -euo pipefail
-          # Extract [package].version (anchored on the [package]
-          # header so an unrelated `version =` line outside the
-          # [package] table can never satisfy the regex).
-          LEAF_VERSION=$(awk -F'"' \
-            '/^\[package\]/{f=1; next} /^\[/{f=0} f && /^version *=/ {print $2; exit}' \
-            tree-sitter-ccomment/Cargo.toml)
-          INDEX="https://index.crates.io/bc/a-/bca-tree-sitter-ccomment"
-          BODY=$(curl -sfL "${INDEX}" 2>/dev/null || true)
-          # Substring-match via bash glob: no pipe (no SIGPIPE under
-          # pipefail) and no regex semantics (dots in the version
-          # string never match arbitrary chars). See leaf-publish step
-          # for the analogous pattern.
-          NEEDLE="\"vers\":\"${LEAF_VERSION}\""
-          if [[ "${BODY}" == *"${NEEDLE}"* ]]; then
-            cargo publish -p big-code-analysis --dry-run --locked
-          else
-            echo "::notice::Skipping big-code-analysis dry-run: bca-tree-sitter-ccomment ${LEAF_VERSION} not yet on crates.io (bootstrap state). The publish-crates job will upload leaves first."
-          fi
+      # The three top-level crates get no dry-run, because none is
+      # possible here. Each pins an internal dependency at
+      # `=<version>` — the parent on the five leaves, the CLI and web
+      # crates on the parent — and the Lockstep version policy
+      # (RELEASING.md, enforced by ./utils/check-versions.py) makes
+      # that the version this tag is releasing. Packaging resolves the
+      # registry requirement, so it cannot succeed against a version
+      # that is by definition not yet published.
+      #
+      # What stood here until #1224 was a `cargo publish --dry-run` for
+      # the parent, wrapped in a sparse-index probe for the ccomment
+      # leaf at that same version, described as a first-release
+      # bootstrap. Since the probed version is always the version being
+      # released, the probe never hit: the notice fired on every
+      # release and the dry-run branch never ran before an upload.
+      #
+      # This gate asserts the metadata a dry-run would have checked
+      # without needing anything on the registry: crates.io-facing
+      # fields (from `cargo metadata`, so `[workspace.package]`
+      # inheritance resolves), the `include` whitelist, and the total
+      # size of what `cargo package --list` reports. It
+      # is deliberately not gated on `ENABLE_CRATES_PUBLISH`: it
+      # touches nothing external, and while that variable is unset a
+      # gated step would once again never run.
+      - name: Check crates.io publish metadata
+        run: python3 utils/check-publish-metadata.py
 
       - name: Extract release notes from CHANGELOG
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -189,6 +189,29 @@ repos:
         entry: python3 -m unittest -q utils/check-ruff-lockstep-test.py
         pass_filenames: false
 
+      # Publish metadata for the crates.io uploads (#1224). The three
+      # top-level crates pin internal deps at `=<version>`, so none can
+      # be `cargo publish --dry-run`-ed before the tag that publishes
+      # that version — this is the registry-independent stand-in.
+      # Scoped to the manifests it reads: `include`, `description`,
+      # `readme` and the workspace-inherited fields all live there.
+      - id: check-publish-metadata
+        name: check-publish-metadata
+        language: system
+        files: '^(Cargo\.toml|big-code-analysis-(cli|web)/Cargo\.toml|utils/check-publish-metadata\.py)$'
+        entry: python3 utils/check-publish-metadata.py
+        pass_filenames: false
+
+      # Self-tests for the publish-metadata gate. Runs on edits to the
+      # script or its test file (the unit tests import the module, so a
+      # logic change there must re-run them).
+      - id: check-publish-metadata-test
+        name: check-publish-metadata-test
+        language: system
+        files: '^utils/check-publish-metadata(-test)?\.py$'
+        entry: python3 -m unittest -q utils/check-publish-metadata-test.py
+        pass_filenames: false
+
       # Self-tests for the worktree-setup submodule classifier. It is
       # what decides when to run a destructive `git submodule update
       # --force`, so a logic change there re-runs them (#1171).

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -194,11 +194,19 @@ repos:
       # be `cargo publish --dry-run`-ed before the tag that publishes
       # that version — this is the registry-independent stand-in.
       # Scoped to the manifests it reads: `include`, `description`,
-      # `readme` and the workspace-inherited fields all live there.
+      # `readme` and the workspace-inherited fields all live there. That
+      # is every *member* manifest, not just today's three publishable
+      # ones — the gate's scope is whatever `publish` is not `false` on,
+      # so an edit flipping that in the bench, Python, or xtask manifest
+      # is exactly the edit this hook has to see. `Cargo.lock` and the
+      # five vendored grammar manifests are in scope for a second reason:
+      # the gate runs `cargo package --locked`, so a version bump in a
+      # path dependency leaves the root lockfile stale and fails it
+      # without touching a member manifest.
       - id: check-publish-metadata
         name: check-publish-metadata
         language: system
-        files: '^(Cargo\.toml|big-code-analysis-(cli|web)/Cargo\.toml|utils/check-publish-metadata\.py)$'
+        files: '^(Cargo\.(toml|lock)|(big-code-analysis-(cli|web|py|bench)|xtask|tree-sitter-(ccomment|mozcpp|mozjs|preproc|tcl))/Cargo\.toml|utils/check-publish-metadata\.py)$'
         entry: python3 utils/check-publish-metadata.py
         pass_filenames: false
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -184,6 +184,16 @@ repos:
         entry: bash utils/gate-status-test.sh
         pass_filenames: false
 
+      # Self-tests for the release-tool probes and install hints.
+      # cargo-about's hint is only correct with `--features cli`;
+      # without it the install exits 0 and installs nothing (#1226).
+      - id: check-tools-test
+        name: check-tools-test
+        language: system
+        files: '^utils/check-tools(-test)?\.sh$'
+        entry: bash utils/check-tools-test.sh
+        pass_filenames: false
+
       # Sync-test for check-grammar-crate.py's EXTENSIONS table against
       # src/langs.rs (#869). Re-runs when the script, its test, or the
       # source-of-truth language table changes.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,10 +14,13 @@ repos:
       - id: taskcluster_yml
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     # Bump in lockstep with the ruff version `uv.lock` resolves under
-    # the big-code-analysis-py/pyproject.toml `ruff>=0.13,<0.17` bound
-    # (`rg '^ruff==' big-code-analysis-py/requirements/dev.txt`), which
-    # is also what CI installs. `ruff-check` and `ruff-format` are the
-    # current hook IDs (the legacy `ruff` alias is deprecated).
+    # the big-code-analysis-py/pyproject.toml `ruff>=0.13,<0.17` bound,
+    # which is also what CI installs (via the hash-pinned
+    # requirements/dev.txt export). This is gated: `make
+    # check-ruff-lockstep` fails when this `rev:` is not `v` + the
+    # locked version, so the comment is documentation rather than the
+    # mechanism it used to be (#1230). `ruff-check` and `ruff-format`
+    # are the current hook IDs (the legacy `ruff` alias is deprecated).
     rev: v0.16.2
     hooks:
     -   id: ruff-check
@@ -162,6 +165,28 @@ repos:
         language: system
         files: '^utils/check-excluded-manifests(-test)?\.py$'
         entry: python3 -m unittest -q utils/check-excluded-manifests-test.py
+        pass_filenames: false
+
+      # ruff version lockstep (#1230). The `rev:` above is the file this
+      # gate most often catches, so it must fire on edits to *this*
+      # config as well as to the three big-code-analysis-py files that
+      # declare the same version. Before #1222 the rev was v0.15.14
+      # while uv.lock resolved 0.15.22 and nothing noticed.
+      - id: check-ruff-lockstep
+        name: check-ruff-lockstep
+        language: system
+        files: '^(\.pre-commit-config\.yaml|big-code-analysis-py/(uv\.lock|pyproject\.toml|requirements/dev\.txt)|utils/check-ruff-lockstep\.py)$'
+        entry: python3 utils/check-ruff-lockstep.py
+        pass_filenames: false
+
+      # Self-tests for the ruff-lockstep gate. Runs on edits to the
+      # script or its test file (the unit tests import the module, so a
+      # logic change there must re-run them).
+      - id: check-ruff-lockstep-test
+        name: check-ruff-lockstep-test
+        language: system
+        files: '^utils/check-ruff-lockstep(-test)?\.py$'
+        entry: python3 -m unittest -q utils/check-ruff-lockstep-test.py
         pass_filenames: false
 
       # Self-tests for the worktree-setup submodule classifier. It is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ and `cargo run -p big-code-analysis-web --`.
   `check-grammar-marker-sync.py`, `check-enums-codegen-drift.sh`,
   `check-grammar-crate.py`, `check-grammars-crates.sh`,
   `check-excluded-manifests.py`, `check-ruff-lockstep.py`,
+  `check-publish-metadata.py`,
   `verify-name-only-churn.py`, and each
   gate's `*-test.py` self-tests.
   Each resolves the repository root from its own location
@@ -283,7 +284,14 @@ ruff-lockstep gate (`make check-ruff-lockstep`, which fails when the
 version `big-code-analysis-py/uv.lock` resolves, when the
 `requirements/dev.txt` export has fallen behind that lockfile, or when
 `pyproject.toml`'s ruff bound was edited without a `make py-relock` —
-see "One ruff version" below), and the
+see "One ruff version" below), the publish-metadata gate
+(`make check-publish-metadata`, which asserts every publishable crate
+carries the `description` / `readme` / `repository` / `license` fields
+crates.io needs, that a crate rooted at the workspace root has a
+non-empty `[package].include`, and that the files `cargo package
+--list` reports total under 32 MiB — the three top-level
+crates pin internal deps at `=<version>` and so cannot be
+`cargo publish --dry-run`-ed before the tag, see `RELEASING.md`), and the
 Python `ruff` lint /
 `ruff format` / `mypy --strict` + `pyright` / `maturin develop` +
 `pytest` / `mypy stubtest` stages for `big-code-analysis-py` (each

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,17 @@ and `cargo run -p big-code-analysis-web --`.
   namespace is the redundant double prefix #609 removed.
 - Edition is 2024 — `let-else`, let-chains, and other 2024 features are
   available.
+- The lint posture (`clippy::pedantic` at `warn`, `missing_docs`) lives
+  in `[workspace.lints]` and reaches members through
+  `lints.workspace = true`. A **workspace-excluded** crate roots its own
+  workspace and inherits nothing, so it needs its own copy of those
+  tables; `enums` carries one, and the five vendored `tree-sitter-*`
+  crates are exempt by decision (generated binding boilerplate that a
+  regeneration replaces wholesale). `utils/check-excluded-manifests.py`
+  gates this — without it a crate gated at `-D warnings` is measured
+  against the compiler defaults and still reads as fully linted (#1228).
+  Additional `allow`s go at file or function level, so the carve-out
+  stays visible at the affected site.
 
 ## Validation gates
 
@@ -625,8 +636,9 @@ weigh them, do not drive them to zero at any cost.
 External grammar crates are version-pinned (`=0.23.5`, `=0.26.10`,
 etc.) in the root `Cargo.toml` **and in each workspace-excluded crate's
 own manifest** (the five vendored grammars plus `enums`) —
-`utils/check-excluded-manifests.py` enforces both, so neither a root
-pin nor a new vendored grammar can reintroduce a caret range (#1151).
+`utils/check-excluded-manifests.py` enforces both (alongside the
+`[lints]`-table rule under "Rust conventions"), so neither a root pin
+nor a new vendored grammar can reintroduce a caret range (#1151).
 Member crates take their grammars through `workspace = true` and carry
 no requirement of their own. The gate reads manifests with `tomllib`,
 so a literal string (`tree-sitter-cpp = '0.23.4'`) is checked like any

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,8 @@ and `cargo run -p big-code-analysis-web --`.
   `check-manpage-assets.py`, `check-diagnostic-prefix.py`,
   `check-grammar-marker-sync.py`, `check-enums-codegen-drift.sh`,
   `check-grammar-crate.py`, `check-grammars-crates.sh`,
-  `check-excluded-manifests.py`, `verify-name-only-churn.py`, and each
+  `check-excluded-manifests.py`, `check-ruff-lockstep.py`,
+  `verify-name-only-churn.py`, and each
   gate's `*-test.py` self-tests.
   Each resolves the repository root from its own location
   (`Path(__file__).resolve().parents[1]`) rather than the cwd, so it
@@ -276,13 +277,43 @@ functions encroaching into the 95-100% band fail before the hard
 gate trips; `make self-scan-write-baseline-headroom` refreshes
 `.bca-baseline.toml` — prefer the headroom variant over the bare
 `make self-scan-write-baseline`, otherwise the soft-tier
-`self-scan-headroom` gate re-fires on untouched files), and the
+`self-scan-headroom` gate re-fires on untouched files), the
+ruff-lockstep gate (`make check-ruff-lockstep`, which fails when the
+`ruff-pre-commit` `rev:` in `.pre-commit-config.yaml` is not `v` + the
+version `big-code-analysis-py/uv.lock` resolves, when the
+`requirements/dev.txt` export has fallen behind that lockfile, or when
+`pyproject.toml`'s ruff bound was edited without a `make py-relock` —
+see "One ruff version" below), and the
 Python `ruff` lint /
 `ruff format` / `mypy --strict` + `pyright` / `maturin develop` +
 `pytest` / `mypy stubtest` stages for `big-code-analysis-py` (each
 Python stage is skipped with a clear "X not found" message when the
 corresponding tool is absent). `make ci` runs the same checks without
 auto-fix, mirroring CI behaviour.
+
+**One ruff version, four declarations.**
+`big-code-analysis-py/uv.lock` is the anchor: it is what `uv sync
+--locked` resolves, and everything else follows it. The
+`ruff-pre-commit` `rev:` must be `v` + that version, the
+`requirements/dev.txt` export (what CI installs with `pip install
+--require-hashes`) must pin it, and `pyproject.toml`'s bound must be
+the one uv recorded resolving against. Adopting a newer ruff is
+therefore two edits in one commit: `uv lock --upgrade-package ruff`
+plus the `uv export` pair that `make py-relock` runs, then the `rev:`.
+The gate names whichever of the three has fallen behind. Before
+`select` landed in #1222 this had already drifted silently — `rev:
+v0.15.14` against a lockfile resolving 0.15.22 — which is invisible
+until the two versions happen to disagree and then reads as "works
+locally, red in CI" (#1230).
+
+The `make py-fmt` / `py-lint` / `py-fmt-check` recipes resolve
+`big-code-analysis-py/.venv/bin/ruff` before PATH, the same way
+`py-typecheck` resolves mypy and pyright, so the local gate runs the
+locked ruff by construction. Three provisioning paths (`mise.toml`,
+the `Dockerfile`, and the `pipx install ruff` CONTRIBUTING documents)
+install an *unpinned* ruff onto PATH and stay that way on purpose:
+each would otherwise be a fifth exact copy of the version, in a file
+no gate reads. Run `make py-bootstrap` and the venv wins.
 
 **Read the outcome from the `BCA_GATE:` line, nothing else.** Both gates
 end with exactly one of `BCA_GATE: pass (gate=pre-commit)` or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,11 @@ for historical reference.
   `pre-commit`, `ci`, and the release workflow's preflight. It reads resolved
   fields from `cargo metadata` so `[workspace.package]` inheritance is
   honoured, and resolves `include.workspace = true` separately because
-  `cargo metadata` does not emit `include` (#1224).
+  `cargo metadata` does not emit `include`. Its `cargo package --list` runs
+  `--locked`, carrying over the flag from the `cargo publish --dry-run
+  --locked` it replaced: without it a stale `Cargo.lock` is silently
+  re-resolved and rewritten and the gate still reports a pass, so a tag
+  could be cut without the committed lockfile ever being verified (#1224).
 - `make release-check` now probes `cargo-deny` and `cargo-about` before
   running them, naming the missing tool and its exact install command instead
   of surfacing cargo's generic `no such command` partway through the gate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,56 @@ for historical reference.
 
 ## [Unreleased]
 
+### Added
+
+- A `check-ruff-lockstep` gate (`make check-ruff-lockstep`, wired into
+  `make lint` / `pre-commit` / `ci` and the pre-commit hooks) holds the one
+  adopted ruff version together across the four files that declare it.
+  `big-code-analysis-py/uv.lock` is the anchor, because the hash-pinned
+  `requirements/dev.txt` CI installs from is *generated* from it — gating on
+  the export would bless a stale export rather than catch one. The
+  `ruff-pre-commit` `rev:` in `.pre-commit-config.yaml` must be `v` + the
+  locked version, the export must pin it, and `pyproject.toml`'s bound must
+  match the one uv recorded resolving against. The `rev:` was previously held
+  by a comment alone and had already drifted silently once (`v0.15.14`
+  against a lockfile resolving 0.15.22), which stays invisible until the two
+  versions disagree and then presents as "works locally, red in CI" (#1230).
+
 ### Fixed
 
+- The pre-tag `cargo publish --dry-run` for `big-code-analysis` was skipped
+  on every release, not only the first. It was gated on a crates.io sparse
+  index probe for a leaf version that the Lockstep policy guarantees is the
+  version being released — and therefore never published yet — so the branch
+  that runs the dry-run was unreachable, while `release.yml` and
+  `RELEASING.md` both told a maintainer it became a hard gate from the second
+  tag onwards. `big-code-analysis-cli` and `big-code-analysis-web` had no
+  such check at all: both pin `big-code-analysis = "=<version>"`, so neither
+  could have been dry-run either. Replaced with `make check-publish-metadata`
+  (`utils/check-publish-metadata.py`), a registry-independent gate over every
+  publishable crate's crates.io-required metadata, `[package].include`
+  whitelist, and packaged size, wired into `release-check`, `lint`,
+  `pre-commit`, `ci`, and the release workflow's preflight. It reads resolved
+  fields from `cargo metadata` so `[workspace.package]` inheritance is
+  honoured, and resolves `include.workspace = true` separately because
+  `cargo metadata` does not emit `include` (#1224).
+- `make release-check` now probes `cargo-deny` and `cargo-about` before
+  running them, naming the missing tool and its exact install command instead
+  of surfacing cargo's generic `no such command` partway through the gate.
+  Both are listed by `make check-tools` and documented in `RELEASING.md`. The
+  `cargo-about` hint spells `--features cli`: the binary sits behind a
+  non-default feature, so a bare `cargo install cargo-about` compiles the
+  library, installs no binary, reports the miss as a *warning*, and exits 0
+  (#1226).
+- `make release-check` rejects uncommitted changes in the vendored grammar
+  leaves before its slow stages, with the commit → gate → tag ordering as the
+  remedy rather than cargo's misleading `--allow-dirty` hint — passing that
+  flag would dry-run content differing from the tag, defeating the gate. The
+  check is scoped to what `cargo publish --dry-run` actually rejects (tracked
+  changes inside the five leaf directories), measured rather than assumed, so
+  it cannot fail on trees cargo would accept. `RELEASING.md`'s pre-release
+  checklist now carries the gate and that ordering explicitly, and notes the
+  push is separable (#1225).
 - The CLI and web crates no longer terminate on a library parse error.
   All fifteen `.expect(FEATURES_PINNED)` call sites — eight in `bca`'s
   dispatch helpers, seven in `bca-web`'s handlers, plus the constant
@@ -42,6 +90,28 @@ for historical reference.
 
 ### Changed
 
+- The workspace-excluded `enums` crate declares the workspace lint posture
+  (`clippy::pedantic`, `missing_docs`) in its own manifest.
+  `[workspace.lints]` reaches members only, so `make enums-check` had been
+  gating the crate at `-D warnings` against the compiler defaults while
+  reading as a full lint gate. Clearing the table cost 38 findings, not the
+  23 pedantic ones alone — `missing_docs` accounted for the other 15 — and
+  none was silenced with a blanket `allow`.
+  `utils/check-excluded-manifests.py` gained a third invariant so this cannot
+  recur: every workspace-excluded crate must declare its own `[lints]` table
+  or be named in the gate's exempt set. It is an exempt list rather than a
+  required list, so the *next* excluded crate has to make the decision
+  explicitly instead of inheriting the silence. The five vendored
+  `tree-sitter-*` grammar crates are exempt — their Rust is generated binding
+  boilerplate a regeneration replaces wholesale (#1228).
+- `make py-fmt`, `py-fmt-check` and `py-lint` resolve
+  `big-code-analysis-py/.venv/bin/ruff` before PATH, the way `py-typecheck`
+  already resolved mypy and pyright, so the local gate runs the
+  `uv.lock`-resolved ruff rather than whichever unpinned copy `mise.toml`,
+  the `Dockerfile`, or a bare `pipx install ruff` left on PATH. Those three
+  provisioning paths stay unpinned deliberately: an exact version in any of
+  them would be a fifth ungated copy to keep in lockstep, which is the
+  failure this change exists to prevent (#1230).
 - `clippy::arithmetic_side_effects` is enforced on the `loc` metric
   module, and the span arithmetic there is now explicitly saturating.
   `Loc` is the one metric computing on tree-sitter row coordinates, and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -209,6 +209,36 @@ Alternative install paths (`mise install` via `mise.toml`, direct
 pip install -e ".[dev]"`) still work but bypass `uv.lock`; resolved
 versions can drift from peers and from CI. They remain documented
 for contributors with environment constraints that preclude uv.
+None of them pins ruff, deliberately — see below.
+
+#### The ruff version is gated
+
+One ruff version is adopted, and `uv.lock` is where it is decided.
+`make check-ruff-lockstep` (wired into `make lint`, `make pre-commit`,
+`make ci`, and the pre-commit hooks) fails unless three other
+declarations agree with it:
+
+- the `ruff-pre-commit` `rev:` in `.pre-commit-config.yaml`, which must
+  be `v` + the locked version — otherwise `pre-commit run --all-files`
+  runs a different ruff than CI;
+- the `ruff==` pin in `big-code-analysis-py/requirements/dev.txt`, the
+  hash-pinned export CI installs from;
+- the `ruff` bound in `pyproject.toml`, which must match the one uv
+  recorded resolving against — a bound edited without `make py-relock`
+  leaves CI installing a version the manifest no longer admits.
+
+Adopting a newer ruff is therefore `uv lock --upgrade-package ruff`
+plus the `uv export` pair `make py-relock` runs, then the `rev:`, all
+in one commit. The gate names whichever file has fallen behind.
+
+`make py-fmt`, `py-fmt-check` and `py-lint` run
+`big-code-analysis-py/.venv/bin/ruff` when it exists and fall back to
+PATH otherwise, mirroring how `py-typecheck` resolves mypy and
+pyright. So the local gate runs the locked ruff as soon as you have
+run `make py-bootstrap`. The alternative install paths above stay
+unpinned on purpose: an exact version in `mise.toml` or the
+`Dockerfile` would be a fifth copy to bump on every ruff release, in a
+file no gate reads.
 
 Then build and test:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -284,6 +284,15 @@ EOF
 # py-bootstrap` => `uv sync --locked`). ruff/mypy/maturin install as uv
 # tools into the system location (see UV_TOOL_* above); pyright ships as a
 # Node package so it uses the system Node instead of downloading its own.
+#
+# These are deliberately unversioned, ruff included, even though this
+# repository holds the ruff version in lockstep across four files
+# (#1230). The image is built without the repository checked out, so it
+# cannot read uv.lock; a literal version here would be a fifth copy to
+# bump on every release, in a file no gate reads. `make py-fmt` /
+# `py-lint` prefer `big-code-analysis-py/.venv/bin/ruff`, so once a
+# contributor runs `make py-bootstrap` inside the container the locked
+# ruff wins over the one installed here.
 # ---------------------------------------------------------------------------
 RUN set -eux; \
     curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -137,6 +137,12 @@ RUN set -eux; \
 # Cargo dev/CI tools via cargo-binstall (prebuilt binaries — no long
 # compiles). cargo-nextest / cargo-llvm-cov mirror CI; cargo-about /
 # cargo-deny back `make release-check`; mdbook backs `make book`.
+#
+# The `cargo about --version` line is a guard, not a version print.
+# binstall's last-resort strategy is a plain `cargo install`, and
+# cargo-about keeps its binary behind a non-default `cli` feature — so
+# that fallback would install no binary, warn, and exit 0, baking a
+# release image that cannot run `make release-check` (#1226).
 RUN set -eux; \
     curl -fsSL https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash; \
     cargo binstall --no-confirm \
@@ -147,6 +153,7 @@ RUN set -eux; \
         cargo-about \
         cargo-deny \
         mdbook; \
+    cargo about --version; \
     rm -rf "$CARGO_HOME/registry" "$CARGO_HOME/git" /tmp/*
 
 # ---------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ find-by-ext = $(if $(FD),$(FD) --extension $(1) $(FD_EXCLUDE) $(2),find . -name 
 NEXTEST        := $(shell command -v cargo-nextest 2>/dev/null)
 TEST_CMD       = $(if $(NEXTEST),$(NEXTEST) nextest run --workspace --all-features,cargo test --workspace --all-features --lib --bins --tests)
 
-.PHONY: help check-tools worktree-setup worktree-setup-test build build-release check test test-doc chain-audit fmt fmt-check markdown-fmt markdown-lint shellcheck sh-fmt sh-fmt-check toml-fmt toml-fmt-check toml-lint makefile-check actionlint snapshot-anchors snapshot-anchors-test rustfmt-bail rustfmt-bail-test grammar-marker-sync grammar-marker-sync-test check-versions check-excluded-manifests check-excluded-manifests-test check-ruff-lockstep check-ruff-lockstep-test check-manpage-assets check-diagnostic-prefix check-diagnostic-prefix-test gate-status-test check-tools-test enums-check enums-codegen-drift enums-codegen-drift-test self-scan self-scan-headroom self-scan-write-baseline self-scan-write-baseline-headroom vcs lint clippy udeps insta-review insta-accept clean distclean install install-cli install-web doc doc-open doc-check doc-check-docsrs book book-serve book-pot book-po-update book-ja book-deploy all pre-commit ci release-check verify-changelog pkg-deb-local pkg-rpm-local dev-env-build dev-env-run dev-env-shell dev-env-rm py-bootstrap py-sync py-relock py-clean py-fmt py-fmt-check py-lint py-typecheck py-test py-stubtest smoke smoke-cli smoke-lib bench bench-scaling bench-walk _check-find _pc-all _pc-fmt _pc-clippy _pc-test _pc-doc-check _pc-udeps _pc-shellcheck _pc-markdown-lint _pc-toml-lint _pc-makefile-check _pc-actionlint _pc-snapshot-anchors _pc-snapshot-anchors-test _pc-rustfmt-bail _pc-rustfmt-bail-test _pc-grammar-marker-sync _pc-grammar-marker-sync-test _pc-check-versions _pc-check-versions-test _pc-check-grammar-crate-test _pc-check-excluded-manifests _pc-check-excluded-manifests-test _pc-check-ruff-lockstep _pc-check-ruff-lockstep-test _pc-check-manpage-assets _pc-check-diagnostic-prefix _pc-check-diagnostic-prefix-test _pc-worktree-setup-test _pc-gate-status-test _pc-check-tools-test _pc-enums-check _pc-enums-codegen-drift _pc-enums-codegen-drift-test _pc-self-scan _pc-self-scan-headroom _pc-py-fmt _pc-py-typecheck _pc-py-test _pc-py-stubtest _ci-all _ci-fmt-check _ci-clippy _ci-test _ci-doc-check _ci-build _ci-udeps _ci-shellcheck _ci-markdown-lint _ci-toml-lint _ci-makefile-check _ci-actionlint _ci-snapshot-anchors _ci-snapshot-anchors-test _ci-rustfmt-bail _ci-rustfmt-bail-test _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-versions-test _ci-check-grammar-crate-test _ci-check-excluded-manifests _ci-check-excluded-manifests-test _ci-check-ruff-lockstep _ci-check-ruff-lockstep-test _ci-check-manpage-assets _ci-check-diagnostic-prefix _ci-check-diagnostic-prefix-test _ci-worktree-setup-test _ci-gate-status-test _ci-check-tools-test _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test _ci-enums-codegen-drift-test _ci-self-scan _ci-self-scan-headroom _ci-cargo-pipeline _ci-py-fmt-check _ci-py-lint _ci-py-typecheck _ci-py-test _ci-py-stubtest
+.PHONY: help check-tools worktree-setup worktree-setup-test build build-release check test test-doc chain-audit fmt fmt-check markdown-fmt markdown-lint shellcheck sh-fmt sh-fmt-check toml-fmt toml-fmt-check toml-lint makefile-check actionlint snapshot-anchors snapshot-anchors-test rustfmt-bail rustfmt-bail-test grammar-marker-sync grammar-marker-sync-test check-versions check-excluded-manifests check-excluded-manifests-test check-ruff-lockstep check-ruff-lockstep-test check-publish-metadata check-publish-metadata-test check-manpage-assets check-diagnostic-prefix check-diagnostic-prefix-test gate-status-test check-tools-test enums-check enums-codegen-drift enums-codegen-drift-test self-scan self-scan-headroom self-scan-write-baseline self-scan-write-baseline-headroom vcs lint clippy udeps insta-review insta-accept clean distclean install install-cli install-web doc doc-open doc-check doc-check-docsrs book book-serve book-pot book-po-update book-ja book-deploy all pre-commit ci release-check verify-changelog pkg-deb-local pkg-rpm-local dev-env-build dev-env-run dev-env-shell dev-env-rm py-bootstrap py-sync py-relock py-clean py-fmt py-fmt-check py-lint py-typecheck py-test py-stubtest smoke smoke-cli smoke-lib bench bench-scaling bench-walk _check-find _pc-all _pc-fmt _pc-clippy _pc-test _pc-doc-check _pc-udeps _pc-shellcheck _pc-markdown-lint _pc-toml-lint _pc-makefile-check _pc-actionlint _pc-snapshot-anchors _pc-snapshot-anchors-test _pc-rustfmt-bail _pc-rustfmt-bail-test _pc-grammar-marker-sync _pc-grammar-marker-sync-test _pc-check-versions _pc-check-versions-test _pc-check-grammar-crate-test _pc-check-excluded-manifests _pc-check-excluded-manifests-test _pc-check-ruff-lockstep _pc-check-ruff-lockstep-test _pc-check-publish-metadata _pc-check-publish-metadata-test _pc-check-manpage-assets _pc-check-diagnostic-prefix _pc-check-diagnostic-prefix-test _pc-worktree-setup-test _pc-gate-status-test _pc-check-tools-test _pc-enums-check _pc-enums-codegen-drift _pc-enums-codegen-drift-test _pc-self-scan _pc-self-scan-headroom _pc-py-fmt _pc-py-typecheck _pc-py-test _pc-py-stubtest _ci-all _ci-fmt-check _ci-clippy _ci-test _ci-doc-check _ci-build _ci-udeps _ci-shellcheck _ci-markdown-lint _ci-toml-lint _ci-makefile-check _ci-actionlint _ci-snapshot-anchors _ci-snapshot-anchors-test _ci-rustfmt-bail _ci-rustfmt-bail-test _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-versions-test _ci-check-grammar-crate-test _ci-check-excluded-manifests _ci-check-excluded-manifests-test _ci-check-ruff-lockstep _ci-check-ruff-lockstep-test _ci-check-publish-metadata _ci-check-publish-metadata-test _ci-check-manpage-assets _ci-check-diagnostic-prefix _ci-check-diagnostic-prefix-test _ci-worktree-setup-test _ci-gate-status-test _ci-check-tools-test _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test _ci-enums-codegen-drift-test _ci-self-scan _ci-self-scan-headroom _ci-cargo-pipeline _ci-py-fmt-check _ci-py-lint _ci-py-typecheck _ci-py-test _ci-py-stubtest
 
 # Default target
 help:
@@ -140,6 +140,8 @@ help:
 	@echo "  check-excluded-manifests-test        Self-tests for the check-excluded-manifests gate"
 	@echo "  check-ruff-lockstep                  Assert the ruff-pre-commit rev, uv.lock, and the requirements export agree"
 	@echo "  check-ruff-lockstep-test             Self-tests for the check-ruff-lockstep gate"
+	@echo "  check-publish-metadata               Assert every publishable crate carries the metadata crates.io needs"
+	@echo "  check-publish-metadata-test          Self-tests for the check-publish-metadata gate"
 	@echo "  check-manpage-assets                 Assert every bca-*.1 man page is in deb+rpm asset lists"
 	@echo "  check-diagnostic-prefix              Block capitalised Warning:/Error:/Note: literals"
 	@echo "  check-diagnostic-prefix-test         Self-tests for the diagnostic-prefix gate"
@@ -561,6 +563,31 @@ check-ruff-lockstep:
 check-ruff-lockstep-test:
 	@echo "Running check-ruff-lockstep self-tests..."
 	@(cd $(BASE_DIR) && python3 -m unittest -q utils/check-ruff-lockstep-test.py)
+
+# Publish-metadata gate (#1224). `cargo publish --dry-run` is the
+# natural pre-tag check, but it cannot run for the three top-level
+# crates: each pins an internal dependency at `=<version>`, and the
+# Lockstep policy makes that the version being released — which is by
+# definition not yet on crates.io. The workaround it replaces skipped
+# the parent dry-run whenever the pinned leaf was absent from the
+# sparse index, so it skipped on every release and the crate went out
+# with no metadata gate at all. This asserts the same fields
+# registry-free, from `cargo metadata` (which resolves
+# `[workspace.package]` inheritance) plus `cargo package --list` (the
+# one packaging step that does not resolve dependencies). Two cargo
+# calls per crate, no build, and no workspace `target/` lock — measured
+# at ~0.8s alongside a running build, so it fans out with the other
+# static gates rather than chaining into the cargo pipeline.
+check-publish-metadata:
+	@echo "Checking crates.io publish metadata..."
+	@python3 $(BASE_DIR)utils/check-publish-metadata.py
+
+# Self-tests for the publish-metadata gate. Separate target for the
+# same reason as the other gate self-tests: the gate stays a one-line
+# invariant check and test failures get their own parallel-arm output.
+check-publish-metadata-test:
+	@echo "Running check-publish-metadata self-tests..."
+	@(cd $(BASE_DIR) && python3 -m unittest -q utils/check-publish-metadata-test.py)
 
 # Man-page packaging gate. Blocks the failure mode from #444:
 # a bca subcommand man page that drops out of the hand-maintained
@@ -1062,7 +1089,7 @@ lint:
 	$(MAKE) -j --output-sync=target \
 	  _ci-clippy \
 	  _ci-shellcheck _ci-markdown-lint _ci-toml-lint _ci-makefile-check \
-	  _ci-actionlint _ci-snapshot-anchors _ci-snapshot-anchors-test _ci-rustfmt-bail _ci-rustfmt-bail-test _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-versions-test _ci-check-grammar-crate-test _ci-check-excluded-manifests _ci-check-excluded-manifests-test _ci-check-ruff-lockstep _ci-check-ruff-lockstep-test _ci-check-manpage-assets _ci-check-diagnostic-prefix _ci-check-diagnostic-prefix-test _ci-worktree-setup-test _ci-gate-status-test _ci-check-tools-test _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test
+	  _ci-actionlint _ci-snapshot-anchors _ci-snapshot-anchors-test _ci-rustfmt-bail _ci-rustfmt-bail-test _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-versions-test _ci-check-grammar-crate-test _ci-check-excluded-manifests _ci-check-excluded-manifests-test _ci-check-ruff-lockstep _ci-check-ruff-lockstep-test _ci-check-publish-metadata _ci-check-publish-metadata-test _ci-check-manpage-assets _ci-check-diagnostic-prefix _ci-check-diagnostic-prefix-test _ci-worktree-setup-test _ci-gate-status-test _ci-check-tools-test _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test
 
 # ---------------------------------------------------------------------------
 # Maintenance
@@ -1227,7 +1254,7 @@ _pc-all:
 	$(MAKE) -j --output-sync=target \
 	  _pc-test \
 	  _pc-shellcheck _pc-markdown-lint _pc-toml-lint _pc-makefile-check \
-	  _pc-actionlint _pc-snapshot-anchors _pc-snapshot-anchors-test _pc-rustfmt-bail _pc-rustfmt-bail-test _pc-grammar-marker-sync _pc-grammar-marker-sync-test _pc-check-versions _pc-check-versions-test _pc-check-grammar-crate-test _pc-check-excluded-manifests _pc-check-excluded-manifests-test _pc-check-ruff-lockstep _pc-check-ruff-lockstep-test _pc-check-manpage-assets _pc-check-diagnostic-prefix _pc-check-diagnostic-prefix-test _pc-worktree-setup-test _pc-gate-status-test _pc-check-tools-test _pc-enums-check _pc-enums-codegen-drift _pc-enums-codegen-drift-test \
+	  _pc-actionlint _pc-snapshot-anchors _pc-snapshot-anchors-test _pc-rustfmt-bail _pc-rustfmt-bail-test _pc-grammar-marker-sync _pc-grammar-marker-sync-test _pc-check-versions _pc-check-versions-test _pc-check-grammar-crate-test _pc-check-excluded-manifests _pc-check-excluded-manifests-test _pc-check-ruff-lockstep _pc-check-ruff-lockstep-test _pc-check-publish-metadata _pc-check-publish-metadata-test _pc-check-manpage-assets _pc-check-diagnostic-prefix _pc-check-diagnostic-prefix-test _pc-worktree-setup-test _pc-gate-status-test _pc-check-tools-test _pc-enums-check _pc-enums-codegen-drift _pc-enums-codegen-drift-test \
 	  _pc-manpages \
 	  _pc-self-scan _pc-self-scan-headroom \
 	  _pc-py-fmt _pc-py-typecheck _pc-py-test _pc-py-stubtest
@@ -1237,7 +1264,7 @@ _ci-all:
 	$(MAKE) -j --output-sync=target \
 	  _ci-cargo-pipeline \
 	  _ci-shellcheck _ci-markdown-lint _ci-toml-lint _ci-makefile-check \
-	  _ci-actionlint _ci-snapshot-anchors _ci-snapshot-anchors-test _ci-rustfmt-bail _ci-rustfmt-bail-test _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-versions-test _ci-check-grammar-crate-test _ci-check-excluded-manifests _ci-check-excluded-manifests-test _ci-check-ruff-lockstep _ci-check-ruff-lockstep-test _ci-check-manpage-assets _ci-check-diagnostic-prefix _ci-check-diagnostic-prefix-test _ci-worktree-setup-test _ci-gate-status-test _ci-check-tools-test _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test \
+	  _ci-actionlint _ci-snapshot-anchors _ci-snapshot-anchors-test _ci-rustfmt-bail _ci-rustfmt-bail-test _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-versions-test _ci-check-grammar-crate-test _ci-check-excluded-manifests _ci-check-excluded-manifests-test _ci-check-ruff-lockstep _ci-check-ruff-lockstep-test _ci-check-publish-metadata _ci-check-publish-metadata-test _ci-check-manpage-assets _ci-check-diagnostic-prefix _ci-check-diagnostic-prefix-test _ci-worktree-setup-test _ci-gate-status-test _ci-check-tools-test _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test \
 	  _ci-py-fmt-check _ci-py-lint _ci-py-typecheck _ci-py-test _ci-py-stubtest
 
 # ---------------------------------------------------------------------------
@@ -1273,6 +1300,8 @@ _ci-all:
 #    ├── _pc-check-versions
 #    ├── _pc-check-ruff-lockstep
 #    ├── _pc-check-ruff-lockstep-test
+#    ├── _pc-check-publish-metadata
+#    ├── _pc-check-publish-metadata-test
 #    ├── _pc-check-diagnostic-prefix
 #    ├── _pc-check-diagnostic-prefix-test
 #    ├── _pc-worktree-setup-test
@@ -1379,6 +1408,12 @@ _pc-check-ruff-lockstep: _pc-fmt
 
 _pc-check-ruff-lockstep-test: _pc-fmt
 	$(MAKE) check-ruff-lockstep-test
+
+_pc-check-publish-metadata: _pc-fmt
+	$(MAKE) check-publish-metadata
+
+_pc-check-publish-metadata-test: _pc-fmt
+	$(MAKE) check-publish-metadata-test
 
 _pc-check-manpage-assets: _pc-fmt
 	$(MAKE) check-manpage-assets
@@ -1568,6 +1603,12 @@ _ci-check-ruff-lockstep:
 _ci-check-ruff-lockstep-test:
 	$(MAKE) check-ruff-lockstep-test
 
+_ci-check-publish-metadata:
+	$(MAKE) check-publish-metadata
+
+_ci-check-publish-metadata-test:
+	$(MAKE) check-publish-metadata-test
+
 _ci-check-manpage-assets:
 	$(MAKE) check-manpage-assets
 
@@ -1683,17 +1724,30 @@ verify-changelog:
 
 # release-check: full pre-tag gate. cargo-deny enforces the license /
 # advisory / source allowlists; cargo-about's dry-run renders the
-# per-binary THIRD-PARTY-LICENSES files the release archives ship;
-# the publish dry-runs catch metadata regressions (missing
-# description/license/readme, deny.toml violations, version drift)
-# before any external publish fires. The five vendored grammar
-# leaves dry-run unconditionally. The parent dry-run mirrors CI's
-# preflight bootstrap probe (see `.github/workflows/release.yml`):
-# we query the sparse index for `bca-tree-sitter-ccomment` at the
-# workspace-pinned version and only run the parent dry-run if that
-# leaf is already on crates.io. On the very first release the probe
-# returns "not on registry", the parent dry-run is skipped with an
-# explanatory note, and CI handles the bootstrap end-to-end.
+# per-binary THIRD-PARTY-LICENSES files the release archives ship; the
+# publish dry-runs catch metadata regressions (missing
+# description/license/readme, non-packageable files, version drift)
+# before any external publish fires.
+#
+# Only the five vendored grammar leaves can be dry-run, so they are all
+# that last sentence covers. They carry no internal pins, so `cargo
+# publish --dry-run` resolves for them at any time. The three top-level
+# crates cannot: each pins an internal
+# dependency at `=<version>` and the Lockstep policy makes that the
+# version being released, which is by definition not yet on
+# crates.io. `make check-publish-metadata` is the registry-independent
+# stand-in — see `utils/check-publish-metadata.py` and #1224. It is
+# also part of `make lint` / `pre-commit` / `ci`, so a regression is
+# normally caught long before anyone reaches for this target; the call
+# here is what makes the pre-tag gate self-contained.
+#
+# What is deliberately *not* here is a `cargo publish --dry-run` for
+# the parent. The version of this recipe #1224 removed wrapped one in
+# a sparse-index probe for `bca-tree-sitter-ccomment` at the
+# workspace-pinned version. Because that is always the version being
+# released, the probe never hit and the dry-run never ran — on any
+# release, not just the first, contrary to what this comment and
+# RELEASING.md both used to claim.
 #
 # cargo-deny and cargo-about are probed up front by
 # `utils/check-tools.sh --release-only`, which names the missing one
@@ -1723,17 +1777,7 @@ release-check:
 	@for d in tree-sitter-ccomment tree-sitter-mozcpp tree-sitter-mozjs tree-sitter-preproc tree-sitter-tcl; do \
 	  cargo publish --dry-run --locked --manifest-path "$$d/Cargo.toml" || exit 1; \
 	done
-	@LEAF_VERSION=$$(awk -F'"' \
-	  '/^\[package\]/{f=1; next} /^\[/{f=0} f && /^version *=/ {print $$2; exit}' \
-	  tree-sitter-ccomment/Cargo.toml); \
-	BODY=$$(curl -sfL "https://index.crates.io/bc/a-/bca-tree-sitter-ccomment" 2>/dev/null || true); \
-	if [ -n "$$BODY" ] && echo "$$BODY" | grep -q "\"vers\":\"$$LEAF_VERSION\""; then \
-	  echo "Dry-running cargo publish for big-code-analysis..."; \
-	  cargo publish -p big-code-analysis --dry-run --locked; \
-	else \
-	  echo "Skipping big-code-analysis dry-run: bca-tree-sitter-ccomment $$LEAF_VERSION not yet on crates.io"; \
-	  echo "(bootstrap state — CI will publish the leaves before the parent on the next release tag)."; \
-	fi
+	@$(MAKE) check-publish-metadata
 	@$(MAKE) verify-changelog VERSION=$(VERSION)
 	@echo "release-check passed for $(VERSION)"
 

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ find-by-ext = $(if $(FD),$(FD) --extension $(1) $(FD_EXCLUDE) $(2),find . -name 
 NEXTEST        := $(shell command -v cargo-nextest 2>/dev/null)
 TEST_CMD       = $(if $(NEXTEST),$(NEXTEST) nextest run --workspace --all-features,cargo test --workspace --all-features --lib --bins --tests)
 
-.PHONY: help check-tools worktree-setup worktree-setup-test build build-release check test test-doc chain-audit fmt fmt-check markdown-fmt markdown-lint shellcheck sh-fmt sh-fmt-check toml-fmt toml-fmt-check toml-lint makefile-check actionlint snapshot-anchors snapshot-anchors-test rustfmt-bail rustfmt-bail-test grammar-marker-sync grammar-marker-sync-test check-versions check-excluded-manifests check-excluded-manifests-test check-manpage-assets check-diagnostic-prefix check-diagnostic-prefix-test gate-status-test check-tools-test enums-check enums-codegen-drift enums-codegen-drift-test self-scan self-scan-headroom self-scan-write-baseline self-scan-write-baseline-headroom vcs lint clippy udeps insta-review insta-accept clean distclean install install-cli install-web doc doc-open doc-check doc-check-docsrs book book-serve book-pot book-po-update book-ja book-deploy all pre-commit ci release-check verify-changelog pkg-deb-local pkg-rpm-local dev-env-build dev-env-run dev-env-shell dev-env-rm py-bootstrap py-sync py-relock py-clean py-fmt py-fmt-check py-lint py-typecheck py-test py-stubtest smoke smoke-cli smoke-lib bench bench-scaling bench-walk _check-find _pc-all _pc-fmt _pc-clippy _pc-test _pc-doc-check _pc-udeps _pc-shellcheck _pc-markdown-lint _pc-toml-lint _pc-makefile-check _pc-actionlint _pc-snapshot-anchors _pc-snapshot-anchors-test _pc-rustfmt-bail _pc-rustfmt-bail-test _pc-grammar-marker-sync _pc-grammar-marker-sync-test _pc-check-versions _pc-check-versions-test _pc-check-grammar-crate-test _pc-check-excluded-manifests _pc-check-excluded-manifests-test _pc-check-manpage-assets _pc-check-diagnostic-prefix _pc-check-diagnostic-prefix-test _pc-worktree-setup-test _pc-gate-status-test _pc-check-tools-test _pc-enums-check _pc-enums-codegen-drift _pc-enums-codegen-drift-test _pc-self-scan _pc-self-scan-headroom _pc-py-fmt _pc-py-typecheck _pc-py-test _pc-py-stubtest _ci-all _ci-fmt-check _ci-clippy _ci-test _ci-doc-check _ci-build _ci-udeps _ci-shellcheck _ci-markdown-lint _ci-toml-lint _ci-makefile-check _ci-actionlint _ci-snapshot-anchors _ci-snapshot-anchors-test _ci-rustfmt-bail _ci-rustfmt-bail-test _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-versions-test _ci-check-grammar-crate-test _ci-check-excluded-manifests _ci-check-excluded-manifests-test _ci-check-manpage-assets _ci-check-diagnostic-prefix _ci-check-diagnostic-prefix-test _ci-worktree-setup-test _ci-gate-status-test _ci-check-tools-test _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test _ci-enums-codegen-drift-test _ci-self-scan _ci-self-scan-headroom _ci-cargo-pipeline _ci-py-fmt-check _ci-py-lint _ci-py-typecheck _ci-py-test _ci-py-stubtest
+.PHONY: help check-tools worktree-setup worktree-setup-test build build-release check test test-doc chain-audit fmt fmt-check markdown-fmt markdown-lint shellcheck sh-fmt sh-fmt-check toml-fmt toml-fmt-check toml-lint makefile-check actionlint snapshot-anchors snapshot-anchors-test rustfmt-bail rustfmt-bail-test grammar-marker-sync grammar-marker-sync-test check-versions check-excluded-manifests check-excluded-manifests-test check-ruff-lockstep check-ruff-lockstep-test check-manpage-assets check-diagnostic-prefix check-diagnostic-prefix-test gate-status-test check-tools-test enums-check enums-codegen-drift enums-codegen-drift-test self-scan self-scan-headroom self-scan-write-baseline self-scan-write-baseline-headroom vcs lint clippy udeps insta-review insta-accept clean distclean install install-cli install-web doc doc-open doc-check doc-check-docsrs book book-serve book-pot book-po-update book-ja book-deploy all pre-commit ci release-check verify-changelog pkg-deb-local pkg-rpm-local dev-env-build dev-env-run dev-env-shell dev-env-rm py-bootstrap py-sync py-relock py-clean py-fmt py-fmt-check py-lint py-typecheck py-test py-stubtest smoke smoke-cli smoke-lib bench bench-scaling bench-walk _check-find _pc-all _pc-fmt _pc-clippy _pc-test _pc-doc-check _pc-udeps _pc-shellcheck _pc-markdown-lint _pc-toml-lint _pc-makefile-check _pc-actionlint _pc-snapshot-anchors _pc-snapshot-anchors-test _pc-rustfmt-bail _pc-rustfmt-bail-test _pc-grammar-marker-sync _pc-grammar-marker-sync-test _pc-check-versions _pc-check-versions-test _pc-check-grammar-crate-test _pc-check-excluded-manifests _pc-check-excluded-manifests-test _pc-check-ruff-lockstep _pc-check-ruff-lockstep-test _pc-check-manpage-assets _pc-check-diagnostic-prefix _pc-check-diagnostic-prefix-test _pc-worktree-setup-test _pc-gate-status-test _pc-check-tools-test _pc-enums-check _pc-enums-codegen-drift _pc-enums-codegen-drift-test _pc-self-scan _pc-self-scan-headroom _pc-py-fmt _pc-py-typecheck _pc-py-test _pc-py-stubtest _ci-all _ci-fmt-check _ci-clippy _ci-test _ci-doc-check _ci-build _ci-udeps _ci-shellcheck _ci-markdown-lint _ci-toml-lint _ci-makefile-check _ci-actionlint _ci-snapshot-anchors _ci-snapshot-anchors-test _ci-rustfmt-bail _ci-rustfmt-bail-test _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-versions-test _ci-check-grammar-crate-test _ci-check-excluded-manifests _ci-check-excluded-manifests-test _ci-check-ruff-lockstep _ci-check-ruff-lockstep-test _ci-check-manpage-assets _ci-check-diagnostic-prefix _ci-check-diagnostic-prefix-test _ci-worktree-setup-test _ci-gate-status-test _ci-check-tools-test _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test _ci-enums-codegen-drift-test _ci-self-scan _ci-self-scan-headroom _ci-cargo-pipeline _ci-py-fmt-check _ci-py-lint _ci-py-typecheck _ci-py-test _ci-py-stubtest
 
 # Default target
 help:
@@ -138,6 +138,8 @@ help:
 	@echo "  check-grammar-crate-test            Sync-test EXTENSIONS table vs src/langs.rs"
 	@echo "  check-excluded-manifests             Assert excluded crates root a workspace, declare lints, and =-pin grammars"
 	@echo "  check-excluded-manifests-test        Self-tests for the check-excluded-manifests gate"
+	@echo "  check-ruff-lockstep                  Assert the ruff-pre-commit rev, uv.lock, and the requirements export agree"
+	@echo "  check-ruff-lockstep-test             Self-tests for the check-ruff-lockstep gate"
 	@echo "  check-manpage-assets                 Assert every bca-*.1 man page is in deb+rpm asset lists"
 	@echo "  check-diagnostic-prefix              Block capitalised Warning:/Error:/Note: literals"
 	@echo "  check-diagnostic-prefix-test         Self-tests for the diagnostic-prefix gate"
@@ -540,6 +542,26 @@ check-excluded-manifests-test:
 	@echo "Running check-excluded-manifests self-tests..."
 	@(cd $(BASE_DIR) && python3 -m unittest -q utils/check-excluded-manifests-test.py)
 
+# ruff version lockstep (#1230). One adopted ruff is declared in four
+# places and nothing compared them: the `ruff-pre-commit` `rev:` in
+# .pre-commit-config.yaml, the version big-code-analysis-py/uv.lock
+# resolves, the `ruff==` pin in its requirements/dev.txt export (what
+# CI installs), and the bound in its pyproject.toml. The rev had
+# already drifted once — v0.15.14 against a lockfile resolving
+# 0.15.22 — which is silent until the two versions happen to disagree,
+# and then presents as "works locally, red in CI". Static lint — no
+# network, no cargo.
+check-ruff-lockstep:
+	@echo "Checking ruff version lockstep..."
+	@python3 $(BASE_DIR)utils/check-ruff-lockstep.py
+
+# Self-tests for the ruff-lockstep gate. Separate target for the same
+# reason as the other gate self-tests: the gate stays a one-line
+# invariant check and test failures get their own parallel-arm output.
+check-ruff-lockstep-test:
+	@echo "Running check-ruff-lockstep self-tests..."
+	@(cd $(BASE_DIR) && python3 -m unittest -q utils/check-ruff-lockstep-test.py)
+
 # Man-page packaging gate. Blocks the failure mode from #444:
 # a bca subcommand man page that drops out of the hand-maintained
 # deb/rpm asset lists in the CLI / web crate Cargo.toml. Static
@@ -793,28 +815,55 @@ py-relock:
 # spuriously flag excluded files. The smoke dir has nothing to exclude, so
 # pointing `--config` at the bindings pyproject just gives it the same
 # ruleset (line-length 100, the `[tool.ruff.lint] select` set) (#995).
+#
+# Resolve ruff the way `py-typecheck` resolves mypy and pyright: prefer
+# the bindings dir's `.venv/bin/ruff`, fall back to PATH, skip cleanly
+# when neither exists. Hoisted into one variable because all three ruff
+# targets need the identical resolution, and because PATH-first was
+# wrong in the same way three times over (#1230). Three provisioning
+# paths install an *unpinned* ruff onto PATH — `mise.toml`'s
+# `"pipx:ruff" = "latest"`, the Dockerfile's `uv tool install ruff`, and
+# the `pipx install ruff` CONTRIBUTING documents — so PATH-first let the
+# local gate run a ruff outside the `pyproject.toml` `<0.17` ceiling
+# while CI ran the `uv.lock`-resolved one. The venv copy is by
+# construction the version `make check-ruff-lockstep` gates.
+#
+# `exit 0` (not a shell `if/else` around the whole body) keeps each
+# recipe a single logical line: the resolve step ends the sub-shell
+# successfully and make moves on, exactly as the old `else echo
+# "...skipping"` arm did.
+#
+# The `|| true` is load-bearing under this Makefile's
+# `.SHELLFLAGS := -eu -o pipefail -c`. An assignment takes the exit
+# status of its command substitution, and the right-hand side of `||`
+# is the list's last command, so a failing `command -v` (bash returns 1
+# when the name is absent) kills the shell under `-e` — turning the
+# skip-when-missing path into `make: *** [py-lint] Error 1` with no
+# diagnostic at all. Measured, not theorised.
+PY_RUFF_RESOLVE = ruff="$(BCA_PY_DIR)/.venv/bin/ruff"; \
+	  [ -x "$$ruff" ] || ruff="$$(command -v ruff 2>/dev/null || true)"; \
+	  if [ -z "$$ruff" ]; then echo "ruff not found; skipping $@"; exit 0; fi
+
 py-fmt:
-	@if command -v ruff >/dev/null 2>&1; then \
+	@$(PY_RUFF_RESOLVE); \
 	  echo "Formatting Python sources..."; \
-	  ruff format "$(BCA_PY_DIR)"; \
-	  ruff format --config "$(BCA_PY_DIR)/pyproject.toml" "$(SMOKE_PY_DIR)"; \
-	else echo "ruff not found; skipping py-fmt"; fi
+	  "$$ruff" format "$(BCA_PY_DIR)" && \
+	  "$$ruff" format --config "$(BCA_PY_DIR)/pyproject.toml" "$(SMOKE_PY_DIR)" || \
+	    { echo "ruff format failed"; exit 1; }
 
 py-fmt-check:
-	@if command -v ruff >/dev/null 2>&1; then \
+	@$(PY_RUFF_RESOLVE); \
 	  echo "Checking Python formatting..."; \
-	  ruff format --check "$(BCA_PY_DIR)" && \
-	  ruff format --check --config "$(BCA_PY_DIR)/pyproject.toml" "$(SMOKE_PY_DIR)" || \
-	    { echo "Python files not formatted (run 'make py-fmt')"; exit 1; }; \
-	else echo "ruff not found; skipping py-fmt-check"; fi
+	  "$$ruff" format --check "$(BCA_PY_DIR)" && \
+	  "$$ruff" format --check --config "$(BCA_PY_DIR)/pyproject.toml" "$(SMOKE_PY_DIR)" || \
+	    { echo "Python files not formatted (run 'make py-fmt')"; exit 1; }
 
 py-lint:
-	@if command -v ruff >/dev/null 2>&1; then \
+	@$(PY_RUFF_RESOLVE); \
 	  echo "Linting Python sources..."; \
-	  ruff check "$(BCA_PY_DIR)" && \
-	  ruff check --config "$(BCA_PY_DIR)/pyproject.toml" "$(SMOKE_PY_DIR)" || \
-	    { echo "ruff lint found issues"; exit 1; }; \
-	else echo "ruff not found; skipping py-lint"; fi
+	  "$$ruff" check "$(BCA_PY_DIR)" && \
+	  "$$ruff" check --config "$(BCA_PY_DIR)/pyproject.toml" "$(SMOKE_PY_DIR)" || \
+	    { echo "ruff lint found issues"; exit 1; }
 
 py-typecheck:
 	@# Prefer the bindings dir's `.venv/bin/{mypy,pyright}` when
@@ -1013,7 +1062,7 @@ lint:
 	$(MAKE) -j --output-sync=target \
 	  _ci-clippy \
 	  _ci-shellcheck _ci-markdown-lint _ci-toml-lint _ci-makefile-check \
-	  _ci-actionlint _ci-snapshot-anchors _ci-snapshot-anchors-test _ci-rustfmt-bail _ci-rustfmt-bail-test _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-versions-test _ci-check-grammar-crate-test _ci-check-excluded-manifests _ci-check-excluded-manifests-test _ci-check-manpage-assets _ci-check-diagnostic-prefix _ci-check-diagnostic-prefix-test _ci-worktree-setup-test _ci-gate-status-test _ci-check-tools-test _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test
+	  _ci-actionlint _ci-snapshot-anchors _ci-snapshot-anchors-test _ci-rustfmt-bail _ci-rustfmt-bail-test _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-versions-test _ci-check-grammar-crate-test _ci-check-excluded-manifests _ci-check-excluded-manifests-test _ci-check-ruff-lockstep _ci-check-ruff-lockstep-test _ci-check-manpage-assets _ci-check-diagnostic-prefix _ci-check-diagnostic-prefix-test _ci-worktree-setup-test _ci-gate-status-test _ci-check-tools-test _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test
 
 # ---------------------------------------------------------------------------
 # Maintenance
@@ -1178,7 +1227,7 @@ _pc-all:
 	$(MAKE) -j --output-sync=target \
 	  _pc-test \
 	  _pc-shellcheck _pc-markdown-lint _pc-toml-lint _pc-makefile-check \
-	  _pc-actionlint _pc-snapshot-anchors _pc-snapshot-anchors-test _pc-rustfmt-bail _pc-rustfmt-bail-test _pc-grammar-marker-sync _pc-grammar-marker-sync-test _pc-check-versions _pc-check-versions-test _pc-check-grammar-crate-test _pc-check-excluded-manifests _pc-check-excluded-manifests-test _pc-check-manpage-assets _pc-check-diagnostic-prefix _pc-check-diagnostic-prefix-test _pc-worktree-setup-test _pc-gate-status-test _pc-check-tools-test _pc-enums-check _pc-enums-codegen-drift _pc-enums-codegen-drift-test \
+	  _pc-actionlint _pc-snapshot-anchors _pc-snapshot-anchors-test _pc-rustfmt-bail _pc-rustfmt-bail-test _pc-grammar-marker-sync _pc-grammar-marker-sync-test _pc-check-versions _pc-check-versions-test _pc-check-grammar-crate-test _pc-check-excluded-manifests _pc-check-excluded-manifests-test _pc-check-ruff-lockstep _pc-check-ruff-lockstep-test _pc-check-manpage-assets _pc-check-diagnostic-prefix _pc-check-diagnostic-prefix-test _pc-worktree-setup-test _pc-gate-status-test _pc-check-tools-test _pc-enums-check _pc-enums-codegen-drift _pc-enums-codegen-drift-test \
 	  _pc-manpages \
 	  _pc-self-scan _pc-self-scan-headroom \
 	  _pc-py-fmt _pc-py-typecheck _pc-py-test _pc-py-stubtest
@@ -1188,7 +1237,7 @@ _ci-all:
 	$(MAKE) -j --output-sync=target \
 	  _ci-cargo-pipeline \
 	  _ci-shellcheck _ci-markdown-lint _ci-toml-lint _ci-makefile-check \
-	  _ci-actionlint _ci-snapshot-anchors _ci-snapshot-anchors-test _ci-rustfmt-bail _ci-rustfmt-bail-test _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-versions-test _ci-check-grammar-crate-test _ci-check-excluded-manifests _ci-check-excluded-manifests-test _ci-check-manpage-assets _ci-check-diagnostic-prefix _ci-check-diagnostic-prefix-test _ci-worktree-setup-test _ci-gate-status-test _ci-check-tools-test _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test \
+	  _ci-actionlint _ci-snapshot-anchors _ci-snapshot-anchors-test _ci-rustfmt-bail _ci-rustfmt-bail-test _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-versions-test _ci-check-grammar-crate-test _ci-check-excluded-manifests _ci-check-excluded-manifests-test _ci-check-ruff-lockstep _ci-check-ruff-lockstep-test _ci-check-manpage-assets _ci-check-diagnostic-prefix _ci-check-diagnostic-prefix-test _ci-worktree-setup-test _ci-gate-status-test _ci-check-tools-test _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test \
 	  _ci-py-fmt-check _ci-py-lint _ci-py-typecheck _ci-py-test _ci-py-stubtest
 
 # ---------------------------------------------------------------------------
@@ -1222,6 +1271,8 @@ _ci-all:
 #    ├── _pc-grammar-marker-sync
 #    ├── _pc-grammar-marker-sync-test
 #    ├── _pc-check-versions
+#    ├── _pc-check-ruff-lockstep
+#    ├── _pc-check-ruff-lockstep-test
 #    ├── _pc-check-diagnostic-prefix
 #    ├── _pc-check-diagnostic-prefix-test
 #    ├── _pc-worktree-setup-test
@@ -1322,6 +1373,12 @@ _pc-check-excluded-manifests: _pc-fmt
 
 _pc-check-excluded-manifests-test: _pc-fmt
 	$(MAKE) check-excluded-manifests-test
+
+_pc-check-ruff-lockstep: _pc-fmt
+	$(MAKE) check-ruff-lockstep
+
+_pc-check-ruff-lockstep-test: _pc-fmt
+	$(MAKE) check-ruff-lockstep-test
 
 _pc-check-manpage-assets: _pc-fmt
 	$(MAKE) check-manpage-assets
@@ -1504,6 +1561,12 @@ _ci-check-excluded-manifests:
 
 _ci-check-excluded-manifests-test:
 	$(MAKE) check-excluded-manifests-test
+
+_ci-check-ruff-lockstep:
+	$(MAKE) check-ruff-lockstep
+
+_ci-check-ruff-lockstep-test:
+	$(MAKE) check-ruff-lockstep-test
 
 _ci-check-manpage-assets:
 	$(MAKE) check-manpage-assets

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ help:
 	@echo "  check-versions                       Enforce lockstep version invariant across owned crates"
 	@echo "  check-versions-test                  Self-tests for the check-versions gate"
 	@echo "  check-grammar-crate-test            Sync-test EXTENSIONS table vs src/langs.rs"
-	@echo "  check-excluded-manifests             Assert excluded crates root a workspace and grammars are =-pinned"
+	@echo "  check-excluded-manifests             Assert excluded crates root a workspace, declare lints, and =-pin grammars"
 	@echo "  check-excluded-manifests-test        Self-tests for the check-excluded-manifests gate"
 	@echo "  check-manpage-assets                 Assert every bca-*.1 man page is in deb+rpm asset lists"
 	@echo "  check-diagnostic-prefix              Block capitalised Warning:/Error:/Note: literals"
@@ -515,7 +515,10 @@ check-versions-test:
 # checkout, breaking `cargo fmt --all` and every `make pre-commit`
 # stage chained behind it. Also asserts every tree-sitter dependency
 # in the root manifest and in each excluded crate carries an `=X.Y.Z`
-# pin (#1151). Static lint — no network, no cargo.
+# pin (#1151), and that each excluded crate declares its own `[lints]`
+# table or is listed exempt — `[workspace.lints]` reaches members only,
+# so without one a crate is gated at `-D warnings` against the compiler
+# defaults (#1228). Static lint — no network, no cargo.
 check-excluded-manifests:
 	@echo "Checking workspace-excluded manifests..."
 	@python3 $(BASE_DIR)utils/check-excluded-manifests.py

--- a/Makefile
+++ b/Makefile
@@ -1708,6 +1708,14 @@ _ci-cargo-pipeline:
 # uploads anything; the release workflow is the only mutator.
 # ---------------------------------------------------------------------------
 
+# The five vendored grammar leaves, in publish order. `release-check`
+# reads this list twice, once to confirm the directories are committed
+# and once to dry-run the publish, so the two cannot drift apart.
+# `release.yml` keeps its own copy; a make variable cannot reach a
+# workflow.
+GRAMMAR_LEAVES := tree-sitter-ccomment tree-sitter-mozcpp tree-sitter-mozjs \
+                  tree-sitter-preproc tree-sitter-tcl
+
 # verify-changelog: confirm CHANGELOG.md has a `## [VERSION]` section.
 # Fixed-string match so dots in the version aren't treated as regex
 # wildcards. Mirrors the preflight check in release.yml.
@@ -1749,18 +1757,43 @@ verify-changelog:
 # release, not just the first, contrary to what this comment and
 # RELEASING.md both used to claim.
 #
-# cargo-deny and cargo-about are probed up front by
+# Two preconditions are checked before any slow stage runs.
+#
+# cargo-deny and cargo-about are probed by
 # `utils/check-tools.sh --release-only`, which names the missing one
 # and its install command. Left to fail in place, a missing subcommand
 # surfaces as cargo's bare `no such command`, and the obvious remedy
 # for cargo-about installs nothing at all unless `--features cli` is
 # passed (#1226).
+#
+# The grammar leaves are then checked for uncommitted changes, because
+# `cargo publish` refuses to package a directory that has any (#1225).
+# Left to fail in place that costs a cargo-deny run and two cargo-about
+# renders first, and cargo's own message offers `--allow-dirty` as the
+# remedy — which would gate content the tag will not carry. The check
+# is scoped and untracked-blind to match what cargo actually rejects:
+# measured, a modified `src/lib.rs` does not stop a leaf packaging, and
+# an untracked file outside the leaf's `include` is never packaged, so
+# neither is worth failing over. cargo stays the backstop for the
+# residue (an untracked file that `include` does cover).
 release-check:
 	@if [ -z "$(VERSION)" ]; then \
 	  echo "ERROR: VERSION not set. Usage: make release-check VERSION=0.1.0"; \
 	  exit 1; \
 	fi
 	@bash $(BASE_DIR)utils/check-tools.sh --release-only
+	@dirty="$$(git status --porcelain --untracked-files=no -- $(GRAMMAR_LEAVES))"; \
+	  if [ -n "$$dirty" ]; then \
+	    echo "ERROR: uncommitted changes in the vendored grammar leaves:"; \
+	    echo "$$dirty"; \
+	    echo ""; \
+	    echo "release-check dry-runs 'cargo publish' for these crates, which"; \
+	    echo "cargo refuses to do while they hold uncommitted changes. Run the"; \
+	    echo "gate on the tree you are about to tag: commit (or amend), then"; \
+	    echo "'make release-check VERSION=$(VERSION)', then tag."; \
+	    echo "Do not pass --allow-dirty; it gates content the tag will not carry."; \
+	    exit 1; \
+	  fi
 	@echo "Running cargo deny check..."
 	@cargo deny check
 	@echo "Generating THIRD-PARTY-LICENSES-bca.md (dry-run)..."
@@ -1774,7 +1807,7 @@ release-check:
 	  --manifest-path big-code-analysis-web/Cargo.toml \
 	  about.hbs > /dev/null
 	@echo "Dry-running cargo publish for the five vendored grammar leaves..."
-	@for d in tree-sitter-ccomment tree-sitter-mozcpp tree-sitter-mozjs tree-sitter-preproc tree-sitter-tcl; do \
+	@for d in $(GRAMMAR_LEAVES); do \
 	  cargo publish --dry-run --locked --manifest-path "$$d/Cargo.toml" || exit 1; \
 	done
 	@$(MAKE) check-publish-metadata

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ find-by-ext = $(if $(FD),$(FD) --extension $(1) $(FD_EXCLUDE) $(2),find . -name 
 NEXTEST        := $(shell command -v cargo-nextest 2>/dev/null)
 TEST_CMD       = $(if $(NEXTEST),$(NEXTEST) nextest run --workspace --all-features,cargo test --workspace --all-features --lib --bins --tests)
 
-.PHONY: help check-tools worktree-setup worktree-setup-test build build-release check test test-doc chain-audit fmt fmt-check markdown-fmt markdown-lint shellcheck sh-fmt sh-fmt-check toml-fmt toml-fmt-check toml-lint makefile-check actionlint snapshot-anchors snapshot-anchors-test rustfmt-bail rustfmt-bail-test grammar-marker-sync grammar-marker-sync-test check-versions check-excluded-manifests check-excluded-manifests-test check-manpage-assets check-diagnostic-prefix check-diagnostic-prefix-test gate-status-test enums-check enums-codegen-drift enums-codegen-drift-test self-scan self-scan-headroom self-scan-write-baseline self-scan-write-baseline-headroom vcs lint clippy udeps insta-review insta-accept clean distclean install install-cli install-web doc doc-open doc-check doc-check-docsrs book book-serve book-pot book-po-update book-ja book-deploy all pre-commit ci release-check verify-changelog pkg-deb-local pkg-rpm-local dev-env-build dev-env-run dev-env-shell dev-env-rm py-bootstrap py-sync py-relock py-clean py-fmt py-fmt-check py-lint py-typecheck py-test py-stubtest smoke smoke-cli smoke-lib bench bench-scaling bench-walk _check-find _pc-all _pc-fmt _pc-clippy _pc-test _pc-doc-check _pc-udeps _pc-shellcheck _pc-markdown-lint _pc-toml-lint _pc-makefile-check _pc-actionlint _pc-snapshot-anchors _pc-snapshot-anchors-test _pc-rustfmt-bail _pc-rustfmt-bail-test _pc-grammar-marker-sync _pc-grammar-marker-sync-test _pc-check-versions _pc-check-versions-test _pc-check-grammar-crate-test _pc-check-excluded-manifests _pc-check-excluded-manifests-test _pc-check-manpage-assets _pc-check-diagnostic-prefix _pc-check-diagnostic-prefix-test _pc-worktree-setup-test _pc-gate-status-test _pc-enums-check _pc-enums-codegen-drift _pc-enums-codegen-drift-test _pc-self-scan _pc-self-scan-headroom _pc-py-fmt _pc-py-typecheck _pc-py-test _pc-py-stubtest _ci-all _ci-fmt-check _ci-clippy _ci-test _ci-doc-check _ci-build _ci-udeps _ci-shellcheck _ci-markdown-lint _ci-toml-lint _ci-makefile-check _ci-actionlint _ci-snapshot-anchors _ci-snapshot-anchors-test _ci-rustfmt-bail _ci-rustfmt-bail-test _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-versions-test _ci-check-grammar-crate-test _ci-check-excluded-manifests _ci-check-excluded-manifests-test _ci-check-manpage-assets _ci-check-diagnostic-prefix _ci-check-diagnostic-prefix-test _ci-worktree-setup-test _ci-gate-status-test _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test _ci-enums-codegen-drift-test _ci-self-scan _ci-self-scan-headroom _ci-cargo-pipeline _ci-py-fmt-check _ci-py-lint _ci-py-typecheck _ci-py-test _ci-py-stubtest
+.PHONY: help check-tools worktree-setup worktree-setup-test build build-release check test test-doc chain-audit fmt fmt-check markdown-fmt markdown-lint shellcheck sh-fmt sh-fmt-check toml-fmt toml-fmt-check toml-lint makefile-check actionlint snapshot-anchors snapshot-anchors-test rustfmt-bail rustfmt-bail-test grammar-marker-sync grammar-marker-sync-test check-versions check-excluded-manifests check-excluded-manifests-test check-manpage-assets check-diagnostic-prefix check-diagnostic-prefix-test gate-status-test check-tools-test enums-check enums-codegen-drift enums-codegen-drift-test self-scan self-scan-headroom self-scan-write-baseline self-scan-write-baseline-headroom vcs lint clippy udeps insta-review insta-accept clean distclean install install-cli install-web doc doc-open doc-check doc-check-docsrs book book-serve book-pot book-po-update book-ja book-deploy all pre-commit ci release-check verify-changelog pkg-deb-local pkg-rpm-local dev-env-build dev-env-run dev-env-shell dev-env-rm py-bootstrap py-sync py-relock py-clean py-fmt py-fmt-check py-lint py-typecheck py-test py-stubtest smoke smoke-cli smoke-lib bench bench-scaling bench-walk _check-find _pc-all _pc-fmt _pc-clippy _pc-test _pc-doc-check _pc-udeps _pc-shellcheck _pc-markdown-lint _pc-toml-lint _pc-makefile-check _pc-actionlint _pc-snapshot-anchors _pc-snapshot-anchors-test _pc-rustfmt-bail _pc-rustfmt-bail-test _pc-grammar-marker-sync _pc-grammar-marker-sync-test _pc-check-versions _pc-check-versions-test _pc-check-grammar-crate-test _pc-check-excluded-manifests _pc-check-excluded-manifests-test _pc-check-manpage-assets _pc-check-diagnostic-prefix _pc-check-diagnostic-prefix-test _pc-worktree-setup-test _pc-gate-status-test _pc-check-tools-test _pc-enums-check _pc-enums-codegen-drift _pc-enums-codegen-drift-test _pc-self-scan _pc-self-scan-headroom _pc-py-fmt _pc-py-typecheck _pc-py-test _pc-py-stubtest _ci-all _ci-fmt-check _ci-clippy _ci-test _ci-doc-check _ci-build _ci-udeps _ci-shellcheck _ci-markdown-lint _ci-toml-lint _ci-makefile-check _ci-actionlint _ci-snapshot-anchors _ci-snapshot-anchors-test _ci-rustfmt-bail _ci-rustfmt-bail-test _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-versions-test _ci-check-grammar-crate-test _ci-check-excluded-manifests _ci-check-excluded-manifests-test _ci-check-manpage-assets _ci-check-diagnostic-prefix _ci-check-diagnostic-prefix-test _ci-worktree-setup-test _ci-gate-status-test _ci-check-tools-test _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test _ci-enums-codegen-drift-test _ci-self-scan _ci-self-scan-headroom _ci-cargo-pipeline _ci-py-fmt-check _ci-py-lint _ci-py-typecheck _ci-py-test _ci-py-stubtest
 
 # Default target
 help:
@@ -143,6 +143,7 @@ help:
 	@echo "  check-diagnostic-prefix-test         Self-tests for the diagnostic-prefix gate"
 	@echo "  worktree-setup-test                  Self-tests for the worktree-setup submodule classifier"
 	@echo "  gate-status-test                     Self-tests for the pre-commit/ci BCA_GATE verdict line"
+	@echo "  check-tools-test                     Self-tests for the check-tools tool probes and hints"
 	@echo "  enums-check                          cargo clippy + cargo test on workspace-excluded enums crate"
 	@echo "  enums-codegen-drift                  Block enums codegen output drifting from checked-in files"
 	@echo "  enums-codegen-drift-test             Self-tests for the enums-codegen-drift gate"
@@ -212,6 +213,14 @@ help:
 # ---------------------------------------------------------------------------
 check-tools:
 	@bash $(BASE_DIR)utils/check-tools.sh
+
+# Self-tests for utils/check-tools.sh. The install hints are the whole
+# product of that script, and one of them — cargo-about's — is only
+# correct with `--features cli`; without the flag the install exits 0
+# and installs nothing (#1226). Cheap enough (~0.1s, stubbed cargo) to
+# run in both gates.
+check-tools-test:
+	@bash $(BASE_DIR)utils/check-tools-test.sh
 
 # One-shot bootstrap for a fresh clone or a fresh `git worktree`: the
 # two steps nothing else states and nothing else detects (#1171).
@@ -1004,7 +1013,7 @@ lint:
 	$(MAKE) -j --output-sync=target \
 	  _ci-clippy \
 	  _ci-shellcheck _ci-markdown-lint _ci-toml-lint _ci-makefile-check \
-	  _ci-actionlint _ci-snapshot-anchors _ci-snapshot-anchors-test _ci-rustfmt-bail _ci-rustfmt-bail-test _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-versions-test _ci-check-grammar-crate-test _ci-check-excluded-manifests _ci-check-excluded-manifests-test _ci-check-manpage-assets _ci-check-diagnostic-prefix _ci-check-diagnostic-prefix-test _ci-worktree-setup-test _ci-gate-status-test _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test
+	  _ci-actionlint _ci-snapshot-anchors _ci-snapshot-anchors-test _ci-rustfmt-bail _ci-rustfmt-bail-test _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-versions-test _ci-check-grammar-crate-test _ci-check-excluded-manifests _ci-check-excluded-manifests-test _ci-check-manpage-assets _ci-check-diagnostic-prefix _ci-check-diagnostic-prefix-test _ci-worktree-setup-test _ci-gate-status-test _ci-check-tools-test _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test
 
 # ---------------------------------------------------------------------------
 # Maintenance
@@ -1169,7 +1178,7 @@ _pc-all:
 	$(MAKE) -j --output-sync=target \
 	  _pc-test \
 	  _pc-shellcheck _pc-markdown-lint _pc-toml-lint _pc-makefile-check \
-	  _pc-actionlint _pc-snapshot-anchors _pc-snapshot-anchors-test _pc-rustfmt-bail _pc-rustfmt-bail-test _pc-grammar-marker-sync _pc-grammar-marker-sync-test _pc-check-versions _pc-check-versions-test _pc-check-grammar-crate-test _pc-check-excluded-manifests _pc-check-excluded-manifests-test _pc-check-manpage-assets _pc-check-diagnostic-prefix _pc-check-diagnostic-prefix-test _pc-worktree-setup-test _pc-gate-status-test _pc-enums-check _pc-enums-codegen-drift _pc-enums-codegen-drift-test \
+	  _pc-actionlint _pc-snapshot-anchors _pc-snapshot-anchors-test _pc-rustfmt-bail _pc-rustfmt-bail-test _pc-grammar-marker-sync _pc-grammar-marker-sync-test _pc-check-versions _pc-check-versions-test _pc-check-grammar-crate-test _pc-check-excluded-manifests _pc-check-excluded-manifests-test _pc-check-manpage-assets _pc-check-diagnostic-prefix _pc-check-diagnostic-prefix-test _pc-worktree-setup-test _pc-gate-status-test _pc-check-tools-test _pc-enums-check _pc-enums-codegen-drift _pc-enums-codegen-drift-test \
 	  _pc-manpages \
 	  _pc-self-scan _pc-self-scan-headroom \
 	  _pc-py-fmt _pc-py-typecheck _pc-py-test _pc-py-stubtest
@@ -1179,7 +1188,7 @@ _ci-all:
 	$(MAKE) -j --output-sync=target \
 	  _ci-cargo-pipeline \
 	  _ci-shellcheck _ci-markdown-lint _ci-toml-lint _ci-makefile-check \
-	  _ci-actionlint _ci-snapshot-anchors _ci-snapshot-anchors-test _ci-rustfmt-bail _ci-rustfmt-bail-test _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-versions-test _ci-check-grammar-crate-test _ci-check-excluded-manifests _ci-check-excluded-manifests-test _ci-check-manpage-assets _ci-check-diagnostic-prefix _ci-check-diagnostic-prefix-test _ci-worktree-setup-test _ci-gate-status-test _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test \
+	  _ci-actionlint _ci-snapshot-anchors _ci-snapshot-anchors-test _ci-rustfmt-bail _ci-rustfmt-bail-test _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-versions-test _ci-check-grammar-crate-test _ci-check-excluded-manifests _ci-check-excluded-manifests-test _ci-check-manpage-assets _ci-check-diagnostic-prefix _ci-check-diagnostic-prefix-test _ci-worktree-setup-test _ci-gate-status-test _ci-check-tools-test _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test \
 	  _ci-py-fmt-check _ci-py-lint _ci-py-typecheck _ci-py-test _ci-py-stubtest
 
 # ---------------------------------------------------------------------------
@@ -1217,6 +1226,7 @@ _ci-all:
 #    ├── _pc-check-diagnostic-prefix-test
 #    ├── _pc-worktree-setup-test
 #    ├── _pc-gate-status-test
+#    ├── _pc-check-tools-test
 #    ├── _pc-enums-check
 #    ├── _pc-enums-codegen-drift (chained after _pc-enums-check)
 #    ├── _pc-py-fmt
@@ -1327,6 +1337,9 @@ _pc-worktree-setup-test: _pc-fmt
 
 _pc-gate-status-test: _pc-fmt
 	$(MAKE) gate-status-test
+
+_pc-check-tools-test: _pc-fmt
+	$(MAKE) check-tools-test
 
 _pc-enums-check: _pc-fmt
 	$(MAKE) enums-check
@@ -1507,6 +1520,9 @@ _ci-worktree-setup-test:
 _ci-gate-status-test:
 	$(MAKE) gate-status-test
 
+_ci-check-tools-test:
+	$(MAKE) check-tools-test
+
 _ci-enums-check:
 	$(MAKE) enums-check
 
@@ -1615,11 +1631,19 @@ verify-changelog:
 # leaf is already on crates.io. On the very first release the probe
 # returns "not on registry", the parent dry-run is skipped with an
 # explanatory note, and CI handles the bootstrap end-to-end.
+#
+# cargo-deny and cargo-about are probed up front by
+# `utils/check-tools.sh --release-only`, which names the missing one
+# and its install command. Left to fail in place, a missing subcommand
+# surfaces as cargo's bare `no such command`, and the obvious remedy
+# for cargo-about installs nothing at all unless `--features cli` is
+# passed (#1226).
 release-check:
 	@if [ -z "$(VERSION)" ]; then \
 	  echo "ERROR: VERSION not set. Usage: make release-check VERSION=0.1.0"; \
 	  exit 1; \
 	fi
+	@bash $(BASE_DIR)utils/check-tools.sh --release-only
 	@echo "Running cargo deny check..."
 	@cargo deny check
 	@echo "Generating THIRD-PARTY-LICENSES-bca.md (dry-run)..."

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -161,22 +161,57 @@ only resolve once each leaf is on crates.io. The sparse-index
 existence check in each step makes the job idempotent across re-runs
 of the same tag.
 
-**Bootstrap on the very first release.** The parent's
-`cargo publish --dry-run -p big-code-analysis` cannot resolve until
-the five leaves are on crates.io. The preflight job in `release.yml`
-handles this automatically: it queries the sparse index for
-`bca-tree-sitter-ccomment` at the workspace-pinned version, and only
-runs the parent dry-run if that leaf is already published. On the
-first tag with `ENABLE_CRATES_PUBLISH=true`, the parent dry-run is
-skipped with a `::notice::` and the `publish-crates` job uploads the
-five leaves *first*, then `big-code-analysis`, then the binaries (in
-one workflow run, no manual intervention). From the second tag
-onwards the parent dry-run becomes a hard gate.
+**The three top-level crates cannot be dry-run before the tag.**
+`big-code-analysis` pins each leaf at `bca-tree-sitter-<lang> =
+"=<version>"`, and `big-code-analysis-cli` / `big-code-analysis-web`
+pin `big-code-analysis` the same way. Packaging resolves those
+requirements against the registry, and the Lockstep version policy
+below makes the pinned version the one this tag is releasing — which
+is, by definition, not yet published. So it fails, every time, not
+only on a first release:
 
-`make release-check VERSION=…` mirrors the same logic: it
-unconditionally dry-runs the five leaves, then wraps the parent
-dry-run in a warning that points back to this section if the
-bootstrap state is detected.
+```console
+$ cargo package -p big-code-analysis --allow-dirty --no-verify
+error: failed to select a version for the requirement
+  `bca-tree-sitter-ccomment = "=2.1.1"`
+candidate versions found which didn't match: 2.1.0, 2.0.0, 1.1.0, ...
+```
+
+Until [#1224](https://github.com/dekobon/big-code-analysis/issues/1224)
+both `release.yml` and `make release-check` wrapped the parent dry-run
+in a sparse-index probe for that same version and described the skip
+as a first-release bootstrap. Because the probed version is always the
+version being released, the probe never hit and the dry-run never ran
+ahead of an upload. This page said the opposite.
+
+What runs in its place is `make check-publish-metadata`
+(`utils/check-publish-metadata.py`), which needs nothing on the
+registry. For every publishable crate it asserts that `description`,
+`readme`, `repository`, and `license` (or `license-file`) are present
+and non-empty; that a crate rooted at the workspace root carries a
+non-empty `[package].include`; and that the files `cargo package
+--list` reports — the one packaging step that does not resolve
+dependencies — total under 32 MiB. Dropping the `include` block
+currently yields 445 MiB across 33,398 files, so the bound is not a
+close call. It does not compile anything, so a feature-resolution or
+build error in the packaged crate is still only caught by the real
+`cargo publish`.
+
+Running `--list` also validates `readme` and `license-file` for free:
+cargo fails outright on a path that does not exist, and packages one
+that `include` does not cover rather than dropping it. That is why the
+gate does not check either itself.
+
+It runs in `make lint`, `make pre-commit`, `make ci`, `make
+release-check`, and the `preflight` job of `release.yml`. The five
+vendored leaves are not in its scope: they carry no internal pins, so
+`release-check` and `preflight` dry-run them for real.
+
+**The leaves still publish first.** That ordering is what lets the
+parent resolve during `publish-crates`, and it is unchanged. It also
+means a metadata regression in the parent or the binaries would fail
+*after* the five leaves are irrevocably on crates.io — the split
+release the gate above exists to make unreachable.
 
 **Lockstep version policy.** Every crate in this repository (the
 library, the CLI, the web crate, the Python crate, the `enums` /
@@ -371,12 +406,22 @@ registered, so the very first publish has to be a hand-rolled
    useful error message. Verify before the first publish:
 
    ```bash
-   cargo package -p big-code-analysis --allow-dirty --no-verify
-   ls -lh target/package/big-code-analysis-*.crate    # expect ≲ 1 MiB
+   make check-publish-metadata
    ```
 
-   If the `.crate` is larger than a few MiB, fix the `include`
-   block before continuing.
+   Do **not** reach for `cargo package --no-verify` here: it resolves
+   the `=<version>` leaf pins against the registry and fails before it
+   measures anything (see
+   [Vendored tree-sitter grammar publishability](#vendored-tree-sitter-grammar-publishability)).
+   The gate above uses `cargo package --list`, which does not. To see
+   the file list yourself:
+
+   ```bash
+   cargo package -p big-code-analysis --allow-dirty --list | wc -l
+   # ~1.3k entries, all under src/ plus Cargo.toml, README.md,
+   # LICENSE, CHANGELOG.md. A count in the tens of thousands means
+   # `include` has regressed and tests/repositories/ is being packaged.
+   ```
 
 3. **Publish leaf-first, with rate-limit pacing.** crates.io
    rate-limits **new** crates at roughly one per ten minutes after
@@ -682,13 +727,12 @@ Before tagging, on `main`:
 - [ ] `minisign.pub` is a real key (run
       `grep '^untrusted comment: placeholder' minisign.pub`; it
       should print nothing).
-- [ ] Parent crate packages to a sane size: `cargo package -p
-      big-code-analysis --allow-dirty --no-verify` followed by
-      `ls -lh target/package/big-code-analysis-*.crate` should show
-      well under 10 MiB (the crates.io upload ceiling). If it
-      balloons, the `[package].include` block has regressed or a
-      newly-added directory needs to be excluded; see
-      [crates.io ownership](#cratesio-ownership).
+- [ ] `make check-publish-metadata` passes. It is the only pre-tag
+      gate on the three top-level crates' publish metadata — none of
+      them can be `cargo publish --dry-run`-ed before the tag — and it
+      is what catches an `[package].include` block that has regressed
+      or stopped covering a newly-added directory. See
+      [Vendored tree-sitter grammar publishability](#vendored-tree-sitter-grammar-publishability).
 - [ ] The defer-and-gate variables (`ENABLE_CRATES_PUBLISH`,
       `ENABLE_HOMEBREW_TAP`, `ENABLE_SCOOP_BUCKET`) are set to the
       intended state for this release.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -737,13 +737,33 @@ Before tagging, on `main`:
       `ENABLE_HOMEBREW_TAP`, `ENABLE_SCOOP_BUCKET`) are set to the
       intended state for this release.
 
-Commit and push these changes. The final commit on `main` before
-tagging should be the release-prep commit.
+Then commit, gate, and tag, in that order:
+
+1. **Commit** the release-prep changes. This is the last commit on
+   `main` before the tag.
+2. **Run `make release-check VERSION=x.y.z`.** This is the pre-tag
+   gate: license and advisory policy, the two `THIRD-PARTY-LICENSES`
+   renders, a real `cargo publish --dry-run` of the five vendored
+   grammar leaves, and the publish-metadata and changelog checks
+   above. It only works on a committed tree, because those dry-runs
+   are `cargo publish`, which refuses to package a directory holding
+   uncommitted changes, and the release-prep commit always touches
+   all five leaves (each carries the version and the install
+   snippet). If the gate fails, amend the commit and re-run. Do not
+   reach for the `--allow-dirty` that cargo's error suggests: it
+   would gate content the tag will not carry.
+3. **Push, then tag**
+   ([Cutting a stable release](#cutting-a-stable-release)). The gate
+   is entirely local, so the push can happen on either side of
+   step 2.
 
 ## Cutting a stable release
 
 Pick a semver version (e.g. `1.2.0`). The tag is the version prefixed
-with `v`.
+with `v`. Work through the
+[Pre-release checklist](#pre-release-checklist) first:
+`make release-check VERSION=1.2.0` runs there, against the
+release-prep commit and before this tag.
 
 ```bash
 # From a clean main checkout at the release-prep commit:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -227,6 +227,29 @@ already matches the workspace version.
 You only need to do this once per project, but verify each item
 before the first real release.
 
+### Local tooling
+
+`make release-check` shells out to two cargo subcommands that the
+day-to-day gate never touches, plus `minisign` if you verify a
+published release locally:
+
+```bash
+cargo install --locked cargo-deny
+cargo install --locked cargo-about --features cli
+```
+
+`--features cli` is not optional. cargo-about moved its binary behind
+a non-default `cli` feature in 0.9.0, so `cargo install cargo-about`
+compiles the library, installs no binary, reports the miss as a
+*warning*, and exits 0 — after which `cargo about` still answers `no
+such command: about`, which reads like a PATH problem rather than an
+install that did nothing.
+
+`make check-tools` lists both alongside the rest of the toolchain, and
+`make release-check` probes them up front and names whichever is
+missing, so neither failure mode has to be diagnosed from cargo's
+generic error.
+
 ### Repository secrets
 
 Configure these under **Settings → Secrets and variables → Actions →

--- a/enums/Cargo.toml
+++ b/enums/Cargo.toml
@@ -55,5 +55,30 @@ tree-sitter-ccomment = { package = "bca-tree-sitter-ccomment", path = "../tree-s
 tree-sitter-mozcpp = { package = "bca-tree-sitter-mozcpp", path = "../tree-sitter-mozcpp", version = "=2.1.1" }
 tree-sitter-mozjs = { package = "bca-tree-sitter-mozjs", path = "../tree-sitter-mozjs", version = "=2.1.1" }
 
+# Mirrors [workspace.lints] in ../Cargo.toml. `enums` is excluded from
+# that workspace (see [workspace].exclude there), so it cannot inherit
+# via `lints.workspace = true` and needs its own copy — without it
+# `make enums-check` reads as a full lint gate while running against a
+# strictly smaller lint set than every shipping crate (#1228).
+#
+# One deliberate divergence: the workspace's
+# `unexpected_cfgs = { check-cfg = ['cfg(chain_audit)'] }` entry is not
+# repeated here. It exists to *admit* the library's `chain_audit` walk
+# assertion (#1122), which this crate has no counterpart to; copying it
+# would only teach rustc to accept a `cfg(chain_audit)` typo in a crate
+# that never sets the flag.
+[lints.rust]
+missing_docs = "warn"
+
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+module_name_repetitions = "allow"
+
+# `clippy::unwrap_used` is a per-root `#![cfg_attr(not(test), ...)]`
+# attribute in src/lib.rs and src/main.rs rather than an entry here, for
+# the reason spelled out in ../Cargo.toml: a Cargo lint applies to every
+# target of its package, and the `unwrap` ban is a production-only rule
+# (#1227).
+
 [profile.release]
 debug = "line-tables-only"

--- a/enums/src/common.rs
+++ b/enums/src/common.rs
@@ -151,12 +151,16 @@ pub fn camel_case(name: &str) -> String {
 }
 
 /// Enumerates a grammar's node kinds as `(rust_name, renamed, ts_name)`
-/// triples, named nodes first, with the tree-sitter ERROR sentinel
+/// triples in node-kind id order, with the tree-sitter ERROR sentinel
 /// appended last.
 ///
 /// `renamed` marks an entry whose Rust name carries a numeric suffix to
-/// break a collision with an earlier one. `escape` is forwarded to
-/// [`sanitize_string`].
+/// break a collision with an earlier one. Named kinds are *resolved*
+/// before anonymous ones, so a named kind keeps the unsuffixed name and
+/// an anonymous namesake takes the suffix; that is a naming priority,
+/// not the order of the returned `Vec`, which stays keyed on the id so
+/// the generated enum's discriminants match tree-sitter's. `escape` is
+/// forwarded to [`sanitize_string`].
 ///
 /// # Panics
 ///

--- a/enums/src/common.rs
+++ b/enums/src/common.rs
@@ -9,10 +9,19 @@ use tree_sitter::Language;
 /// formatting error rather than a malformed template — but "unlikely"
 /// is not "impossible", and each caller is three lines from an `Err`
 /// it can return (#1227).
+#[must_use]
 pub fn render_error(err: askama::Error) -> std::io::Error {
     std::io::Error::other(err)
 }
 
+/// Rewrites a tree-sitter node-kind string into a valid Rust identifier.
+///
+/// Punctuation becomes its symbolic name (`+` -> `PLUS`), separated
+/// from any preceding alphanumeric run by `_`; characters with no
+/// mapping are dropped. A handful of whole-token special cases (the
+/// BOM, `_`, `self`, `Self`) are translated up front because the
+/// generic rule would leave them empty or reserved.
+#[must_use]
 pub fn sanitize_identifier(name: &str) -> String {
     // Match both the canonical U+FEFF (a UTF-8-decoded BOM token, the
     // shape tree-sitter actually produces from `node_kind_for_id`) and
@@ -83,6 +92,15 @@ pub fn sanitize_identifier(name: &str) -> String {
     result
 }
 
+/// Escapes a tree-sitter node-kind string for embedding in a string
+/// literal.
+///
+/// `escape` selects how many rounds of literal interpretation the value
+/// must survive: `false` emits the single-backslash form for a literal
+/// parsed once (Rust source, JSON — see issue #862), `true` the
+/// double-backslash form for a value that is re-interpreted a second
+/// time.
+#[must_use]
 pub fn sanitize_string(name: &str, escape: bool) -> String {
     let mut result = String::with_capacity(name.len());
     if escape {
@@ -111,7 +129,12 @@ pub fn sanitize_string(name: &str, escape: bool) -> String {
     result
 }
 
-pub fn camel_case(name: String) -> String {
+/// Converts a `snake_case` identifier to `CamelCase`.
+///
+/// Underscores only toggle the capitalize-next flag and are never
+/// emitted, so leading, trailing, and doubled ones collapse away.
+#[must_use]
+pub fn camel_case(name: &str) -> String {
     let mut result = String::with_capacity(name.len());
     let mut cap = true;
     for c in name.chars() {
@@ -127,6 +150,23 @@ pub fn camel_case(name: String) -> String {
     result
 }
 
+/// Enumerates a grammar's node kinds as `(rust_name, renamed, ts_name)`
+/// triples, named nodes first, with the tree-sitter ERROR sentinel
+/// appended last.
+///
+/// `renamed` marks an entry whose Rust name carries a numeric suffix to
+/// break a collision with an earlier one. `escape` is forwarded to
+/// [`sanitize_string`].
+///
+/// # Panics
+///
+/// Panics when the grammar reports a `node_kind_count` outside
+/// tree-sitter's own `u16` id space, which means a provably-broken
+/// grammar (#548). Wrapping the index instead would silently read a
+/// different node kind, and this is a build-time generator rather than
+/// shipped library code, so failing the run loudly is the cheaper
+/// outcome.
+#[must_use]
 pub fn get_token_names(language: &Language, escape: bool) -> Vec<(String, bool, String)> {
     let count = language.node_kind_count();
     let mut names = BTreeMap::default();
@@ -151,9 +191,8 @@ pub fn get_token_names(language: &Language, escape: bool) -> Vec<(String, bool, 
             let kind = language
                 .node_kind_for_id(id)
                 .expect("id < node_kind_count is a valid node kind");
-            let name = sanitize_identifier(kind);
             let ts_name = sanitize_string(kind, escape);
-            let mut name = camel_case(name);
+            let mut name = camel_case(&sanitize_identifier(kind));
             if name.is_empty() {
                 name = format!("Anon{i}");
             }
@@ -274,7 +313,7 @@ mod tests {
 
     #[test]
     fn camel_case_simple() {
-        assert_eq!(camel_case("foo_bar".to_string()), "FooBar");
+        assert_eq!(camel_case("foo_bar"), "FooBar");
     }
 
     // Underscores only toggle the capitalize-next flag; they are never
@@ -282,14 +321,14 @@ mod tests {
     // collapse away entirely.
     #[test]
     fn camel_case_underscore_variants() {
-        assert_eq!(camel_case("_foo".to_string()), "Foo");
-        assert_eq!(camel_case("foo_".to_string()), "Foo");
-        assert_eq!(camel_case("foo__bar".to_string()), "FooBar");
+        assert_eq!(camel_case("_foo"), "Foo");
+        assert_eq!(camel_case("foo_"), "Foo");
+        assert_eq!(camel_case("foo__bar"), "FooBar");
     }
 
     #[test]
     fn camel_case_empty_is_empty() {
-        assert_eq!(camel_case(String::new()), "");
+        assert_eq!(camel_case(""), "");
     }
 
     #[test]

--- a/enums/src/go.rs
+++ b/enums/src/go.rs
@@ -3,8 +3,8 @@ use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
-use crate::common::*;
-use crate::languages::*;
+use crate::common::{camel_case, get_token_names, render_error};
+use crate::languages::{Lang, get_language, get_language_name};
 
 #[derive(Debug, Template)]
 #[template(path = "go.go", escape = "none")]
@@ -13,17 +13,25 @@ struct GoTemplate {
     names: Vec<(String, bool, String, String)>,
 }
 
+/// Writes one Go token-kind package per [`Lang`] into `output`.
+///
+/// `file_template` is the file stem with `$` standing in for the
+/// lowercased language name, so `language_$` yields `language_rust.go`.
+///
+/// # Errors
+///
+/// Returns the underlying [`std::io::Error`] when a destination file
+/// cannot be created or written, or when a template fails to render.
 pub fn generate_go(output: &Path, file_template: &str) -> std::io::Result<()> {
     for lang in Lang::into_enum_iter() {
         let language = get_language(&lang);
-        let name = get_language_name(&lang);
-        let c_name = camel_case(name.to_string());
+        let c_name = camel_case(get_language_name(&lang));
 
         let file_name = format!("{}.go", file_template.replace('$', &c_name.to_lowercase()));
         let path = output.join(file_name);
         let mut file = File::create(path)?;
 
-        let mut names = get_token_names(&language, false);
+        let names = get_token_names(&language, false);
         // `unwrap_or(0)` is the identity, not a swallowed error: with no
         // names the `map` below yields nothing, so the padding width is
         // never read. The empty case is unreachable — `get_token_names`
@@ -33,8 +41,11 @@ pub fn generate_go(output: &Path, file_template: &str) -> std::io::Result<()> {
         // alone because an `unwrap()` states no invariant at all (#1227).
         let max_len = names.iter().map(|x| x.0.len()).max().unwrap_or(0);
         let names: Vec<_> = names
-            .drain(..)
-            .map(move |(n, d, t)| (n.clone(), d, t, format!("{: <width$}", n, width = max_len)))
+            .into_iter()
+            .map(|(n, d, t)| {
+                let padded = format!("{n: <max_len$}");
+                (n, d, t, padded)
+            })
             .collect();
 
         let args = GoTemplate { c_name, names };

--- a/enums/src/json.rs
+++ b/enums/src/json.rs
@@ -3,8 +3,8 @@ use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
-use crate::common::*;
-use crate::languages::*;
+use crate::common::{camel_case, get_token_names, render_error};
+use crate::languages::{Lang, get_language, get_language_name};
 
 #[derive(Debug, Template)]
 #[template(path = "json.json", escape = "none")]
@@ -19,11 +19,20 @@ struct JsonTemplate {
 // source-string interpretation layer (issue #862).
 const JSON_TOKEN_ESCAPE: bool = false;
 
+/// Writes one JSON token-kind table per [`Lang`] into `output`.
+///
+/// `file_template` is the file stem with `$` standing in for the
+/// lowercased language name, so `language_$` yields
+/// `language_rust.json`.
+///
+/// # Errors
+///
+/// Returns the underlying [`std::io::Error`] when a destination file
+/// cannot be created or written, or when a template fails to render.
 pub fn generate_json(output: &Path, file_template: &str) -> std::io::Result<()> {
     for lang in Lang::into_enum_iter() {
         let language = get_language(&lang);
-        let name = get_language_name(&lang);
-        let c_name = camel_case(name.to_string());
+        let c_name = camel_case(get_language_name(&lang));
 
         let file_name = format!(
             "{}.json",
@@ -45,6 +54,7 @@ pub fn generate_json(output: &Path, file_template: &str) -> std::io::Result<()> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::sanitize_string;
 
     // Minimal JSON string-literal unescaper, sufficient for the escape
     // sequences `sanitize_string` can emit (`\"`, `\\`, `\t`, `\n`, `\r`).
@@ -58,7 +68,9 @@ mod tests {
             if c == '\\' {
                 match chars.next() {
                     Some('"') => out.push('"'),
-                    Some('\\') => out.push('\\'),
+                    // A trailing lone backslash has nothing to escape,
+                    // so it stands for itself — same body as `\\`.
+                    Some('\\') | None => out.push('\\'),
                     Some('t') => out.push('\t'),
                     Some('n') => out.push('\n'),
                     Some('r') => out.push('\r'),
@@ -66,7 +78,6 @@ mod tests {
                         out.push('\\');
                         out.push(other);
                     }
-                    None => out.push('\\'),
                 }
             } else {
                 out.push(c);

--- a/enums/src/lib.rs
+++ b/enums/src/lib.rs
@@ -1,3 +1,12 @@
+//! Build-time generator for the per-language token-kind enums.
+//!
+//! Every grammar in [`Lang`] is loaded through its tree-sitter crate,
+//! its node kinds are enumerated, and the result is rendered through
+//! one of the `templates/` files into a Rust, Go, or JSON module. The
+//! Rust output is what lands in the parent crate's `src/languages/`;
+//! `make enums-codegen-drift` fails when the checked-in files no longer
+//! match what this crate emits.
+
 // Production-only `unwrap()` ban. See `[workspace.lints.clippy]` in the
 // root `Cargo.toml` for why this is a per-root attribute and not a
 // Cargo lint (#1227). `enums` is excluded from that workspace, so it

--- a/enums/src/macros.rs
+++ b/enums/src/macros.rs
@@ -1,12 +1,15 @@
 macro_rules! mk_enum {
     ( $( $camel:ident ),* ) => {
+        /// Every grammar the generator emits token-kind enums for.
         #[derive(Clone, Debug, PartialEq)]
         pub enum Lang {
             $(
+                #[doc = concat!("The `", stringify!($camel), "` grammar.")]
                 $camel,
             )*
         }
         impl Lang {
+            /// Iterates every variant, in the order `mk_langs!` lists them.
             pub fn into_enum_iter() -> impl Iterator<Item=Lang> {
                 use Lang::*;
                 [$( $camel, )*].into_iter()
@@ -22,6 +25,7 @@ macro_rules! mk_enum {
 // is hand-written and exhaustiveness-checked by the compiler. See #867.
 macro_rules! mk_get_language {
     () => {
+        /// Loads the tree-sitter grammar backing `lang`.
         pub fn get_language(lang: &Lang) -> Language {
             match lang {
                 Lang::Kotlin => tree_sitter_kotlin_ng::LANGUAGE.into(),
@@ -56,6 +60,8 @@ macro_rules! mk_get_language {
 
 macro_rules! mk_get_language_name {
     ( $( $camel:ident ),* ) => {
+        /// Returns `lang`'s variant name, the stem every generated file
+        /// and `CamelCase` type name is derived from.
         pub fn get_language_name(lang: &Lang) -> &'static str {
             match lang {
                 $(

--- a/enums/src/main.rs
+++ b/enums/src/main.rs
@@ -1,3 +1,7 @@
+//! Command-line front end for the token-kind enum generator: picks an
+//! output language and a destination directory, then delegates to the
+//! matching `generate_*` entry point in the library half of this crate.
+
 // Production-only `unwrap()` ban. See `[workspace.lints.clippy]` in the
 // root `Cargo.toml` for why this is a per-root attribute and not a
 // Cargo lint (#1227). `enums` is excluded from that workspace, so it
@@ -8,7 +12,7 @@ use std::path::PathBuf;
 
 use clap::{Parser, ValueEnum};
 
-use enums::*;
+use enums::{generate_go, generate_json, generate_macros, generate_rust};
 
 // `ValueEnum` is the single source of truth for the `--language` values:
 // clap both restricts input to these variants and constructs the enum

--- a/enums/src/rust.rs
+++ b/enums/src/rust.rs
@@ -3,8 +3,8 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::Path;
 
-use crate::common::*;
-use crate::languages::*;
+use crate::common::{camel_case, get_token_names, render_error};
+use crate::languages::{Lang, get_language, get_language_name};
 
 const MACROS_DEFINITION_DIR: &str = "data";
 
@@ -20,9 +20,18 @@ struct RustTemplate {
     error_sentinel: String,
 }
 
+/// Writes one Rust token-kind module per [`Lang`] into `output`.
+///
+/// `file_template` is the file stem with `$` standing in for the
+/// lowercased language name, so `language_$` yields `language_rust.rs`.
+///
+/// # Errors
+///
+/// Returns the underlying [`std::io::Error`] when a destination file
+/// cannot be created or written, or when a template fails to render.
 pub fn generate_rust(output: &Path, file_template: &str) -> std::io::Result<()> {
     for lang in Lang::into_enum_iter() {
-        let c_name = camel_case(get_language_name(&lang).to_string());
+        let c_name = camel_case(get_language_name(&lang));
         let file_name = format!("{}.rs", file_template.replace('$', &c_name.to_lowercase()));
         let path = output.join(file_name);
         let mut file = File::create(path)?;
@@ -35,7 +44,7 @@ pub fn generate_rust(output: &Path, file_template: &str) -> std::io::Result<()> 
 }
 
 fn build_rust_template(lang: &Lang) -> RustTemplate {
-    let c_name = camel_case(get_language_name(lang).to_string());
+    let c_name = camel_case(get_language_name(lang));
     let names = get_token_names(&get_language(lang), false);
 
     // `get_token_names` always appends the tree-sitter ERROR sentinel last
@@ -62,6 +71,14 @@ struct CMacrosTemplate {
     names: Vec<String>,
 }
 
+/// Writes the C predefined-macro and special-identifier tables into
+/// `output`, read from the checked-in lists under `data/`.
+///
+/// # Errors
+///
+/// Returns the underlying [`std::io::Error`] when a source list cannot
+/// be read, holds non-UTF-8 bytes, or a destination file cannot be
+/// created or written.
 pub fn generate_macros(output: &Path) -> std::io::Result<()> {
     create_macros_file(output, "c_macros", "PREDEFINED_MACROS")?;
     create_macros_file(output, "c_specials", "SPECIALS")
@@ -96,7 +113,7 @@ fn create_macros_file(output: &Path, filename: &str, u_name: &str) -> std::io::R
     names.dedup();
     let l_name = u_name.to_lowercase();
 
-    let path = output.join(format!("{}.rs", filename));
+    let path = output.join(format!("{filename}.rs"));
 
     let mut file = File::create(&path)?;
 

--- a/enums/tests/dispatch.rs
+++ b/enums/tests/dispatch.rs
@@ -27,38 +27,38 @@ use tree_sitter::Language;
 // under test. We deliberately repeat the `LANGUAGE.into()` call here
 // rather than reuse `get_language` — comparing `get_language(...)` to
 // itself would be a tautology and would not catch macro-arm drift.
-fn assert_dispatch(lang: Lang, name: &'static str, expected: Language) {
-    assert_eq!(get_language(&lang), expected, "{name} grammar mismatch");
-    assert_eq!(get_language_name(&lang), name, "{name} name mismatch");
+fn assert_dispatch(lang: &Lang, name: &'static str, expected: &Language) {
+    assert_eq!(&get_language(lang), expected, "{name} grammar mismatch");
+    assert_eq!(get_language_name(lang), name, "{name} name mismatch");
 }
 
 #[test]
 fn lang_kotlin_resolves_to_tree_sitter_kotlin_ng() {
     assert_dispatch(
-        Lang::Kotlin,
+        &Lang::Kotlin,
         "Kotlin",
-        tree_sitter_kotlin_ng::LANGUAGE.into(),
+        &tree_sitter_kotlin_ng::LANGUAGE.into(),
     );
 }
 
 #[test]
 fn lang_lua_resolves_to_tree_sitter_lua() {
-    assert_dispatch(Lang::Lua, "Lua", tree_sitter_lua::LANGUAGE.into());
+    assert_dispatch(&Lang::Lua, "Lua", &tree_sitter_lua::LANGUAGE.into());
 }
 
 #[test]
 fn lang_java_resolves_to_tree_sitter_java() {
-    assert_dispatch(Lang::Java, "Java", tree_sitter_java::LANGUAGE.into());
+    assert_dispatch(&Lang::Java, "Java", &tree_sitter_java::LANGUAGE.into());
 }
 
 #[test]
 fn lang_go_resolves_to_tree_sitter_go() {
-    assert_dispatch(Lang::Go, "Go", tree_sitter_go::LANGUAGE.into());
+    assert_dispatch(&Lang::Go, "Go", &tree_sitter_go::LANGUAGE.into());
 }
 
 #[test]
 fn lang_rust_resolves_to_tree_sitter_rust() {
-    assert_dispatch(Lang::Rust, "Rust", tree_sitter_rust::LANGUAGE.into());
+    assert_dispatch(&Lang::Rust, "Rust", &tree_sitter_rust::LANGUAGE.into());
 }
 
 // Tcl is backed by the vendored `bca-tree-sitter-tcl` fork; the
@@ -66,14 +66,18 @@ fn lang_rust_resolves_to_tree_sitter_rust() {
 // import path. See enums/Cargo.toml.
 #[test]
 fn lang_tcl_resolves_to_vendored_tcl() {
-    assert_dispatch(Lang::Tcl, "Tcl", tree_sitter_tcl::LANGUAGE.into());
+    assert_dispatch(&Lang::Tcl, "Tcl", &tree_sitter_tcl::LANGUAGE.into());
 }
 
 // iRules (an F5 Tcl dialect) is a crates.io grammar, not a vendored fork,
 // so it dispatches through the plain `tree_sitter_irules::LANGUAGE`.
 #[test]
 fn lang_irules_resolves_to_tree_sitter_irules() {
-    assert_dispatch(Lang::Irules, "Irules", tree_sitter_irules::LANGUAGE.into());
+    assert_dispatch(
+        &Lang::Irules,
+        "Irules",
+        &tree_sitter_irules::LANGUAGE.into(),
+    );
 }
 
 // The Cpp -> mozcpp swap is the original drift bug this test file
@@ -83,30 +87,38 @@ fn lang_irules_resolves_to_tree_sitter_irules() {
 fn lang_cpp_resolves_to_upstream_tree_sitter_cpp() {
     // Since #720 `Lang::Cpp` is backed by the upstream community
     // grammar; the Mozilla fork moved to `Lang::Mozcpp` below.
-    assert_dispatch(Lang::Cpp, "Cpp", tree_sitter_cpp::LANGUAGE.into());
+    assert_dispatch(&Lang::Cpp, "Cpp", &tree_sitter_cpp::LANGUAGE.into());
 }
 
 #[test]
 fn lang_c_resolves_to_tree_sitter_c() {
     // Dedicated C language added in #721 (upstream `tree-sitter-c`).
-    assert_dispatch(Lang::C, "C", tree_sitter_c::LANGUAGE.into());
+    assert_dispatch(&Lang::C, "C", &tree_sitter_c::LANGUAGE.into());
 }
 
 #[test]
 fn lang_mozcpp_resolves_to_vendored_mozcpp() {
-    assert_dispatch(Lang::Mozcpp, "Mozcpp", tree_sitter_mozcpp::LANGUAGE.into());
+    assert_dispatch(
+        &Lang::Mozcpp,
+        "Mozcpp",
+        &tree_sitter_mozcpp::LANGUAGE.into(),
+    );
 }
 
 #[test]
 fn lang_objc_resolves_to_tree_sitter_objc() {
     // Dedicated Objective-C language added in #724 (upstream
     // `tree-sitter-objc`). `.mm` Objective-C++ stays on `Lang::Cpp`.
-    assert_dispatch(Lang::Objc, "Objc", tree_sitter_objc::LANGUAGE.into());
+    assert_dispatch(&Lang::Objc, "Objc", &tree_sitter_objc::LANGUAGE.into());
 }
 
 #[test]
 fn lang_python_resolves_to_tree_sitter_python() {
-    assert_dispatch(Lang::Python, "Python", tree_sitter_python::LANGUAGE.into());
+    assert_dispatch(
+        &Lang::Python,
+        "Python",
+        &tree_sitter_python::LANGUAGE.into(),
+    );
 }
 
 // Both Tsx and Typescript share the `tree_sitter_typescript` crate
@@ -115,45 +127,53 @@ fn lang_python_resolves_to_tree_sitter_python() {
 #[test]
 fn lang_tsx_resolves_to_typescript_tsx() {
     assert_dispatch(
-        Lang::Tsx,
+        &Lang::Tsx,
         "Tsx",
-        tree_sitter_typescript::LANGUAGE_TSX.into(),
+        &tree_sitter_typescript::LANGUAGE_TSX.into(),
     );
 }
 
 #[test]
 fn lang_typescript_resolves_to_typescript_typescript() {
     assert_dispatch(
-        Lang::Typescript,
+        &Lang::Typescript,
         "Typescript",
-        tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+        &tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
     );
 }
 
 #[test]
 fn lang_bash_resolves_to_tree_sitter_bash() {
-    assert_dispatch(Lang::Bash, "Bash", tree_sitter_bash::LANGUAGE.into());
+    assert_dispatch(&Lang::Bash, "Bash", &tree_sitter_bash::LANGUAGE.into());
 }
 
 // The Csharp variant uses the `tree_sitter_c_sharp` crate (note the
 // underscore-separated import name vs the camel-cased enum variant).
 #[test]
 fn lang_csharp_resolves_to_tree_sitter_c_sharp() {
-    assert_dispatch(Lang::Csharp, "Csharp", tree_sitter_c_sharp::LANGUAGE.into());
+    assert_dispatch(
+        &Lang::Csharp,
+        "Csharp",
+        &tree_sitter_c_sharp::LANGUAGE.into(),
+    );
 }
 
 #[test]
 fn lang_elixir_resolves_to_tree_sitter_elixir() {
-    assert_dispatch(Lang::Elixir, "Elixir", tree_sitter_elixir::LANGUAGE.into());
+    assert_dispatch(
+        &Lang::Elixir,
+        "Elixir",
+        &tree_sitter_elixir::LANGUAGE.into(),
+    );
 }
 
 // Vendored fork: bca-tree-sitter-ccomment.
 #[test]
 fn lang_ccomment_resolves_to_vendored_ccomment() {
     assert_dispatch(
-        Lang::Ccomment,
+        &Lang::Ccomment,
         "Ccomment",
-        tree_sitter_ccomment::LANGUAGE.into(),
+        &tree_sitter_ccomment::LANGUAGE.into(),
     );
 }
 
@@ -161,30 +181,30 @@ fn lang_ccomment_resolves_to_vendored_ccomment() {
 #[test]
 fn lang_preproc_resolves_to_vendored_preproc() {
     assert_dispatch(
-        Lang::Preproc,
+        &Lang::Preproc,
         "Preproc",
-        tree_sitter_preproc::LANGUAGE.into(),
+        &tree_sitter_preproc::LANGUAGE.into(),
     );
 }
 
 // Vendored Mozilla JS grammar fork: bca-tree-sitter-mozjs.
 #[test]
 fn lang_mozjs_resolves_to_vendored_mozjs() {
-    assert_dispatch(Lang::Mozjs, "Mozjs", tree_sitter_mozjs::LANGUAGE.into());
+    assert_dispatch(&Lang::Mozjs, "Mozjs", &tree_sitter_mozjs::LANGUAGE.into());
 }
 
 #[test]
 fn lang_javascript_resolves_to_tree_sitter_javascript() {
     assert_dispatch(
-        Lang::Javascript,
+        &Lang::Javascript,
         "Javascript",
-        tree_sitter_javascript::LANGUAGE.into(),
+        &tree_sitter_javascript::LANGUAGE.into(),
     );
 }
 
 #[test]
 fn lang_perl_resolves_to_tree_sitter_perl() {
-    assert_dispatch(Lang::Perl, "Perl", tree_sitter_perl::LANGUAGE.into());
+    assert_dispatch(&Lang::Perl, "Perl", &tree_sitter_perl::LANGUAGE.into());
 }
 
 // PHP uses `LANGUAGE_PHP` (not the bare `LANGUAGE`), since the crate
@@ -192,12 +212,12 @@ fn lang_perl_resolves_to_tree_sitter_perl() {
 // against a macro arm flipping between them.
 #[test]
 fn lang_php_resolves_to_tree_sitter_php_language_php() {
-    assert_dispatch(Lang::Php, "Php", tree_sitter_php::LANGUAGE_PHP.into());
+    assert_dispatch(&Lang::Php, "Php", &tree_sitter_php::LANGUAGE_PHP.into());
 }
 
 #[test]
 fn lang_ruby_resolves_to_tree_sitter_ruby() {
-    assert_dispatch(Lang::Ruby, "Ruby", tree_sitter_ruby::LANGUAGE.into());
+    assert_dispatch(&Lang::Ruby, "Ruby", &tree_sitter_ruby::LANGUAGE.into());
 }
 
 // Groovy is backed by the `dekobon-tree-sitter-groovy` crate (not
@@ -206,9 +226,9 @@ fn lang_ruby_resolves_to_tree_sitter_ruby() {
 #[test]
 fn lang_groovy_resolves_to_dekobon_tree_sitter_groovy() {
     assert_dispatch(
-        Lang::Groovy,
+        &Lang::Groovy,
         "Groovy",
-        dekobon_tree_sitter_groovy::LANGUAGE.into(),
+        &dekobon_tree_sitter_groovy::LANGUAGE.into(),
     );
 }
 

--- a/mise.toml
+++ b/mise.toml
@@ -24,6 +24,16 @@ python = "3.12"
 # entries, because pipx itself needs a Python interpreter on PATH.
 # Listing python = "3.12" above is therefore load-bearing — do not
 # reorder.
+#
+# Deliberately unpinned, including ruff, whose version this repository
+# otherwise holds in lockstep across four files (#1230). mise's pipx
+# backend takes a single exact version, not a PEP 440 range, so pinning
+# here would add a fifth exact copy to bump on every ruff release —
+# reproducing the drift the lockstep gate exists to stop, in a file no
+# gate reads. Instead `make py-fmt` / `py-lint` prefer
+# `big-code-analysis-py/.venv/bin/ruff`, so a contributor who has run
+# `make py-bootstrap` never reaches these; these are the fallback for
+# one who has not, and CI is the backstop there.
 "pipx:ruff" = "latest"
 "pipx:mypy" = "latest"
 "pipx:pyright" = "latest"

--- a/utils/check-excluded-manifests-test.py
+++ b/utils/check-excluded-manifests-test.py
@@ -6,7 +6,8 @@ Three kinds of test, matching the check-versions-test.py pattern:
 * Unit tests against synthetic manifests, weighted toward the legal
   TOML shapes the gate's regex predecessor mis-read: literal strings,
   commented-out entries, inline arrays, indented keys, and the text
-  ``[workspace]`` inside a multi-line string.
+  ``[workspace]`` inside a multi-line string, plus the ``[lints]``-table
+  rule's shapes (absent, empty, ``workspace = true``, exempt).
 * ``main()`` tests over a synthetic repository root, covering both
   error branches and the remediation text they print.
 * A smoke test running the real gate against the real repository,
@@ -58,6 +59,22 @@ exclude = [
 [workspace.package]
 version = "2.1.0"
 """
+
+
+def excluded_crate(extra_table: str = "", name: str = "a") -> str:
+    """A minimal excluded-crate manifest that clears every check.
+
+    It roots its own workspace (#1145) and declares its own lint set
+    (#1228), so a `main()` test can splice in `extra_table` as the one
+    defect it is actually about. Passed as a whole table block, since a
+    bare key appended after `[lints.clippy]` would land inside it.
+    """
+    return (
+        f'[package]\nname = "{name}"\n'
+        f"{extra_table}"
+        "\n[workspace]\n"
+        '\n[lints.clippy]\npedantic = { level = "warn", priority = -1 }\n'
+    )
 
 
 class ReadExcludedCratesTest(unittest.TestCase):
@@ -176,6 +193,92 @@ class MissingWorkspaceTableTest(unittest.TestCase):
         root = pathlib.Path(self.enterContext(tempfile.TemporaryDirectory()))
         with self.assertRaises(SystemExit):
             GATE.missing_workspace_table(["absent"], root)
+
+
+class LintsTableTest(unittest.TestCase):
+    """The `[lints]`-table invariant (#1228).
+
+    `[workspace.lints]` reaches members only, so an excluded crate that
+    omits the table builds on compiler defaults while `make enums-check`
+    still runs it at `-D warnings` — a gate that reads as complete and
+    is not.
+    """
+
+    def _root_with(self, crates: dict[str, str]) -> pathlib.Path:
+        root = pathlib.Path(self.enterContext(tempfile.TemporaryDirectory()))
+        for name, body in crates.items():
+            (root / name).mkdir(parents=True)
+            (root / name / "Cargo.toml").write_text(body, encoding="utf-8")
+        return root
+
+    def test_a_clippy_table_satisfies_the_rule(self) -> None:
+        self.assertIsNone(
+            GATE.lints_table_problem(
+                '[package]\nname = "g"\n\n[lints.clippy]\npedantic = "warn"\n',
+                "g/Cargo.toml",
+            )
+        )
+
+    def test_a_rust_only_table_satisfies_the_rule(self) -> None:
+        # `[lints.rust]` alone is a real posture (the crate may have no
+        # clippy carve-outs); the gate asserts a declared lint set, not a
+        # particular one.
+        self.assertIsNone(
+            GATE.lints_table_problem(
+                '[package]\nname = "g"\n\n[lints.rust]\nmissing_docs = "warn"\n',
+                "g/Cargo.toml",
+            )
+        )
+
+    def test_no_table_at_all_is_reported(self) -> None:
+        self.assertEqual(
+            GATE.lints_table_problem('[package]\nname = "g"\n', "g/Cargo.toml"),
+            "no [lints] table",
+        )
+
+    def test_an_empty_table_is_reported(self) -> None:
+        # `[lints]` with nothing under it changes no lint level, so it
+        # must not buy the crate a pass.
+        self.assertEqual(
+            GATE.lints_table_problem(
+                '[package]\nname = "g"\n\n[lints]\n', "g/Cargo.toml"
+            ),
+            "no [lints] table",
+        )
+
+    def test_workspace_inheritance_is_reported_distinctly(self) -> None:
+        # The spelling every member crate uses, and the one most likely
+        # to be copied in. An excluded crate roots its own workspace, so
+        # it inherits nothing from the repository root.
+        problem = GATE.lints_table_problem(
+            '[package]\nname = "g"\n\n[lints]\nworkspace = true\n', "g/Cargo.toml"
+        )
+        self.assertIsNotNone(problem)
+        assert problem is not None
+        self.assertIn("workspace = true", problem)
+
+    def test_a_non_exempt_crate_without_a_table_is_collected(self) -> None:
+        root = self._root_with({"a": '[package]\nname = "a"\n'})
+        self.assertEqual(GATE.unlinted_crates(["a"], root), [("a", "no [lints] table")])
+
+    def test_an_exempt_vendored_grammar_is_skipped(self) -> None:
+        # The five vendored forks hold generated binding boilerplate that
+        # a regeneration replaces wholesale; the exemption is a recorded
+        # decision, not an oversight.
+        exempt = sorted(GATE.LINTS_EXEMPT_CRATES)[0]
+        root = self._root_with({exempt: f'[package]\nname = "{exempt}"\n'})
+        self.assertEqual(GATE.unlinted_crates([exempt], root), [])
+
+    def test_the_exempt_set_names_only_the_vendored_grammars(self) -> None:
+        # Non-vacuity guard: the rule would also "pass" if every excluded
+        # crate were exempt. Pin that `enums` — the crate #1228 is about
+        # — is the one the real repository actually checks.
+        crates = GATE.read_excluded_crates(
+            (REPO_ROOT / "Cargo.toml").read_text(encoding="utf-8")
+        )
+        self.assertEqual(
+            [c for c in crates if c not in GATE.LINTS_EXEMPT_CRATES], ["enums"]
+        )
 
 
 class UnpinnedGrammarDepsTest(unittest.TestCase):
@@ -367,7 +470,38 @@ class MainTest(unittest.TestCase):
         self._repo(
             '[workspace]\nexclude = ["a"]\n\n'
             '[workspace.dependencies]\ntree-sitter-cpp = "=0.23.4"\n',
+            {"a": excluded_crate()},
+        )
+        code, err = self._run()
+        self.assertEqual(code, 0, err)
+
+    def test_an_excluded_crate_without_a_lints_table_is_reported(self) -> None:
+        self._repo(
+            '[workspace]\nexclude = ["a"]\n',
             {"a": '[package]\nname = "a"\n\n[workspace]\n'},
+        )
+        code, err = self._run()
+        self.assertEqual(code, 1)
+        self.assertIn("a/Cargo.toml: no [lints] table", err)
+        self.assertIn("#1228", err)
+
+    def test_a_lints_workspace_true_in_an_excluded_crate_is_reported(self) -> None:
+        # Inheriting is what a *member* does; here it resolves to nothing.
+        self._repo(
+            '[workspace]\nexclude = ["a"]\n',
+            {
+                "a": '[package]\nname = "a"\n\n[workspace]\n\n[lints]\nworkspace = true\n'
+            },
+        )
+        code, err = self._run()
+        self.assertEqual(code, 1)
+        self.assertIn("workspace = true", err)
+
+    def test_an_exempt_crate_needs_no_lints_table(self) -> None:
+        exempt = sorted(GATE.LINTS_EXEMPT_CRATES)[0]
+        self._repo(
+            f'[workspace]\nexclude = ["{exempt}"]\n',
+            {exempt: f'[package]\nname = "{exempt}"\n\n[workspace]\n'},
         )
         code, err = self._run()
         self.assertEqual(code, 0, err)
@@ -389,10 +523,7 @@ class MainTest(unittest.TestCase):
     def test_an_unpinned_grammar_in_an_excluded_crate_is_reported(self) -> None:
         self._repo(
             '[workspace]\nexclude = ["a"]\n',
-            {
-                "a": '[package]\nname = "a"\n\n[dependencies]\n'
-                'tree-sitter-cpp = "0.23.4"\n\n[workspace]\n'
-            },
+            {"a": excluded_crate('\n[dependencies]\ntree-sitter-cpp = "0.23.4"\n')},
         )
         code, err = self._run()
         self.assertEqual(code, 1)
@@ -406,7 +537,7 @@ class MainTest(unittest.TestCase):
         self._repo(
             '[workspace]\nexclude = ["a"]\n\n'
             '[workspace.dependencies]\ntree-sitter-python = "^0.25.0"\n',
-            {"a": '[package]\nname = "a"\n\n[workspace]\n'},
+            {"a": excluded_crate()},
         )
         code, err = self._run()
         self.assertEqual(code, 1)
@@ -417,7 +548,7 @@ class MainTest(unittest.TestCase):
         self._repo(
             '[workspace]\nexclude = ["a"]\n\n'
             '[workspace.dependencies]\ntree-sitter-go = ">=0.23, <0.24"\n',
-            {"a": '[package]\nname = "a"\n\n[workspace]\n'},
+            {"a": excluded_crate()},
         )
         code, err = self._run()
         self.assertEqual(code, 1)
@@ -435,6 +566,9 @@ class RealRepositoryTest(unittest.TestCase):
         )
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("Excluded manifests OK", result.stdout)
+        # The lint-checked tally is what distinguishes a real pass from
+        # one where every excluded crate happened to be exempt.
+        self.assertIn("1 lint-checked", result.stdout)
 
 
 if __name__ == "__main__":

--- a/utils/check-excluded-manifests-test.py
+++ b/utils/check-excluded-manifests-test.py
@@ -246,6 +246,38 @@ class LintsTableTest(unittest.TestCase):
             "no [lints] table",
         )
 
+    def test_an_empty_sub_table_is_reported(self) -> None:
+        # The same vacuity as an empty `[lints]`, one level down: a
+        # `[lints.clippy]` header with no keys under it sets no level, so
+        # the crate still builds on compiler defaults while the manifest
+        # reads as having a lint posture. This is the shape the bare
+        # `[lints]` case above is checked for, and it must not slip
+        # through by being nested.
+        bodies = (
+            "[lints.rust]\n",
+            "[lints.clippy]\n",
+            "[lints.rust]\n\n[lints.clippy]\n",
+        )
+        for body in bodies:
+            with self.subTest(body=body):
+                self.assertEqual(
+                    GATE.lints_table_problem(
+                        f'[package]\nname = "g"\n\n{body}', "g/Cargo.toml"
+                    ),
+                    "[lints] declares no lint levels",
+                )
+
+    def test_one_populated_sub_table_is_enough(self) -> None:
+        # Non-vacuity guard for the rule above: an empty sibling must not
+        # veto a real declaration.
+        self.assertIsNone(
+            GATE.lints_table_problem(
+                '[package]\nname = "g"\n\n[lints.rust]\n\n'
+                '[lints.clippy]\npedantic = "warn"\n',
+                "g/Cargo.toml",
+            )
+        )
+
     def test_workspace_inheritance_is_reported_distinctly(self) -> None:
         # The spelling every member crate uses, and the one most likely
         # to be copied in. An excluded crate roots its own workspace, so
@@ -256,6 +288,70 @@ class LintsTableTest(unittest.TestCase):
         self.assertIsNotNone(problem)
         assert problem is not None
         self.assertIn("workspace = true", problem)
+
+    def test_self_rooted_inheritance_is_a_real_posture(self) -> None:
+        # An excluded crate roots its own workspace, so `workspace = true`
+        # resolves against `[workspace.lints]` in this same file. Measured
+        # on cargo 1.95: this manifest builds and emits the inherited
+        # `missing_docs`, so rejecting it — as this gate did until the
+        # value was resolved rather than assumed absent — is a false
+        # positive stating a reason that is not true.
+        self.assertIsNone(
+            GATE.lints_table_problem(
+                '[package]\nname = "g"\n\n'
+                '[workspace]\n\n[workspace.lints.rust]\nmissing_docs = "warn"\n\n'
+                "[lints]\nworkspace = true\n",
+                "g/Cargo.toml",
+            )
+        )
+
+    def test_inherited_lints_face_the_same_vacuity_rule(self) -> None:
+        # Resolving the inheritance must not become a way around the
+        # emptiness check: an inherited table that declares no level is as
+        # vacuous as a local one.
+        self.assertEqual(
+            GATE.lints_table_problem(
+                '[package]\nname = "g"\n\n'
+                "[workspace]\n\n[workspace.lints.rust]\n\n"
+                "[lints]\nworkspace = true\n",
+                "g/Cargo.toml",
+            ),
+            "[lints] declares no lint levels",
+        )
+
+    def test_an_empty_inherited_table_reads_as_vacuous_not_absent(self) -> None:
+        # `[workspace.lints]` with nothing under it resolves fine — it just
+        # sets no level. Naming that "inherits nothing" would misdescribe
+        # which half is broken.
+        self.assertEqual(
+            GATE.lints_table_problem(
+                '[package]\nname = "g"\n\n'
+                "[workspace]\n\n[workspace.lints]\n\n"
+                "[lints]\nworkspace = true\n",
+                "g/Cargo.toml",
+            ),
+            "[lints] declares no lint levels",
+        )
+
+    def test_inheritance_with_nothing_to_inherit_is_reported(self) -> None:
+        # `[workspace]` present but carrying no `lints` table: the
+        # `workspace = true` really does resolve to nothing here.
+        problem = GATE.lints_table_problem(
+            '[package]\nname = "g"\n\n[workspace]\n\n[lints]\nworkspace = true\n',
+            "g/Cargo.toml",
+        )
+        self.assertEqual(problem, "[lints] workspace = true, which inherits nothing here")
+
+    def test_the_reported_workspace_value_is_the_one_written(self) -> None:
+        # `workspace = false` fails too — cargo refuses it outright — but
+        # quoting it as `= true` sends the reader hunting for text the
+        # manifest does not contain.
+        problem = GATE.lints_table_problem(
+            '[package]\nname = "g"\n\n[lints]\nworkspace = false\n', "g/Cargo.toml"
+        )
+        self.assertIsNotNone(problem)
+        assert problem is not None
+        self.assertIn("workspace = false", problem)
 
     def test_a_non_exempt_crate_without_a_table_is_collected(self) -> None:
         root = self._root_with({"a": '[package]\nname = "a"\n'})

--- a/utils/check-excluded-manifests.py
+++ b/utils/check-excluded-manifests.py
@@ -5,7 +5,7 @@ Invariants for the root manifest and for the crates listed in its
 ``[workspace] exclude`` array — the five vendored ``tree-sitter-*``
 grammars and the ``enums`` codegen helper.
 
-Two invariants are checked.
+Three invariants are checked.
 
 **Every excluded crate must root its own workspace.** ``exclude``
 denies workspace membership but does **not** terminate cargo's upward
@@ -25,6 +25,18 @@ tables; member crates take their grammars through ``workspace = true``
 and so carry no requirement of their own. Non-grammar dependencies
 (``cc``, ``clap``, ``askama``) are out of scope; the rule is about
 grammars.
+
+**Every excluded crate must declare its own ``[lints]``, or be listed
+as exempt.** ``[workspace.lints]`` reaches members through
+``lints.workspace = true``; an excluded crate is not a member, so it
+silently gets rustc's and clippy's defaults instead. ``enums`` was
+gated by ``make enums-check`` at ``-D warnings`` for two years against
+a lint set 38 findings smaller than every shipping crate's, which reads
+as "fully linted" and is not (#1228). The five vendored
+``tree-sitter-*`` grammars are exempt by decision, recorded in
+:data:`LINTS_EXEMPT_CRATES`; the point of checking the rest is that the
+*next* crate added to ``exclude`` forces the same decision instead of
+inheriting silence.
 
 Manifests are parsed with ``tomllib`` rather than matched with regexes.
 The regex version of this gate silently skipped TOML literal strings
@@ -76,6 +88,28 @@ NON_CRATE_EXCLUDES = frozenset({".claude/worktrees"})
 # `^tree-sitter` anchor left it — and any future `bca-tree-sitter-*` —
 # unchecked.
 GRAMMAR_DEP_SUBSTRING = "tree-sitter"
+
+# Excluded crates deliberately exempt from carrying a `[lints]` table.
+#
+# The five vendored grammar forks hold ~60 lines of Rust each, and none
+# of it is ours: `bindings/rust/lib.rs` and `build.rs` come out of
+# `tree-sitter generate` from the upstream binding templates, and are
+# replaced wholesale when a grammar is regenerated. Applying the
+# workspace's `pedantic` + `missing_docs` posture there would buy
+# annotations on generated code that the next regeneration discards,
+# against a body of code with no branching to get wrong. Nothing lints
+# them today either — they are path dependencies rather than members, and
+# clippy does not lint dependencies — so this exemption records a
+# decision rather than describing a gate that exists (#1228).
+LINTS_EXEMPT_CRATES = frozenset(
+    {
+        "tree-sitter-ccomment",
+        "tree-sitter-mozcpp",
+        "tree-sitter-mozjs",
+        "tree-sitter-preproc",
+        "tree-sitter-tcl",
+    }
+)
 
 # `tree-sitter` dependencies that must NOT carry an `=` pin.
 #
@@ -183,6 +217,37 @@ def missing_workspace_table(crates: list[str], root: pathlib.Path) -> list[str]:
     return offenders
 
 
+def lints_table_problem(manifest_text: str, label: str) -> str | None:
+    """Describe why ``label``'s ``[lints]`` table is unusable, or ``None``.
+
+    Two ways to fail. An absent or empty table leaves the crate on
+    compiler defaults. A ``workspace = true`` table is worse than absent:
+    it is the spelling every *member* crate uses, so it looks right, but
+    an excluded crate roots its own workspace and inherits nothing from
+    the repository root's ``[workspace.lints]``.
+    """
+    lints = parse_manifest(manifest_text, label).get("lints")
+    if not isinstance(lints, dict) or not lints:
+        return "no [lints] table"
+    if "workspace" in lints:
+        return "[lints] workspace = true, which inherits nothing here"
+    return None
+
+
+def unlinted_crates(crates: list[str], root: pathlib.Path) -> list[tuple[str, str]]:
+    """Return ``(crate, problem)`` for excluded crates declaring no lints."""
+    offenders = []
+    for crate in crates:
+        if crate in LINTS_EXEMPT_CRATES:
+            continue
+        label = f"{crate}/Cargo.toml"
+        text = (root / crate / "Cargo.toml").read_text(encoding="utf-8")
+        problem = lints_table_problem(text, label)
+        if problem is not None:
+            offenders.append((crate, problem))
+    return offenders
+
+
 def _dependency_entries(
     data: Any, depth: int = 0, in_dep_table: bool = False
 ) -> Iterator[tuple[str, Any]]:
@@ -259,6 +324,20 @@ def _report_missing_workspace(offenders: list[str]) -> None:
     )
 
 
+def _report_unlinted(offenders: list[tuple[str, str]]) -> None:
+    print(
+        "error: excluded crates not declaring their own lint set:\n"
+        + "\n".join(f"  {crate}/Cargo.toml: {problem}" for crate, problem in offenders)
+        + "\n\n[workspace.lints] in the root Cargo.toml reaches members only.\n"
+        "An excluded crate roots its own workspace, so without a [lints]\n"
+        "table of its own it builds on compiler defaults while any gate\n"
+        "over it still reads as complete (#1228). Copy the root's\n"
+        "[lints.rust] / [lints.clippy] tables into the manifest, or add\n"
+        "the crate to LINTS_EXEMPT_CRATES with the reason.",
+        file=sys.stderr,
+    )
+
+
 def _report_unpinned(drifted: list[tuple[str, str, str]]) -> None:
     print(
         "error: tree-sitter dependencies without an `=X.Y.Z` pin:\n"
@@ -282,6 +361,14 @@ def main() -> int:
         _report_missing_workspace(offenders)
         return 1
 
+    # Ordered after the workspace-table check so a crate with no manifest
+    # at all is reported by that one's explicit hard error rather than as
+    # a read failure here.
+    unlinted = unlinted_crates(crates, REPO_ROOT)
+    if unlinted:
+        _report_unlinted(unlinted)
+        return 1
+
     # The root manifest is checked alongside the excluded crates: its
     # `[workspace.dependencies]` block holds ~20 grammar pins, and
     # AGENTS.md claims this gate enforces them.
@@ -301,9 +388,11 @@ def main() -> int:
         _report_unpinned(drifted)
         return 1
 
+    linted = len(crates) - len(LINTS_EXEMPT_CRATES.intersection(crates))
     print(
         f"Excluded manifests OK ({len(crates)} crates checked, "
-        f"{len(manifests)} manifests pin-checked)."
+        f"{len(manifests)} manifests pin-checked, "
+        f"{linted} lint-checked)."
     )
     return 0
 

--- a/utils/check-excluded-manifests.py
+++ b/utils/check-excluded-manifests.py
@@ -217,20 +217,61 @@ def missing_workspace_table(crates: list[str], root: pathlib.Path) -> list[str]:
     return offenders
 
 
+def workspace_lints(manifest: dict[str, Any]) -> dict[str, Any] | None:
+    """Return a manifest's own ``[workspace.lints]``, or ``None``.
+
+    An excluded crate roots its *own* workspace — every one here carries a
+    ``[workspace]`` table — so ``[lints] workspace = true`` resolves
+    against this same file rather than the repository root. Measured on
+    cargo 1.95: a self-rooted crate spelling both tables builds and emits
+    the inherited lints, so that shape is a real lint posture and not the
+    copied-in mistake it resembles.
+
+    An *empty* ``[workspace.lints]`` is returned rather than rejected
+    here, so the caller's vacuity rule names it as declaring no levels —
+    which is what it does. Reporting it as inheriting nothing would be
+    the less accurate of the two: the inheritance resolves fine.
+    """
+    workspace = manifest.get("workspace")
+    if not isinstance(workspace, dict):
+        return None
+    lints = workspace.get("lints")
+    return lints if isinstance(lints, dict) else None
+
+
 def lints_table_problem(manifest_text: str, label: str) -> str | None:
     """Describe why ``label``'s ``[lints]`` table is unusable, or ``None``.
 
-    Two ways to fail. An absent or empty table leaves the crate on
-    compiler defaults. A ``workspace = true`` table is worse than absent:
-    it is the spelling every *member* crate uses, so it looks right, but
-    an excluded crate roots its own workspace and inherits nothing from
-    the repository root's ``[workspace.lints]``.
+    Three ways to fail. An absent or empty table leaves the crate on
+    compiler defaults. A ``[lints.rust]`` / ``[lints.clippy]`` sub-table
+    with no keys under it is exactly as vacuous — it sets no level, so it
+    must not buy a pass either. And ``workspace = true`` with no local
+    ``[workspace.lints]`` to resolve against inherits nothing: it is the
+    spelling every *member* crate uses, so it looks right, but an
+    excluded crate does not reach the repository root's table.
+
+    ``workspace = true`` *with* a populated ``[workspace.lints]`` in the
+    same file is legitimate and passes — the effective table is the
+    inherited one, and it faces the same vacuity rule.
     """
-    lints = parse_manifest(manifest_text, label).get("lints")
+    manifest = parse_manifest(manifest_text, label)
+    lints = manifest.get("lints")
     if not isinstance(lints, dict) or not lints:
         return "no [lints] table"
     if "workspace" in lints:
-        return "[lints] workspace = true, which inherits nothing here"
+        if lints["workspace"] is not True:
+            # cargo refuses `workspace = false` outright ("`workspace`
+            # cannot be false"), so there is nothing to resolve. Quote
+            # what the manifest says: reporting `= true` here would send
+            # the reader hunting for text that is not there.
+            spelled = str(lints["workspace"]).lower()
+            return f"[lints] workspace = {spelled}, which cargo rejects"
+        inherited = workspace_lints(manifest)
+        if inherited is None:
+            return "[lints] workspace = true, which inherits nothing here"
+        lints = inherited
+    if not any(isinstance(table, dict) and table for table in lints.values()):
+        return "[lints] declares no lint levels"
     return None
 
 

--- a/utils/check-publish-metadata-test.py
+++ b/utils/check-publish-metadata-test.py
@@ -289,6 +289,69 @@ class PackagedSizeTest(unittest.TestCase):
         self.assertIn("include", problems[0])
 
 
+class PackageListingTest(unittest.TestCase):
+    def test_the_listing_invocation_is_pinned_in_full(self) -> None:
+        # Every flag here is load-bearing and none is observable anywhere
+        # else, so the whole argv is the assertion rather than the two
+        # flags that happen to be interesting today. `--locked` is the
+        # difference between checking the lockfile this tag carries and
+        # quietly rewriting it; `--allow-dirty` is what keeps the gate
+        # usable mid-edit, and dropping it would make the gate refuse on
+        # any uncommitted change while every test here still passed.
+        with mock.patch.object(GATE, "run_cargo", return_value="Cargo.toml\n") as run:
+            GATE.package_listing("demo", pathlib.Path("/ws"))
+        self.assertEqual(
+            run.call_args.args[0],
+            ["package", "-p", "demo", "--allow-dirty", "--locked", "--list"],
+        )
+
+
+class LockfileRemedyTest(unittest.TestCase):
+    # cargo answers a `--locked` refusal with "remove the --locked flag and
+    # use --offline instead", which for this gate is the one remedy that
+    # must not be followed.
+    STDERR = (
+        "error: cannot update the lock file because --locked was passed to "
+        "prevent this\nhelp: to generate the lock file without accessing the "
+        "network, remove the --locked flag and use --offline instead.\n"
+    )
+
+    def test_the_note_fires_on_a_locked_refusal(self) -> None:
+        note = GATE.lockfile_remedy(["package", "--locked", "--list"], self.STDERR)
+        self.assertIn("Cargo.lock` is stale", note)
+        self.assertIn("cargo check", note)
+
+    def test_the_note_is_silent_on_an_unrelated_failure(self) -> None:
+        # A note on every failure reads as boilerplate and stops carrying
+        # the case it exists for.
+        self.assertEqual(
+            GATE.lockfile_remedy(
+                ["package", "--locked", "--list"], "error: no such package `demo`\n"
+            ),
+            "",
+        )
+
+    def test_the_note_is_silent_when_the_flag_was_not_passed(self) -> None:
+        self.assertEqual(GATE.lockfile_remedy(["metadata"], self.STDERR), "")
+
+    def test_the_note_reaches_the_raised_error(self) -> None:
+        # The three cases above pin the note's content; this one pins that
+        # `run_cargo` still calls it. Without this, deleting the call site
+        # leaves cargo's "remove the --locked flag" advice as the only
+        # thing the maintainer reads, and no test notices.
+        completed = subprocess.CompletedProcess(
+            args=["cargo"], returncode=101, stdout="", stderr=self.STDERR
+        )
+        with mock.patch.object(GATE.subprocess, "run", return_value=completed):
+            with self.assertRaises(SystemExit) as raised:
+                GATE.run_cargo(["package", "--locked", "--list"], pathlib.Path("/ws"))
+        message = str(raised.exception)
+        self.assertIn("Cargo.lock` is stale", message)
+        # cargo's own text is still shown — the note overrides its advice,
+        # it does not hide the diagnosis.
+        self.assertIn("--locked was passed", message)
+
+
 class PublishablePackagesTest(unittest.TestCase):
     def test_publish_false_is_excluded(self) -> None:
         metadata = {

--- a/utils/check-publish-metadata-test.py
+++ b/utils/check-publish-metadata-test.py
@@ -1,0 +1,539 @@
+#!/usr/bin/env python3
+"""Tests for check-publish-metadata.py.
+
+Three kinds of test, matching the check-ruff-lockstep-test.py pattern:
+
+* Unit tests against synthetic manifests and `cargo metadata`-shaped
+  dicts, one case per regression the gate claims to catch and one per
+  malformed input it must fail loudly on.
+* ``audit()`` / ``main()`` tests over a synthetic workspace with the two
+  cargo subprocess calls stubbed, covering each finding branch and the
+  remediation text it prints.
+* A smoke test running the real gate against the real repository,
+  asserting a clean tree reports OK.
+
+The size ceiling is exercised by patching ``MAX_PACKAGED_BYTES`` down
+rather than by writing 32 MiB of fixtures: the branch under test is the
+comparison, and both sides of the boundary matter.
+
+Run with:
+    python3 -m unittest -q utils/check-publish-metadata-test.py
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+from typing import Any
+from unittest import mock
+
+UTILS_DIR = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = UTILS_DIR.parent
+SCRIPT_SRC = UTILS_DIR / "check-publish-metadata.py"
+
+
+def _load_module():  # type: ignore[no-untyped-def]
+    spec = importlib.util.spec_from_file_location("check_publish_metadata", SCRIPT_SRC)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+GATE = _load_module()
+
+# A package entry shaped like `cargo metadata --no-deps` emits one, with
+# every field the gate requires populated. Values are deliberately
+# distinct from each other and from the empty string so a test that
+# mutates one field cannot pass because another happened to match.
+GOOD_PACKAGE: dict[str, Any] = {
+    "name": "demo",
+    "description": "A demonstration crate",
+    "readme": "README.md",
+    "repository": "https://example.invalid/demo",
+    "license": "MPL-2.0",
+    "license_file": None,
+    "publish": None,
+    "manifest_path": "/ws/Cargo.toml",
+}
+
+
+def package(**overrides: Any) -> dict[str, Any]:
+    """A `GOOD_PACKAGE` with fields replaced or removed.
+
+    An override of ``None`` replaces the value; to drop a key entirely,
+    pass it through ``drop``.
+    """
+    entry = dict(GOOD_PACKAGE)
+    entry.update(overrides)
+    return entry
+
+
+def drop(entry: dict[str, Any], *keys: str) -> dict[str, Any]:
+    """A copy of `entry` with `keys` absent rather than empty."""
+    return {key: value for key, value in entry.items() if key not in keys}
+
+
+class BlankTest(unittest.TestCase):
+    def test_recognises_text(self) -> None:
+        self.assertFalse(GATE._blank("x"))
+
+    def test_absent_empty_and_whitespace_are_blank(self) -> None:
+        for value in (None, "", "   ", "\n\t", 17, [], {"workspace": True}):
+            with self.subTest(value=value):
+                self.assertTrue(GATE._blank(value))
+
+
+class MetadataFieldsTest(unittest.TestCase):
+    def test_complete_package_has_no_findings(self) -> None:
+        self.assertEqual(GATE.check_metadata_fields(GOOD_PACKAGE), [])
+
+    def test_each_required_field_is_reported_when_absent(self) -> None:
+        for field in ("description", "readme", "repository"):
+            with self.subTest(field=field):
+                problems = GATE.check_metadata_fields(drop(GOOD_PACKAGE, field))
+                self.assertEqual(len(problems), 1, problems)
+                self.assertIn(field, problems[0])
+
+    def test_each_required_field_is_reported_when_empty(self) -> None:
+        # Present-but-empty is the case a `in package` test would miss.
+        for field in ("description", "readme", "repository"):
+            with self.subTest(field=field):
+                problems = GATE.check_metadata_fields(package(**{field: "   "}))
+                self.assertEqual(len(problems), 1, problems)
+                self.assertIn(field, problems[0])
+
+    def test_missing_both_license_forms_is_reported(self) -> None:
+        problems = GATE.check_metadata_fields(package(license=None, license_file=None))
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("license", problems[0])
+
+    def test_empty_license_string_is_reported(self) -> None:
+        problems = GATE.check_metadata_fields(package(license="", license_file=None))
+        self.assertEqual(len(problems), 1, problems)
+
+    def test_license_file_alone_satisfies_the_licence_requirement(self) -> None:
+        # crates.io accepts either spelling; requiring `license` would
+        # reject a legitimate manifest.
+        self.assertEqual(
+            GATE.check_metadata_fields(package(license=None, license_file="LICENSE")),
+            [],
+        )
+
+    def test_several_missing_fields_are_all_reported(self) -> None:
+        problems = GATE.check_metadata_fields(
+            drop(GOOD_PACKAGE, "description", "repository")
+        )
+        self.assertEqual(len(problems), 2, problems)
+
+
+class ResolveIncludeTest(unittest.TestCase):
+    def test_literal_list_is_returned(self) -> None:
+        manifest = {"package": {"include": ["/src/**/*"]}}
+        self.assertEqual(GATE.resolve_include(manifest, {}), ["/src/**/*"])
+
+    def test_absent_include_resolves_to_none(self) -> None:
+        self.assertIsNone(GATE.resolve_include({"package": {}}, {}))
+
+    def test_workspace_inheritance_is_resolved(self) -> None:
+        # The trap: `include.workspace = true` is a legitimate spelling
+        # that a plain `.get("include")` reads as a dict, not a list.
+        manifest = {"package": {"include": {"workspace": True}}}
+        workspace = {"workspace": {"package": {"include": ["/src/**/*", "/README.md"]}}}
+        self.assertEqual(
+            GATE.resolve_include(manifest, workspace), ["/src/**/*", "/README.md"]
+        )
+
+    def test_inheritance_from_a_workspace_without_the_key_is_none(self) -> None:
+        manifest = {"package": {"include": {"workspace": True}}}
+        self.assertIsNone(GATE.resolve_include(manifest, {"workspace": {"package": {}}}))
+        self.assertIsNone(GATE.resolve_include(manifest, {}))
+
+    def test_unrecognised_include_table_is_a_hard_error(self) -> None:
+        for value in ({"workspace": False}, {"path": "x"}, {}):
+            with self.subTest(value=value):
+                with self.assertRaises(SystemExit) as caught:
+                    GATE.resolve_include({"package": {"include": value}}, {})
+                self.assertIn("unrecognised", str(caught.exception))
+
+    def test_manifest_without_a_package_table_is_a_hard_error(self) -> None:
+        with self.assertRaises(SystemExit) as caught:
+            GATE.resolve_include({"workspace": {}}, {})
+        self.assertIn("[package]", str(caught.exception))
+
+
+class CheckIncludeTest(unittest.TestCase):
+    def test_populated_include_passes(self) -> None:
+        manifest = {"package": {"include": ["/src/**/*", "/Cargo.toml"]}}
+        self.assertEqual(GATE.check_include(manifest, {}), [])
+
+    def test_absent_include_is_reported(self) -> None:
+        problems = GATE.check_include({"package": {}}, {})
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("absent", problems[0])
+
+    def test_empty_include_is_reported(self) -> None:
+        problems = GATE.check_include({"package": {"include": []}}, {})
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("empty", problems[0])
+
+    def test_include_of_only_blank_entries_is_reported(self) -> None:
+        problems = GATE.check_include({"package": {"include": ["", "  "]}}, {})
+        self.assertEqual(len(problems), 1, problems)
+
+    def test_non_list_include_is_reported(self) -> None:
+        problems = GATE.check_include({"package": {"include": "/src/**/*"}}, {})
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("malformed", problems[0])
+
+    def test_inherited_include_passes(self) -> None:
+        manifest = {"package": {"include": {"workspace": True}}}
+        workspace = {"workspace": {"package": {"include": ["/src/**/*"]}}}
+        self.assertEqual(GATE.check_include(manifest, workspace), [])
+
+    def test_inherited_but_undeclared_include_is_reported(self) -> None:
+        manifest = {"package": {"include": {"workspace": True}}}
+        problems = GATE.check_include(manifest, {"workspace": {"package": {}}})
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("absent", problems[0])
+
+
+class LoadTomlTest(unittest.TestCase):
+    def test_parses_a_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            path = pathlib.Path(raw) / "Cargo.toml"
+            path.write_text('[package]\nname = "demo"\n', encoding="utf-8")
+            self.assertEqual(GATE.load_toml(path)["package"]["name"], "demo")
+
+    def test_missing_file_is_a_hard_error(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            with self.assertRaises(SystemExit) as caught:
+                GATE.load_toml(pathlib.Path(raw) / "absent.toml")
+            self.assertIn("cannot read", str(caught.exception))
+
+    def test_malformed_toml_is_a_hard_error(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            path = pathlib.Path(raw) / "Cargo.toml"
+            path.write_text("[package\nname =", encoding="utf-8")
+            with self.assertRaises(SystemExit) as caught:
+                GATE.load_toml(path)
+            self.assertIn("not valid TOML", str(caught.exception))
+
+
+class MeasureListingTest(unittest.TestCase):
+    def _tree(self, root: pathlib.Path) -> None:
+        (root / "src").mkdir()
+        # Distinct sizes so a total can only be right for one reason.
+        (root / "src" / "lib.rs").write_bytes(b"a" * 100)
+        (root / "README.md").write_bytes(b"b" * 23)
+
+    def test_sums_only_files_present_on_disk(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = pathlib.Path(raw)
+            self._tree(root)
+            listing = ["src/lib.rs", "README.md", "Cargo.toml.orig", ".cargo_vcs_info.json"]
+            self.assertEqual(GATE.measure_listing(listing, root), 123)
+
+    def test_every_generated_entry_is_skipped(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = pathlib.Path(raw)
+            self.assertEqual(GATE.measure_listing(sorted(GATE.GENERATED_ENTRIES), root), 0)
+
+    def test_an_unexpected_absent_entry_is_a_hard_error(self) -> None:
+        # Without this the wrong-base-directory case totals zero bytes
+        # and passes the ceiling, which is the silent pass being fixed.
+        with tempfile.TemporaryDirectory() as raw:
+            root = pathlib.Path(raw)
+            self._tree(root)
+            with self.assertRaises(SystemExit) as caught:
+                GATE.measure_listing(["src/lib.rs", "src/gone.rs"], root)
+            self.assertIn("gone.rs", str(caught.exception))
+
+
+class PackagedSizeTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self._tmp.name)
+        (self.root / "src").mkdir()
+        # 1_000 + 24 + 40 = 1_064, so the ceiling cases below can sit
+        # exactly on the boundary and one byte past it.
+        (self.root / "src" / "lib.rs").write_bytes(b"a" * 1_000)
+        (self.root / "README.md").write_bytes(b"b" * 24)
+        (self.root / "LICENSE").write_bytes(b"c" * 40)
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_a_listing_under_the_ceiling_passes(self) -> None:
+        listing = ["src/lib.rs", "README.md", "LICENSE"]
+        self.assertEqual(GATE.check_packaged_size(listing, self.root), [])
+
+    def test_a_listing_exactly_at_the_ceiling_passes(self) -> None:
+        # The passing side of the boundary: a `>=` comparison reports
+        # this one, so the bound cannot silently tighten.
+        listing = ["src/lib.rs", "README.md", "LICENSE"]
+        with mock.patch.object(GATE, "MAX_PACKAGED_BYTES", 1_064):
+            self.assertEqual(GATE.check_packaged_size(listing, self.root), [])
+
+    def test_a_listing_one_byte_over_the_ceiling_is_reported(self) -> None:
+        listing = ["src/lib.rs", "README.md", "LICENSE"]
+        with mock.patch.object(GATE, "MAX_PACKAGED_BYTES", 1_063):
+            problems = GATE.check_packaged_size(listing, self.root)
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("ceiling", problems[0])
+        self.assertIn("include", problems[0])
+
+
+class PublishablePackagesTest(unittest.TestCase):
+    def test_publish_false_is_excluded(self) -> None:
+        metadata = {
+            "packages": [
+                package(name="shipped", publish=None),
+                package(name="private", publish=[]),
+                package(name="registry-scoped", publish=["crates-io"]),
+            ]
+        }
+        names = [entry["name"] for entry in GATE.publishable_packages(metadata)]
+        self.assertEqual(names, ["shipped", "registry-scoped"])
+
+    def test_missing_packages_array_is_a_hard_error(self) -> None:
+        with self.assertRaises(SystemExit) as caught:
+            GATE.publishable_packages({})
+        self.assertIn("packages", str(caught.exception))
+
+
+class RunCargoTest(unittest.TestCase):
+    def test_stdout_is_returned_on_success(self) -> None:
+        completed = subprocess.CompletedProcess(["cargo"], 0, stdout="out", stderr="")
+        with mock.patch.object(subprocess, "run", return_value=completed):
+            self.assertEqual(GATE.run_cargo(["metadata"], REPO_ROOT), "out")
+
+    def test_non_zero_exit_is_a_hard_error_carrying_stderr(self) -> None:
+        completed = subprocess.CompletedProcess(["cargo"], 101, stdout="", stderr="boom")
+        with (
+            mock.patch.object(subprocess, "run", return_value=completed),
+            self.assertRaises(SystemExit) as caught,
+        ):
+            GATE.run_cargo(["metadata"], REPO_ROOT)
+        self.assertIn("boom", str(caught.exception))
+
+    def test_a_missing_cargo_binary_is_a_hard_error(self) -> None:
+        with (
+            mock.patch.object(subprocess, "run", side_effect=OSError("no cargo")),
+            self.assertRaises(SystemExit) as caught,
+        ):
+            GATE.run_cargo(["metadata"], REPO_ROOT)
+        self.assertIn("no cargo", str(caught.exception))
+
+
+class CargoMetadataTest(unittest.TestCase):
+    def test_json_is_parsed(self) -> None:
+        with mock.patch.object(GATE, "run_cargo", return_value='{"packages": []}'):
+            self.assertEqual(GATE.cargo_metadata(REPO_ROOT), {"packages": []})
+
+    def test_non_json_output_is_a_hard_error(self) -> None:
+        with (
+            mock.patch.object(GATE, "run_cargo", return_value="not json"),
+            self.assertRaises(SystemExit) as caught,
+        ):
+            GATE.cargo_metadata(REPO_ROOT)
+        self.assertIn("did not emit JSON", str(caught.exception))
+
+    def test_non_object_json_is_a_hard_error(self) -> None:
+        with (
+            mock.patch.object(GATE, "run_cargo", return_value="[1, 2]"),
+            self.assertRaises(SystemExit) as caught,
+        ):
+            GATE.cargo_metadata(REPO_ROOT)
+        self.assertIn("JSON object", str(caught.exception))
+
+
+class AuditTest(unittest.TestCase):
+    """`audit()` over a synthetic workspace, with `--list` stubbed."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+        (self.root / "src").mkdir()
+        (self.root / "src" / "lib.rs").write_bytes(b"a" * 1_000)
+        (self.root / "README.md").write_bytes(b"b" * 24)
+        self.member = self.root / "member"
+        (self.member / "src").mkdir(parents=True)
+        (self.member / "src" / "main.rs").write_bytes(b"c" * 500)
+        (self.member / "README.md").write_bytes(b"d" * 12)
+        self.write_manifest(include=["/src/**/*", "/README.md"])
+        (self.member / "Cargo.toml").write_text(
+            '[package]\nname = "member"\n', encoding="utf-8"
+        )
+        self.listings = {
+            "root": ["src/lib.rs", "README.md", "Cargo.toml.orig"],
+            "member": ["src/main.rs", "README.md"],
+        }
+
+    def write_manifest(self, include: Any) -> None:
+        """Write the workspace-root manifest, `include` set as given."""
+        body = '[workspace]\nmembers = ["member"]\n\n[package]\nname = "root"\n'
+        if include is not None:
+            body += f"include = {json.dumps(include)}\n"
+        (self.root / "Cargo.toml").write_text(body, encoding="utf-8")
+
+    def metadata(self, **root_overrides: Any) -> dict[str, Any]:
+        return {
+            "workspace_root": str(self.root),
+            "packages": [
+                package(
+                    name="root",
+                    manifest_path=str(self.root / "Cargo.toml"),
+                    **root_overrides,
+                ),
+                package(name="member", manifest_path=str(self.member / "Cargo.toml")),
+            ],
+        }
+
+    @contextlib.contextmanager
+    def stubbed_listings(self):  # type: ignore[no-untyped-def]
+        def listing(name: str, package_root: pathlib.Path) -> list[str]:
+            return self.listings[name]
+
+        with mock.patch.object(GATE, "package_listing", side_effect=listing):
+            yield
+
+    def test_a_compliant_workspace_reports_nothing(self) -> None:
+        with self.stubbed_listings():
+            self.assertEqual(GATE.audit(self.metadata()), [])
+
+    def test_findings_name_the_offending_crate(self) -> None:
+        with self.stubbed_listings():
+            problems = GATE.audit(self.metadata(description=""))
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("root:", problems[0])
+        self.assertIn("description", problems[0])
+
+    def test_include_is_required_only_at_the_workspace_root(self) -> None:
+        # `member/Cargo.toml` carries no `include` and must not be
+        # faulted for it: a package in a subdirectory already packages
+        # only its own tree.
+        with self.stubbed_listings():
+            problems = GATE.audit(self.metadata())
+        self.assertEqual(problems, [])
+
+    def test_a_dropped_include_at_the_workspace_root_is_reported(self) -> None:
+        self.write_manifest(include=None)
+        with self.stubbed_listings():
+            problems = GATE.audit(self.metadata())
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("root:", problems[0])
+        self.assertIn("include", problems[0])
+
+    def test_an_oversized_crate_is_reported(self) -> None:
+        with self.stubbed_listings(), mock.patch.object(GATE, "MAX_PACKAGED_BYTES", 600):
+            problems = GATE.audit(self.metadata())
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("root:", problems[0])
+        self.assertIn("ceiling", problems[0])
+
+    def test_a_workspace_with_no_publishable_member_is_a_hard_error(self) -> None:
+        metadata = self.metadata()
+        for entry in metadata["packages"]:
+            entry["publish"] = []
+        with self.assertRaises(SystemExit) as caught:
+            GATE.audit(metadata)
+        self.assertIn("would have checked nothing", str(caught.exception))
+
+    def test_missing_workspace_root_is_a_hard_error(self) -> None:
+        metadata = self.metadata()
+        del metadata["workspace_root"]
+        with self.assertRaises(SystemExit) as caught:
+            GATE.audit(metadata)
+        self.assertIn("workspace_root", str(caught.exception))
+
+    def test_a_package_entry_without_a_manifest_path_is_a_hard_error(self) -> None:
+        metadata = self.metadata()
+        del metadata["packages"][0]["manifest_path"]
+        with self.assertRaises(SystemExit) as caught:
+            GATE.audit(metadata)
+        self.assertIn("malformed", str(caught.exception))
+
+
+class MainTest(unittest.TestCase):
+    def _run(self, problems: list[str]) -> tuple[int, str, str]:
+        metadata = {"packages": [package(publish=None)]}
+        out, err = io.StringIO(), io.StringIO()
+        with (
+            mock.patch.object(GATE, "cargo_metadata", return_value=metadata),
+            mock.patch.object(GATE, "audit", return_value=problems),
+            contextlib.redirect_stdout(out),
+            contextlib.redirect_stderr(err),
+        ):
+            code = GATE.main()
+        return code, out.getvalue(), err.getvalue()
+
+    def test_a_clean_workspace_exits_zero_and_reports_the_count(self) -> None:
+        code, out, err = self._run([])
+        self.assertEqual(code, 0)
+        self.assertIn("1 publishable crates checked", out)
+        self.assertEqual(err, "")
+
+    def test_findings_exit_one_and_reach_stderr_with_remediation(self) -> None:
+        code, out, err = self._run(["  demo: [package].description is missing or empty"])
+        self.assertEqual(code, 1)
+        self.assertEqual(out, "")
+        self.assertIn("demo: [package].description", err)
+        self.assertIn("RELEASING.md", err)
+        self.assertIn("#1224", err)
+
+
+class RealRepositoryTest(unittest.TestCase):
+    """The gate against the tree it ships in."""
+
+    def test_the_repository_passes_its_own_gate(self) -> None:
+        completed = subprocess.run(
+            [sys.executable, str(SCRIPT_SRC)],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            completed.returncode, 0, f"{completed.stdout}\n{completed.stderr}"
+        )
+        self.assertIn("publish metadata OK", completed.stdout)
+
+    def test_cargo_packages_the_declared_readme_without_being_asked(self) -> None:
+        # The gate does not verify that `readme` reaches the archive,
+        # because cargo already does: measured against cargo 1.95, it
+        # fails `--list` outright on a readme that does not exist, and
+        # packages one that `include` does not cover. Pinned here so a
+        # future cargo that stopped doing either is a red test rather
+        # than a silent loss of coverage.
+        metadata = GATE.cargo_metadata(REPO_ROOT)
+        parent = next(
+            entry
+            for entry in GATE.publishable_packages(metadata)
+            if entry["name"] == "big-code-analysis"
+        )
+        self.assertIn(
+            parent["readme"], GATE.package_listing("big-code-analysis", REPO_ROOT)
+        )
+
+    def test_the_three_top_level_crates_are_the_ones_checked(self) -> None:
+        # Pins the discovery rule, not just that discovery found
+        # something: `publish = false` on the bench and Python crates is
+        # what keeps them out, and a change there must be deliberate.
+        names = sorted(
+            entry["name"] for entry in GATE.publishable_packages(GATE.cargo_metadata(REPO_ROOT))
+        )
+        self.assertEqual(
+            names,
+            ["big-code-analysis", "big-code-analysis-cli", "big-code-analysis-web"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/check-publish-metadata.py
+++ b/utils/check-publish-metadata.py
@@ -131,6 +131,34 @@ GENERATED_ENTRIES = frozenset({".cargo_vcs_info.json", "Cargo.lock", "Cargo.toml
 MAX_PACKAGED_BYTES = 32 * 1024 * 1024
 
 
+# cargo's own advice on a `--locked` failure is "remove the --locked flag
+# and use --offline instead", which here would let the gate rewrite the
+# lockfile and pass — the regression it exists to catch. Matched on
+# cargo's wording so the override fires only on that failure.
+_LOCKED_REFUSAL = "--locked was passed"
+
+_LOCKED_REMEDY = (
+    "\n\nnote: `Cargo.lock` is stale — that is the finding, and cargo's "
+    "advice above is wrong for this gate. Refresh the lockfile with a "
+    "plain `cargo check` (or `cargo generate-lockfile`) and commit the "
+    "result. Dropping `--locked` would make this gate rewrite the "
+    "lockfile and report a pass, so a tag could be cut without the "
+    "committed lockfile ever being verified (#1224)."
+)
+
+
+def lockfile_remedy(args: list[str], stderr: str) -> str:
+    """Return a note overriding cargo's advice to drop ``--locked``.
+
+    Empty for every other failure: a note that fires indiscriminately
+    would be read as boilerplate and stop carrying the one case where
+    following cargo's own hint defeats the gate.
+    """
+    if "--locked" not in args or _LOCKED_REFUSAL not in stderr:
+        return ""
+    return _LOCKED_REMEDY
+
+
 def run_cargo(args: list[str], cwd: pathlib.Path) -> str:
     """Run a cargo subcommand, hard-erroring on a non-zero exit."""
     try:
@@ -147,6 +175,7 @@ def run_cargo(args: list[str], cwd: pathlib.Path) -> str:
         raise SystemExit(
             f"error: `cargo {' '.join(args)}` failed with exit "
             f"{completed.returncode}:\n{completed.stderr.rstrip()}"
+            + lockfile_remedy(args, completed.stderr)
         )
     return completed.stdout
 
@@ -174,8 +203,18 @@ def package_listing(name: str, package_root: pathlib.Path) -> list[str]:
     `--allow-dirty` is unconditional: the question is what the *working
     tree* would package, and without it cargo refuses outright on any
     uncommitted change, which would make this unusable mid-edit.
+
+    `--locked` carries over from the `cargo publish --dry-run --locked`
+    this gate replaced, and is not optional. Measured: with a
+    `[[package]]` entry deleted from `Cargo.lock`, the flagless form
+    re-resolves, rewrites the lockfile in place, and reports a pass — a
+    static gate mutating the tree in `make lint`, and, in `release.yml`'s
+    preflight, a tag cut without the committed lockfile ever being
+    checked. With the flag cargo exits 101 and says so.
     """
-    raw = run_cargo(["package", "-p", name, "--allow-dirty", "--list"], package_root)
+    raw = run_cargo(
+        ["package", "-p", name, "--allow-dirty", "--locked", "--list"], package_root
+    )
     return [line.strip() for line in raw.splitlines() if line.strip()]
 
 

--- a/utils/check-publish-metadata.py
+++ b/utils/check-publish-metadata.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""check-publish-metadata
+
+Registry-independent gate on the publish metadata of every crate this
+repository uploads to crates.io.
+
+Why it exists
+-------------
+``cargo publish --dry-run`` is the natural pre-tag gate: it rejects a
+missing ``description`` / ``license``, a ``readme`` pointing outside the
+package, and an ``include`` whitelist that stopped covering what the
+crate needs. For the three top-level crates it cannot run before the
+tag, and the workaround that was in place did not run *ever*.
+
+``big-code-analysis`` pins each vendored grammar leaf at
+``bca-tree-sitter-<lang> = "=<version>"``, and the Lockstep version
+policy (``utils/check-versions.py``) makes that version equal to the one
+being released. Packaging resolves the registry requirement, so it fails
+on a version that is by definition not yet published::
+
+    $ cargo package -p big-code-analysis --allow-dirty --no-verify
+    error: failed to select a version for the requirement
+      `bca-tree-sitter-ccomment = "=2.1.1"`
+    candidate versions found which didn't match: 2.1.0, 2.0.0, 1.1.0, ...
+
+``big-code-analysis-cli`` and ``big-code-analysis-web`` pin
+``big-code-analysis = "=<version>"`` and hit the same wall one level up.
+The previous code skipped the parent dry-run whenever that leaf was
+absent from the sparse index and called the skip a first-release
+bootstrap; because the probed version is always the version being
+released, the skip fired on every release and the dry-run branch never
+ran before an upload (#1224).
+
+What this checks instead
+------------------------
+Everything above that does not need the dependency graph resolved:
+
+* **Metadata fields.** ``description``, ``readme``, ``repository``, and
+  ``license`` (or ``license-file``) present and non-blank.
+* **The ``include`` whitelist**, for a package rooted at the workspace
+  root. ``big-code-analysis``'s manifest *is* the workspace manifest, so
+  without ``include`` cargo packages the whole repository — notably
+  ``tests/repositories/`` — and the upload dies against crates.io's size
+  limit with a Varnish ``503 backend write error``.
+* **The packaged size**, totalled from ``cargo package --list``.
+
+``cargo package --list`` is the one packaging operation that does *not*
+resolve the registry — measured: it exits 0 on this workspace while
+``--no-verify`` fails on the unpublished pin — which is what makes a
+real, behavioural packaging check available pre-tag.
+
+Running it also gets ``readme`` / ``license-file`` validation for free,
+which is why nothing here re-checks them. Measured against cargo 1.95:
+a path that does not exist fails ``--list`` outright (``error: readme
+`X` does not appear to exist``), and a path *outside* ``include`` is
+added to the archive anyway rather than dropped. An earlier revision of
+this gate asserted both were present in the listing; neither assertion
+could ever have fired.
+
+What it does not check
+----------------------
+It does not build anything, so it cannot catch a feature-resolution or
+compile error in the packaged crate, and it does not validate dependency
+version pins (``utils/check-versions.py`` owns those). The five
+``bca-tree-sitter-*`` leaves are deliberately out of scope: they carry no
+internal pins, so ``release-check`` dry-runs them for real, which is
+strictly stronger than this.
+
+Fields are read from ``cargo metadata``, never from the manifest text,
+because ``[workspace.package]`` inheritance is real here — the root
+manifest spells ``license.workspace = true`` and
+``repository.workspace = true``, which a raw ``tomllib`` read would
+report as missing. ``include`` is the exception: ``cargo metadata`` does
+not emit it, so it is read from the manifest with inheritance resolved
+by hand.
+
+See `#1224`, ``RELEASING.md``, and AGENTS.md "Validation gates".
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+from typing import Any
+
+# tomllib landed in 3.11. On older Python, fall back to the external
+# `tomli` package (same API), matching check-excluded-manifests.py.
+try:
+    import tomllib
+except ImportError:
+    try:
+        import tomli as tomllib  # type: ignore[import-not-found,no-redef]
+    except ImportError:
+        sys.stderr.write(
+            "error: check-publish-metadata.py requires Python 3.11+\n"
+            "       (tomllib lives in the standard library starting at 3.11).\n"
+            "       On older Python, install `tomli` and retry:\n"
+            "           pip install tomli\n"
+        )
+        sys.exit(2)
+
+# `parents[1]`, not `parent`: this gate lives in `utils/` but every path
+# it reads is anchored at the repository root.
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+# Fields crates.io requires or renders on the crate's landing page. Each
+# maps to a `cargo metadata` package key.
+REQUIRED_FIELDS = ("description", "readme", "repository")
+
+# `license` and `license-file` are alternatives, not both-required:
+# crates.io accepts either. Spelled as cargo metadata emits them.
+LICENSE_FIELDS = ("license", "license_file")
+
+# Entries `cargo package` synthesises into the archive. They have no
+# counterpart on disk, so they are the only listing rows allowed to be
+# absent; anything else missing means the listing is being measured
+# against the wrong directory.
+GENERATED_ENTRIES = frozenset({".cargo_vcs_info.json", "Cargo.lock", "Cargo.toml.orig"})
+
+# crates.io rejects a `.crate` above 10 MiB. The uploaded tarball is
+# gzipped, and this repository's parent crate measures 6.3 MiB of source
+# for a 1.4 MiB archive (~4.4x), so the ceiling is worth roughly 44 MiB
+# of source here. 32 MiB is deliberately below that: the gate fires
+# before crates.io would, while leaving ~5x headroom over today's
+# largest crate so ordinary `src/` growth cannot trip it. The regression
+# it exists to catch is not incremental — dropping `include` pulls in
+# `tests/repositories/` (30k+ corpus files) and clears this bound by
+# more than an order of magnitude.
+MAX_PACKAGED_BYTES = 32 * 1024 * 1024
+
+
+def run_cargo(args: list[str], cwd: pathlib.Path) -> str:
+    """Run a cargo subcommand, hard-erroring on a non-zero exit."""
+    try:
+        completed = subprocess.run(
+            ["cargo", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:
+        raise SystemExit(f"error: cannot run `cargo {' '.join(args)}`: {exc}") from exc
+    if completed.returncode != 0:
+        raise SystemExit(
+            f"error: `cargo {' '.join(args)}` failed with exit "
+            f"{completed.returncode}:\n{completed.stderr.rstrip()}"
+        )
+    return completed.stdout
+
+
+def cargo_metadata(root: pathlib.Path) -> dict[str, Any]:
+    """Return `cargo metadata` for the workspace, dependencies excluded.
+
+    `--no-deps` keeps this to workspace members and, more importantly,
+    keeps it from resolving the dependency graph — the resolution that
+    fails on the not-yet-published leaf pins.
+    """
+    raw = run_cargo(["metadata", "--format-version", "1", "--no-deps"], root)
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"error: `cargo metadata` did not emit JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise SystemExit("error: `cargo metadata` did not emit a JSON object.")
+    return data
+
+
+def package_listing(name: str, package_root: pathlib.Path) -> list[str]:
+    """Return the paths `cargo package` would put in the archive.
+
+    `--allow-dirty` is unconditional: the question is what the *working
+    tree* would package, and without it cargo refuses outright on any
+    uncommitted change, which would make this unusable mid-edit.
+    """
+    raw = run_cargo(["package", "-p", name, "--allow-dirty", "--list"], package_root)
+    return [line.strip() for line in raw.splitlines() if line.strip()]
+
+
+def publishable_packages(metadata: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return the workspace members that `cargo publish` would upload.
+
+    `publish = false` renders as an empty registry list, which is how
+    `big-code-analysis-bench` and `big-code-analysis-py` opt out.
+    """
+    packages = metadata.get("packages")
+    if not isinstance(packages, list):
+        raise SystemExit("error: `cargo metadata` emitted no `packages` array.")
+    return [
+        package
+        for package in packages
+        if isinstance(package, dict) and package.get("publish") != []
+    ]
+
+
+def _blank(value: Any) -> bool:
+    """True when a metadata field is absent or carries no text.
+
+    Present-but-empty is the interesting case: `description = ""` parses,
+    inherits, and serialises like a real value, and crates.io rejects it
+    only at upload time.
+    """
+    return not isinstance(value, str) or not value.strip()
+
+
+def check_metadata_fields(package: dict[str, Any]) -> list[str]:
+    """Report the crates.io-facing fields this package is missing."""
+    problems = [
+        f"[package].{field} is missing or empty"
+        for field in REQUIRED_FIELDS
+        if _blank(package.get(field))
+    ]
+    if all(_blank(package.get(field)) for field in LICENSE_FIELDS):
+        problems.append("[package].license and .license-file are both missing or empty")
+    return problems
+
+
+def load_toml(path: pathlib.Path) -> dict[str, Any]:
+    """Parse a manifest, hard-erroring on an unreadable or invalid file."""
+    try:
+        with path.open("rb") as handle:
+            return tomllib.load(handle)
+    except OSError as exc:
+        raise SystemExit(f"error: cannot read {path}: {exc}") from exc
+    except tomllib.TOMLDecodeError as exc:
+        raise SystemExit(f"error: {path} is not valid TOML: {exc}") from exc
+
+
+def resolve_include(manifest: dict[str, Any], workspace_manifest: dict[str, Any]) -> Any:
+    """Return a manifest's `[package].include`, resolving inheritance.
+
+    `include` is one of cargo's inheritable keys, so `include.workspace =
+    true` is a legitimate spelling that a plain lookup would read as an
+    unrecognised value rather than as the workspace's list. Any other
+    table shape is a hard error: guessing at it is how a gate comes to
+    pass on input it did not understand.
+    """
+    package = manifest.get("package")
+    if not isinstance(package, dict):
+        raise SystemExit("error: manifest has no [package] table.")
+    value = package.get("include")
+    if isinstance(value, dict):
+        if value.get("workspace") is not True:
+            raise SystemExit(
+                f"error: unrecognised [package].include table {value!r}; "
+                "expected `include.workspace = true`."
+            )
+        workspace = workspace_manifest.get("workspace")
+        workspace_package = workspace.get("package") if isinstance(workspace, dict) else None
+        value = workspace_package.get("include") if isinstance(workspace_package, dict) else None
+    return value
+
+
+def check_include(manifest: dict[str, Any], workspace_manifest: dict[str, Any]) -> list[str]:
+    """Report an absent or vacuous `include` whitelist."""
+    value = resolve_include(manifest, workspace_manifest)
+    if value is None:
+        return [
+            (
+                "[package].include is absent — a package rooted at the workspace "
+                "root packages the entire repository without it"
+            )
+        ]
+    if not isinstance(value, list) or not any(
+        isinstance(entry, str) and entry.strip() for entry in value
+    ):
+        return [f"[package].include is empty or malformed: {value!r}"]
+    return []
+
+
+def measure_listing(listing: list[str], package_root: pathlib.Path) -> int:
+    """Return the on-disk bytes of a `cargo package --list` output.
+
+    Rows cargo synthesises have no file to size and are skipped. Any
+    *other* absent row means the listing is being measured against the
+    wrong directory, which would otherwise total zero bytes and pass —
+    the silent-pass failure this gate exists to remove.
+    """
+    total = 0
+    for entry in listing:
+        path = package_root / entry
+        if path.is_file():
+            total += path.stat().st_size
+        elif entry not in GENERATED_ENTRIES:
+            raise SystemExit(
+                f"error: `cargo package --list` named {entry!r}, which does not "
+                f"exist under {package_root}."
+            )
+    return total
+
+
+def check_packaged_size(listing: list[str], package_root: pathlib.Path) -> list[str]:
+    """Report a packaged file set that clears the size ceiling."""
+    total = measure_listing(listing, package_root)
+    if total <= MAX_PACKAGED_BYTES:
+        return []
+    return [
+        f"packaged files total {total / 1024 / 1024:.1f} MiB across "
+        f"{len(listing)} entries, over the {MAX_PACKAGED_BYTES // 1024 // 1024} "
+        "MiB ceiling — check [package].include"
+    ]
+
+
+def audit(metadata: dict[str, Any]) -> list[str]:
+    """Return one finding per problem, over every publishable member.
+
+    Findings are indented and prefixed with the crate they belong to, so
+    `main()` can join them straight into its error block. An empty list
+    is a pass.
+    """
+    workspace_root = metadata.get("workspace_root")
+    if not isinstance(workspace_root, str):
+        raise SystemExit("error: `cargo metadata` emitted no `workspace_root`.")
+    root = pathlib.Path(workspace_root)
+    workspace_manifest = load_toml(root / "Cargo.toml")
+
+    targets = publishable_packages(metadata)
+    if not targets:
+        raise SystemExit(
+            "error: no publishable workspace members found; this gate would "
+            "have checked nothing."
+        )
+
+    problems: list[str] = []
+    for package in sorted(targets, key=lambda entry: str(entry.get("name"))):
+        name = package.get("name")
+        manifest_path = package.get("manifest_path")
+        if not isinstance(name, str) or not isinstance(manifest_path, str):
+            raise SystemExit(f"error: malformed `cargo metadata` package entry: {package!r}")
+        package_root = pathlib.Path(manifest_path).parent
+
+        findings = check_metadata_fields(package)
+        if package_root == root:
+            # A package rooted here *is* the workspace manifest, so the
+            # already-parsed copy serves as both sides — `include` may
+            # still be spelled as an inheritance from the
+            # `[workspace.package]` table in that same file.
+            findings += check_include(workspace_manifest, workspace_manifest)
+        findings += check_packaged_size(package_listing(name, package_root), package_root)
+        problems += [f"  {name}: {finding}" for finding in findings]
+    return problems
+
+
+def main() -> int:
+    metadata = cargo_metadata(REPO_ROOT)
+    problems = audit(metadata)
+    if problems:
+        print(
+            "error: publish metadata is incomplete or would package the wrong files:\n"
+            + "\n".join(problems)
+            + "\n\nFix the manifest before tagging: these crates cannot be\n"
+            "`cargo publish --dry-run`-ed pre-tag, so this is the only gate\n"
+            "standing between a metadata regression and a half-finished\n"
+            "upload to crates.io. See RELEASING.md and #1224.",
+            file=sys.stderr,
+        )
+        return 1
+    checked = len(publishable_packages(metadata))
+    print(f"publish metadata OK ({checked} publishable crates checked).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utils/check-ruff-lockstep-test.py
+++ b/utils/check-ruff-lockstep-test.py
@@ -1,0 +1,512 @@
+#!/usr/bin/env python3
+"""Tests for check-ruff-lockstep.py.
+
+Three kinds of test, matching the check-excluded-manifests-test.py
+pattern:
+
+* Unit tests against synthetic file contents, weighted toward the shapes
+  a line-oriented YAML read can get wrong — a reordered config, a
+  neighbouring repo's ``rev:``, a quoted or comment-trailed scalar — and
+  toward the malformed inputs on which a version gate must fail loudly
+  rather than pass.
+* ``main()`` tests over a synthetic repository root, covering each drift
+  branch and the remediation text it prints.
+* A smoke test running the real gate against the real repository,
+  asserting a clean tree reports OK.
+
+Run with:
+    python3 -m unittest -q utils/check-ruff-lockstep-test.py
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+UTILS_DIR = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = UTILS_DIR.parent
+SCRIPT_SRC = UTILS_DIR / "check-ruff-lockstep.py"
+
+
+def _load_module():  # type: ignore[no-untyped-def]
+    spec = importlib.util.spec_from_file_location("check_ruff_lockstep", SCRIPT_SRC)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+GATE = _load_module()
+
+# Deliberately non-alphabetical repo order, with a `rev:` on either side
+# of the ruff block: the gate must anchor on the URL, not on position.
+PRE_COMMIT_SAMPLE = """\
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+    -   id: check-yaml
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    # Bump in lockstep with uv.lock.
+    rev: v0.16.2
+    hooks:
+    -   id: ruff-check
+        args: [--fix]
+-   repo: https://github.com/marco-c/taskcluster_yml_validator
+    rev: v0.0.12
+    hooks:
+      - id: taskcluster_yml
+"""
+
+UV_LOCK_SAMPLE = """\
+version = 1
+
+[[package]]
+name = "big-code-analysis"
+source = { editable = "." }
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=2.3" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.13,<0.17" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.2"
+source = { registry = "https://pypi.org/simple" }
+"""
+
+REQUIREMENTS_SAMPLE = """\
+mypy==2.3.0 ; python_full_version >= '3.10' \\
+    --hash=sha256:aaaa
+ruff==0.16.2 ; python_full_version < '3.15' and sys_platform != 'emscripten' \\
+    --hash=sha256:bbbb \\
+    --hash=sha256:cccc
+"""
+
+PYPROJECT_SAMPLE = """\
+[project]
+name = "big-code-analysis"
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0",
+  "mypy>=2.3",
+  "ruff>=0.13,<0.17",
+]
+"""
+
+
+class PreCommitRevTest(unittest.TestCase):
+    """Reading `rev:` out of `.pre-commit-config.yaml` by line."""
+
+    def test_the_ruff_blocks_rev_is_returned(self) -> None:
+        self.assertEqual(GATE.read_pre_commit_rev(PRE_COMMIT_SAMPLE), "v0.16.2")
+
+    def test_a_neighbouring_repos_rev_is_not_returned(self) -> None:
+        # The whole point of anchoring on the URL. `v5.0.0` sits above
+        # the ruff block and `v0.0.12` below it; a position-based read
+        # would return one of them the moment the file is reordered.
+        rev = GATE.read_pre_commit_rev(PRE_COMMIT_SAMPLE)
+        self.assertNotIn(rev, {"v5.0.0", "v0.0.12"})
+
+    def test_reordering_the_config_does_not_change_the_answer(self) -> None:
+        blocks = PRE_COMMIT_SAMPLE.split("-   repo:")
+        reordered = "-   repo:".join([blocks[0], blocks[2], blocks[1], blocks[3]])
+        self.assertEqual(GATE.read_pre_commit_rev(reordered), "v0.16.2")
+
+    def test_a_quoted_rev_is_unquoted(self) -> None:
+        text = PRE_COMMIT_SAMPLE.replace("rev: v0.16.2", 'rev: "v0.16.2"')
+        self.assertEqual(GATE.read_pre_commit_rev(text), "v0.16.2")
+
+    def test_a_trailing_comment_is_stripped(self) -> None:
+        text = PRE_COMMIT_SAMPLE.replace("rev: v0.16.2", "rev: v0.16.2  # pinned")
+        self.assertEqual(GATE.read_pre_commit_rev(text), "v0.16.2")
+
+    def test_the_compact_dash_spelling_is_accepted(self) -> None:
+        # This config mixes `-   repo:` and `- repo:` (the local block
+        # uses the latter). Both must reach the same parser.
+        text = PRE_COMMIT_SAMPLE.replace(
+            "-   repo: https://github.com/astral-sh",
+            "- repo: https://github.com/astral-sh",
+        )
+        self.assertEqual(GATE.read_pre_commit_rev(text), "v0.16.2")
+
+    def test_crlf_line_endings_are_handled(self) -> None:
+        self.assertEqual(
+            GATE.read_pre_commit_rev(PRE_COMMIT_SAMPLE.replace("\n", "\r\n")),
+            "v0.16.2",
+        )
+
+    def test_a_missing_ruff_block_is_a_hard_error(self) -> None:
+        text = PRE_COMMIT_SAMPLE.replace("astral-sh/ruff-pre-commit", "example/other")
+        with self.assertRaises(SystemExit) as caught:
+            GATE.read_pre_commit_rev(text)
+        self.assertIn("found 0", str(caught.exception))
+
+    def test_a_ruff_block_without_a_rev_is_a_hard_error(self) -> None:
+        text = PRE_COMMIT_SAMPLE.replace("    rev: v0.16.2\n", "")
+        with self.assertRaises(SystemExit) as caught:
+            GATE.read_pre_commit_rev(text)
+        self.assertIn("found 0", str(caught.exception))
+
+    def test_two_ruff_blocks_are_a_hard_error(self) -> None:
+        # Ambiguous rather than wrong: picking either silently would let
+        # a stale duplicate govern what pre-commit actually runs.
+        text = PRE_COMMIT_SAMPLE + (
+            "-   repo: https://github.com/astral-sh/ruff-pre-commit\n"
+            "    rev: v0.15.14\n"
+        )
+        with self.assertRaises(SystemExit) as caught:
+            GATE.read_pre_commit_rev(text)
+        self.assertIn("found 2", str(caught.exception))
+
+    def test_an_empty_config_is_a_hard_error(self) -> None:
+        with self.assertRaises(SystemExit):
+            GATE.read_pre_commit_rev("")
+
+
+class ScalarTest(unittest.TestCase):
+    def test_a_bare_token_is_returned_unchanged(self) -> None:
+        self.assertEqual(GATE._scalar("v0.16.2"), "v0.16.2")
+
+    def test_a_comment_only_value_reduces_to_empty(self) -> None:
+        # Not a crash: the caller compares the result and reports drift.
+        self.assertEqual(GATE._scalar("# nothing here"), "")
+
+    def test_single_and_double_quotes_are_both_stripped(self) -> None:
+        self.assertEqual(GATE._scalar("'v1'"), "v1")
+        self.assertEqual(GATE._scalar('"v1"'), "v1")
+
+
+class LockVersionTest(unittest.TestCase):
+    def test_the_ruff_package_version_is_returned(self) -> None:
+        self.assertEqual(GATE.read_lock_version(UV_LOCK_SAMPLE), "0.16.2")
+
+    def test_a_lock_without_ruff_is_a_hard_error(self) -> None:
+        text = UV_LOCK_SAMPLE.replace(
+            'name = "ruff"\nversion', 'name = "rust"\nversion'
+        )
+        with self.assertRaises(SystemExit) as caught:
+            GATE.read_lock_version(text)
+        self.assertIn("found 0", str(caught.exception))
+
+    def test_two_ruff_packages_are_a_hard_error(self) -> None:
+        text = UV_LOCK_SAMPLE + '\n[[package]]\nname = "ruff"\nversion = "0.15.22"\n'
+        with self.assertRaises(SystemExit) as caught:
+            GATE.read_lock_version(text)
+        self.assertIn("found 2", str(caught.exception))
+
+    def test_a_versionless_ruff_entry_is_a_hard_error_not_a_crash(self) -> None:
+        # uv writes a `version` for every registry package, so this is
+        # malformed input — and malformed input must reach the gate's
+        # own diagnostic rather than a KeyError traceback, which reads
+        # as a bug in whatever the contributor was changing.
+        text = UV_LOCK_SAMPLE.replace(
+            'name = "ruff"\nversion = "0.16.2"', 'name = "ruff"'
+        )
+        with self.assertRaises(SystemExit) as caught:
+            GATE.read_lock_version(text)
+        self.assertIn("found 0", str(caught.exception))
+
+    def test_invalid_toml_is_a_hard_error(self) -> None:
+        with self.assertRaises(SystemExit) as caught:
+            GATE.read_lock_version("[[package\n")
+        self.assertIn("not valid TOML", str(caught.exception))
+
+    def test_a_lock_with_no_package_array_is_a_hard_error(self) -> None:
+        with self.assertRaises(SystemExit) as caught:
+            GATE.read_lock_version("version = 1\n")
+        self.assertIn("no [[package]] entries", str(caught.exception))
+
+
+class LockSpecifierTest(unittest.TestCase):
+    def test_the_dev_extra_bound_is_returned(self) -> None:
+        self.assertEqual(GATE.read_lock_specifier(UV_LOCK_SAMPLE), ">=0.13,<0.17")
+
+    def test_a_double_quoted_marker_still_names_the_extra(self) -> None:
+        text = UV_LOCK_SAMPLE.replace("extra == 'dev'", 'extra == \\"dev\\"')
+        self.assertEqual(GATE.read_lock_specifier(text), ">=0.13,<0.17")
+
+    def test_a_ruff_row_under_another_extra_is_ignored(self) -> None:
+        text = UV_LOCK_SAMPLE.replace(
+            '{ name = "ruff", marker = "extra == \'dev\'"',
+            '{ name = "ruff", marker = "extra == \'examples\'"',
+        )
+        with self.assertRaises(SystemExit) as caught:
+            GATE.read_lock_specifier(text)
+        self.assertIn("found 0", str(caught.exception))
+
+    def test_a_package_without_metadata_contributes_nothing(self) -> None:
+        # The `ruff` package entry itself has no `metadata` table; the
+        # walk must skip it rather than raise.
+        self.assertEqual(GATE._requires_dist({"name": "ruff"}), [])
+
+    def test_a_non_list_requires_dist_contributes_nothing(self) -> None:
+        self.assertEqual(GATE._requires_dist({"metadata": {"requires-dist": "x"}}), [])
+
+    def test_non_mapping_rows_are_dropped(self) -> None:
+        self.assertEqual(
+            GATE._requires_dist(
+                {"metadata": {"requires-dist": ["ruff", {"name": "a"}]}}
+            ),
+            [{"name": "a"}],
+        )
+
+    def test_a_non_string_marker_does_not_name_an_extra(self) -> None:
+        self.assertFalse(GATE._names_extra(None, "dev"))
+
+    def test_a_different_extra_does_not_match(self) -> None:
+        self.assertFalse(GATE._names_extra("extra == 'examples'", "dev"))
+
+
+class RequirementsVersionTest(unittest.TestCase):
+    def test_the_pinned_version_is_returned(self) -> None:
+        self.assertEqual(GATE.read_requirements_version(REQUIREMENTS_SAMPLE), "0.16.2")
+
+    def test_a_file_without_ruff_is_a_hard_error(self) -> None:
+        with self.assertRaises(SystemExit) as caught:
+            GATE.read_requirements_version("mypy==2.3.0\n")
+        self.assertIn("found 0", str(caught.exception))
+
+    def test_two_ruff_pins_are_a_hard_error(self) -> None:
+        with self.assertRaises(SystemExit) as caught:
+            GATE.read_requirements_version("ruff==0.16.2\nruff==0.15.22\n")
+        self.assertIn("found 2", str(caught.exception))
+
+    def test_a_similarly_named_distribution_is_not_matched(self) -> None:
+        # `ruff-lsp` shares the prefix. Requiring `==` immediately after
+        # the name is what keeps it out.
+        self.assertEqual(
+            GATE.read_requirements_version("ruff-lsp==0.0.62\nruff==0.16.2\n"),
+            "0.16.2",
+        )
+
+    def test_an_indented_mention_is_not_a_pin(self) -> None:
+        # A `uv export` is mostly continuation and `# via` lines, all
+        # indented. Without the start-of-line anchor a comment naming an
+        # old version counts as a second pin and the gate hard-errors on
+        # a perfectly good export — or, with one real pin removed,
+        # reports the comment's version as the installed one.
+        self.assertEqual(
+            GATE.read_requirements_version(
+                "ruff==0.16.2 ; python_full_version < '3.15' \\\n"
+                "    --hash=sha256:bbbb\n"
+                "    # was ruff==0.15.22 before #1222\n"
+            ),
+            "0.16.2",
+        )
+
+
+class PyprojectSpecifierTest(unittest.TestCase):
+    def test_the_dev_extra_bound_is_returned(self) -> None:
+        self.assertEqual(
+            GATE.read_pyproject_specifier(PYPROJECT_SAMPLE), ">=0.13,<0.17"
+        )
+
+    def test_the_name_is_normalised_before_matching(self) -> None:
+        # PEP 503 treats `Ruff` and `ruff` as one project.
+        text = PYPROJECT_SAMPLE.replace('"ruff>=0.13', '"Ruff>=0.13')
+        self.assertEqual(GATE.read_pyproject_specifier(text), ">=0.13,<0.17")
+
+    def test_a_distribution_merely_containing_ruff_is_not_matched(self) -> None:
+        # `ruff-lsp` normalises to a name *containing* `ruff`. Matching
+        # on containment rather than equality would collect two
+        # specifiers here and hard-error on a legal manifest.
+        text = PYPROJECT_SAMPLE.replace(
+            '  "ruff>=0.13,<0.17",', '  "ruff-lsp>=0.0.62",\n  "ruff>=0.13,<0.17",'
+        )
+        self.assertEqual(GATE.read_pyproject_specifier(text), ">=0.13,<0.17")
+
+    def test_an_unbounded_requirement_yields_an_empty_specifier(self) -> None:
+        text = PYPROJECT_SAMPLE.replace('"ruff>=0.13,<0.17"', '"ruff"')
+        self.assertEqual(GATE.read_pyproject_specifier(text), "")
+
+    def test_non_string_entries_are_skipped(self) -> None:
+        text = PYPROJECT_SAMPLE.replace('  "pytest>=8.0",', "  1,")
+        self.assertEqual(GATE.read_pyproject_specifier(text), ">=0.13,<0.17")
+
+    def test_a_missing_project_table_is_a_hard_error(self) -> None:
+        with self.assertRaises(SystemExit) as caught:
+            GATE.read_pyproject_specifier("[tool.ruff]\nline-length = 100\n")
+        self.assertIn("optional-dependencies", str(caught.exception))
+
+    def test_a_missing_dev_extra_is_a_hard_error(self) -> None:
+        with self.assertRaises(SystemExit) as caught:
+            GATE.read_pyproject_specifier(
+                '[project]\nname = "x"\n\n'
+                '[project.optional-dependencies]\nexamples = ["jupyter"]\n'
+            )
+        self.assertIn("optional-dependencies", str(caught.exception))
+
+    def test_a_dev_extra_without_ruff_is_a_hard_error(self) -> None:
+        text = PYPROJECT_SAMPLE.replace('  "ruff>=0.13,<0.17",\n', "")
+        with self.assertRaises(SystemExit) as caught:
+            GATE.read_pyproject_specifier(text)
+        self.assertIn("found 0", str(caught.exception))
+
+    def test_two_ruff_requirements_are_a_hard_error(self) -> None:
+        text = PYPROJECT_SAMPLE.replace(
+            '  "ruff>=0.13,<0.17",', '  "ruff>=0.13,<0.17",\n  "ruff<0.20",'
+        )
+        with self.assertRaises(SystemExit) as caught:
+            GATE.read_pyproject_specifier(text)
+        self.assertIn("found 2", str(caught.exception))
+
+    def test_invalid_toml_is_a_hard_error(self) -> None:
+        with self.assertRaises(SystemExit) as caught:
+            GATE.read_pyproject_specifier("[project\n")
+        self.assertIn("not valid TOML", str(caught.exception))
+
+
+class ClauseSetTest(unittest.TestCase):
+    def test_whitespace_is_insignificant(self) -> None:
+        self.assertEqual(
+            GATE.clause_set(">= 0.13, <0.17"), GATE.clause_set(">=0.13,<0.17")
+        )
+
+    def test_clause_order_is_insignificant(self) -> None:
+        self.assertEqual(
+            GATE.clause_set("<0.17,>=0.13"), GATE.clause_set(">=0.13,<0.17")
+        )
+
+    def test_a_different_bound_is_a_different_set(self) -> None:
+        self.assertNotEqual(
+            GATE.clause_set(">=0.13,<0.17"), GATE.clause_set(">=0.13,<0.16")
+        )
+
+    def test_an_empty_specifier_yields_an_empty_set(self) -> None:
+        # `"".split(",")` is `[""]`, so without the filter this would be
+        # a one-element set and an unbounded requirement would compare
+        # equal to nothing at all.
+        self.assertEqual(GATE.clause_set(""), frozenset())
+
+
+class MainTest(unittest.TestCase):
+    """`main()` over a synthetic repository root."""
+
+    def _repo(
+        self,
+        pre_commit: str = PRE_COMMIT_SAMPLE,
+        uv_lock: str = UV_LOCK_SAMPLE,
+        requirements: str = REQUIREMENTS_SAMPLE,
+        pyproject: str = PYPROJECT_SAMPLE,
+    ) -> None:
+        root = pathlib.Path(self.enterContext(tempfile.TemporaryDirectory()))
+        (root / "big-code-analysis-py" / "requirements").mkdir(parents=True)
+        (root / GATE.PRE_COMMIT_CONFIG).write_text(pre_commit, encoding="utf-8")
+        (root / GATE.UV_LOCK).write_text(uv_lock, encoding="utf-8")
+        (root / GATE.REQUIREMENTS_DEV).write_text(requirements, encoding="utf-8")
+        (root / GATE.PYPROJECT).write_text(pyproject, encoding="utf-8")
+        self.enterContext(mock.patch.object(GATE, "REPO_ROOT", root))
+
+    def _run(self) -> tuple[int, str, str]:
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            code = GATE.main()
+        return code, out.getvalue(), err.getvalue()
+
+    def test_an_aligned_tree_passes(self) -> None:
+        self._repo()
+        code, out, _ = self._run()
+        self.assertEqual(code, 0)
+        self.assertIn("ruff lockstep OK", out)
+        # The version, not just the word OK: a pass that names the wrong
+        # version is the drift this gate exists to report.
+        self.assertIn("ruff 0.16.2", out)
+
+    def test_a_drifted_pre_commit_rev_fails(self) -> None:
+        # The exact shape #1230 documents: rev v0.15.14 against a
+        # lockfile resolving 0.16.2.
+        self._repo(pre_commit=PRE_COMMIT_SAMPLE.replace("v0.16.2", "v0.15.14"))
+        code, _, err = self._run()
+        self.assertEqual(code, 1)
+        self.assertIn(".pre-commit-config.yaml", err)
+        self.assertIn("v0.15.14", err)
+        self.assertIn("expected v0.16.2", err)
+
+    def test_a_stale_requirements_export_fails(self) -> None:
+        self._repo(
+            requirements=REQUIREMENTS_SAMPLE.replace("ruff==0.16.2", "ruff==0.15.22")
+        )
+        code, _, err = self._run()
+        self.assertEqual(code, 1)
+        self.assertIn("requirements/dev.txt", err)
+        self.assertIn("make py-relock", err)
+
+    def test_a_bound_edited_without_a_relock_fails(self) -> None:
+        self._repo(pyproject=PYPROJECT_SAMPLE.replace("<0.17", "<0.18"))
+        code, _, err = self._run()
+        self.assertEqual(code, 1)
+        self.assertIn("pyproject.toml", err)
+        self.assertIn(">=0.13,<0.18", err)
+
+    def test_a_cosmetically_respelled_bound_still_passes(self) -> None:
+        # uv normalises the specifier it writes back, so a human's
+        # spacing must not read as drift.
+        self._repo(
+            pyproject=PYPROJECT_SAMPLE.replace(">=0.13,<0.17", ">= 0.13, < 0.17")
+        )
+        code, _, _ = self._run()
+        self.assertEqual(code, 0)
+
+    def test_every_drifted_site_is_reported_in_one_run(self) -> None:
+        # Reporting only the first would make fixing this a three-round
+        # trip through a gate that takes minutes in `make pre-commit`.
+        self._repo(
+            pre_commit=PRE_COMMIT_SAMPLE.replace("v0.16.2", "v0.15.14"),
+            requirements=REQUIREMENTS_SAMPLE.replace("ruff==0.16.2", "ruff==0.15.22"),
+            pyproject=PYPROJECT_SAMPLE.replace("<0.17", "<0.18"),
+        )
+        code, _, err = self._run()
+        self.assertEqual(code, 1)
+        self.assertIn(".pre-commit-config.yaml", err)
+        self.assertIn("requirements/dev.txt", err)
+        self.assertIn("pyproject.toml", err)
+
+    def test_an_absent_input_file_is_a_hard_error(self) -> None:
+        self._repo()
+        (GATE.REPO_ROOT / GATE.PRE_COMMIT_CONFIG).unlink()
+        with self.assertRaises(SystemExit) as caught:
+            self._run()
+        self.assertIn("cannot read .pre-commit-config.yaml", str(caught.exception))
+
+
+class RealRepositoryTest(unittest.TestCase):
+    def test_clean_tree_passes(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_SRC)],
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("ruff lockstep OK", result.stdout)
+        # The bound is echoed so a pass distinguishes "all four agree"
+        # from "the gate found nothing to compare".
+        self.assertIn("3 sites checked", result.stdout)
+
+    def test_it_runs_from_an_unrelated_cwd(self) -> None:
+        # `REPO_ROOT` is derived from the script's own location, so the
+        # gate must not depend on being invoked from the repository root
+        # (AGENTS.md, "Project layout").
+        with tempfile.TemporaryDirectory() as elsewhere:
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT_SRC)],
+                capture_output=True,
+                text=True,
+                cwd=elsewhere,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/check-ruff-lockstep.py
+++ b/utils/check-ruff-lockstep.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""check-ruff-lockstep
+
+One ruff version is adopted by this repository, and it is declared in
+four places that nothing previously compared.
+
+``big-code-analysis-py/uv.lock`` is the anchor. It is what ``uv sync
+--locked`` resolves, and every other declaration is either derived from
+it (``requirements/dev.txt`` is a ``uv export`` of it) or is a
+hand-maintained copy that must follow it.
+
+Three invariants are checked.
+
+**The ``ruff-pre-commit`` ``rev:`` must equal ``v`` + the locked
+version.** Before #1222 that ``rev:`` was ``v0.15.14`` while ``uv.lock``
+resolved ``0.15.22``, so ``pre-commit run --all-files`` ran a different
+ruff than CI installs. Nothing failed, because neither version happened
+to disagree on this tree — which is the failure mode worth gating: it is
+silent until they do disagree, and then it presents as "works locally,
+red in CI" (#1230). The comment above the ``rev:`` asking for a lockstep
+bump was the entire previous mechanism.
+
+**The ``requirements/dev.txt`` ``ruff==`` pin must equal the locked
+version.** CI installs its ruff with ``pip install --require-hashes -r
+requirements/dev.txt`` rather than through uv, so a stale export is a
+ruff CI runs that the lockfile never resolved. AGENTS.md requires a
+``uv.lock`` change and its regenerated exports to land in the same
+commit; this is that rule as a check.
+
+**``pyproject.toml``'s dev-extra ruff bound must equal the one recorded
+in ``uv.lock``.** uv writes the requirement it resolved against into
+``[package.metadata] requires-dist``, so comparing the two catches a
+bound edited without a ``make py-relock``. That case would otherwise
+leave CI installing, from the export, a version the manifest no longer
+admits. Bounds are compared as *sets of whitespace-stripped clauses*, so
+``>= 0.13, <0.17`` and ``>=0.13,<0.17`` agree and clause order does not
+matter — uv normalises both, and a false failure here would be
+indistinguishable from the drift the gate exists to report.
+
+``uv.lock`` and ``pyproject.toml`` are parsed with ``tomllib``.
+``.pre-commit-config.yaml`` is parsed by line, anchored to the
+``ruff-pre-commit`` repo block, because PyYAML is not in the standard
+library: this gate runs under a contributor's bare ``python3`` and as a
+``language: system`` pre-commit hook, so a third-party import would make
+it crash or be skipped exactly where it is needed. Every parse helper
+hard-errors on a shape it does not recognise rather than returning a
+default — a version gate that silently passes on malformed input is the
+bug being fixed, not a lenient version of the fix.
+
+See `#1230` and AGENTS.md "Validation gates".
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+from typing import Any
+
+# tomllib landed in 3.11. On older Python, fall back to the external
+# `tomli` package (same API), matching check-excluded-manifests.py.
+try:
+    import tomllib
+except ImportError:
+    try:
+        import tomli as tomllib  # type: ignore[import-not-found,no-redef]
+    except ImportError:
+        sys.stderr.write(
+            "error: check-ruff-lockstep.py requires Python 3.11+\n"
+            "       (tomllib lives in the standard library starting at 3.11).\n"
+            "       On older Python, install `tomli` and retry:\n"
+            "           pip install tomli\n"
+        )
+        sys.exit(2)
+
+# `parents[1]`, not `parent`: this gate lives in `utils/` but every path
+# it reads is anchored at the repository root.
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+PRE_COMMIT_CONFIG = pathlib.Path(".pre-commit-config.yaml")
+UV_LOCK = pathlib.Path("big-code-analysis-py/uv.lock")
+REQUIREMENTS_DEV = pathlib.Path("big-code-analysis-py/requirements/dev.txt")
+PYPROJECT = pathlib.Path("big-code-analysis-py/pyproject.toml")
+
+# The distribution whose version is under lockstep, and the extra it is
+# declared in.
+RUFF = "ruff"
+DEV_EXTRA = "dev"
+
+# The `repo:` URL identifying the ruff hook block in
+# `.pre-commit-config.yaml`. Matching the URL rather than the position
+# is what keeps a reordered config from handing us a neighbouring
+# repo's `rev:`.
+RUFF_PRE_COMMIT_REPO = "https://github.com/astral-sh/ruff-pre-commit"
+
+# A `- repo: <url>` line, in either the `-   repo:` or `- repo:`
+# spelling this config mixes. The capture is the bare URL; any trailing
+# comment is stripped by `_scalar`.
+_REPO_LINE_RE = re.compile(r"^\s*-\s+repo:\s*(\S.*)$")
+# A `rev:` key. Anchored to the start-of-line whitespace so a `rev:`
+# appearing inside a hook's `args:` list cannot match.
+_REV_LINE_RE = re.compile(r"^\s*rev:\s*(\S.*)$")
+# `ruff==0.16.2 ; markers \` in a `uv export` requirements file. The
+# version runs to the first whitespace or `;`.
+_REQUIREMENT_PIN_RE = re.compile(rf"^{RUFF}==([^\s;]+)", re.MULTILINE)
+# Splits `ruff>=0.13,<0.17` into name and specifier. PEP 508 allows an
+# extras bracket and a marker; neither is used for ruff here, and both
+# would fail the name comparison loudly rather than silently.
+_REQUIREMENT_RE = re.compile(r"^\s*([A-Za-z0-9._-]+)\s*(.*)$")
+
+
+def _scalar(raw: str) -> str:
+    """Reduce a YAML scalar to its value: no comment, no quotes.
+
+    Only the shapes a `rev:` can legally take are handled — a bare
+    token, a quoted token, and either followed by a `#` comment. A
+    ``rev`` value never contains whitespace or ``#``, so taking the
+    first whitespace-delimited token is sufficient and cannot swallow
+    one.
+    """
+    words = raw.split("#", 1)[0].split()
+    return words[0].strip("\"'") if words else ""
+
+
+def read_pre_commit_rev(text: str) -> str:
+    """Return the ``rev:`` of the ``ruff-pre-commit`` repo block.
+
+    The block runs from its ``- repo:`` line to the next one, so a
+    ``rev:`` belonging to a neighbouring repo is never returned however
+    the file is ordered. Anything other than exactly one ``rev:`` across
+    all such blocks is a hard error: no block, no ``rev:``, a duplicated
+    block, or two ``rev:`` keys in one. Picking the first of several
+    would let a stale duplicate govern what pre-commit actually runs.
+    """
+    revs: list[str] = []
+    in_ruff_block = False
+    for line in text.splitlines():
+        repo_match = _REPO_LINE_RE.match(line)
+        if repo_match:
+            in_ruff_block = _scalar(repo_match.group(1)) == RUFF_PRE_COMMIT_REPO
+            continue
+        rev_match = _REV_LINE_RE.match(line)
+        if in_ruff_block and rev_match:
+            revs.append(_scalar(rev_match.group(1)))
+    if len(revs) != 1:
+        raise SystemExit(
+            f"error: expected exactly one `rev:` under a {RUFF_PRE_COMMIT_REPO}\n"
+            f"       repo block in {PRE_COMMIT_CONFIG}, found {len(revs)}."
+        )
+    return revs[0]
+
+
+def _packages(lock_text: str) -> list[dict[str, Any]]:
+    """Return ``uv.lock``'s ``[[package]]`` entries."""
+    try:
+        data = tomllib.loads(lock_text)
+    except tomllib.TOMLDecodeError as exc:
+        raise SystemExit(f"error: {UV_LOCK} is not valid TOML: {exc}") from exc
+    packages = data.get("package")
+    if not isinstance(packages, list):
+        raise SystemExit(f"error: {UV_LOCK} has no [[package]] entries.")
+    return [entry for entry in packages if isinstance(entry, dict)]
+
+
+def read_lock_version(lock_text: str) -> str:
+    """Return the version ``uv.lock`` resolves for ruff."""
+    versions = [
+        entry["version"]
+        for entry in _packages(lock_text)
+        if entry.get("name") == RUFF and isinstance(entry.get("version"), str)
+    ]
+    if len(versions) != 1:
+        raise SystemExit(
+            f"error: expected exactly one versioned `{RUFF}` package in "
+            f"{UV_LOCK},\n       found {len(versions)}."
+        )
+    return versions[0]
+
+
+def read_lock_specifier(lock_text: str) -> str:
+    """Return the ruff dev-extra bound ``uv.lock`` recorded resolving.
+
+    uv writes each project requirement into ``[package.metadata]
+    requires-dist``, so this is the ``pyproject.toml`` bound as it stood
+    at the last ``uv lock``.
+    """
+    specifiers = [
+        requirement["specifier"]
+        for entry in _packages(lock_text)
+        for requirement in _requires_dist(entry)
+        if requirement.get("name") == RUFF
+        and _names_extra(requirement.get("marker"), DEV_EXTRA)
+        and isinstance(requirement.get("specifier"), str)
+    ]
+    if len(specifiers) != 1:
+        raise SystemExit(
+            f"error: expected exactly one `{RUFF}` `{DEV_EXTRA}`-extra entry in "
+            f"{UV_LOCK}'s\n       requires-dist, found {len(specifiers)}."
+        )
+    return specifiers[0]
+
+
+def _requires_dist(package: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return a ``[[package]]`` entry's ``metadata.requires-dist`` rows."""
+    metadata = package.get("metadata")
+    if not isinstance(metadata, dict):
+        return []
+    requirements = metadata.get("requires-dist")
+    if not isinstance(requirements, list):
+        return []
+    return [row for row in requirements if isinstance(row, dict)]
+
+
+def _names_extra(marker: Any, extra: str) -> bool:
+    """True when a uv ``requires-dist`` marker selects ``extra``.
+
+    uv writes the marker as ``extra == 'dev'``; quoting is compared
+    loosely so a switch to double quotes does not read as "the dev extra
+    disappeared".
+    """
+    if not isinstance(marker, str):
+        return False
+    pattern = rf"""extra\s*==\s*['"]{re.escape(extra)}['"]"""
+    return re.search(pattern, marker) is not None
+
+
+def read_requirements_version(requirements_text: str) -> str:
+    """Return the ``ruff==`` version pinned in a ``uv export`` file."""
+    versions = _REQUIREMENT_PIN_RE.findall(requirements_text)
+    if len(versions) != 1:
+        raise SystemExit(
+            f"error: expected exactly one `{RUFF}==` line in {REQUIREMENTS_DEV},\n"
+            f"       found {len(versions)}."
+        )
+    return versions[0]
+
+
+def read_pyproject_specifier(pyproject_text: str) -> str:
+    """Return the ruff bound declared in the ``dev`` optional extra."""
+    try:
+        data = tomllib.loads(pyproject_text)
+    except tomllib.TOMLDecodeError as exc:
+        raise SystemExit(f"error: {PYPROJECT} is not valid TOML: {exc}") from exc
+    project = data.get("project")
+    extras = project.get("optional-dependencies") if isinstance(project, dict) else None
+    entries = extras.get(DEV_EXTRA) if isinstance(extras, dict) else None
+    if not isinstance(entries, list):
+        raise SystemExit(
+            f"error: {PYPROJECT} has no "
+            f"[project.optional-dependencies] {DEV_EXTRA} array."
+        )
+    specifiers = []
+    for entry in entries:
+        if not isinstance(entry, str):
+            continue
+        match = _REQUIREMENT_RE.match(entry)
+        if match and match.group(1).lower().replace("_", "-") == RUFF:
+            specifiers.append(match.group(2).strip())
+    if len(specifiers) != 1:
+        raise SystemExit(
+            f"error: expected exactly one `{RUFF}` requirement in {PYPROJECT}'s\n"
+            f"       {DEV_EXTRA} extra, found {len(specifiers)}."
+        )
+    return specifiers[0]
+
+
+def clause_set(specifier: str) -> frozenset[str]:
+    """Normalise a version bound for comparison.
+
+    A PEP 508 specifier is a comma-separated, unordered set of clauses
+    whose internal whitespace is insignificant, so compare it as one.
+    Otherwise a purely cosmetic difference between what a human wrote in
+    `pyproject.toml` and what uv wrote back into `uv.lock` would report
+    as drift.
+    """
+    return frozenset(
+        clause for clause in "".join(specifier.split()).split(",") if clause
+    )
+
+
+def read_repo_file(relative: pathlib.Path) -> str:
+    """Read a repository file, hard-erroring when it is absent."""
+    path = REPO_ROOT / relative
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SystemExit(f"error: cannot read {relative}: {exc}") from exc
+
+
+def main() -> int:
+    # Read and parse the lockfile once: it answers both the resolved
+    # version and the bound uv resolved against.
+    lock_text = read_repo_file(UV_LOCK)
+    locked = read_lock_version(lock_text)
+    expected_rev = f"v{locked}"
+
+    problems: list[str] = []
+
+    rev = read_pre_commit_rev(read_repo_file(PRE_COMMIT_CONFIG))
+    if rev != expected_rev:
+        problems.append(
+            f"  {PRE_COMMIT_CONFIG}: rev: {rev} (expected {expected_rev})\n"
+            f"    `pre-commit run --all-files` would run ruff {rev.lstrip('v')} "
+            f"while CI installs {locked}."
+        )
+
+    exported = read_requirements_version(read_repo_file(REQUIREMENTS_DEV))
+    if exported != locked:
+        problems.append(
+            f"  {REQUIREMENTS_DEV}: {RUFF}=={exported} (expected {locked})\n"
+            f"    The export is stale; re-run `make py-relock`."
+        )
+
+    declared = read_pyproject_specifier(read_repo_file(PYPROJECT))
+    recorded = read_lock_specifier(lock_text)
+    if clause_set(declared) != clause_set(recorded):
+        problems.append(
+            f"  {PYPROJECT}: {RUFF}{declared} but {UV_LOCK} resolved against "
+            f"{recorded}\n    The lockfile predates the bound; re-run "
+            f"`make py-relock`."
+        )
+
+    if problems:
+        print(
+            "error: ruff version declarations disagree:\n"
+            + "\n".join(problems)
+            + f"\n\n{UV_LOCK} is the anchor ({RUFF} {locked}). Bump the\n"
+            f"`ruff-pre-commit` rev: to {expected_rev} and/or re-run\n"
+            "`make py-relock`, in the same commit. See #1230.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"ruff lockstep OK ({RUFF} {locked}, bound {declared}, 3 sites checked).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utils/check-tools-test.sh
+++ b/utils/check-tools-test.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Self-tests for utils/check-tools.sh.
+#
+# The assertion that matters most is `cargo-about hint spells --features
+# cli`. That string is the artifact #1226 is about, not a proxy for it:
+# cargo-about's binary sits behind a non-default `cli` feature, so a
+# hint that drops the flag sends the reader back into the exact trap the
+# gate exists to close — `cargo install cargo-about` compiles the
+# library, installs no binary, and exits 0.
+#
+# The probes run against a stub `cargo` on PATH rather than the real
+# one, so the present/absent cases are both reachable on any machine and
+# neither depends on what the developer happens to have installed.
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+CHECK_TOOLS="$SCRIPT_DIR/check-tools.sh"
+
+failures=0
+out=$(mktemp)
+err=$(mktemp)
+stubdir=$(mktemp -d)
+trap 'rm -f -- "$out" "$err"; rm -rf -- "$stubdir"' EXIT
+
+fail() {
+	printf 'FAIL: %s\n' "$1" >&2
+	failures=$((failures + 1))
+}
+
+expect_eq() {
+	# expect_eq <what> <expected> <actual>
+	if [ "$2" != "$3" ]; then
+		fail "$1: expected [$2], got [$3]"
+	fi
+}
+
+expect_contains() {
+	# expect_contains <what> <needle> <file>
+	if ! grep -qF -- "$2" "$3"; then
+		fail "$1: [$2] not found in $(basename "$3")"
+	fi
+}
+
+expect_absent() {
+	# expect_absent <what> <needle> <file>
+	if grep -qF -- "$2" "$3"; then
+		fail "$1: [$2] unexpectedly present in $(basename "$3")"
+	fi
+}
+
+# Writes a `cargo` stub that answers `--version` for each subcommand
+# named in "$@" and reports every other subcommand the way cargo does.
+# Bare `cargo --version` always succeeds so the script's own core-tool
+# probe is unaffected.
+write_cargo_stub() {
+	local supported=" $* "
+	cat >"$stubdir/cargo" <<STUB
+#!/usr/bin/env bash
+if [ "\$#" -eq 1 ] && [ "\$1" = "--version" ]; then
+	echo "cargo 1.0.0-stub"
+	exit 0
+fi
+case "$supported" in
+	*" \$1 "*)
+		echo "cargo-\$1 9.9.9-stub"
+		exit 0
+		;;
+esac
+echo "error: no such command: \\\`\$1\\\`" >&2
+exit 101
+STUB
+	chmod +x "$stubdir/cargo"
+}
+
+run_release_only() {
+	PATH="$stubdir:$PATH" "$CHECK_TOOLS" --release-only >"$out" 2>"$err"
+	rc=$?
+}
+
+# --- both tools present ----------------------------------------------
+write_cargo_stub deny about
+run_release_only
+expect_eq 'both tools present exits 0' 0 "$rc"
+expect_contains 'cargo-deny is reported present' '✓ cargo-deny' "$out"
+expect_contains 'cargo-about is reported present' '✓ cargo-about' "$out"
+expect_absent 'no hints are printed when nothing is missing' \
+	'Missing release tools:' "$out"
+
+# --- cargo-about missing: the #1226 case ------------------------------
+write_cargo_stub deny
+run_release_only
+expect_eq 'a missing cargo-about fails the probe' 1 "$rc"
+expect_contains 'the missing tool is named' '✗ cargo-about' "$out"
+expect_contains 'the present tool is not' '✓ cargo-deny' "$out"
+# The whole point of the issue: an install line without `--features cli`
+# reproduces the silent no-op it is supposed to prevent.
+expect_contains 'cargo-about hint spells --features cli' \
+	'cargo install --locked cargo-about --features cli' "$out"
+expect_contains 'the hint says why the flag is needed' \
+	'installs nothing and still exits 0' "$out"
+
+# --- cargo-deny missing ----------------------------------------------
+write_cargo_stub about
+run_release_only
+expect_eq 'a missing cargo-deny fails the probe' 1 "$rc"
+expect_contains 'the missing tool is named' '✗ cargo-deny' "$out"
+expect_contains 'cargo-deny hint is the plain install' \
+	'cargo install --locked cargo-deny' "$out"
+expect_absent 'no cargo-about hint when only cargo-deny is missing' \
+	'cargo install --locked cargo-about' "$out"
+
+# --- both missing -----------------------------------------------------
+write_cargo_stub
+run_release_only
+expect_eq 'both missing fails the probe' 1 "$rc"
+expect_contains 'both hints are printed' \
+	'cargo install --locked cargo-about --features cli' "$out"
+expect_contains 'both hints are printed' \
+	'- cargo-deny: Install with:' "$out"
+
+# --- usage ------------------------------------------------------------
+PATH="$stubdir:$PATH" "$CHECK_TOOLS" --bogus >"$out" 2>"$err"
+expect_eq 'an unknown flag is a usage error' 2 "$?"
+expect_eq 'the usage line goes to stderr' \
+	'usage: check-tools.sh [--release-only]' "$(cat "$err")"
+expect_eq 'a usage error writes nothing to stdout' 0 "$(wc -c <"$out")"
+
+PATH="$stubdir:$PATH" "$CHECK_TOOLS" --release-only extra >"$out" 2>"$err"
+expect_eq 'a surplus argument is a usage error' 2 "$?"
+
+if [ "$failures" -ne 0 ]; then
+	printf '%d check-tools check(s) failed\n' "$failures" >&2
+	exit 1
+fi
+printf 'check-tools: all checks passed\n'

--- a/utils/check-tools.sh
+++ b/utils/check-tools.sh
@@ -1,7 +1,92 @@
 #!/usr/bin/env bash
 # Check for required and optional tools used by the Makefile.
+#
+# `--release-only` probes just the two tools `make release-check`
+# invokes and exits non-zero if either is absent; the gate calls it that
+# way so a missing tool is named up front instead of surfacing as
+# cargo's generic `no such command` partway through (#1226).
 
 set -euo pipefail
+
+usage() {
+	echo "usage: check-tools.sh [--release-only]" >&2
+	exit 2
+}
+
+release_only=0
+if [ "$#" -gt 1 ]; then
+	usage
+elif [ "$#" -eq 1 ]; then
+	[ "$1" = "--release-only" ] || usage
+	release_only=1
+fi
+
+# The exact install commands for the two tools `make release-check`
+# cannot run without. cargo-about 0.9.0 moved its binary behind a
+# non-default `cli` feature, so a bare `cargo install cargo-about`
+# compiles the library, installs no binary, reports the miss as a
+# *warning*, and exits 0 — after which `cargo about` still answers "no
+# such command" (#1226). Both readers of these strings — the section
+# further down and `make release-check` through `--release-only` — take
+# them from here, so the `--features cli` spelling cannot go missing
+# from one of them.
+CARGO_DENY_INSTALL="cargo install --locked cargo-deny"
+CARGO_ABOUT_INSTALL="cargo install --locked cargo-about --features cli"
+
+# Probes the release tooling, printing one status line each and setting
+# deny_missing / about_missing / release_missing.
+#
+# `cargo <sub> --version` rather than `command -v cargo-about`: it is
+# what the gate itself does, so a binary that is on PATH but which cargo
+# cannot dispatch to still reads as missing here.
+check_release_tools() {
+	deny_missing=0
+	if cargo deny --version >/dev/null 2>&1; then
+		deny_version=$(cargo deny --version 2>/dev/null | awk 'NR==1{print $2; exit}' || true)
+		echo "  ✓ cargo-deny (version: ${deny_version:-unknown})"
+	else
+		echo "  ✗ cargo-deny (not found)"
+		deny_missing=1
+	fi
+
+	about_missing=0
+	if cargo about --version >/dev/null 2>&1; then
+		about_version=$(cargo about --version 2>/dev/null | awk 'NR==1{print $2; exit}' || true)
+		echo "  ✓ cargo-about (version: ${about_version:-unknown})"
+	else
+		echo "  ✗ cargo-about (not found)"
+		about_missing=1
+	fi
+
+	release_missing=$((deny_missing + about_missing))
+}
+
+print_release_hints() {
+	if [ "$deny_missing" -eq 1 ]; then
+		echo "  - cargo-deny: Install with: $CARGO_DENY_INSTALL"
+	fi
+	if [ "$about_missing" -eq 1 ]; then
+		echo "  - cargo-about: Install with: $CARGO_ABOUT_INSTALL"
+		echo "                 (--features cli is not optional: the binary is behind a"
+		echo "                  non-default feature, so a bare 'cargo install cargo-about'"
+		echo "                  installs nothing and still exits 0)"
+	fi
+}
+
+if [ "$release_only" -eq 1 ]; then
+	echo "Checking release tooling ('make release-check')..."
+	check_release_tools
+	if [ "$release_missing" -gt 0 ]; then
+		echo ""
+		echo "Missing release tools:"
+		print_release_hints
+		echo ""
+		echo "'make release-check' invokes 'cargo deny' and 'cargo about' directly"
+		echo "and cannot proceed without them."
+		exit 1
+	fi
+	exit 0
+fi
 
 echo "Checking required tools..."
 echo ""
@@ -153,6 +238,13 @@ else
 fi
 
 echo ""
+echo "Optional Tools (Release engineering — 'make release-check'):"
+echo "  (optional day to day; 'make release-check' hard-fails without both,"
+echo "   so a release cannot be cut until they are installed)"
+
+check_release_tools
+
+echo ""
 echo "Optional Tools (Python tooling — big-code-analysis-py):"
 echo "  (any work on big-code-analysis-py needs uv + the four py-* tools;"
 echo "   skip this section entirely if you only touch Rust)"
@@ -202,7 +294,7 @@ fi
 echo ""
 
 core_missing=$((cargo_missing + nightly_missing + udeps_missing + insta_missing + checkmake_missing))
-optional_missing=$((rumdl_missing + fd_missing + taplo_missing + shellcheck_missing + shfmt_missing + nextest_missing + actionlint_missing + mdbook_missing + uv_missing + ruff_missing + mypy_missing + pyright_missing + maturin_py_missing))
+optional_missing=$((rumdl_missing + fd_missing + taplo_missing + shellcheck_missing + shfmt_missing + nextest_missing + actionlint_missing + mdbook_missing + release_missing + uv_missing + ruff_missing + mypy_missing + pyright_missing + maturin_py_missing))
 
 if [ "$core_missing" -gt 0 ]; then
 	echo "Missing core tools:"
@@ -253,6 +345,7 @@ if [ "$optional_missing" -gt 0 ]; then
 	if [ "$mdbook_missing" -eq 1 ]; then
 		echo "  - mdbook: Install with: cargo install --locked mdbook (needed for 'make book')"
 	fi
+	print_release_hints
 	if [ "$uv_missing" -eq 1 ]; then
 		echo "  - uv: needed for 'make py-bootstrap' (creates .venv from uv.lock)."
 		echo "        Install with: curl -LsSf https://astral.sh/uv/install.sh | sh"


### PR DESCRIPTION
Fixes five issues filed while cutting 2.1.0, plus three commits
remediating a code review of the batch itself.

Each fix commit carries its own `Fixes #N` trailer, so all five close on
merge (a single trailer listing several issues closes only the first).

## What landed

**#1224 — the parent publish dry-run was dead.** It was gated on a
crates.io sparse-index probe for a leaf version the Lockstep policy
guarantees is the version being released, so the branch that ran it was
unreachable, while `release.yml` and `RELEASING.md` both said it became a
hard gate from the second tag onwards. The issue understated the gap:
`big-code-analysis-cli` and `big-code-analysis-web` had no such check at
all, since both pin `big-code-analysis = "=<version>"`. Replaced with
`utils/check-publish-metadata.py`, a registry-independent gate over every
publishable crate's crates.io metadata, `[package].include`, and packaged
size.

**#1226 — release tooling was undiscoverable.** `release-check` now
probes `cargo-deny` and `cargo-about` up front. The `cargo-about` hint
spells `--features cli`: the binary sits behind a non-default feature, so
a bare `cargo install cargo-about` compiles the library, installs no
binary, warns, and exits 0. Confirmed from the sparse index rather than
by running an install. CI was unaffected (prebuilt 0.8.4), but the
`Dockerfile`'s `cargo binstall` falls back to a plain `cargo install`, so
it gained a guard.

**#1225 — `release-check` was absent from the checklist.** Added, with
the commit → gate → tag ordering and a note that the push is separable.
The recipe now rejects uncommitted changes in the grammar leaves before
its slow stages. Scoped to what `cargo publish --dry-run` actually
rejects — measured across five tree states, since it checks only the
package directory and only shipped files, so the obvious whole-tree guard
would have rejected four states cargo accepts.

**#1230 — ruff version lockstep.** New `check-ruff-lockstep` gate.
`uv.lock` is the anchor, not `requirements/dev.txt` as proposed: the
export is generated from the lockfile, so gating on it would bless a
stale export rather than catch one. `py-fmt`/`py-fmt-check`/`py-lint`
now prefer the venv ruff, as `py-typecheck` already did for mypy — the
drift was live, with PATH ruff at 0.15.14 against 0.16.2 in the venv.

**#1228 — `enums` was CI-linted without the workspace pedantic set.**
The issue's 23-warning table was right but undercounted: `missing_docs`
added 15 more, so clearing the table cost 38. No blanket allows.
`check-excluded-manifests.py` gained an exempt-list invariant so the next
excluded crate has to make the decision explicitly.

## Review remediation

`/code-review` found five issues and a follow-up review found four more.
Three are worth noting:

- `cargo package --list` ran without `--locked`. Measured: with a
  `[[package]]` entry deleted from `Cargo.lock`, the flagless form
  re-resolves, rewrites the lockfile, and reports a pass.
- `lints_table_problem` rejected a valid self-rooted `[lints] workspace =
  true` and stated a reason measurably false of it — every excluded crate
  roots its own workspace, so it resolves against `[workspace.lints]` in
  the same file.
- The remedy note added for the `--locked` failure was tested only in
  isolation, leaving `run_cargo`'s call site free to be deleted with
  nothing failing. Now pinned.

## Verification

- `BCA_GATE: pass (gate=pre-commit)`
- Gate self-tests: `check-publish-metadata` 57, `check-excluded-manifests`
  56, `check-ruff-lockstep` 56, `check-tools-test.sh`
- `make release-check VERSION=2.1.1` runs the composed recipe end to end
  and reaches `publish metadata OK (3 publishable crates checked)`. It
  then fails at `verify-changelog` because 2.1.1 is the post-tag dev
  version with no CHANGELOG section — pre-existing, unrelated.
- Perturbation sweeps across the batch: 35 during the fixes, 9 more
  during review remediation, all caught, none unobserved.

Patch coverage is unaffected: all changed Rust is under `enums/`, which
is `exclude`d from the workspace and so outside `cargo llvm-cov
--workspace`. The Python gates are covered by their paired self-tests.
