### PR TITLE
ci(fuzz): raise default FUZZ_TIMEOUT to 60 seconds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1083,7 +1083,15 @@ bench-walk:
 #               the grammars without ASan and reproduces a C-scanner
 #               crash weakly or not at all.
 FUZZ_RUNS ?= 100000
-FUZZ_TIMEOUT ?= 10
+# 60 s is measured, not chosen: the slowest *legitimate* input seen so
+# far — nested_depth's 5-byte seed decoding to 508 alternating
+# Block/Lambda levels of JavaScript — takes 11 s solo under ASan plus
+# the harness's ten-walk fan-out, so the previous default of 10 failed
+# on correct behaviour (#1308). Sixty keeps ~5x headroom over that
+# while still catching the one thing a wall-clock timeout reliably
+# catches, an unbounded loop. Raise it only for a new, slower,
+# *measured* legitimate input; investigate anything else.
+FUZZ_TIMEOUT ?= 60
 FUZZ_TARGET ?= parse_cpp
 FUZZ_INPUT ?=
 

--- a/docs/development/fuzzing.md
+++ b/docs/development/fuzzing.md
@@ -167,7 +167,7 @@ make fuzz-tmin FUZZ_TARGET=parse_cpp FUZZ_INPUT=fuzz/artifacts/parse_cpp/<file>
 --all` stops at the workspace, and `fuzz/` is excluded from it.
 
 Both run targets take `FUZZ_RUNS` (default 100 000) and `FUZZ_TIMEOUT`
-(default 10 seconds per input). Every recipe skips with a printed reason
+(default 60 seconds per input). Every recipe skips with a printed reason
 when nightly or `cargo-fuzz` is absent, so a stable-only checkout is not
 blocked.
 
@@ -179,8 +179,15 @@ neither result can be checked.
 `FUZZ_TIMEOUT` is a separate thing — a per-input limit — but it is
 wall-clock too, and that limits what it can be trusted to mean. It
 reliably catches an *unbounded* loop, where no timeout value would
-matter. It is **not** a complexity gate on a loaded machine, and the
-default of 10 seconds assumes the targets are running one at a time.
+matter. It is **not** a complexity gate, even on an idle machine: the
+slowest *legitimate* input measured so far — `nested_depth`'s 5-byte
+seed decoding to 508 alternating `Block`/`Lambda` levels of
+JavaScript — takes **11 s** when run solo under ASan plus the harness's
+ten-walk fan-out, while the 4.8 KB JavaScript file it generates costs
+0.06 s through `bca metrics` in a plain release build. The default of
+60 seconds is that measurement plus ~5x headroom (#1308; the previous
+default of 10 failed on correct behaviour), and it still assumes the
+targets are running one at a time.
 
 Measured, because this bit a parallel sweep for #1154: `nested_depth`
 reported a timeout on a 7-byte input while ten sibling targets shared 16


### PR DESCRIPTION
## Summary

Raises the default `FUZZ_TIMEOUT` from 10 to 60 seconds (`Makefile`).
The previous default was below what a legitimate input already costs:
the slowest measured legitimate input — `nested_depth`'s 5-byte seed
decoding to 508 alternating `Block`/`Lambda` levels of JavaScript —
takes 11 s solo under ASan plus the harness's ten-walk fan-out, so the
quarterly fuzz cron was set up to auto-file a false crash issue on
correct behaviour.

Sixty gives ~5x headroom over that measurement while still catching
the one thing a wall-clock timeout reliably catches: an unbounded
loop. The rationale is recorded in a comment next to the default so a
future timeout report is triaged as raise-or-investigate rather than
re-derived, and `docs/development/fuzzing.md` is updated in both
places that stated the 10 s default.

## What deliberately did not change

- `.github/workflows/fuzz.yml` sets no `FUZZ_TIMEOUT`, so the cron
  inherits the Makefile default — no per-step override, and the local
  `make fuzz-smoke` trap closes at the same time.
- No CHANGELOG entry: the fuzz tooling is itself still under
  `## [Unreleased]`, so the 10 s default never shipped in a release.
- No library change — the 11 s is harness cost (ASan + ten-walk
  fan-out), not a product defect; the same input costs 0.06 s through
  `bca metrics` in a plain release build.

## Validation

`make pre-commit` passed (`BCA_GATE: pass (gate=pre-commit)`).

Fixes #1308
