### PR TITLE
ci(fuzz): replay seeds on PRs, hunt on the cron

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -15,23 +15,10 @@ name: Fuzz
 #
 # See docs/development/fuzzing.md.
 
-# The two `paths:` lists are duplicated rather than shared through a YAML
-# anchor. Anchors are not reliably supported across GitHub's workflow
-# parser and nothing local can prove they are, so a silently-dropped
-# filter would leave the job running on every docs-only PR — or not
-# running at all.
+# No `push:` trigger. A merge re-runs the identical tree the pull request
+# already validated, so it costs ~17 minutes to learn nothing.
 on:
   pull_request:
-    paths:
-      - 'src/**'
-      - 'fuzz/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'tree-sitter-*/**'
-      - 'Makefile'
-      - '.github/workflows/fuzz.yml'
-  push:
-    branches: [main]
     paths:
       - 'src/**'
       - 'fuzz/**'
@@ -146,16 +133,23 @@ jobs:
       - name: Lint and build fuzz targets
         run: make fuzz-check
 
-      # `-runs`, never `-max_total_time`: a wall-clock bound makes a
-      # failure non-reproducible across runners of different speeds. The
-      # per-PR budget is deliberately small — the compile gate above is
-      # the part that must be fast — and the quarterly cron carries the
-      # long sweep.
-      - name: Smoke the targets
+      # A pull request replays the committed seeds and stops: the
+      # regression question ("did this change break an input that used to
+      # be fine") rather than the hunt. Seconds, against the ~16 minutes
+      # 11 targets x 10 000 mutations used to cost — and that spend bought
+      # a search too short to find anything the cron will not.
+      #
+      # The cron does the real fuzzing. `-runs`, never `-max_total_time`:
+      # a wall-clock bound makes a failure non-reproducible across
+      # runners of different speeds.
+      - name: Fuzz the targets
         id: smoke
-        env:
-          FUZZ_RUNS: ${{ github.event_name == 'schedule' && '200000' || '10000' }}
-        run: make fuzz-smoke FUZZ_RUNS="$FUZZ_RUNS"
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            make fuzz-replay
+          else
+            make fuzz-smoke FUZZ_RUNS=200000
+          fi
 
       # libFuzzer writes the offending input to fuzz/artifacts/<target>/.
       # Without this the reproducer dies with the runner.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -461,8 +461,11 @@ quadratic walk makes the unit tests *slow* rather than red, so run
 [`docs/development/benchmarking.md`](docs/development/benchmarking.md).
 
 **Fuzzing** is the third out-of-band gate (`.github/workflows/fuzz.yml`,
-the workspace-excluded `fuzz/` crate). Also not per-commit: cargo-fuzz
-needs nightly and builds every grammar under ASan, so it lives in its own
+the workspace-excluded `fuzz/` crate). Out-of-band means out of `make
+pre-commit`, not out of CI: a pull request touching `src/`, `fuzz/`, a
+manifest or a grammar still builds every target and replays the committed
+seeds, and the quarterly cron does the actual fuzzing. cargo-fuzz needs
+nightly and builds every grammar under ASan, so it lives in its own
 workflow — `ci.yml` sets `RUSTFLAGS: "-D warnings"` workflow-wide and
 pairing that with nightly red-Xes CI on unrelated new nightly lints. Run
 `make fuzz-check` after editing anything under `fuzz/`, since the crate is

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ find-by-ext = $(if $(FD),$(FD) --extension $(1) $(FD_EXCLUDE) $(2),find . -name 
 NEXTEST        := $(shell command -v cargo-nextest 2>/dev/null)
 TEST_CMD       = $(if $(NEXTEST),$(NEXTEST) nextest run --workspace --all-features,cargo test --workspace --all-features --lib --bins --tests)
 
-.PHONY: help check-tools worktree-setup worktree-setup-test build build-release check test test-doc chain-audit fmt fmt-check markdown-fmt markdown-lint shellcheck sh-fmt sh-fmt-check toml-fmt toml-fmt-check toml-lint makefile-check actionlint snapshot-anchors snapshot-anchors-test rustfmt-bail rustfmt-bail-test grammar-marker-sync grammar-marker-sync-test check-versions check-excluded-manifests check-excluded-manifests-test check-ruff-lockstep check-ruff-lockstep-test check-publish-metadata check-publish-metadata-test check-manpage-assets check-diagnostic-prefix check-diagnostic-prefix-test gate-status-test check-tools-test enums-check enums-codegen-drift enums-codegen-drift-test self-scan self-scan-headroom self-scan-write-baseline self-scan-write-baseline-headroom vcs lint clippy udeps insta-review insta-accept clean distclean install install-cli install-web doc doc-open doc-check doc-check-docsrs book book-serve book-pot book-po-update book-ja book-deploy all pre-commit ci release-check verify-changelog pkg-deb-local pkg-rpm-local dev-env-build dev-env-run dev-env-shell dev-env-rm py-bootstrap py-sync py-relock py-clean py-fmt py-fmt-check py-lint py-typecheck py-test py-stubtest smoke smoke-cli smoke-lib bench bench-scaling bench-walk fuzz-check fuzz-smoke fuzz-run fuzz-tmin _check-find _pc-all _pc-fmt _pc-clippy _pc-test _pc-doc-check _pc-udeps _pc-shellcheck _pc-markdown-lint _pc-toml-lint _pc-makefile-check _pc-actionlint _pc-snapshot-anchors _pc-snapshot-anchors-test _pc-rustfmt-bail _pc-rustfmt-bail-test _pc-grammar-marker-sync _pc-grammar-marker-sync-test _pc-check-versions _pc-check-versions-test _pc-check-grammar-crate-test _pc-check-excluded-manifests _pc-check-excluded-manifests-test _pc-check-ruff-lockstep _pc-check-ruff-lockstep-test _pc-check-publish-metadata _pc-check-publish-metadata-test _pc-check-manpage-assets _pc-check-diagnostic-prefix _pc-check-diagnostic-prefix-test _pc-worktree-setup-test _pc-gate-status-test _pc-check-tools-test _pc-enums-check _pc-enums-codegen-drift _pc-enums-codegen-drift-test _pc-self-scan _pc-self-scan-headroom _pc-py-fmt _pc-py-typecheck _pc-py-test _pc-py-stubtest _ci-all _ci-fmt-check _ci-clippy _ci-test _ci-doc-check _ci-build _ci-udeps _ci-shellcheck _ci-markdown-lint _ci-toml-lint _ci-makefile-check _ci-actionlint _ci-snapshot-anchors _ci-snapshot-anchors-test _ci-rustfmt-bail _ci-rustfmt-bail-test _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-versions-test _ci-check-grammar-crate-test _ci-check-excluded-manifests _ci-check-excluded-manifests-test _ci-check-ruff-lockstep _ci-check-ruff-lockstep-test _ci-check-publish-metadata _ci-check-publish-metadata-test _ci-check-manpage-assets _ci-check-diagnostic-prefix _ci-check-diagnostic-prefix-test _ci-worktree-setup-test _ci-gate-status-test _ci-check-tools-test _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test _ci-enums-codegen-drift-test _ci-self-scan _ci-self-scan-headroom _ci-cargo-pipeline _ci-py-fmt-check _ci-py-lint _ci-py-typecheck _ci-py-test _ci-py-stubtest
+.PHONY: help check-tools worktree-setup worktree-setup-test build build-release check test test-doc chain-audit fmt fmt-check markdown-fmt markdown-lint shellcheck sh-fmt sh-fmt-check toml-fmt toml-fmt-check toml-lint makefile-check actionlint snapshot-anchors snapshot-anchors-test rustfmt-bail rustfmt-bail-test grammar-marker-sync grammar-marker-sync-test check-versions check-excluded-manifests check-excluded-manifests-test check-ruff-lockstep check-ruff-lockstep-test check-publish-metadata check-publish-metadata-test check-manpage-assets check-diagnostic-prefix check-diagnostic-prefix-test gate-status-test check-tools-test enums-check enums-codegen-drift enums-codegen-drift-test self-scan self-scan-headroom self-scan-write-baseline self-scan-write-baseline-headroom vcs lint clippy udeps insta-review insta-accept clean distclean install install-cli install-web doc doc-open doc-check doc-check-docsrs book book-serve book-pot book-po-update book-ja book-deploy all pre-commit ci release-check verify-changelog pkg-deb-local pkg-rpm-local dev-env-build dev-env-run dev-env-shell dev-env-rm py-bootstrap py-sync py-relock py-clean py-fmt py-fmt-check py-lint py-typecheck py-test py-stubtest smoke smoke-cli smoke-lib bench bench-scaling bench-walk fuzz-check fuzz-smoke fuzz-replay fuzz-run fuzz-tmin _check-find _pc-all _pc-fmt _pc-clippy _pc-test _pc-doc-check _pc-udeps _pc-shellcheck _pc-markdown-lint _pc-toml-lint _pc-makefile-check _pc-actionlint _pc-snapshot-anchors _pc-snapshot-anchors-test _pc-rustfmt-bail _pc-rustfmt-bail-test _pc-grammar-marker-sync _pc-grammar-marker-sync-test _pc-check-versions _pc-check-versions-test _pc-check-grammar-crate-test _pc-check-excluded-manifests _pc-check-excluded-manifests-test _pc-check-ruff-lockstep _pc-check-ruff-lockstep-test _pc-check-publish-metadata _pc-check-publish-metadata-test _pc-check-manpage-assets _pc-check-diagnostic-prefix _pc-check-diagnostic-prefix-test _pc-worktree-setup-test _pc-gate-status-test _pc-check-tools-test _pc-enums-check _pc-enums-codegen-drift _pc-enums-codegen-drift-test _pc-self-scan _pc-self-scan-headroom _pc-py-fmt _pc-py-typecheck _pc-py-test _pc-py-stubtest _ci-all _ci-fmt-check _ci-clippy _ci-test _ci-doc-check _ci-build _ci-udeps _ci-shellcheck _ci-markdown-lint _ci-toml-lint _ci-makefile-check _ci-actionlint _ci-snapshot-anchors _ci-snapshot-anchors-test _ci-rustfmt-bail _ci-rustfmt-bail-test _ci-grammar-marker-sync _ci-grammar-marker-sync-test _ci-check-versions _ci-check-versions-test _ci-check-grammar-crate-test _ci-check-excluded-manifests _ci-check-excluded-manifests-test _ci-check-ruff-lockstep _ci-check-ruff-lockstep-test _ci-check-publish-metadata _ci-check-publish-metadata-test _ci-check-manpage-assets _ci-check-diagnostic-prefix _ci-check-diagnostic-prefix-test _ci-worktree-setup-test _ci-gate-status-test _ci-check-tools-test _ci-enums-check _ci-enums-codegen-drift _ci-enums-codegen-drift-test _ci-enums-codegen-drift-test _ci-self-scan _ci-self-scan-headroom _ci-cargo-pipeline _ci-py-fmt-check _ci-py-lint _ci-py-typecheck _ci-py-test _ci-py-stubtest
 
 # Default target
 help:
@@ -161,6 +161,7 @@ help:
 	@echo "  bench-walk                           Criterion metric-walk benchmarks over a corpus slice"
 	@echo "  fuzz-check                           Lint, test + build the cargo-fuzz targets (out-of-band)"
 	@echo "  fuzz-smoke                           Short bounded fuzz run over the committed corpora"
+	@echo "  fuzz-replay                          Replay the committed seeds only (regression check)"
 	@echo "  fuzz-run                             One target, FUZZ_RUNS iterations (FUZZ_TARGET=name)"
 	@echo "  fuzz-tmin                            Minimise a crash artifact (FUZZ_TARGET, FUZZ_INPUT)"
 	@echo "  lint                                 Run all linters"
@@ -1195,6 +1196,26 @@ fuzz-smoke:
 	  done; \
 	else \
 	  echo "nightly toolchain or cargo-fuzz not found; skipping fuzz-smoke"; \
+	fi
+
+# Replay the committed seeds and stop: `-runs=0` executes the corpus once
+# and exits without mutating. This is the regression half of fuzzing —
+# "did this change break an input that used to be fine" — as opposed to
+# the hunt, and it is what CI runs per PR. Seconds, not minutes.
+fuzz-replay:
+	@if rustup toolchain list 2>/dev/null | grep -q '^nightly' && \
+	    command -v cargo-fuzz >/dev/null 2>&1; then \
+	  $(FUZZ_REQUIRE_SYMBOLIZER); \
+	  for t in $$(cargo +nightly fuzz list); do \
+	    echo "Replaying committed seeds for $$t..."; \
+	    mkdir -p $(FUZZ_WORK)/"$$t"; \
+	    $(FUZZ_CC_ENV) $(FUZZ_RUN_ENV) cargo +nightly fuzz run \
+	      --target $(FUZZ_HOST_TRIPLE) "$$t" \
+	      $(FUZZ_WORK)/"$$t" $(BASE_DIR)fuzz/corpus/"$$t" \
+	      -- -runs=0 -timeout=$(FUZZ_TIMEOUT); \
+	  done; \
+	else \
+	  echo "nightly toolchain or cargo-fuzz not found; skipping fuzz-replay"; \
 	fi
 
 fuzz-run:

--- a/docs/development/fuzzing.md
+++ b/docs/development/fuzzing.md
@@ -111,9 +111,20 @@ reason, not a wish for symmetry.
 around a minute even warm, which does not belong in the per-commit loop —
 the same call `chain-audit`, `bench-scaling` and mutation testing make.
 
-`.github/workflows/fuzz.yml` runs them instead: on pull requests and
-pushes that touch `src/`, `fuzz/`, a manifest, a vendored grammar or the
-`Makefile`, and on a quarterly cron with a much larger iteration budget.
+`.github/workflows/fuzz.yml` runs them instead, and splits the two
+questions fuzzing answers. A pull request touching `src/`, `fuzz/`, a
+manifest, a vendored grammar or the `Makefile` builds every target and
+then **replays the committed seeds** — the regression question, answered
+in seconds. The quarterly cron does the **hunt**, at 200 000 runs per
+target.
+
+That split is a correction, and the numbers are why. The job first ran
+11 targets x 10 000 mutations on every pull-request push: 156 s to build
+and 977 s to fuzz, nine times over one pull request, 96 minutes of runner
+time. A 10 000-run search is far too short to find what the cron will and
+long enough to dominate the job, so the spend bought neither answer. It
+also ran again on every push to `main`, re-validating a tree the pull
+request had just validated.
 It is a separate workflow rather than a job in `ci.yml` because
 cargo-fuzz needs nightly and `ci.yml` sets `RUSTFLAGS: "-D warnings"`
 workflow-wide; pairing the two turns every new nightly lint into a red X


### PR DESCRIPTION
Follow-up to #1251. The fuzz job was running on every pull-request push
*and* every push to `main`, which is not what "out-of-band" was supposed
to mean.

## Measured, over one pull request

| | |
|---|---|
| Build all 11 targets | 156 s |
| Fuzz (11 × 10 000 mutations) | 977 s |
| Runs fired for #1251 | 9 (8 PR pushes + 1 post-merge) |
| Runner time | **96 minutes** |

## Both halves of that were wrong

**10 000 mutations is too short to find anything and long enough to
dominate the job.** It is 86% of the runtime, and the one real bug this
harness has found so far — the `SIGSEGV` in #1289 — took 34 633 runs to
surface. A per-PR search at 10 000 buys neither the fast gate nor the
hunt; it is a slow gate that finds what a fast one would.

**The push-to-`main` run re-validated a tree the pull request had just
validated.** ~17 minutes to learn nothing, on every merge.

## What this does instead

Splits the two questions fuzzing answers.

- **Pull request** — build every target, then `make fuzz-replay`, a new
  target that runs `-runs=0` so libFuzzer executes the committed corpus
  once and exits. That is the *regression* question: did this change
  break an input that used to be fine. Seconds.
- **Quarterly cron** — unchanged, and now the only place the *hunt*
  happens, at 200 000 runs per target.
- **`push:` trigger** — removed.

Per-PR cost drops from ~17 minutes to ~3. Quarterly coverage is
untouched.

## A documentation error this exposed

`AGENTS.md` described the gate as "Also not per-commit". I meant "not in
`make pre-commit`"; it reads as "does not run per commit in CI", which it
did. `docs/development/fuzzing.md` described the real behaviour
correctly, so the two files disagreed and the wrong one was the one being
quoted. Both now say the same thing, and `fuzzing.md` carries the numbers
above so the next person to weigh this has them.

## Validation

`make pre-commit` green. `make fuzz-replay` replays all 11 targets clean
locally. `make actionlint` green.

Note this PR touches `.github/workflows/fuzz.yml` and the `Makefile`,
both in the fuzz job's own path filter, so the job runs on this PR — in
its new, cheap form. That is the change validating itself.
