### PR TITLE
fix(metrics): seven metric-correctness fixes across Tcl, Elixir, Ruby, and TS

### DIFF
--- a/.bca-baseline.toml
+++ b/.bca-baseline.toml
@@ -888,12 +888,6 @@ metric = "cyclomatic"
 value = 16.0
 
 [[entry]]
-path = "src/metrics/cognitive.rs"
-qualified = "tcl_switch_decision_arms"
-metric = "nexits"
-value = 6.0
-
-[[entry]]
 path = "src/metrics/cognitive/bash.rs"
 qualified = "BashCode::compute"
 metric = "nargs"
@@ -1000,6 +994,12 @@ path = "src/metrics/cognitive/rust.rs"
 qualified = "RustCode::compute"
 metric = "nargs"
 value = 5.0
+
+[[entry]]
+path = "src/metrics/cognitive/tcl.rs"
+qualified = "TclCode::compute"
+metric = "cyclomatic"
+value = 15.0
 
 [[entry]]
 path = "src/metrics/cognitive/tcl.rs"

--- a/.bca-baseline.toml
+++ b/.bca-baseline.toml
@@ -813,7 +813,7 @@ value = 64170.027458982564
 path = "src/getter/elixir.rs"
 qualified = "ElixirCode::get_op_type"
 metric = "halstead.effort"
-value = 54685.446169787065
+value = 74457.74988084711
 
 [[entry]]
 path = "src/getter/irules.rs"

--- a/.rustfmt-bail-baseline.txt
+++ b/.rustfmt-bail-baseline.txt
@@ -124,7 +124,7 @@ src/getter/perl.rs 2
 src/getter/php.rs 8
 src/getter/python.rs 7
 src/getter/ruby.rs 2
-src/getter/tcl.rs 4
+src/getter/tcl.rs 5
 src/macros/mod.rs 38
 src/metrics/abc/elixir.rs 5
 src/metrics/abc/perl.rs 8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,14 +127,20 @@ for historical reference.
   node (which is already the operand); `~` remains the single
   per-sigil operator, and standalone `/`, `<`, `|`, … in ordinary
   expressions — including inside a sigil's interpolation — still
-  count (#1256).
-- Elixir's bare `_ ->` catch-all arm (`case` / `fn` / `receive`) and
-  `cond`'s idiomatic `true ->` final arm counted toward standard
-  cyclomatic complexity, while every sibling language excludes its
-  default arm (Rust `_ =>`, Python `case _:`, Kotlin `else ->`,
-  C-family `default:`, …). Both are now excluded; guarded wildcards
-  (`_ when …`), named discards (`_x ->`), and `true ->` under a
-  `case` still count (#1272).
+  count. The ABC condition count had the same delimiter sensitivity
+  through `<` / `>` (`x = ~s<hi>` scored 2 conditions, `x = ~s(hi)`
+  zero) and now applies the same parent-is-sigil guard (#1256).
+- Elixir's bare `_ ->` catch-all arm (`case` / `receive` / `rescue`)
+  and any unguarded `true ->` directly under a `cond` (shape-based,
+  whatever the arm's position — matching Rust's position-blind
+  bare-`_` rule) counted toward standard cyclomatic complexity, while
+  every sibling language excludes its default arm (Rust `_ =>`,
+  Python `case _:`, Kotlin `else ->`, C-family `default:`, …). Both
+  are now excluded; guarded wildcards (`_ when …`), named discards
+  (`_x ->`), `true ->` under a `case`, and a multi-clause `fn`'s
+  trailing `_ ->` (its free base path is the #776 head-clause skip,
+  so its 2nd+ clauses all count, in parity with the identical `case`)
+  still count (#1272).
 - A Tcl `try { … } on error { … }` construct contributed zero to
   cyclomatic and cognitive complexity. Each `on` / `trap` handler now
   counts +1 in both metrics (`finally` stays free), matching `catch`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,16 @@ for historical reference.
   trees for Ruby files with stabby lambdas lose the phantom entries,
   which also removes their zero contributions from `function_spaces`
   averages and per-file minimums (#1257).
+- Ruby cognitive complexity charged a stabby lambda's body twice for
+  lambda nesting: both the `Lambda` wrapper and its own body `Block` /
+  `DoBlock` incremented the surcharge, so `f = ->(a) { if a then 1
+  end }` scored 3 where the equivalent keyword form `f = lambda { |a|
+  if a then 1 end }` scored 2. The body block is now excluded via the
+  same shared stabby-lambda-body predicate as the closure count and
+  the space tree (the sweep #1257's rationale mandated), and both
+  forms score 2. Cognitive values drop by 1 per nesting-sensitive
+  construct inside each stabby lambda; keyword lambdas, `proc`, and
+  iterator blocks are unchanged.
 - Elixir sigil delimiter tokens (`/`, `(`, `{`, `[`, `<`, `>`, `|`)
   counted as ordinary Halstead operators, so the delimiter choice
   changed `n1`/`N1` and `~r/abc/` fabricated two division operators.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,18 @@ for historical reference.
 
 ### Fixed
 
+- A Ruby stabby lambda (`->(z) { … }` / `->(z) do … end`) opened two
+  nested anonymous Function spaces — one for the `Lambda` node and a
+  phantom zero-metric one for the `Block` / `DoBlock` that is the
+  lambda's own body. #465 had fixed the closure *count* half; the
+  space-promotion walk still promoted the body block a second time.
+  The `Block | DoBlock` promotion is now gated on the same
+  parent-is-not-`Lambda` predicate `is_closure` uses, so each stabby
+  lambda opens exactly one space; keyword forms (`lambda { }`,
+  `proc { }`) and iterator blocks are unchanged. Serialized space
+  trees for Ruby files with stabby lambdas lose the phantom entries,
+  which also removes their zero contributions from `function_spaces`
+  averages and per-file minimums (#1257).
 - The `enums` code generator minted collision-breaking names
   (`Foo` → `Foo2`) without registering them, so a minted suffix could
   silently duplicate a node kind whose own sanitized name is literally

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,18 @@ for historical reference.
 
 ### Fixed
 
+- In TypeScript and TSX, a `: string` type annotation counted as both a
+  Halstead operator (the `predefined_type` wrapper) and an operand (its
+  inner anonymous `"string"` keyword token, added by #313 for parity
+  with `Checker::is_string`) — one source token, two tallies, while
+  `: number` / `: boolean` counted once. The keyword now counts exactly
+  once, as the text-keyed `string` operator, symmetric with every other
+  predefined type; Halstead length and vocabulary drop accordingly for
+  annotation-dense TS/TSX code. `Checker::is_string` was narrowed in
+  the same direction, so `bca find --type string` / `bca count --type
+  string` report string literals and templates only, no longer the
+  `: string` annotation keyword; string *literals* whose contents spell
+  `"string"` are unaffected (#1261).
 - A Ruby stabby lambda (`->(z) { … }` / `->(z) do … end`) opened two
   nested anonymous Function spaces — one for the `Lambda` node and a
   phantom zero-metric one for the `Block` / `DoBlock` that is the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,40 @@ for historical reference.
   trees for Ruby files with stabby lambdas lose the phantom entries,
   which also removes their zero contributions from `function_spaces`
   averages and per-file minimums (#1257).
+- Elixir sigil delimiter tokens (`/`, `(`, `{`, `[`, `<`, `>`, `|`)
+  counted as ordinary Halstead operators, so the delimiter choice
+  changed `n1`/`N1` and `~r/abc/` fabricated two division operators.
+  The delimiters are now suppressed when their parent is the sigil
+  node (which is already the operand); `~` remains the single
+  per-sigil operator, and standalone `/`, `<`, `|`, … in ordinary
+  expressions — including inside a sigil's interpolation — still
+  count (#1256).
+- Elixir's bare `_ ->` catch-all arm (`case` / `fn` / `receive`) and
+  `cond`'s idiomatic `true ->` final arm counted toward standard
+  cyclomatic complexity, while every sibling language excludes its
+  default arm (Rust `_ =>`, Python `case _:`, Kotlin `else ->`,
+  C-family `default:`, …). Both are now excluded; guarded wildcards
+  (`_ when …`), named discards (`_x ->`), and `true ->` under a
+  `case` still count (#1272).
+- A Tcl `try { … } on error { … }` construct contributed zero to
+  cyclomatic and cognitive complexity. Each `on` / `trap` handler now
+  counts +1 in both metrics (`finally` stays free), matching `catch`
+  and every exception-bearing sibling language, and the iRules `Try`
+  sibling counts the same way — its `on_handler` / `trap_handler`
+  nodes previously opened spurious anonymous function spaces,
+  inflating `nom`, instead of counting as decisions (#1266).
+- A Tcl `for` loop contributed zero to cyclomatic and cognitive
+  complexity because the grammar has no `for` rule — the loop parses
+  as a generic `command` node. It is now recognised by command name
+  at the same out-of-band slot as `switch` (#467) and counts like
+  `while` / `foreach`, nesting increments included (#1264).
+- Every variable a Tcl script assigned was absent from Halstead
+  operands: the parser emits the anonymous `id` kind in both of its
+  positions, and the getter excluded it wholesale on the false
+  premise that it only appears inside `$var` substitutions (whose
+  wrapper is already the operand). The exclusion is now scoped to
+  the substitution-leaf position, so `set` targets count in
+  `n2`/`N2`, matching the iRules parent guard (#1294).
 - The `enums` code generator minted collision-breaking names
   (`Foo` → `Foo2`) without registering them, so a minted suffix could
   silently duplicate a node kind whose own sanitized name is literally

--- a/src/alterator.rs
+++ b/src/alterator.rs
@@ -448,10 +448,12 @@ impl Alterator for TypescriptCode {
         children: Vec<AstNode>,
     ) -> AstNode {
         match Typescript::from(node.kind_id()) {
-            // `TemplateString` joins `String`/`String2` so the dump
-            // matches `Checker::is_string`; its `${…}` interpolations
-            // collapse into the flat text payload (#699).
-            Typescript::String | Typescript::String2 | Typescript::TemplateString => {
+            // `TemplateString` joins `String` so the dump matches
+            // `Checker::is_string`; its `${…}` interpolations collapse
+            // into the flat text payload (#699). TS's `String2` (the
+            // `: string` type keyword, a childless leaf for which this
+            // arm is a no-op anyway) left the string set with #1261.
+            Typescript::String | Typescript::TemplateString => {
                 let (text, span) = Self::get_text_span(node, code, span, true);
                 AstNode::with_field_name(node.kind(), text, span, field_name, Vec::new())
             }
@@ -469,10 +471,13 @@ impl Alterator for TsxCode {
         children: Vec<AstNode>,
     ) -> AstNode {
         match Tsx::from(node.kind_id()) {
-            // `TemplateString` joins `String`/`String2`/`String3` so the
-            // dump matches `Checker::is_string`; its `${…}` interpolations
-            // collapse into the flat text payload (#699).
-            Tsx::String | Tsx::String2 | Tsx::String3 | Tsx::TemplateString => {
+            // `TemplateString` joins `String`/`String2` (the
+            // string-literal alias) so the dump matches
+            // `Checker::is_string`; its `${…}` interpolations collapse
+            // into the flat text payload (#699). `String3` (the
+            // `: string` type keyword, a childless leaf for which this
+            // arm is a no-op anyway) left the string set with #1261.
+            Tsx::String | Tsx::String2 | Tsx::TemplateString => {
                 let (text, span) = Self::get_text_span(node, code, span, true);
                 AstNode::with_field_name(node.kind(), text, span, field_name, Vec::new())
             }

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -203,18 +203,20 @@ macro_rules! is_js_func_and_closure_checker {
     };
 }
 
-// Generate an `is_string` impl for a JS-family `Checker` block. The
-// MozJS / JavaScript / TypeScript grammars expose `String2` as the
-// anonymous `"string"` keyword alias for `String`; TSX additionally
-// exposes `String3` (the JSX-attribute string production). The
-// alterator flattens these aliases; the generic `string` filter must
-// agree (issue #283).
+// Generate an `is_string` impl for a JS-family `Checker` block: the
+// named `String` literal, `TemplateString`, plus per-language
+// anonymous *literal* aliases passed as extras. The alterator
+// flattens the same kinds; the generic `string` filter must agree
+// (issue #283). Type-keyword aliases (`: string`, which parses as an
+// anonymous `"string"` token under a `predefined_type` wrapper) are
+// not literals and stay out (#1261); per-call rationale sits above
+// each invocation.
 macro_rules! impl_js_family_is_string {
     ($lang:ident $(, $extra:ident)* $(,)?) => {
         fn is_string(node: &Node) -> bool {
             matches!(
                 node.kind_id().into(),
-                $lang::String | $lang::String2 | $lang::TemplateString
+                $lang::String | $lang::TemplateString
                     $(| $lang::$extra)*
             )
         }
@@ -984,38 +986,52 @@ mod tests {
     }
 
     #[test]
-    fn typescript_is_string_matches_string2_alias() {
-        // TypeScript exposes both the primary `String` literal and
-        // a `String2` alias (kind_id 135). The latter sits among the
-        // type-keyword tokens in the enum, so a `: string` annotation
-        // is a reliable producer.
+    fn typescript_is_string_excludes_type_keyword_alias_1261() {
+        // TypeScript's only anonymous `"string"` alias, `String2`
+        // (kind_id 135), is the `: string` type-annotation keyword —
+        // not a literal. #313 made it match `is_string` for parity
+        // with the operand classification; #1261 dropped it from both,
+        // so `find string` / `count string` report literals only.
+        // The `String` literal kinds must keep matching (the fixture's
+        // `'x'` / `'y'`), otherwise this test would pass by
+        // over-narrowing.
         let src = "const a: string = 'x';\nfunction f(): string { return 'y'; }\n";
         let parser = TypescriptParser::new(src.as_bytes().to_vec(), &PathBuf::from("t.ts"), None);
         assert!(
             ast_has_kind_id(&parser, Typescript::String2 as u16),
             "expected Typescript::String2 to appear in the parse",
         );
-        assert!(
+        assert_eq!(
             count_string_matches_for_kind(
                 &parser,
                 Typescript::String2 as u16,
                 TypescriptCode::is_string,
+            ),
+            0,
+            "Typescript::String2 (type keyword) must not match is_string",
+        );
+        assert!(
+            count_string_matches_for_kind(
+                &parser,
+                Typescript::String as u16,
+                TypescriptCode::is_string,
             ) > 0,
-            "Typescript::String2 nodes must match is_string",
+            "Typescript::String literals must still match is_string",
         );
     }
 
     #[test]
-    fn tsx_is_string_matches_string2_and_string3_aliases() {
+    fn tsx_is_string_matches_literal_alias_not_type_keyword_1261() {
         // TSX uniquely carries two anonymous `"string"` aliases:
         // `String3` (kind_id 141, the type-annotation keyword) and
-        // `String2` (kind_id 261). Both must appear in this fixture:
-        // the `: string` annotation produces `String3`, and the
-        // `'x'` / `"y"` / `"m"` / `"c"` literals produce `String2`.
-        // Asserting presence of both *before* checking `is_string`
-        // ensures a future grammar bump that stops emitting either
-        // alias fails loudly here rather than silently dropping
-        // coverage (which would invalidate the regression for #283).
+        // `String2` (kind_id 261, the string-literal alias). Both must
+        // appear in this fixture: the `: string` annotation produces
+        // `String3`, and the `'x'` / `"y"` / `"m"` / `"c"` literals
+        // produce `String2`. Asserting presence of both *before*
+        // checking `is_string` ensures a future grammar bump that
+        // stops emitting either alias fails loudly here rather than
+        // silently dropping coverage. The literal alias matches
+        // (#283); the type keyword must not (#1261).
         let src = "const a: string = 'x';\n\
                    const b = \"y\";\n\
                    import \"m\";\n\
@@ -1029,13 +1045,14 @@ mod tests {
             ast_has_kind_id(&parser, Tsx::String2 as u16),
             "expected Tsx::String2 (string-literal alias) in the parse",
         );
-        assert!(
-            count_string_matches_for_kind(&parser, Tsx::String3 as u16, TsxCode::is_string) > 0,
-            "Tsx::String3 nodes must match is_string",
+        assert_eq!(
+            count_string_matches_for_kind(&parser, Tsx::String3 as u16, TsxCode::is_string),
+            0,
+            "Tsx::String3 (type keyword) must not match is_string",
         );
         assert!(
             count_string_matches_for_kind(&parser, Tsx::String2 as u16, TsxCode::is_string) > 0,
-            "Tsx::String2 nodes must match is_string",
+            "Tsx::String2 (string-literal alias) nodes must match is_string",
         );
     }
 

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -519,7 +519,7 @@ mod perl;
 mod php;
 mod preproc;
 mod python;
-mod ruby;
+pub(crate) mod ruby;
 mod rust;
 mod tcl;
 mod tsx;

--- a/src/checker/irules.rs
+++ b/src/checker/irules.rs
@@ -16,32 +16,25 @@ impl Checker for IrulesCode {
     // bodies are recursively-parsed `braced_word`s, so nested control flow
     // is attributed correctly.
     //
-    // `OnHandler` / `TrapHandler` are defensive arms (lesson #34): the
-    // grammar declares dedicated `on_handler` / `trap_handler` nodes, but at
-    // statement level a bare `on …` / `trap …` parses as a generic `command`
-    // (the `command` rule wins), so these kinds do not surface in practice
-    // and have no dedicated test. They are listed here so that if a future
-    // grammar revision starts emitting them they are handled as spaces
-    // rather than silently dropped — never removed in favour of an
-    // `unreachable!` (lesson #5).
+    // `OnHandler` / `TrapHandler` are deliberately NOT spaces. The grammar
+    // references `on_handler` / `trap_handler` from the `try` rule alone,
+    // so they surface only as `try` error-handler clauses — the `catch`
+    // analogue, not the `when`-style event handlers their names suggest.
+    // Listing them here fabricated an anonymous nested function space (and
+    // a `nom` function) per handler; they are branch points, counted by
+    // the Cognitive / Cyclomatic impls instead (issue #1266).
     fn is_func_space(node: &Node) -> bool {
         matches!(
             node.kind_id().into(),
-            Irules::SourceFile
-                | Irules::Procedure
-                | Irules::WhenEvent
-                | Irules::OnHandler
-                | Irules::TrapHandler
+            Irules::SourceFile | Irules::Procedure | Irules::WhenEvent
         )
     }
 
-    // Handlers count as functions (not closures): `nom.functions` on a
-    // typical iRules file is then the handler count, the intuitive metric.
+    // Event handlers count as functions (not closures): `nom.functions` on
+    // a typical iRules file is then the handler count, the intuitive
+    // metric. `try` handlers are excluded — see `is_func_space`.
     fn is_func<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
-        matches!(
-            node.kind_id().into(),
-            Irules::Procedure | Irules::WhenEvent | Irules::OnHandler | Irules::TrapHandler
-        )
+        matches!(node.kind_id().into(), Irules::Procedure | Irules::WhenEvent)
     }
 
     // iRules has no anonymous lambda node (`apply` is an ordinary command).

--- a/src/checker/javascript.rs
+++ b/src/checker/javascript.rs
@@ -46,7 +46,10 @@ impl Checker for JavascriptCode {
         )
     }
 
-    impl_js_family_is_string!(Javascript);
+    // `String2` (kind_id 221) is JS's anonymous string-*literal* alias
+    // (e.g. the module string in `import "m"`), so it counts as a
+    // string alongside `String` (#283).
+    impl_js_family_is_string!(Javascript, String2);
 
     impl_is_else_if_parent_clause!(Javascript, IfStatement, ElseClause);
 }

--- a/src/checker/mozjs.rs
+++ b/src/checker/mozjs.rs
@@ -45,7 +45,10 @@ impl Checker for MozjsCode {
         )
     }
 
-    impl_js_family_is_string!(Mozjs);
+    // `String2` is MozJS's anonymous string-*literal* alias (same
+    // production as JS's, e.g. `import "m"` module strings), so it
+    // counts as a string alongside `String` (#283).
+    impl_js_family_is_string!(Mozjs, String2);
 
     impl_is_else_if_parent_clause!(Mozjs, IfStatement, ElseClause);
 }

--- a/src/checker/ruby.rs
+++ b/src/checker/ruby.rs
@@ -13,15 +13,16 @@ use super::*;
 /// parse as a `Call` carrying the block argument — the parent is not a
 /// `Lambda` — so they still classify exactly once.
 ///
-/// One helper shared by [`Checker::is_closure`] and
-/// [`Checker::is_func_space_with_code`], so the closure count and the
-/// space tree cannot drift apart
+/// One helper shared by [`Checker::is_closure`],
+/// [`Checker::is_func_space_with_code`], and the cognitive lambda-nesting
+/// arm (`crate::metrics::cognitive`'s Ruby impl), so the closure count,
+/// the space tree, and the nesting surcharge cannot drift apart
 /// (`.claude/rules/grammar-dispatch.md` §6).
 ///
-/// The parent comes off the caller's chain: both consumers run per node
+/// The parent comes off the caller's chain: all consumers run per node
 /// from a walk, and `Node::parent` costs `O(depth)` because
 /// `tree_sitter` resolves it by descending from the root (#1088).
-fn is_stabby_lambda_body<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>) -> bool {
+pub(crate) fn is_stabby_lambda_body<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>) -> bool {
     ancestors
         .parent(node)
         .is_some_and(|parent| parent.kind_id() == Ruby::Lambda)
@@ -53,15 +54,17 @@ impl Checker for RubyCode {
         )
     }
 
+    // Derives from `is_func_space` so the kind set lives in one place;
+    // this override only subtracts the stabby-lambda body blocks the
+    // byte-less spelling over-approximates on.
     fn is_func_space_with_code<'a>(
         node: &Node<'a>,
         _code: &[u8],
         ancestors: Ancestors<'a, '_>,
     ) -> bool {
-        match node.kind_id().into() {
-            Ruby::Block | Ruby::DoBlock => !is_stabby_lambda_body(node, ancestors),
-            _ => Self::is_func_space(node),
-        }
+        Self::is_func_space(node)
+            && !(matches!(node.kind_id().into(), Ruby::Block | Ruby::DoBlock)
+                && is_stabby_lambda_body(node, ancestors))
     }
 
     fn is_func<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {

--- a/src/checker/ruby.rs
+++ b/src/checker/ruby.rs
@@ -3,11 +3,41 @@
 
 use super::*;
 
+/// Whether `node` — a `Block` / `DoBlock` — is the body of a stabby
+/// lambda (`->(z) { … }` / `->(z) do … end`), which parses as a `Lambda`
+/// node that CONTAINS the block. The `Lambda` wrapper already counts as
+/// the closure (#465) and opens the function space (#1257), so
+/// classifying the body again would double-count one lambda as two
+/// closures, or open a phantom nested Function space. The keyword forms
+/// `lambda { }` / `proc { }` and iterator blocks (`[1].each { |x| x }`)
+/// parse as a `Call` carrying the block argument — the parent is not a
+/// `Lambda` — so they still classify exactly once.
+///
+/// One helper shared by [`Checker::is_closure`] and
+/// [`Checker::is_func_space_with_code`], so the closure count and the
+/// space tree cannot drift apart
+/// (`.claude/rules/grammar-dispatch.md` §6).
+///
+/// The parent comes off the caller's chain: both consumers run per node
+/// from a walk, and `Node::parent` costs `O(depth)` because
+/// `tree_sitter` resolves it by descending from the root (#1088).
+fn is_stabby_lambda_body<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>) -> bool {
+    ancestors
+        .parent(node)
+        .is_some_and(|parent| parent.kind_id() == Ruby::Lambda)
+}
+
 impl Checker for RubyCode {
     fn is_comment(node: &Node) -> bool {
         node.kind_id() == Ruby::Comment
     }
 
+    // Over-approximates for `Block` / `DoBlock`: a stabby lambda's own
+    // body block is NOT a space of its own (the wrapping `Lambda` is),
+    // but telling the two apart needs the parent and this spelling has
+    // no ancestor access. The walker promotes through the
+    // [`Checker::is_func_space_with_code`] override below, which
+    // carries the lambda-body gate (#1257).
     fn is_func_space(node: &Node) -> bool {
         matches!(
             node.kind_id().into(),
@@ -23,29 +53,29 @@ impl Checker for RubyCode {
         )
     }
 
+    fn is_func_space_with_code<'a>(
+        node: &Node<'a>,
+        _code: &[u8],
+        ancestors: Ancestors<'a, '_>,
+    ) -> bool {
+        match node.kind_id().into() {
+            Ruby::Block | Ruby::DoBlock => !is_stabby_lambda_body(node, ancestors),
+            _ => Self::is_func_space(node),
+        }
+    }
+
     fn is_func<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> bool {
         matches!(node.kind_id().into(), Ruby::Method | Ruby::SingletonMethod)
     }
 
+    // Ruby is the one non-JS grammar whose closure test is not
+    // answerable from the node's own kind: a `Block` / `DoBlock` counts
+    // only when it is not a stabby lambda's own body (#465, see
+    // `is_stabby_lambda_body`).
     fn is_closure<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>) -> bool {
         match node.kind_id().into() {
             Ruby::Lambda => true,
-            // A stabby lambda `->(z) { … }` parses as a `Lambda` node that
-            // CONTAINS the `Block`/`DoBlock` for its body, so the `Lambda`
-            // arm above already counts it. Counting the inner block again
-            // would double-count one closure as two (#465). The keyword
-            // forms `lambda { }` / `proc { }` parse as a `Call` carrying a
-            // `Block`/`DoBlock` argument (parent is not a `Lambda`), so they
-            // still count exactly once.
-            //
-            // The parent comes off the caller's chain: `is_closure` runs
-            // per node from `Nom` / `NArgs`, and `Node::parent` costs
-            // `O(depth)` because `tree_sitter` resolves it by descending
-            // from the root (#1088). Ruby is the one non-JS grammar whose
-            // closure test is not answerable from the node's own kind.
-            Ruby::Block | Ruby::DoBlock => ancestors
-                .parent(node)
-                .is_none_or(|parent| parent.kind_id() != Ruby::Lambda),
+            Ruby::Block | Ruby::DoBlock => !is_stabby_lambda_body(node, ancestors),
             _ => false,
         }
     }

--- a/src/checker/tsx.rs
+++ b/src/checker/tsx.rs
@@ -45,7 +45,12 @@ impl Checker for TsxCode {
         )
     }
 
-    impl_js_family_is_string!(Tsx, String3);
+    // TSX's `String2` (kind_id 261) is its string-*literal* alias —
+    // ordinary and JSX-attribute literals both parse as it — so it
+    // counts as a string (#283). `String3` (kind_id 141) is the
+    // `: string` type-annotation keyword (the role TS's `String2`
+    // plays) and is deliberately excluded, matching TS (#1261).
+    impl_js_family_is_string!(Tsx, String2);
 
     impl_is_else_if_parent_clause!(Tsx, IfStatement, ElseClause);
 

--- a/src/checker/typescript.rs
+++ b/src/checker/typescript.rs
@@ -48,6 +48,12 @@ impl Checker for TypescriptCode {
         )
     }
 
+    // TS's only anonymous `"string"` alias, `String2` (kind_id 135),
+    // is the `: string` type-annotation keyword — not a literal — so
+    // it is deliberately excluded: `find string` / `count string`
+    // report literals, and `Getter::get_op_type` classifies the
+    // keyword's `predefined_type` wrapper as an operator (#1261,
+    // retiring the #313 parity that made the keyword an operand).
     impl_js_family_is_string!(Typescript);
 
     impl_is_else_if_parent_clause!(Typescript, IfStatement, ElseClause);

--- a/src/getter.rs
+++ b/src/getter.rs
@@ -76,20 +76,17 @@ macro_rules! get_operator {
 // `$operand_extras` per language:
 //   * JavaScript / MozJS: `Identifier2`, `String2` — anonymous keyword
 //     aliases the JS grammar exposes for `Identifier` and `String`.
-//   * TypeScript: `String2`, `NestedIdentifier`, `MemberExpression4`.
-//     `String2` is the TS-only anonymous `"string"` alias the grammar
-//     emits for the `string` type-annotation keyword (kind_id 135, in
-//     the type-keyword range alongside `Boolean` / `Symbol`); it must
-//     be in `operand_extras` to agree with `Checker::is_string` which
-//     also matches it (issue #313, parallel to #283).
-//     `NestedIdentifier` and `MemberExpression4` are other TS-only
-//     productions.
-//   * TSX: union of the above plus `String3`. TSX uniquely exposes
-//     *two* anonymous `"string"` aliases: `String2` (kind_id 261, the
-//     string-literal alias) and `String3` (kind_id 141, the
-//     type-annotation keyword — the role TS's `String2` plays).
-//     `Checker::is_string` matches both, so both must be operands
-//     (#313).
+//   * TypeScript: `NestedIdentifier`, `MemberExpression4` — TS-only
+//     member-expression productions.
+//   * TSX: union of the above. TSX's `String2` (kind_id 261) is its
+//     string-literal alias, so it stays an operand like JS's.
+//     The `: string` type-keyword aliases (TS `String2`, kind_id 135;
+//     TSX `String3`, kind_id 141) are deliberately absent: they are
+//     emitted only as the child of a `predefined_type` wrapper, which
+//     already contributes the text-keyed `"string"` operator, and
+//     #313's listing of the keyword child as an operand counted one
+//     source token twice (#1261, which also narrowed
+//     `Checker::is_string` to match).
 //
 // The `TemplateString` interpolation guard is shared verbatim (issue
 // #192): a bare `` `...` `` mirrors a `"..."` operand, but an
@@ -111,9 +108,11 @@ macro_rules! impl_js_family_get_op_type {
             // `primitive_operators` map as `"void"`) and the inner `Void`
             // token (a standalone expression operator, e.g. `void 0`) would
             // otherwise classify as operators, double-counting one source
-            // `void` as two Halstead operators (issue #453). Other predefined
-            // types (`: string`, `: number`, …) do not have an operator-kind
-            // child, so only `void` collides. Suppress the wrapper here and
+            // `void` as two Halstead operators (issue #453). Only `void` has
+            // an operator-kind child; the `string` keyword's child is an
+            // operand-kind alias, which collided in the other direction
+            // (operator + operand) until #1261 dropped it from the operand
+            // extras. Suppress the wrapper here and
             // let the inner `Void` token carry the single operator, keeping
             // the kind_id-keyed count consistent with expression `void 0`
             // (the lesson-4 `n1 == dedupe(ops.operators)` invariant).

--- a/src/getter/elixir.rs
+++ b/src/getter/elixir.rs
@@ -139,10 +139,33 @@ impl Getter for ElixirCode {
         Some("<anonymous>")
     }
 
-    fn get_op_type<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> HalsteadType {
+    fn get_op_type<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>) -> HalsteadType {
         use Elixir as E;
 
         match node.kind_id().into() {
+            // Sigil delimiter punctuation. The delimiter choice is
+            // spelling, not semantics — `~r/abc/` is not two divisions
+            // and `~w(a b)` opens no call — so counting these tokens
+            // made `n1`/`N1` vary with the author's delimiter choice
+            // (#1256). The `Sigil` node itself is the operand (below)
+            // and `~` the single per-sigil operator; the delimiters are
+            // suppressed exactly when their parent is the sigil — the
+            // compound-leaf guard of grammar-dispatch §5, mirroring
+            // Bash's `SimpleExpansion` parent check. Verified via
+            // `bca dump` at the pinned grammar: `/ ( { [ < > |` are the
+            // only delimiter kinds surfacing as `Sigil` children that
+            // the operator arm below also matches; the quote delimiters
+            // (`"`, `'`, `"""`, `'''`) and the closers `) } ]` have no
+            // operator arm and need no guard. Same-kind tokens outside
+            // a sigil (division `a / b`, comparison `<`, pipe `|`) fall
+            // through to the operator arm and still count.
+            E::SLASH | E::LPAREN | E::LBRACE | E::LBRACK | E::LT | E::GT | E::PIPE
+                if ancestors
+                    .parent(node)
+                    .is_some_and(|p| p.kind_id() == E::Sigil as u16) =>
+            {
+                HalsteadType::Unknown
+            }
             // Reserved-word keywords that have dedicated token kinds in
             // the grammar — block delimiters, exception clauses, the
             // `fn` keyword, and word-form logical / membership operators.
@@ -172,7 +195,10 @@ impl Getter for ElixirCode {
             | E::LT | E::GT | E::LTEQ | E::GTEQ
             // Logical
             | E::AMPAMP | E::PIPEPIPE | E::BANG
-            // Bitwise / Erlang-band
+            // Bitwise / Erlang-band. `TILDE` is only reachable as the
+            // sigil marker in this grammar (Elixir has no unary `~`;
+            // the Erlang-style ops are `~~~` etc.) and is kept as the
+            // deliberate single per-sigil operator (#1256).
             | E::AMP | E::PIPE | E::CARET | E::TILDE
             | E::AMPAMPAMP | E::PIPEPIPEPIPE | E::CARETCARETCARET | E::TILDETILDETILDE
             | E::LTLTLT | E::GTGTGT
@@ -194,10 +220,11 @@ impl Getter for ElixirCode {
             // the interpolated expressions are already walked and counted
             // as operands in their own right; counting the wrapping
             // literal as well would double-count the inner identifiers'
-            // contribution (issue #180). The interpolation markers
-            // `#{` / `}` are classified as operators via `HASHLBRACE` /
-            // `RBRACE`, so an interpolated literal still adds operator
-            // weight without inflating `N2`.
+            // contribution (issue #180). The `#{` marker is classified
+            // as an operator via `HASHLBRACE` (the closing `}` is not —
+            // #695 removed every closing-delimiter arm), so an
+            // interpolated literal still adds operator weight without
+            // inflating `N2`.
             E::String | E::Charlist | E::Sigil => {
                 Self::string_operand_type(node, &[E::Interpolation as u16])
             }

--- a/src/getter/irules.rs
+++ b/src/getter/irules.rs
@@ -110,11 +110,12 @@ impl Getter for IrulesCode {
             // already the operand for the reference, so counting its inner
             // `Id` too would double-count every `$var` (inflating n2/N2 and
             // every derived Halstead value). Exclude `Id` exactly in that
-            // position. NB: unlike Tcl — whose var-sub leaf is the anonymous
-            // `Id2` token (so a blanket `Id2` exclusion sufficed) — iRules'
-            // grammar emits the *named* `Id` there, so the guard must be a
-            // parent check, not a kind exclusion (`Id2` here is a different,
-            // non-surfacing token).
+            // position. NB: Tcl has the identical shape — its anonymous
+            // `Id2` token is emitted both as the `set` target and as the
+            // var-sub leaf, so it needs this same parent guard; the blanket
+            // `Id2` kind exclusion it used to carry dropped every `set`
+            // target from n2/N2 (#1294). (`Id2` here is a different,
+            // non-surfacing token.)
             Irules::Id => {
                 if ancestors
                     .parent(node)

--- a/src/getter/irules.rs
+++ b/src/getter/irules.rs
@@ -7,10 +7,11 @@ impl Getter for IrulesCode {
     fn get_space_kind(node: &Node) -> SpaceKind {
         match node.kind_id().into() {
             // Event handlers and procs are the function units (see the
-            // `IrulesCode` Checker impl for the handler-as-function rationale).
-            Irules::Procedure | Irules::WhenEvent | Irules::OnHandler | Irules::TrapHandler => {
-                SpaceKind::Function
-            }
+            // `IrulesCode` Checker impl for the handler-as-function
+            // rationale, and for why `try` handlers are excluded — this arm
+            // must stay gated by the same set as `is_func_space`,
+            // grammar-dispatch §6/§7).
+            Irules::Procedure | Irules::WhenEvent => SpaceKind::Function,
             Irules::SourceFile => SpaceKind::Unit,
             _ => SpaceKind::Unknown,
         }

--- a/src/getter/perl.rs
+++ b/src/getter/perl.rs
@@ -18,6 +18,11 @@ impl Getter for PerlCode {
         use Perl as P;
 
         match node.kind_id().into() {
+            // FIXME(#1312): regex delimiter counted as division — the
+            // `SLASH` arm below also matches a bare `PatternMatcher`
+            // literal's delimiter tokens; see #1256's parent-guard
+            // pattern.
+            //
             // Control-flow and declaration keywords. `Perl::Sub` is the
             // `sub` keyword (token id 16); `Perl::SUB` is the `__SUB__`
             // literal (token id 7) — that one is an operand, not an

--- a/src/getter/ruby.rs
+++ b/src/getter/ruby.rs
@@ -22,6 +22,10 @@ impl Getter for RubyCode {
         use Ruby as R;
 
         match node.kind_id().into() {
+            // FIXME(#1312): regex delimiter counted as division — the
+            // `SLASH` arm below also matches a `Regex` literal's
+            // delimiter tokens; see #1256's parent-guard pattern.
+            //
             // Control-flow keyword tokens. tree-sitter-ruby gives each
             // keyword its own anonymous numbered variant (e.g. `If2` is
             // the `if` keyword token; `If` is the named statement node).

--- a/src/getter/tcl.rs
+++ b/src/getter/tcl.rs
@@ -12,7 +12,7 @@ impl Getter for TclCode {
         }
     }
 
-    fn get_op_type<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> HalsteadType {
+    fn get_op_type<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>) -> HalsteadType {
         match node.kind_id().into() {
             // Anonymous keyword tokens (control-flow and declaration keywords).
             Tcl::Proc
@@ -77,13 +77,31 @@ impl Getter for TclCode {
             // Ternary conditional operator.
             | Tcl::QMARK => HalsteadType::Operator,
 
+            // The anonymous `id` token (`Id2`) is the kind the parser
+            // actually emits, in *both* of its positions: as a standalone
+            // `set` target (`set s …` → `s`, a real operand) and as the
+            // inner leaf of every `variable_substitution` (`$s` →
+            // `(variable_substitution (id "s"))`), whose wrapper is already
+            // the operand for the reference. A blanket `Id2` exclusion
+            // therefore dropped every `set` target from n2/N2 (#1294); the
+            // correct guard is a parent check, the same shape as iRules'
+            // `Id` arm. The named `Id` never surfaces at the pinned grammar
+            // (drift marker: `tcl_named_id_variant_is_unreachable`) and is
+            // listed defensively so a grammar bump that starts emitting it
+            // classifies it identically.
+            Tcl::Id | Tcl::Id2 => {
+                if ancestors
+                    .parent(node)
+                    .is_some_and(|p| p.kind_id() == Tcl::VariableSubstitution as u16)
+                {
+                    HalsteadType::Unknown
+                } else {
+                    HalsteadType::Operand
+                }
+            }
+
             // Operands: identifiers and literals.
-            // Id2 (anonymous "id" token, kind_id=85) is intentionally excluded: it only
-            // appears as a leaf child of VariableSubstitution ($varname syntax), which is
-            // already counted as an operand. Including Id2 would double-count each bare
-            // variable reference.
-            Tcl::Id
-            | Tcl::SimpleWord
+            Tcl::SimpleWord
             | Tcl::Number
             | Tcl::BracedWord
             | Tcl::BracedWordSimple

--- a/src/getter/tsx.rs
+++ b/src/getter/tsx.rs
@@ -52,16 +52,20 @@ impl Getter for TsxCode {
         bound_name.map_or(Some("<anonymous>"), |name| node_text(code, &name))
     }
 
-    // TSX exposes two anonymous `"string"` aliases: `String2` (the
-    // string-literal alias, kind_id 261) and `String3` (the
-    // type-annotation keyword, kind_id 141 — the role TS's `String2`
-    // plays). `Checker::is_string` matches both (#283); including
-    // `String3` here closes the audit gap surfaced by #313 (the same
-    // class of inconsistency that #313 fixed for TS::String2).
+    // TSX exposes two anonymous `"string"` aliases: `String2` (kind_id
+    // 261, the string-literal alias — ordinary and JSX-attribute
+    // literals both parse as it), which is an operand like any other
+    // string literal, and `String3` (kind_id 141, the `: string` type
+    // keyword — the role TS's `String2` plays, emitted only as the
+    // child of a `predefined_type` wrapper). `String3` is deliberately
+    // NOT an operand: the wrapper already counts as the text-keyed
+    // `"string"` operator, so #313's listing of the child too counted
+    // one source token as operator AND operand while `: number` /
+    // `: boolean` counted once (#1261; see the TS invocation).
     impl_js_family_get_op_type!(
         Tsx,
         op_extras: [QMARKDOT, PredefinedType],
-        operand_extras: [Identifier2, String2, String3, NestedIdentifier, MemberExpression4],
+        operand_extras: [Identifier2, String2, NestedIdentifier, MemberExpression4],
         predefined_void: PredefinedType,
     );
 

--- a/src/getter/typescript.rs
+++ b/src/getter/typescript.rs
@@ -52,16 +52,21 @@ impl Getter for TypescriptCode {
         bound_name.map_or(Some("<anonymous>"), |name| node_text(code, &name))
     }
 
-    // TS exposes `String2` as the anonymous `"string"` alias for the
-    // type-annotation keyword (kind_id 135, in the type-keyword block
-    // of the enum). `Checker::is_string` already matches it (#283);
-    // including it here closes the Checker/Getter agreement gap
-    // (#313). `NestedIdentifier` and `MemberExpression4` are TS-only
-    // member-expression productions.
+    // `NestedIdentifier` and `MemberExpression4` are TS-only
+    // member-expression productions. TS's anonymous `"string"` alias
+    // `String2` (kind_id 135, the `: string` type keyword, emitted only
+    // as the child of a `predefined_type` wrapper) is deliberately NOT
+    // an operand: the wrapper already counts as the text-keyed
+    // `"string"` operator via `is_primitive`, so #313's listing of the
+    // child too counted one source token as operator AND operand — the
+    // mirror image of the #453 `void` collision — while `: number` /
+    // `: boolean` counted once (#1261). `Checker::is_string` no longer
+    // matches the keyword either, so the #313 parity rationale is
+    // retired rather than contradicted.
     impl_js_family_get_op_type!(
         Typescript,
         op_extras: [QMARKDOT, PredefinedType],
-        operand_extras: [String2, NestedIdentifier, MemberExpression4],
+        operand_extras: [NestedIdentifier, MemberExpression4],
         predefined_void: PredefinedType,
     );
 

--- a/src/metrics/abc.rs
+++ b/src/metrics/abc.rs
@@ -6930,6 +6930,39 @@ function f(int $a, int $b): int {
         );
     }
 
+    // Sigil delimiter choice must not move ABC: `~s<hi>` and `~s(hi)`
+    // are the same value spelled differently, but the `<` / `>`
+    // delimiter tokens carry the comparison kind ids, so the unguarded
+    // condition arm scored `~s<hi>` as 2 conditions and `~s(hi)` as 0.
+    // The parent-is-`Sigil` guard (mirroring the Halstead getter's,
+    // #1256) suppresses the delimiter case. expected, for each
+    // spelling: A = 1 (the `x =` pattern match), B = 0 (a bare sigil
+    // is not a `Call` node — verified by AST dump: `binary_operator`
+    // wrapping `identifier`, `=`, `sigil`), C = 0 (no comparison, no
+    // guard, no keyword Call).
+    #[test]
+    fn elixir_sigil_delimiter_choice_is_abc_invariant() {
+        for src in ["x = ~s<hi>\n", "x = ~s(hi)\n"] {
+            check_metrics::<ElixirParser>(src, "foo.ex", |metric| {
+                assert_eq!(metric.abc.assignments_sum(), 1);
+                assert_eq!(metric.abc.branches_sum(), 0);
+                assert_eq!(metric.abc.conditions_sum(), 0);
+            });
+        }
+    }
+
+    // Control for the guard above: `<` *outside* a sigil is a genuine
+    // comparison and must keep counting even with a `<`-delimited
+    // sigil in the same unit. expected: A = 2 (`x =`, `y =`), C = 1
+    // (only `a < b`; the sigil's `<` / `>` delimiters are guarded).
+    #[test]
+    fn elixir_lt_comparison_still_counts_beside_sigil() {
+        check_metrics::<ElixirParser>("x = ~s<hi>\ny = a < b\n", "foo.ex", |metric| {
+            assert_eq!(metric.abc.assignments_sum(), 2);
+            assert_eq!(metric.abc.conditions_sum(), 1);
+        });
+    }
+
     // ----- C++ -----
 
     #[test]

--- a/src/metrics/abc.rs
+++ b/src/metrics/abc.rs
@@ -9023,6 +9023,33 @@ function f(int $a, int $b): int {
     }
 
     #[test]
+    fn tcl_computed_command_name_is_not_an_assignment() {
+        // A command whose leading word is computed (`$cmd args`) names no
+        // builtin the parser can resolve, so it stays a branch. Pins the
+        // field-addressed, `simple_word`-gated read the classifier shares
+        // with the Cognitive / Cyclomatic detectors (grammar-dispatch §3):
+        // the earlier `child(0)` byte-slice addressed the slot by position
+        // and compared whatever literal text sat there, which agrees with
+        // the gated read on today's grammar only because no mutator name is
+        // spelled with a leading `$`. A grammar that moved the name out of
+        // `child(0)`, or a mutator list that grew a computed-looking entry,
+        // would diverge — this fixture is where that surfaces.
+        check_metrics::<TclParser>(
+            "proc f {cmd x} {\n\
+                 $cmd $x\n\
+                 incr x\n\
+             }",
+            "foo.tcl",
+            |metric| {
+                // `incr x` is the only assignment; `$cmd $x` is a branch.
+                assert_eq!(metric.abc.assignments_sum(), 1);
+                assert_eq!(metric.abc.branches_sum(), 1);
+                assert_eq!(metric.abc.conditions_sum(), 0);
+            },
+        );
+    }
+
+    #[test]
     fn tcl_generic_commands_are_branches() {
         // Anything that isn't `set` or a known mutator command
         // counts as a branch — including builtins like `puts` and

--- a/src/metrics/abc/elixir.rs
+++ b/src/metrics/abc/elixir.rs
@@ -204,10 +204,21 @@ impl Abc for ElixirCode {
                     stats.conditions += 1.;
                 }
             }
+            // Sigil delimiter `<` / `>` (`~s<hi>`) are spelling, not
+            // comparisons — suppressed with the same parent-is-`Sigil`
+            // guard the Halstead getter uses (#1256). Of the other
+            // delimiter kinds the getter guards (`SLASH` / `LPAREN` /
+            // `LBRACE` / `LBRACK` / `PIPE`), none has an arm in this
+            // impl, so `LT` / `GT` are the only overlap to guard.
+            E::LT | E::GT
+                if ancestors
+                    .parent(node)
+                    .is_some_and(|p| p.kind_id() == E::Sigil as u16) => {}
             // Comparison operator tokens. `Elixir::LT` / `Elixir::GT`
-            // are unambiguously comparison ops here — unlike Go's
-            // generic-instantiation `<` / `>`, Elixir has no type
-            // parameter brackets that share the token.
+            // reach here only outside a sigil (the guard arm above
+            // consumes the delimiter case); Elixir has no Go-style
+            // generic-instantiation brackets, so what remains is a
+            // genuine comparison.
             E::EQEQ | E::EQEQEQ | E::BANGEQ | E::BANGEQEQ
             | E::LT | E::GT | E::LTEQ | E::GTEQ
             // Guard `when` token: introduces the guard clause of a

--- a/src/metrics/abc/tcl.rs
+++ b/src/metrics/abc/tcl.rs
@@ -22,7 +22,7 @@ use crate::*;
 // left as branches; treating them as assignments would require
 // inspecting the command's second word, and the additional
 // fidelity is not worth the complexity for the ABC magnitude.
-const TCL_ASSIGNMENT_COMMANDS: &[&[u8]] = &[b"incr", b"append", b"lappend"];
+const TCL_ASSIGNMENT_COMMANDS: &[&str] = &["incr", "append", "lappend"];
 
 // Fitzpatrick's ABC rules adapted for Tcl.
 //
@@ -302,20 +302,15 @@ impl Abc for TclCode {
     }
 }
 
-// Returns true when the `command` node's first word is one of the
-// recognised Tcl assignment commands. The first word is the leftmost
-// non-comment child; we slice the source bytes directly using the
-// child node's byte range, which is robust to `simple_word` wrappers
-// and avoids depending on a particular grammar shape.
+// Returns true when the `command` node's leading word is one of the
+// recognised Tcl assignment commands. The word is read through the shared
+// `tcl_command_name` — field-addressed (`name`) and gated on `simple_word`
+// (grammar-dispatch §3) — rather than by slicing `child(0)`'s byte range,
+// which addressed the slot positionally and read the literal text of
+// whatever sat there. A command with a computed leading word (`$cmd x`,
+// `[pick] x`) therefore stays a branch: it is not statically a builtin,
+// which is what the assignment classification claims.
 fn tcl_command_is_assignment(node: &Node, code: &[u8]) -> bool {
-    let Some(first) = node.child(0) else {
-        return false;
-    };
-    let start = first.start_byte();
-    let end = first.end_byte();
-    if end > code.len() || start >= end {
-        return false;
-    }
-    let word = &code[start..end];
-    TCL_ASSIGNMENT_COMMANDS.contains(&word)
+    crate::metrics::cognitive::tcl_command_name(node, code)
+        .is_some_and(|name| TCL_ASSIGNMENT_COMMANDS.contains(&name))
 }

--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -598,6 +598,18 @@ pub(crate) fn elixir_call_keyword<'a>(node: &'a Node<'a>, code: &'a [u8]) -> Opt
 // statically resolvable to a builtin), and for non-UTF-8 bytes. Shared by
 // the out-of-band control-flow detectors below (grammar-dispatch §10:
 // identity questions read the bytes).
+//
+// A *literal* name in a quoted or braced spelling is also unresolved, and
+// that is a deliberate limitation: `"for" {set i 0} {$i < 3} {incr i} {…}`
+// and `{for} …` are legal Tcl that still invoke the builtin, but the
+// grammar parses their name as `quoted_word` / `braced_word` rather than
+// `simple_word`, so they score as plain commands. The `simple_word` gate
+// is what keeps the computed forms out; matching the quoted spellings
+// would mean unquoting the bytes for a style no real Tcl uses.
+//
+// Callers dispatch on the returned name so each `command` node resolves it
+// exactly once per metric walk — the helpers below take the resolved
+// identity as a precondition rather than re-deriving it.
 pub(crate) fn tcl_command_name<'a>(node: &'a Node<'a>, code: &'a [u8]) -> Option<&'a str> {
     if node.kind_id() != Tcl::Command as u16 {
         return None;
@@ -609,55 +621,38 @@ pub(crate) fn tcl_command_name<'a>(node: &'a Node<'a>, code: &'a [u8]) -> Option
     name.utf8_text(code)
 }
 
-// Tcl's `for` is a generic `command` — the grammar has no `for` rule, so
-// the enum carries no `For` variant and the Cognitive / Cyclomatic kind
-// dispatch never sees the loop (issue #1264, the grammar-dispatch §9 class
-// that #467 fixed for `switch`). Detected by leading word instead. ABC
-// cannot be repaired the same way: with no grammar rule there is no `expr`
-// slot, so the loop condition (`{$i < $n}`) stays an opaque `braced_word`
-// and its comparison never surfaces as a condition token — a grammar
-// limitation, not a metric-layer bug.
-pub(crate) fn tcl_command_is_for(node: &Node<'_>, code: &[u8]) -> bool {
-    tcl_command_name(node, code) == Some("for")
-}
-
 // Tcl's `switch` is a generic `command` (no dedicated kind_id, unlike
 // `if`/`while`/`foreach`/`catch`), so the kind-dispatch in the Cognitive
-// and Cyclomatic impls never sees it (issue #467, lesson 19). This helper
-// is shared by both metrics: it detects a `switch` command and returns the
-// number of *decision* arms — every non-`default` arm.
+// and Cyclomatic impls never sees it (issue #467, lesson 19). Both metrics
+// reach it through `tcl_command_name` and then through this pair: the arm
+// list locates the supported form, and `tcl_switch_decision_arms` counts
+// it. Cognitive needs only the former — it charges one structure whatever
+// the arm count is — so the count stays out of its path.
 //
 // Grammar shape (tree-sitter-tcl 0.x), canonical brace-list form:
 //
 //   (command name: (simple_word "switch")
 //     (word_list <options…> <value> (braced_word (command (simple_word PAT) …) …)))
 //
-// The arm list is the LAST `braced_word` argument, which makes the helper
-// robust to leading options (`-exact`, `-glob`, `-regexp`, `-nocase`, `--`)
-// and the matched value, all of which precede it in the `word_list`. Each
-// arm is itself a nested `command` whose leading word is the pattern; the
-// `default` arm is excluded, matching the C-family `default:` convention
-// (lesson 11). The rarer split form (`switch $x a {b} c {d}` — arms as
-// separate `word_list` arguments rather than wrapped in one `braced_word`)
-// is intentionally NOT counted: its body braces are sibling arguments, not
-// nested commands, so there is no reliable arm node to count. Idiomatic
-// Tcl uses the brace-list form, so this scoping under-counts only the
-// uncommon style.
+// The arm list is the sole `braced_word` argument inside the command's
+// `word_list`, which makes the lookup robust to leading options (`-exact`,
+// `-glob`, `-regexp`, `-nocase`, `--`) and the matched value, all of which
+// precede it and never parse as `braced_word`. The rarer split form
+// (`switch $x a {b} c {d}` — arms as separate `word_list` arguments rather
+// than wrapped in one `braced_word`) produces *several* sibling
+// `braced_word`s, one per arm body, so requiring exactly one distinguishes
+// the brace-list form and excludes the split form, where the last
+// `braced_word` is merely a body rather than the full arm list. The split
+// form is intentionally NOT counted: its body braces are sibling
+// arguments, not nested commands, so there is no reliable arm node to
+// count. Idiomatic Tcl uses the brace-list form, so this scoping
+// under-counts only the uncommon style.
 //
-// Returns `None` for any command that is not a leading-word `switch`, so
-// callers can leave non-switch commands untouched.
-pub(crate) fn tcl_switch_decision_arms(node: &Node, code: &[u8]) -> Option<usize> {
-    if tcl_command_name(node, code) != Some("switch") {
-        return None;
-    }
-
-    // The arm list is the sole `braced_word` argument inside the command's
-    // `word_list`; the matched value and any leading options precede it and
-    // never parse as `braced_word`. The split form (`switch $x a {b} c {d}`)
-    // produces *several* sibling `braced_word`s — one per arm body — so
-    // requiring exactly one direct `braced_word` child distinguishes the
-    // brace-list form and excludes the unsupported split form, where the last
-    // `braced_word` is merely a body rather than the full arm list.
+// **Precondition**: `node` is a `command` whose leading word resolved to
+// `"switch"` — the callers' `tcl_command_name` dispatch establishes that,
+// and re-checking it here would resolve the name a second time on every
+// switch.
+pub(crate) fn tcl_switch_arm_list<'a>(node: &Node<'a>) -> Option<Node<'a>> {
     let word_list = node
         .children()
         .find(|child| child.kind_id() == Tcl::WordList as u16)?;
@@ -665,17 +660,22 @@ pub(crate) fn tcl_switch_decision_arms(node: &Node, code: &[u8]) -> Option<usize
         .children()
         .filter(|child| child.kind_id() == Tcl::BracedWord as u16);
     let arm_list = braced_words.next()?;
-    if braced_words.next().is_some() {
-        return None;
-    }
+    braced_words.next().is_none().then_some(arm_list)
+}
 
-    let decision_arms = arm_list
+// The number of *decision* arms of a `switch` — every arm but `default`,
+// which is the fallback and does not contribute a decision point, matching
+// the C-family `default:` convention (lesson 11). Each arm is a nested
+// `command` whose leading word is the pattern.
+//
+// Carries [`tcl_switch_arm_list`]'s precondition, and returns `None` for
+// the same unsupported split form, so callers leave it untouched exactly
+// as they leave a non-switch command.
+pub(crate) fn tcl_switch_decision_arms(node: &Node, code: &[u8]) -> Option<usize> {
+    let decision_arms = tcl_switch_arm_list(node)?
         .children()
         .filter(|arm| arm.kind_id() == Tcl::Command as u16)
         .filter(|arm| {
-            // The arm pattern is the arm command's leading word; the
-            // `default` arm is the switch fallback and does not contribute a
-            // decision point.
             arm.child_by_field_name("name")
                 .and_then(|pat| pat.utf8_text(code))
                 != Some("default")
@@ -697,31 +697,27 @@ pub(crate) fn tcl_switch_decision_arms(node: &Node, code: &[u8]) -> Option<usize
 // forms keeps counting without an edit here.
 //
 // Each handler body is located by structural position, never fixed index
-// (grammar-dispatch §3): it is the child that follows the `arguments` node
-// of a preceding `on` token. The `finally` clause is a wrapper kind
-// (`Tcl::Finally`) and is never yielded — unconditional cleanup costs
-// nothing, matching the cross-language `finally` convention (#416).
+// (grammar-dispatch §3): it is the child directly following the handler's
+// `arguments` node. That makes the scan pairwise — every child paired with
+// its predecessor, yielding the successor of each `arguments` — rather
+// than a state machine over the `on` / `error` / `arguments` run. The
+// grammar's extras are whitespace-only, so nothing can interpose between
+// the `arguments` node and the body it introduces, and `arguments` appears
+// among a `try`'s direct children only in handler position. Repetition
+// costs nothing here: a grammar bump that admits several handlers (or
+// `trap`) is counted without an edit, because each `arguments` yields its
+// own successor. The `finally` clause is a wrapper kind (`Tcl::Finally`)
+// and is never yielded — unconditional cleanup costs nothing, matching the
+// cross-language `finally` convention (#416).
 //
 // Shared by Cognitive (which also seeds each body's nesting slot) and
 // Cyclomatic (which counts the bodies); both call it from their `Tcl::Try`
 // dispatch arm.
 pub(crate) fn tcl_try_handler_bodies<'a>(node: &Node<'a>) -> impl Iterator<Item = Node<'a>> {
-    let mut saw_on = false;
-    let mut saw_arguments = false;
-    node.children().filter(move |child| {
-        let kind = child.kind_id();
-        if kind == Tcl::On as u16 {
-            saw_on = true;
-            saw_arguments = false;
-        } else if saw_on && !saw_arguments {
-            saw_arguments = kind == Tcl::Arguments as u16;
-        } else if saw_on {
-            saw_on = false;
-            saw_arguments = false;
-            return true;
-        }
-        false
-    })
+    node.children()
+        .zip(node.children().skip(1))
+        .filter(|(previous, _)| previous.kind_id() == Tcl::Arguments as u16)
+        .map(|(_, body)| body)
 }
 
 // iRules counterpart to [`tcl_switch_decision_arms`]. Unlike Tcl, the iRules

--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -9684,6 +9684,46 @@ end",
     }
 
     #[test]
+    fn ruby_stabby_and_keyword_lambda_nesting_parity() {
+        // A stabby lambda parses as a `Lambda` node CONTAINING its own
+        // body `Block`; the keyword form parses as a `Call` carrying the
+        // block argument. Only the `Lambda` wrapper pays the lambda
+        // nesting surcharge — its body block must not pay again, or the
+        // same logical construct scores differently across the two
+        // spellings (lesson #11; the #1257 shared discriminator).
+        //
+        // expected: `if`(+1) + one level of lambda nesting(+1) = 2.
+        check_metrics::<RubyParser>("f = ->(a) { if a then 1 end }\n", "foo.rb", |metric| {
+            assert_eq!(metric.cognitive.cognitive_sum(), 2);
+        });
+        // expected: identical derivation for the keyword form — the
+        // `Block` under the `lambda` call is the sole closure node:
+        // `if`(+1) + lambda nesting(+1) = 2.
+        check_metrics::<RubyParser>("f = lambda { |a| if a then 1 end }\n", "foo.rb", |metric| {
+            assert_eq!(metric.cognitive.cognitive_sum(), 2);
+        });
+    }
+
+    #[test]
+    fn ruby_if_inside_stabby_lambda_inside_method() {
+        // expected: the method boundary resets nesting for its contents
+        // (top-level method, so function_depth stays 0); the stabby
+        // lambda adds exactly ONE lambda-nesting level (`Lambda` wrapper
+        // only — its body `Block` is gated out); the `if` then charges
+        // 1 + nesting(0 conditional + 0 function_depth + 1 lambda) = 2.
+        // Before the gate the body block paid a second surcharge and
+        // this scored 3.
+        check_metrics::<RubyParser>(
+            "def foo\n  f = ->(a) { if a then 1 end }\nend\n",
+            "foo.rb",
+            |metric| {
+                assert_eq!(metric.cognitive.cognitive_sum(), 2);
+                assert_eq!(metric.cognitive.cognitive_max(), 2);
+            },
+        );
+    }
+
+    #[test]
     fn javascript_labeled_break_continue() {
         // Per SonarSource Cognitive Complexity §B2 (issue #435), a labeled
         // `break LABEL` / `continue LABEL` is an unstructured jump and adds

--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -6776,6 +6776,79 @@ mod tests {
         });
     }
 
+    /// Drift marker for #1266 (lesson 34 / grammar-dispatch §2): the
+    /// iRules `on_handler` / `trap_handler` kinds are emitted **only**
+    /// under `try`.
+    ///
+    /// Statement-level `on <event> { … }` and `trap { … }` inside an event
+    /// body are generic `command` nodes at the pinned grammar, which is
+    /// what lets Cognitive and Cyclomatic charge those two kinds
+    /// unconditionally as catch clauses. A bump that promoted the
+    /// statement-level spelling to the same kinds would silently turn
+    /// every one of those commands into a decision point — and, since the
+    /// checker treats handler kinds as part of the `try` shape, would
+    /// re-run the mistake #1266 fixed, where the handlers were read as
+    /// `when`-style event handlers and opened function spaces of their
+    /// own. Nothing else in the suite would go red.
+    #[test]
+    fn irules_try_handler_kinds_appear_only_under_try() {
+        use std::path::PathBuf;
+
+        use crate::test_support::ast_has_kind_id;
+
+        let path = PathBuf::from("foo.irule");
+
+        let statement_level = "when HTTP_REQUEST {\n\
+                               \x20   on scriptbody { log \"x\" }\n\
+                               \x20   trap { log \"y\" }\n\
+                               }\n";
+        let parser = IrulesParser::new(statement_level.as_bytes().to_vec(), &path, None);
+        // Non-vacuity: both spellings must really be in this parse, as
+        // `command`s whose leading word is the handler keyword. Asserting
+        // only the absence below would pass just as well against a source
+        // the grammar rejected outright.
+        let command_names: Vec<&str> = parser
+            .root()
+            .preorder()
+            .filter(|node| node.kind_id() == Irules::Command as u16)
+            .filter_map(|node| {
+                node.child_by_field_name("name")
+                    .and_then(|name| name.utf8_text(statement_level.as_bytes()))
+            })
+            .collect();
+        assert!(
+            command_names.contains(&"on") && command_names.contains(&"trap"),
+            "statement-level `on` / `trap` no longer parse as commands: {command_names:?}",
+        );
+        assert!(
+            !ast_has_kind_id(&parser, Irules::OnHandler as u16),
+            "statement-level `on` now emits `on_handler`; re-derive the \
+             Cognitive / Cyclomatic handler arms and the checker's `try` \
+             shape before trusting them",
+        );
+        assert!(
+            !ast_has_kind_id(&parser, Irules::TrapHandler as u16),
+            "statement-level `trap` now emits `trap_handler`; re-derive the \
+             Cognitive / Cyclomatic handler arms and the checker's `try` \
+             shape before trusting them",
+        );
+
+        // And the kinds are reachable, so the assertions above discriminate
+        // rather than naming variants the grammar never emits at all.
+        let under_try = "when HTTP_REQUEST {\n\
+                         \x20   try { risky } on error {e} { log $e } trap {POSIX} {e} { log $e }\n\
+                         }\n";
+        let parser = IrulesParser::new(under_try.as_bytes().to_vec(), &path, None);
+        assert!(
+            ast_has_kind_id(&parser, Irules::OnHandler as u16),
+            "`on error` under `try` no longer emits `on_handler`",
+        );
+        assert!(
+            ast_has_kind_id(&parser, Irules::TrapHandler as u16),
+            "`trap` under `try` no longer emits `trap_handler`",
+        );
+    }
+
     #[test]
     fn lua_cognitive_no_cognitive() {
         // Top-level local assignment, no control flow → cognitive complexity is zero.

--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -6550,6 +6550,28 @@ mod tests {
     }
 
     #[test]
+    fn tcl_switch_split_form_adds_no_cognitive() {
+        // The split arm form passes each arm body as its own sibling
+        // `braced_word` argument, so `tcl_switch_arm_list` finds no
+        // single wrapping arm list and declines the construct (issue
+        // #467). Cognitive then treats it as an ordinary command: no
+        // structural increment and no nesting for its bodies, which is
+        // why the inner `if` here charges 1 rather than 2.
+        check_metrics::<TclParser>(
+            "proc f {x} {
+    switch $x a { puts a } b { if {$x} { puts b } }
+}",
+            "foo.tcl",
+            |metric| {
+                // The `switch` adds nothing; the `if` sits at proc-body
+                // nesting 0 and charges +1.
+                assert_eq!(metric.cognitive.cognitive_sum(), 1);
+                assert_eq!(metric.cognitive.cognitive_max(), 1);
+            },
+        );
+    }
+
+    #[test]
     fn tcl_for_cognitive() {
         // Tcl `for` is a generic command — the grammar has no `for` rule —
         // so it is detected by leading word (issue #1264): a loop adds +1
@@ -9784,6 +9806,41 @@ end",
         // this scored 3.
         check_metrics::<RubyParser>(
             "def foo\n  f = ->(a) { if a then 1 end }\nend\n",
+            "foo.rb",
+            |metric| {
+                assert_eq!(metric.cognitive.cognitive_sum(), 2);
+                assert_eq!(metric.cognitive.cognitive_max(), 2);
+            },
+        );
+    }
+
+    #[test]
+    fn ruby_do_block_spelling_matches_brace_spelling() {
+        // The lambda-nesting arm is gated on `Block | DoBlock`, and the
+        // two alternatives are separate dispatch paths: every other Ruby
+        // cognitive fixture uses the brace spelling, so the `do … end`
+        // half of both the arm and its stabby-lambda-body gate went
+        // unexercised. A block's spelling is pure syntax — the same
+        // closure must score identically either way (lesson 11).
+        //
+        // expected: the `Lambda` wrapper pays the one lambda-nesting
+        // level and its `do_block` body is gated out, so `if` charges
+        // 1 + nesting(1) = 2 — the same figure the brace form reports in
+        // `ruby_stabby_and_keyword_lambda_nesting_parity`.
+        check_metrics::<RubyParser>(
+            "f = ->(a) do\n  if a then 1 end\nend\n",
+            "foo.rb",
+            |metric| {
+                assert_eq!(metric.cognitive.cognitive_sum(), 2);
+                assert_eq!(metric.cognitive.cognitive_max(), 2);
+            },
+        );
+        // expected: an iterator `do … end` has a `Call` parent, not a
+        // `Lambda`, so the gate lets it through and the `do_block` is
+        // itself the closure: `if`(+1) + lambda nesting(+1) = 2. This is
+        // the arm-taken direction of the same gate.
+        check_metrics::<RubyParser>(
+            "[1].each do |x|\n  if x then 1 end\nend\n",
             "foo.rb",
             |metric| {
                 assert_eq!(metric.cognitive.cognitive_sum(), 2);

--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -684,6 +684,46 @@ pub(crate) fn tcl_switch_decision_arms(node: &Node, code: &[u8]) -> Option<usize
     Some(decision_arms)
 }
 
+// Tcl's `try` has a dedicated kind (unlike `switch`/`for`), but its error
+// handler is a flat run of sibling tokens rather than a wrapper node
+// (issue #1266):
+//
+//   (try "try" <body> ["on" "error" (arguments) <body>] [(finally)])
+//
+// The vendored grammar permits at most one `on error` handler and has no
+// `trap` rule at all — Tcl 8.6's multi-handler and `trap` forms degrade to
+// an `ERROR` node, a grammar limitation like the `for` condition in #1264.
+// The scan still tolerates repetition so a grammar bump that adds those
+// forms keeps counting without an edit here.
+//
+// Each handler body is located by structural position, never fixed index
+// (grammar-dispatch §3): it is the child that follows the `arguments` node
+// of a preceding `on` token. The `finally` clause is a wrapper kind
+// (`Tcl::Finally`) and is never yielded — unconditional cleanup costs
+// nothing, matching the cross-language `finally` convention (#416).
+//
+// Shared by Cognitive (which also seeds each body's nesting slot) and
+// Cyclomatic (which counts the bodies); both call it from their `Tcl::Try`
+// dispatch arm.
+pub(crate) fn tcl_try_handler_bodies<'a>(node: &Node<'a>) -> impl Iterator<Item = Node<'a>> {
+    let mut saw_on = false;
+    let mut saw_arguments = false;
+    node.children().filter(move |child| {
+        let kind = child.kind_id();
+        if kind == Tcl::On as u16 {
+            saw_on = true;
+            saw_arguments = false;
+        } else if saw_on && !saw_arguments {
+            saw_arguments = kind == Tcl::Arguments as u16;
+        } else if saw_on {
+            saw_on = false;
+            saw_arguments = false;
+            return true;
+        }
+        false
+    })
+}
+
 // iRules counterpart to [`tcl_switch_decision_arms`]. Unlike Tcl, the iRules
 // grammar models `switch` as a dedicated node with `switch_arm` children, so
 // the arms are read off the tree directly instead of re-parsing a generic
@@ -6605,6 +6645,139 @@ mod tests {
                 assert_eq!(metric.cognitive.cognitive_max(), 1);
             },
         );
+    }
+
+    #[test]
+    fn tcl_try_on_error_cognitive() {
+        // Tcl `try`'s `on error` handler is a conditional error path:
+        // +1 plus current nesting (issue #1266), matching `catch`;
+        // `finally` is unconditional and free.
+        check_metrics::<TclParser>(
+            "proc f {} {
+    try {
+        risky
+    } on error {msg} {
+        puts $msg
+    } finally {
+        cleanup
+    }
+}",
+            "foo.tcl",
+            |metric| {
+                // One handler at proc-body nesting 0 → +1.
+                assert_eq!(metric.cognitive.cognitive_sum(), 1);
+                assert_eq!(metric.cognitive.cognitive_max(), 1);
+            },
+        );
+    }
+
+    #[test]
+    fn tcl_try_finally_only_cognitive() {
+        // A `try` with only a `finally` has no conditional path and must
+        // stay at zero (issue #1266, the cross-language `finally`
+        // convention of #416).
+        check_metrics::<TclParser>(
+            "proc f {} {
+    try {
+        risky
+    } finally {
+        cleanup
+    }
+}",
+            "foo.tcl",
+            |metric| {
+                assert_eq!(metric.cognitive.cognitive_sum(), 0);
+                assert_eq!(metric.cognitive.cognitive_max(), 0);
+            },
+        );
+    }
+
+    #[test]
+    fn tcl_try_handler_nesting_cognitive() {
+        // Only the handler body nests (issue #1266): the `try` body and
+        // `finally` body run unconditionally and stay at the inherited
+        // level, so an `if` inside each of the three blocks is charged
+        // differently. This pins the per-child nesting seed — charging
+        // `increase_nesting` at the whole `try` node instead would score
+        // the try-body and finally-body `if`s +2 each (sum 7).
+        check_metrics::<TclParser>(
+            "proc f {} {
+    try {
+        if {1} {
+            a
+        }
+    } on error {msg} {
+        if {1} {
+            b
+        }
+    } finally {
+        if {1} {
+            c
+        }
+    }
+}",
+            "foo.tcl",
+            |metric| {
+                // handler(+1) + try-body if(+1, nesting 0)
+                // + handler-body if(+2, nesting 1)
+                // + finally-body if(+1, nesting 0) = 5.
+                assert_eq!(metric.cognitive.cognitive_sum(), 5);
+                assert_eq!(metric.cognitive.cognitive_max(), 5);
+            },
+        );
+    }
+
+    #[test]
+    fn irules_try_trap_cognitive() {
+        // iRules wraps each `try` handler in a dedicated `on_handler` /
+        // `trap_handler` node: +1 each plus nesting, and the handler body
+        // nests (issue #1266). Before this the handlers opened anonymous
+        // function spaces, which reset nesting and hid the construct from
+        // the enclosing proc entirely.
+        check_metrics::<IrulesParser>(
+            "proc f {} {
+    try {
+        risky
+    } on error {msg} {
+        puts $msg
+    } trap {POSIX} {msg} {
+        if {1} {
+            puts $msg
+        }
+    }
+}",
+            "foo.irule",
+            |metric| {
+                // on(+1) + trap(+1) + if at nesting 1 inside trap (+2) = 4.
+                assert_eq!(metric.cognitive.cognitive_sum(), 4);
+                assert_eq!(metric.cognitive.cognitive_max(), 4);
+            },
+        );
+    }
+
+    #[test]
+    fn tcl_irules_try_parity() {
+        // The same single-handler `try` must score identically in Tcl
+        // (flat `on`/`error` tokens under `try`, per-child nesting seed)
+        // and iRules (a dedicated `on_handler` wrapper) — issue #1266.
+        // handler(+1) + if at nesting 1 inside the handler (+2) = 3.
+        let source = "proc f {} {
+    try {
+        risky
+    } on error {msg} {
+        if {1} {
+            puts $msg
+        }
+    }
+}";
+        check_metrics::<TclParser>(source, "foo.tcl", |metric| {
+            assert_eq!(metric.cognitive.cognitive_sum(), 3);
+            assert_eq!(metric.cognitive.cognitive_max(), 3);
+        });
+        check_metrics::<IrulesParser>(source, "foo.irule", |metric| {
+            assert_eq!(metric.cognitive.cognitive_sum(), 3);
+            assert_eq!(metric.cognitive.cognitive_max(), 3);
+        });
     }
 
     #[test]

--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -591,6 +591,36 @@ pub(crate) fn elixir_call_keyword<'a>(node: &'a Node<'a>, code: &'a [u8]) -> Opt
     target.utf8_text(code)
 }
 
+// Reads the leading word of a Tcl `command` node when it is a plain
+// `simple_word` (`switch`, `for`, `puts`, …). Returns `None` for any other
+// node kind, for commands whose leading word is computed (`$cmd`, `[cmd]`
+// parse it as `variable_substitution` / `command_substitution`, never
+// statically resolvable to a builtin), and for non-UTF-8 bytes. Shared by
+// the out-of-band control-flow detectors below (grammar-dispatch §10:
+// identity questions read the bytes).
+pub(crate) fn tcl_command_name<'a>(node: &'a Node<'a>, code: &'a [u8]) -> Option<&'a str> {
+    if node.kind_id() != Tcl::Command as u16 {
+        return None;
+    }
+    let name = node.child_by_field_name("name")?;
+    if name.kind_id() != Tcl::SimpleWord as u16 {
+        return None;
+    }
+    name.utf8_text(code)
+}
+
+// Tcl's `for` is a generic `command` — the grammar has no `for` rule, so
+// the enum carries no `For` variant and the Cognitive / Cyclomatic kind
+// dispatch never sees the loop (issue #1264, the grammar-dispatch §9 class
+// that #467 fixed for `switch`). Detected by leading word instead. ABC
+// cannot be repaired the same way: with no grammar rule there is no `expr`
+// slot, so the loop condition (`{$i < $n}`) stays an opaque `braced_word`
+// and its comparison never surfaces as a condition token — a grammar
+// limitation, not a metric-layer bug.
+pub(crate) fn tcl_command_is_for(node: &Node<'_>, code: &[u8]) -> bool {
+    tcl_command_name(node, code) == Some("for")
+}
+
 // Tcl's `switch` is a generic `command` (no dedicated kind_id, unlike
 // `if`/`while`/`foreach`/`catch`), so the kind-dispatch in the Cognitive
 // and Cyclomatic impls never sees it (issue #467, lesson 19). This helper
@@ -617,11 +647,7 @@ pub(crate) fn elixir_call_keyword<'a>(node: &'a Node<'a>, code: &'a [u8]) -> Opt
 // Returns `None` for any command that is not a leading-word `switch`, so
 // callers can leave non-switch commands untouched.
 pub(crate) fn tcl_switch_decision_arms(node: &Node, code: &[u8]) -> Option<usize> {
-    if node.kind_id() != Tcl::Command as u16 {
-        return None;
-    }
-    let name = node.child_by_field_name("name")?;
-    if name.kind_id() != Tcl::SimpleWord as u16 || name.utf8_text(code) != Some("switch") {
+    if tcl_command_name(node, code) != Some("switch") {
         return None;
     }
 
@@ -6483,6 +6509,100 @@ mod tests {
                 // outer switch(+1) + inner switch at nesting 1 (+2) = 3.
                 assert_eq!(metric.cognitive.cognitive_sum(), 3);
                 assert_eq!(metric.cognitive.cognitive_max(), 3);
+            },
+        );
+    }
+
+    #[test]
+    fn tcl_for_cognitive() {
+        // Tcl `for` is a generic command — the grammar has no `for` rule —
+        // so it is detected by leading word (issue #1264): a loop adds +1
+        // plus current nesting, matching `while`/`foreach`.
+        check_metrics::<TclParser>(
+            "proc f {n} {
+    for {set i 0} {$i < $n} {incr i} {
+        puts $i
+    }
+}",
+            "foo.tcl",
+            |metric| {
+                // One `for` at proc-body nesting 0 → +1.
+                assert_eq!(metric.cognitive.cognitive_sum(), 1);
+                assert_eq!(metric.cognitive.cognitive_max(), 1);
+            },
+        );
+    }
+
+    #[test]
+    fn tcl_for_cognitive_nested() {
+        // The `for` also nests its body: constructs inside it pay the
+        // nesting penalty the missing loop previously swallowed (#1264).
+        check_metrics::<TclParser>(
+            "proc f {n} {
+    for {set i 0} {$i < $n} {incr i} {
+        if {$i == 2} {
+            puts $i
+        }
+    }
+}",
+            "foo.tcl",
+            |metric| {
+                // for(+1, nesting 0) + if at nesting 1 (+2) = 3.
+                assert_eq!(metric.cognitive.cognitive_sum(), 3);
+                assert_eq!(metric.cognitive.cognitive_max(), 3);
+            },
+        );
+    }
+
+    #[test]
+    fn tcl_for_cognitive_name_gate() {
+        // The detection reads the command's `name` field: a command whose
+        // name merely starts with "for" (`format`, with `for`-shaped braced
+        // arguments) and a `for` word in argument position (`puts for`) must
+        // both stay at zero (issue #1264).
+        check_metrics::<TclParser>(
+            "proc f {} {
+    format {a} {b} {c} {d}
+    puts for
+}",
+            "foo.tcl",
+            |metric| {
+                assert_eq!(metric.cognitive.cognitive_sum(), 0);
+                assert_eq!(metric.cognitive.cognitive_max(), 0);
+            },
+        );
+    }
+
+    #[test]
+    fn tcl_irules_for_parity() {
+        // iRules models `for` as a dedicated kind counted by the kind
+        // dispatch; Tcl detects it by leading word (issue #1264). The same
+        // loop must score identically in both — and the iRules figure also
+        // pins that its dedicated kind is not double-counted through the
+        // Tcl command-name path. One loop at nesting 0 → +1 in each.
+        check_metrics::<TclParser>(
+            "proc f {} {
+    for {set i 0} {$i < 10} {incr i} {
+        puts $i
+    }
+}",
+            "foo.tcl",
+            |metric| {
+                assert_eq!(metric.cognitive.cognitive_sum(), 1);
+                assert_eq!(metric.cognitive.cognitive_max(), 1);
+            },
+        );
+        check_metrics::<IrulesParser>(
+            "when HTTP_REQUEST {
+    for {set i 0} {$i < 10} {incr i} {
+        puts $i
+    }
+}
+",
+            "foo.irule",
+            |metric| {
+                assert_eq!(metric.cognitive.cognitive_sum(), 1);
+                assert_eq!(metric.cognitive.cognitive_max(), 1);
             },
         );
     }

--- a/src/metrics/cognitive/irules.rs
+++ b/src/metrics/cognitive/irules.rs
@@ -48,6 +48,15 @@ impl Cognitive for IrulesCode {
             Catch => {
                 increase_nesting(stats, &mut nesting);
             }
+            // `try` handlers are conditional error paths too: +1 plus current
+            // nesting, and the handler body nests (issue #1266). The grammar
+            // wraps each in a dedicated node (unlike Tcl's flat tokens), and
+            // emits them only inside `try` — they are catch clauses, not the
+            // `when`-style event handlers they were once mistaken for. `Try`
+            // itself and `Finally` are unconditional and stay free.
+            OnHandler | TrapHandler => {
+                increase_nesting(stats, &mut nesting);
+            }
             // iRules `switch` is a dedicated node (unlike Tcl): +1 plus current
             // nesting, with the `default` arm free, matching the C-family
             // `SwitchStatement` cognitive handling (lesson 11).
@@ -61,15 +70,10 @@ impl Cognitive for IrulesCode {
                     matches!(id.into(), AMPAMP | PIPEPIPE | And | Or)
                 });
             }
-            // All four function-space kinds reset nesting and bump the
+            // The two function-space kinds reset nesting and bump the
             // function depth (see the `IrulesCode` Checker impl).
-            Procedure | WhenEvent | OnHandler | TrapHandler => {
-                enter_function_boundary(
-                    &mut nesting,
-                    node,
-                    ancestors,
-                    &[Procedure, WhenEvent, OnHandler, TrapHandler],
-                );
+            Procedure | WhenEvent => {
+                enter_function_boundary(&mut nesting, node, ancestors, &[Procedure, WhenEvent]);
             }
             _ => {}
         }

--- a/src/metrics/cognitive/ruby.rs
+++ b/src/metrics/cognitive/ruby.rs
@@ -12,6 +12,7 @@
 )]
 
 use super::*;
+use crate::checker::ruby::is_stabby_lambda_body;
 
 /// Folds a Ruby `binary`'s short-circuit operator children into the
 /// boolean-sequence counter — Ruby has four (`&&`, `||`, word-form
@@ -35,6 +36,10 @@ impl Cognitive for RubyCode {
     ) {
         use Ruby as R;
 
+        // bca: suppress(halstead) — exhaustive one-arm-per-grammar-kind
+        // dispatch table (see the rationale on `abc/perl.rs`'s compute):
+        // effort here counts distinct enum operands, not reasoning a
+        // reader must do.
         let mut nesting = get_nesting_from_map(node, nesting_map);
 
         match node.kind_id().into() {
@@ -138,7 +143,16 @@ impl Cognitive for RubyCode {
                 );
             }
             // Blocks, do-blocks and lambdas are the closure/lambda forms.
-            R::Block | R::DoBlock | R::Lambda => {
+            // A stabby lambda's own body block is skipped: the wrapping
+            // `Lambda` node already paid the surcharge, so counting the
+            // body too made a stabby lambda's contents inherit
+            // lambda-nesting 2 where the keyword form (`lambda { … }`)
+            // inherits 1. Same shared discriminator as `is_closure` and
+            // the space tree (#1257).
+            R::Lambda => {
+                nesting.lambda += 1;
+            }
+            R::Block | R::DoBlock if !is_stabby_lambda_body(node, ancestors) => {
                 nesting.lambda += 1;
             }
             _ => {}

--- a/src/metrics/cognitive/tcl.rs
+++ b/src/metrics/cognitive/tcl.rs
@@ -62,22 +62,34 @@ impl Cognitive for TclCode {
                     nesting_map.insert(body.id(), handler_nesting);
                 }
             }
-            // Tcl `switch` is a generic `command`, not a dedicated kind, so it
-            // would otherwise fall through to `_` (issue #467). It is a
-            // switch-like structure: +1 plus current nesting, with the
-            // `default` arm free, matching C-family `SwitchStatement` cognitive
-            // handling (lesson 11). `tcl_switch_decision_arms` returns `Some`
-            // only for a leading-word `switch` command.
-            Command if tcl_switch_decision_arms(node, code).is_some() => {
-                increase_nesting(stats, &mut nesting);
-            }
-            // Tcl `for` is likewise a generic `command` with no dedicated
-            // kind (issue #1264): a loop adds +1 plus current nesting and
-            // nests its body, matching `While`/`Foreach` above and the
-            // dedicated iRules `For`.
-            Command if tcl_command_is_for(node, code) => {
-                increase_nesting(stats, &mut nesting);
-            }
+            // Tcl `switch` and `for` are generic `command`s, not dedicated
+            // kinds, so they would otherwise fall through to `_` (issues
+            // #467, #1264). The leading word is resolved once here and
+            // dispatched on; the two constructs used to re-resolve it
+            // independently.
+            //
+            // `for` has a second, unrepairable consequence: with no grammar
+            // rule there is no `expr` slot, so the loop condition
+            // (`{$i < $n}`) stays an opaque `braced_word` and its comparison
+            // never surfaces as a condition token for ABC — a grammar
+            // limitation, not a metric-layer bug.
+            Command => match tcl_command_name(node, code) {
+                // A switch-like structure: +1 plus current nesting, with the
+                // `default` arm free, matching C-family `SwitchStatement`
+                // cognitive handling (lesson 11). The arm list must be the
+                // supported brace-list form, the same scoping cyclomatic
+                // applies; cognitive needs no arm count.
+                Some("switch") if tcl_switch_arm_list(node).is_some() => {
+                    increase_nesting(stats, &mut nesting);
+                }
+                // A loop adds +1 plus current nesting and nests its body,
+                // matching `While`/`Foreach` above and the dedicated iRules
+                // `For`.
+                Some("for") => {
+                    increase_nesting(stats, &mut nesting);
+                }
+                _ => {}
+            },
             BinopExpr => {
                 compute_booleans(node, stats, AMPAMP, PIPEPIPE);
             }

--- a/src/metrics/cognitive/tcl.rs
+++ b/src/metrics/cognitive/tcl.rs
@@ -54,6 +54,13 @@ impl Cognitive for TclCode {
             Command if tcl_switch_decision_arms(node, code).is_some() => {
                 increase_nesting(stats, &mut nesting);
             }
+            // Tcl `for` is likewise a generic `command` with no dedicated
+            // kind (issue #1264): a loop adds +1 plus current nesting and
+            // nests its body, matching `While`/`Foreach` above and the
+            // dedicated iRules `For`.
+            Command if tcl_command_is_for(node, code) => {
+                increase_nesting(stats, &mut nesting);
+            }
             BinopExpr => {
                 compute_booleans(node, stats, AMPAMP, PIPEPIPE);
             }

--- a/src/metrics/cognitive/tcl.rs
+++ b/src/metrics/cognitive/tcl.rs
@@ -45,6 +45,23 @@ impl Cognitive for TclCode {
             Catch => {
                 increase_nesting(stats, &mut nesting);
             }
+            // `try` itself is free; each `on error` handler is a conditional
+            // error path: +1 plus current nesting, nesting only the handler
+            // body (issue #1266). The `try` body and `finally` run
+            // unconditionally and stay at the inherited level, matching the
+            // C-family split of a free `try` and a charged `CatchClause`.
+            // The grammar exposes no handler wrapper node, so the body's
+            // slot is seeded here directly — the walker's
+            // `propagate_nesting_to_children` uses `or_insert`, so a slot
+            // written by the parent survives propagation (the #421
+            // comprehension-clause pattern).
+            Try => {
+                for body in tcl_try_handler_bodies(node) {
+                    let mut handler_nesting = nesting;
+                    increase_nesting(stats, &mut handler_nesting);
+                    nesting_map.insert(body.id(), handler_nesting);
+                }
+            }
             // Tcl `switch` is a generic `command`, not a dedicated kind, so it
             // would otherwise fall through to `_` (issue #467). It is a
             // switch-like structure: +1 plus current nesting, with the

--- a/src/metrics/cyclomatic.rs
+++ b/src/metrics/cyclomatic.rs
@@ -5454,37 +5454,44 @@ f() {
     // alongside the Unit / defmodule Class / def Function entries.
     // The FIRST `stab_clause` is the closure's head/definition and does
     // NOT count (issue #776); only the 2nd+ clauses are pattern-dispatch
-    // branches. The head-clause skip and the bare-`_` default-arm
-    // exclusion (issue #1272) compose: the 2nd clause here IS the
-    // dispatch's catch-all, so it is excluded for the wildcard reason
-    // while the head is excluded for the head reason. The anon-fn
-    // itself is not a `Call`, so it adds no modified-CCN container
-    // decision. Standard = 4 entries (Unit, defmodule, def, anon-fn)
-    // + 0 counted branches = 4; modified = 4 entries = 4.
+    // branches. The bare-`_` default-arm exclusion (issue #1272) does
+    // NOT apply inside a `fn`: the head skip already grants the free
+    // base path, so the trailing `_ ->` here is a real dispatch
+    // decision — a two-clause fn must report the same one decision as
+    // the identical two-arm `case`. The anon-fn itself is not a
+    // `Call`, so it adds no modified-CCN container decision.
+    // Standard = 4 entries (Unit, defmodule, def, anon-fn) + 1 counted
+    // branch (`_ ->`) = 5; modified = 4 entries = 4.
     #[test]
     fn elixir_anonymous_fn_arms_count() {
         check_metrics::<ElixirParser>(
             "defmodule Foo do\n  def f do\n    multi = fn 0 -> :zero; _ -> :other end\n    multi.(0)\n  end\nend\n",
             "foo.ex",
             |metric| {
-                assert_eq!(metric.cyclomatic.cyclomatic_sum(), 4);
+                assert_eq!(metric.cyclomatic.cyclomatic_sum(), 5);
                 assert_eq!(metric.cyclomatic.cyclomatic_modified_sum(), 4);
             },
         );
     }
 
-    // Three-clause anonymous fn ending in a catch-all: the head clause
-    // is skipped (#776), the middle `1 ->` clause is a real dispatch
-    // branch and counts, and the final bare `_ ->` is the dispatch's
-    // default arm and does not (issue #1272). Standard = 4 entries
-    // (Unit, defmodule, def, anon-fn) + 1 branch = 5; modified = 4.
+    // Three-clause anonymous fn ending in a catch-all: a multi-clause
+    // `fn` is a dispatch like `case` — n clauses are n−1 decisions —
+    // and its free base path is the head-clause skip (#776), so the
+    // bare-`_` exclusion (issue #1272) must not stack on top of it:
+    // when both applied, this fn contributed ZERO decisions while the
+    // identical `case 0/1/_` contributed one per counted arm. The head
+    // is skipped, and BOTH the `1 ->` clause and the final `_ ->`
+    // count, matching the 2 decisions of a 3-arm `case` ending in
+    // `_ ->` (2 counted arms there: the bare `_ ->` is free but the
+    // container's arms 1 and 2 count). Standard = 4 entries (Unit,
+    // defmodule, def, anon-fn) + 2 branches = 6; modified = 4.
     #[test]
     fn elixir_multi_clause_fn_catchall_composition() {
         check_metrics::<ElixirParser>(
             "defmodule Foo do\n  def f do\n    multi = fn 0 -> :zero; 1 -> :one; _ -> :other end\n    multi.(0)\n  end\nend\n",
             "foo.ex",
             |metric| {
-                assert_eq!(metric.cyclomatic.cyclomatic_sum(), 5);
+                assert_eq!(metric.cyclomatic.cyclomatic_sum(), 6);
                 assert_eq!(metric.cyclomatic.cyclomatic_modified_sum(), 4);
             },
         );
@@ -5558,6 +5565,26 @@ f() {
             "foo.ex",
             |metric| {
                 assert_eq!(metric.cyclomatic.cyclomatic_sum(), 5);
+                assert_eq!(metric.cyclomatic.cyclomatic_modified_sum(), 4);
+            },
+        );
+    }
+
+    // The `cond` `true ->` exclusion is shape-based, not positional: a
+    // NON-final unguarded `true ->` (which shadows every later arm) is
+    // excluded exactly like the idiomatic final one. This is the
+    // deliberate, Rust-convention-matching choice — Rust's bare-`_`
+    // MatchArm exclusion is equally position-blind, so the sibling
+    // family sets the precedent (issue #1272). standard = 3 entries +
+    // 1 counted stab (`x > 5 ->`; the shadowing `true ->` is free)
+    // = 4; modified = 3 entries + 1 cond Call = 4.
+    #[test]
+    fn elixir_cond_shadowing_true_arm_also_excluded() {
+        check_metrics::<ElixirParser>(
+            "defmodule Foo do\n  def f(x) do\n    cond do\n      true -> :forced\n      x > 5 -> :b\n    end\n  end\nend\n",
+            "foo.ex",
+            |metric| {
+                assert_eq!(metric.cyclomatic.cyclomatic_sum(), 4);
                 assert_eq!(metric.cyclomatic.cyclomatic_modified_sum(), 4);
             },
         );

--- a/src/metrics/cyclomatic.rs
+++ b/src/metrics/cyclomatic.rs
@@ -3908,6 +3908,32 @@ f() {
     }
 
     #[test]
+    fn tcl_switch_split_form_stays_uncounted() {
+        // The split arm form (`switch $x a {…} b {…}`) passes each arm
+        // body as its own sibling `braced_word` argument instead of
+        // wrapping the whole arm list in one, so there is no arm node to
+        // count and `tcl_switch_arm_list` deliberately declines it
+        // (issue #467). The construct is then left uncounted in BOTH
+        // tiers, exactly as an unrecognised command is — not counted as a
+        // container in modified CCN.
+        check_metrics::<TclParser>(
+            "proc f {x} {
+    switch $x a { puts a } b { puts b }
+}",
+            "foo.tcl",
+            |metric| {
+                // unit(1) + proc(base 1) and nothing else, in either
+                // tier; the brace-list spelling of the same two-arm
+                // switch scores 4 / 3 (see `tcl_switch_cyclomatic`).
+                assert_eq!(metric.cyclomatic.cyclomatic_sum(), 2);
+                assert_eq!(metric.cyclomatic.cyclomatic_max(), 1);
+                assert_eq!(metric.cyclomatic.cyclomatic_modified_sum(), 2);
+                assert_eq!(metric.cyclomatic.cyclomatic_modified_max(), 1);
+            },
+        );
+    }
+
+    #[test]
     fn tcl_for_cyclomatic() {
         // Tcl `for` is a generic command — the grammar has no `for` rule —
         // so it is detected by leading word (issue #1264): one loop decision
@@ -5530,6 +5556,31 @@ f() {
             |metric| {
                 assert_eq!(metric.cyclomatic.cyclomatic_sum(), 4);
                 assert_eq!(metric.cyclomatic.cyclomatic_modified_sum(), 4);
+            },
+        );
+    }
+
+    // A zero-arity multi-clause `fn` is the one shape whose clauses
+    // carry an *empty* pattern list (`()`), so neither clause has a sole
+    // pattern for the default-arm exclusion to inspect. The head clause
+    // is still free (#776) and the second clause is still a real
+    // dispatch decision — "no pattern" must not be mistaken for the bare
+    // `_ ->` catch-all, which is only free under a non-`fn` container
+    // anyway (#1272). Standard = 4 entries (Unit, defmodule, def,
+    // anon-fn) + 1 branch = 5; modified = 4 entries, the `fn` itself
+    // being no container Call.
+    #[test]
+    fn elixir_zero_arity_multi_clause_fn_counts_second_clause() {
+        check_metrics::<ElixirParser>(
+            "defmodule Foo do\n  def f do\n    both = fn () -> :a; () -> :b end\n    both.()\n  end\nend\n",
+            "foo.ex",
+            |metric| {
+                assert_eq!(metric.cyclomatic.cyclomatic_sum(), 5);
+                assert_eq!(metric.cyclomatic.cyclomatic_modified_sum(), 4);
+                // The anonymous fn's own space carries base 1 + the one
+                // counted clause; every enclosing space stays at base 1.
+                assert_eq!(metric.cyclomatic.cyclomatic_max(), 2);
+                assert_eq!(metric.cyclomatic.cyclomatic_modified_max(), 1);
             },
         );
     }

--- a/src/metrics/cyclomatic.rs
+++ b/src/metrics/cyclomatic.rs
@@ -3988,6 +3988,113 @@ f() {
     }
 
     #[test]
+    fn tcl_try_on_error_cyclomatic() {
+        // Tcl `try` is a dedicated kind whose single permitted `on error`
+        // handler is a flat token run (issue #1266): the handler is one
+        // decision point in both tiers, matching `catch`; `finally` is
+        // unconditional and free.
+        check_metrics::<TclParser>(
+            "proc f {} {
+    try {
+        risky
+    } on error {msg} {
+        puts $msg
+    } finally {
+        cleanup
+    }
+}",
+            "foo.tcl",
+            |metric| {
+                // unit(1) + proc(base 1 + handler 1) = sum 3, max 2, both tiers.
+                assert_eq!(metric.cyclomatic.cyclomatic_sum(), 3);
+                assert_eq!(metric.cyclomatic.cyclomatic_max(), 2);
+                assert_eq!(metric.cyclomatic.cyclomatic_modified_sum(), 3);
+                assert_eq!(metric.cyclomatic.cyclomatic_modified_max(), 2);
+            },
+        );
+    }
+
+    #[test]
+    fn tcl_try_finally_only_cyclomatic() {
+        // A `try` with no handler has no decision point: `finally` is
+        // unconditional cleanup and must stay +0 (issue #1266, the
+        // cross-language `finally` convention of #416).
+        check_metrics::<TclParser>(
+            "proc f {} {
+    try {
+        risky
+    } finally {
+        cleanup
+    }
+}",
+            "foo.tcl",
+            |metric| {
+                // unit(1) + proc(base 1) only.
+                assert_eq!(metric.cyclomatic.cyclomatic_sum(), 2);
+                assert_eq!(metric.cyclomatic.cyclomatic_max(), 1);
+                assert_eq!(metric.cyclomatic.cyclomatic_modified_sum(), 2);
+            },
+        );
+    }
+
+    #[test]
+    fn irules_try_handlers_cyclomatic() {
+        // iRules wraps each `try` handler in a dedicated `on_handler` /
+        // `trap_handler` node (unlike Tcl's flat tokens): one decision
+        // point each in both tiers (issue #1266). The figure also pins
+        // that the handlers no longer open anonymous function spaces —
+        // as spaces each would carry its own base 1, making the sum 6.
+        check_metrics::<IrulesParser>(
+            "proc f {} {
+    try {
+        risky
+    } on error {msg} {
+        puts $msg
+    } trap {POSIX} {msg} {
+        puts $msg
+    } finally {
+        cleanup
+    }
+}",
+            "foo.irule",
+            |metric| {
+                // unit(1) + proc(base 1 + on 1 + trap 1) = sum 4, max 3.
+                assert_eq!(metric.cyclomatic.cyclomatic_sum(), 4);
+                assert_eq!(metric.cyclomatic.cyclomatic_max(), 3);
+                assert_eq!(metric.cyclomatic.cyclomatic_modified_sum(), 4);
+                assert_eq!(metric.cyclomatic.cyclomatic_modified_max(), 3);
+            },
+        );
+    }
+
+    #[test]
+    fn tcl_irules_try_parity() {
+        // The same single-handler `try` must score identically in Tcl
+        // (flat `on`/`error` tokens under `try`) and iRules (a dedicated
+        // `on_handler` wrapper) — issue #1266.
+        // unit(1) + proc(base 1 + handler 1) = sum 3, max 2, both tiers.
+        let source = "proc f {} {
+    try {
+        risky
+    } on error {msg} {
+        puts $msg
+    } finally {
+        cleanup
+    }
+}";
+        check_metrics::<TclParser>(source, "foo.tcl", |metric| {
+            assert_eq!(metric.cyclomatic.cyclomatic_sum(), 3);
+            assert_eq!(metric.cyclomatic.cyclomatic_max(), 2);
+            assert_eq!(metric.cyclomatic.cyclomatic_modified_sum(), 3);
+        });
+        check_metrics::<IrulesParser>(source, "foo.irule", |metric| {
+            assert_eq!(metric.cyclomatic.cyclomatic_sum(), 3);
+            assert_eq!(metric.cyclomatic.cyclomatic_max(), 2);
+            assert_eq!(metric.cyclomatic.cyclomatic_modified_sum(), 3);
+        });
+    }
+
+    #[test]
     fn mozjs_for_loop() {
         check_metrics::<MozjsParser>(
             "function f(n) { // +2 (+1 unit)

--- a/src/metrics/cyclomatic.rs
+++ b/src/metrics/cyclomatic.rs
@@ -3908,6 +3908,86 @@ f() {
     }
 
     #[test]
+    fn tcl_for_cyclomatic() {
+        // Tcl `for` is a generic command — the grammar has no `for` rule —
+        // so it is detected by leading word (issue #1264): one loop decision
+        // in both standard and modified CCN, matching `foreach`/`while`.
+        check_metrics::<TclParser>(
+            "proc f {n} {
+    for {set i 0} {$i < $n} {incr i} {
+        puts $i
+    }
+}",
+            "foo.tcl",
+            |metric| {
+                // unit(1) + proc(base 1 + for 1) = sum 3, max 2, both tiers.
+                assert_eq!(metric.cyclomatic.cyclomatic_sum(), 3);
+                assert_eq!(metric.cyclomatic.cyclomatic_max(), 2);
+                assert_eq!(metric.cyclomatic.cyclomatic_modified_sum(), 3);
+                assert_eq!(metric.cyclomatic.cyclomatic_modified_max(), 2);
+            },
+        );
+    }
+
+    #[test]
+    fn tcl_for_cyclomatic_name_gate() {
+        // The detection reads the command's `name` field: a command whose
+        // name merely starts with "for" (`format`, with `for`-shaped braced
+        // arguments) and a `for` word in argument position (`puts for`) must
+        // both stay at zero (issue #1264).
+        check_metrics::<TclParser>(
+            "proc f {} {
+    format {a} {b} {c} {d}
+    puts for
+}",
+            "foo.tcl",
+            |metric| {
+                // unit(1) + proc(base 1) only; no decision points.
+                assert_eq!(metric.cyclomatic.cyclomatic_sum(), 2);
+                assert_eq!(metric.cyclomatic.cyclomatic_max(), 1);
+                assert_eq!(metric.cyclomatic.cyclomatic_modified_sum(), 2);
+            },
+        );
+    }
+
+    #[test]
+    fn tcl_irules_for_parity() {
+        // iRules models `for` as a dedicated kind counted by the kind
+        // dispatch; Tcl detects it by leading word (issue #1264). The same
+        // loop must score identically in both — and the iRules figure also
+        // pins that its dedicated kind is not double-counted through the
+        // Tcl command-name path.
+        // unit(1) + container(base 1 + for 1) = sum 3, max 2, both tiers.
+        check_metrics::<TclParser>(
+            "proc f {} {
+    for {set i 0} {$i < 10} {incr i} {
+        puts $i
+    }
+}",
+            "foo.tcl",
+            |metric| {
+                assert_eq!(metric.cyclomatic.cyclomatic_sum(), 3);
+                assert_eq!(metric.cyclomatic.cyclomatic_max(), 2);
+                assert_eq!(metric.cyclomatic.cyclomatic_modified_sum(), 3);
+            },
+        );
+        check_metrics::<IrulesParser>(
+            "when HTTP_REQUEST {
+    for {set i 0} {$i < 10} {incr i} {
+        puts $i
+    }
+}
+",
+            "foo.irule",
+            |metric| {
+                assert_eq!(metric.cyclomatic.cyclomatic_sum(), 3);
+                assert_eq!(metric.cyclomatic.cyclomatic_max(), 2);
+                assert_eq!(metric.cyclomatic.cyclomatic_modified_sum(), 3);
+            },
+        );
+    }
+
+    #[test]
     fn mozjs_for_loop() {
         check_metrics::<MozjsParser>(
             "function f(n) { // +2 (+1 unit)

--- a/src/metrics/cyclomatic.rs
+++ b/src/metrics/cyclomatic.rs
@@ -5281,18 +5281,70 @@ f() {
 
     // `case`/`cond`/`with` arms surface as `stab_clause` nodes and
     // contribute to standard CCN, mirroring the C-family `case:` arm
-    // treatment. The container Call (`case`) contributes once to
+    // treatment — including its `default:` exclusion: the bare `_ ->`
+    // catch-all is the construct's default arm and adds no decision
+    // (issue #1272). The container Call (`case`) contributes once to
     // modified CCN, collapsing arms back to a single decision point.
     // Three func spaces (Unit + defmodule Class + def Function) each
-    // seed one entry: standard = 3 entries + 3 stabs = 6; modified =
-    // 3 entries + 1 case Call = 4.
+    // seed one entry: standard = 3 entries + 2 counted stabs = 5;
+    // modified = 3 entries + 1 case Call = 4.
     #[test]
     fn elixir_case_arms() {
         check_metrics::<ElixirParser>(
             "defmodule Foo do\n  def classify(x) do\n    case x do\n      1 -> :one\n      2 -> :two\n      _ -> :other\n    end\n  end\nend\n",
             "foo.ex",
             |metric| {
-                assert_eq!(metric.cyclomatic.cyclomatic_sum(), 6);
+                assert_eq!(metric.cyclomatic.cyclomatic_sum(), 5);
+                assert_eq!(metric.cyclomatic.cyclomatic_modified_sum(), 4);
+            },
+        );
+    }
+
+    // A guarded wildcard (`_ when g ->`) is a real decision — the
+    // guard can fail, so control can fall through — and must keep
+    // counting, matching Rust's `_ if guard` rule (issue #1272).
+    // standard = 3 entries + `1 ->` + `_ when x > 5 ->` = 5 (only the
+    // final bare `_ ->` is excluded); modified = 3 entries + case = 4.
+    #[test]
+    fn elixir_case_guarded_wildcard_counts() {
+        check_metrics::<ElixirParser>(
+            "defmodule Foo do\n  def classify(x) do\n    case x do\n      1 -> :one\n      _ when x > 5 -> :big\n      _ -> :other\n    end\n  end\nend\n",
+            "foo.ex",
+            |metric| {
+                assert_eq!(metric.cyclomatic.cyclomatic_sum(), 5);
+                assert_eq!(metric.cyclomatic.cyclomatic_modified_sum(), 4);
+            },
+        );
+    }
+
+    // A named discard (`_x ->`) binds a value the body can read; only
+    // the bare `_` is the default arm, matching Rust's bare-`_`-only
+    // MatchArm rule (issue #1272). standard = 3 entries + `1 ->` +
+    // `_x ->` = 5; modified = 3 entries + case Call = 4.
+    #[test]
+    fn elixir_case_named_discard_counts() {
+        check_metrics::<ElixirParser>(
+            "defmodule Foo do\n  def classify(x) do\n    case x do\n      1 -> :one\n      _x -> :named\n    end\n  end\nend\n",
+            "foo.ex",
+            |metric| {
+                assert_eq!(metric.cyclomatic.cyclomatic_sum(), 5);
+                assert_eq!(metric.cyclomatic.cyclomatic_modified_sum(), 4);
+            },
+        );
+    }
+
+    // `true ->` under `case` is an ordinary boolean pattern, not a
+    // designated default — the cond-only exclusion must not leak here
+    // (issue #1272, grammar-dispatch §8: anchor the exclusion to the
+    // owning construct). standard = 3 entries + `true ->` +
+    // `false ->` = 5; modified = 3 entries + case Call = 4.
+    #[test]
+    fn elixir_case_true_pattern_counts() {
+        check_metrics::<ElixirParser>(
+            "defmodule Foo do\n  def f(x) do\n    case x do\n      true -> :t\n      false -> :f\n    end\n  end\nend\n",
+            "foo.ex",
+            |metric| {
+                assert_eq!(metric.cyclomatic.cyclomatic_sum(), 5);
                 assert_eq!(metric.cyclomatic.cyclomatic_modified_sum(), 4);
             },
         );
@@ -5402,14 +5454,51 @@ f() {
     // alongside the Unit / defmodule Class / def Function entries.
     // The FIRST `stab_clause` is the closure's head/definition and does
     // NOT count (issue #776); only the 2nd+ clauses are pattern-dispatch
-    // branches. The anon-fn itself is not a `Call`, so it adds no
-    // modified-CCN container decision. Standard = 4 entries (Unit,
-    // defmodule, def, anon-fn) + 1 branch (2nd clause) = 5; modified =
-    // 4 entries = 4.
+    // branches. The head-clause skip and the bare-`_` default-arm
+    // exclusion (issue #1272) compose: the 2nd clause here IS the
+    // dispatch's catch-all, so it is excluded for the wildcard reason
+    // while the head is excluded for the head reason. The anon-fn
+    // itself is not a `Call`, so it adds no modified-CCN container
+    // decision. Standard = 4 entries (Unit, defmodule, def, anon-fn)
+    // + 0 counted branches = 4; modified = 4 entries = 4.
     #[test]
     fn elixir_anonymous_fn_arms_count() {
         check_metrics::<ElixirParser>(
             "defmodule Foo do\n  def f do\n    multi = fn 0 -> :zero; _ -> :other end\n    multi.(0)\n  end\nend\n",
+            "foo.ex",
+            |metric| {
+                assert_eq!(metric.cyclomatic.cyclomatic_sum(), 4);
+                assert_eq!(metric.cyclomatic.cyclomatic_modified_sum(), 4);
+            },
+        );
+    }
+
+    // Three-clause anonymous fn ending in a catch-all: the head clause
+    // is skipped (#776), the middle `1 ->` clause is a real dispatch
+    // branch and counts, and the final bare `_ ->` is the dispatch's
+    // default arm and does not (issue #1272). Standard = 4 entries
+    // (Unit, defmodule, def, anon-fn) + 1 branch = 5; modified = 4.
+    #[test]
+    fn elixir_multi_clause_fn_catchall_composition() {
+        check_metrics::<ElixirParser>(
+            "defmodule Foo do\n  def f do\n    multi = fn 0 -> :zero; 1 -> :one; _ -> :other end\n    multi.(0)\n  end\nend\n",
+            "foo.ex",
+            |metric| {
+                assert_eq!(metric.cyclomatic.cyclomatic_sum(), 5);
+                assert_eq!(metric.cyclomatic.cyclomatic_modified_sum(), 4);
+            },
+        );
+    }
+
+    // A non-head `true ->` clause of an anonymous fn is an ordinary
+    // dispatch branch — its parent is the `anonymous_function`, not a
+    // `cond`'s `do_block`, so the cond-default exclusion must not fire
+    // (issue #1272). Standard = 4 entries (Unit, defmodule, def,
+    // anon-fn) + 1 branch (the `true ->` clause) = 5; modified = 4.
+    #[test]
+    fn elixir_fn_true_clause_counts() {
+        check_metrics::<ElixirParser>(
+            "defmodule Foo do\n  def f do\n    flag = fn false -> :f; true -> :t end\n    flag.(true)\n  end\nend\n",
             "foo.ex",
             |metric| {
                 assert_eq!(metric.cyclomatic.cyclomatic_sum(), 5);
@@ -5439,18 +5528,56 @@ f() {
     }
 
     // `cond do ... end` is the standard Elixir multi-way conditional.
-    // Each clause is a `stab_clause` (standard CCN), and the `cond`
-    // Call is a multi-arm container (modified CCN, once).
+    // Each clause is a `stab_clause` (standard CCN), except the
+    // idiomatic `true ->` final arm — the construct's designated
+    // default, the analogue of `if`/`elif`/`else`'s free `else`
+    // (issue #1272). The `cond` Call is a multi-arm container
+    // (modified CCN, once).
     #[test]
     fn elixir_cond_arms() {
         check_metrics::<ElixirParser>(
             "defmodule Foo do\n  def f(x) do\n    cond do\n      x < 0 -> :neg\n      x == 0 -> :zero\n      true -> :pos\n    end\n  end\nend\n",
             "foo.ex",
             |metric| {
-                // standard: 3 entries + 3 stabs = 6
+                // standard: 3 entries + 2 counted stabs (`true ->` free) = 5
                 // modified: 3 entries + 1 cond Call = 4
-                assert_eq!(metric.cyclomatic.cyclomatic_sum(), 6);
+                assert_eq!(metric.cyclomatic.cyclomatic_sum(), 5);
                 assert_eq!(metric.cyclomatic.cyclomatic_modified_sum(), 4);
+            },
+        );
+    }
+
+    // A `cond` with no `true ->` default counts every arm — the
+    // exclusion targets only the designated-default clause, not the
+    // container's last arm (issue #1272). standard = 3 entries +
+    // 2 stabs = 5; modified = 3 entries + 1 cond Call = 4.
+    #[test]
+    fn elixir_cond_without_default_counts_all_arms() {
+        check_metrics::<ElixirParser>(
+            "defmodule Foo do\n  def f(x) do\n    cond do\n      x > 10 -> :big\n      x > 5 -> :mid\n    end\n  end\nend\n",
+            "foo.ex",
+            |metric| {
+                assert_eq!(metric.cyclomatic.cyclomatic_sum(), 5);
+                assert_eq!(metric.cyclomatic.cyclomatic_modified_sum(), 4);
+            },
+        );
+    }
+
+    // Nesting keeps each exclusion anchored to its own construct
+    // (issue #1272, grammar-dispatch §8): the outer `cond`'s `true ->`
+    // is free (cond default), the inner `case`'s `true ->` counts
+    // (ordinary pattern — its container is the case, not the cond),
+    // and the inner bare `_ ->` is free (case default).
+    // standard: 3 entries + outer `x > 1 ->` + inner `true ->` = 5;
+    // modified: 3 entries + cond Call + case Call = 5.
+    #[test]
+    fn elixir_nested_case_inside_cond_keeps_exclusions_scoped() {
+        check_metrics::<ElixirParser>(
+            "defmodule Foo do\n  def f(x, y) do\n    cond do\n      x > 1 ->\n        case y do\n          true -> :t\n          _ -> :o\n        end\n      true -> :d\n    end\n  end\nend\n",
+            "foo.ex",
+            |metric| {
+                assert_eq!(metric.cyclomatic.cyclomatic_sum(), 5);
+                assert_eq!(metric.cyclomatic.cyclomatic_modified_sum(), 5);
             },
         );
     }

--- a/src/metrics/cyclomatic/elixir.rs
+++ b/src/metrics/cyclomatic/elixir.rs
@@ -44,15 +44,17 @@ fn elixir_is_anonymous_fn_head_clause<'a>(node: &Node<'a>, ancestors: Ancestors<
 /// kind is compared as a string because the grammar aliases several
 /// internal rules to `arguments` with distinct kind ids
 /// (`Arguments2`..`Arguments5`); grammar-dispatch §1 prefers the one
-/// string comparison over enumerating them. Named-children filtering
-/// skips the anonymous `(` `)` tokens a parenthesised clause head
-/// carries. Clauses with zero (`fn -> … end`) or several patterns
-/// return `None`.
+/// string comparison over enumerating them. A zero-arity clause carries
+/// no `left` field at all (`fn -> … end`), which the same `filter` folds
+/// into "no plain pattern list" — the two spellings of "nothing to
+/// inspect" are one question, so they share one exit. Named-children
+/// filtering skips the anonymous `(` `)` tokens a parenthesised clause
+/// head carries, so an empty pair (`fn () -> … end`) also yields zero
+/// patterns. Clauses with zero or several patterns return `None`.
 fn elixir_sole_unguarded_pattern<'a>(node: &Node<'a>) -> Option<Node<'a>> {
-    let left = node.child_by_field_name("left")?;
-    if left.kind() != "arguments" {
-        return None;
-    }
+    let left = node
+        .child_by_field_name("left")
+        .filter(|left| left.kind() == "arguments")?;
     let mut patterns = left.children().filter(Node::is_named);
     let sole = patterns.next()?;
     patterns.next().is_none().then_some(sole)
@@ -119,10 +121,9 @@ fn elixir_is_default_clause<'a>(
                 return false;
             }
             let mut chain = ancestors.iter(node);
-            let Some((parent, _)) = chain.next() else {
-                return false;
-            };
-            parent.kind_id() == E::DoBlock as u16
+            chain
+                .next()
+                .is_some_and(|(parent, _)| parent.kind_id() == E::DoBlock as u16)
                 && chain.next().is_some_and(|(grandparent, _)| {
                     crate::metrics::cognitive::elixir_call_keyword(&grandparent, code)
                         == Some("cond")

--- a/src/metrics/cyclomatic/elixir.rs
+++ b/src/metrics/cyclomatic/elixir.rs
@@ -34,6 +34,82 @@ fn elixir_is_anonymous_fn_head_clause<'a>(node: &Node<'a>, ancestors: Ancestors<
         .is_some_and(|first| first.id() == node.id())
 }
 
+/// Returns the sole pattern of a `stab_clause` whose left-hand side
+/// carries no `when` guard, or `None` otherwise.
+///
+/// The grammar's `left` field is an `arguments` node for a plain
+/// pattern list, but a guarded clause (`_ when g ->`) re-shapes it
+/// into a `binary_operator` wrapping the patterns and the guard — so
+/// checking the field's kind answers "is there a guard" for free. The
+/// kind is compared as a string because the grammar aliases several
+/// internal rules to `arguments` with distinct kind ids
+/// (`Arguments2`..`Arguments5`); grammar-dispatch §1 prefers the one
+/// string comparison over enumerating them. Named-children filtering
+/// skips the anonymous `(` `)` tokens a parenthesised clause head
+/// carries. Clauses with zero (`fn -> … end`) or several patterns
+/// return `None`.
+fn elixir_sole_unguarded_pattern<'a>(node: &Node<'a>) -> Option<Node<'a>> {
+    let left = node.child_by_field_name("left")?;
+    if left.kind() != "arguments" {
+        return None;
+    }
+    let mut patterns = left.children().filter(Node::is_named);
+    let sole = patterns.next()?;
+    patterns.next().is_none().then_some(sole)
+}
+
+/// Returns `true` when `node` is a bare catch-all `stab_clause`: a
+/// single `_` pattern with no `when` guard (`_ -> …`).
+///
+/// Elixir has no dedicated wildcard token — `_` parses as an ordinary
+/// `identifier` — so the bytes decide (grammar-dispatch §10). A named
+/// discard (`_x ->`) binds a value the body can read and keeps
+/// counting, matching Rust's bare-`_`-only `MatchArm` rule; guarded
+/// wildcards never reach the text check because
+/// [`elixir_sole_unguarded_pattern`] rejects them.
+fn elixir_is_bare_catchall_clause<'a>(node: &Node<'a>, code: &'a [u8]) -> bool {
+    use Elixir as E;
+
+    elixir_sole_unguarded_pattern(node).is_some_and(|pattern| {
+        pattern.kind_id() == E::Identifier as u16 && pattern.utf8_text(code) == Some("_")
+    })
+}
+
+/// Returns `true` when `node` is the idiomatic `true -> …` default
+/// clause of a `cond` container.
+///
+/// `cond`'s final `true ->` arm is the construct's designated default
+/// — the direct analogue of `if`/`elif`/`else`'s free `else` — but
+/// the same clause under `case` is an ordinary boolean pattern match,
+/// so the exclusion is anchored to the owning construct
+/// (grammar-dispatch §8): the clause's parent must be the `do_block`
+/// of a `Call` whose target spells `cond`. A guarded `true when g ->`
+/// is a real decision and never reaches the container check.
+fn elixir_is_cond_default_clause<'a>(
+    node: &Node<'a>,
+    code: &'a [u8],
+    ancestors: Ancestors<'a, '_>,
+) -> bool {
+    use Elixir as E;
+
+    let is_literal_true = elixir_sole_unguarded_pattern(node).is_some_and(|pattern| {
+        pattern.kind_id() == E::Boolean as u16 && pattern.utf8_text(code) == Some("true")
+    });
+    if !is_literal_true {
+        return false;
+    }
+    let mut chain = ancestors.iter(node);
+    let Some((parent, _)) = chain.next() else {
+        return false;
+    };
+    if parent.kind_id() != E::DoBlock as u16 {
+        return false;
+    }
+    chain.next().is_some_and(|(grandparent, _)| {
+        crate::metrics::cognitive::elixir_call_keyword(&grandparent, code) == Some("cond")
+    })
+}
+
 impl Cyclomatic for ElixirCode {
     // Elixir's control-flow constructs are not distinct grammar
     // productions: `if`/`unless`/`for`/`while`/`with`/`case`/`cond`/`try`
@@ -73,7 +149,27 @@ impl Cyclomatic for ElixirCode {
             // `fn` are real branches. `case`/`cond`/`with` arms have a
             // `do_block` parent — not `anonymous_function` — so they are
             // unaffected and keep counting.
-            E::StabClause if elixir_is_anonymous_fn_head_clause(node, ancestors) => {}
+            //
+            // Two further clause shapes are the construct's default arm
+            // and are excluded to match the sibling family — Rust's
+            // `_ =>`, Python's `case _:`, Ruby's `in _`, Kotlin's
+            // `else ->`, C#'s `_ =>`, Bash's `*)`, C-family `default:`
+            // (issue #1272, lesson 11): a bare `_ ->` catch-all
+            // (any container — `case`, `receive`, and a multi-clause
+            // `fn`'s dispatch all use it as their default; a `rescue`
+            // arm's `_ ->` is likewise free, a deliberate divergence
+            // from C-family `catch (...)` — the bare-`_` rescue form
+            // is vanishingly rare and the `try` container still pays
+            // modified), and `cond`'s
+            // idiomatic `true ->` final arm (only under a `cond`
+            // container; `true ->` under `case` is an ordinary pattern
+            // and keeps counting). Guarded forms (`_ when g ->`,
+            // `true when g ->`) and named discards (`_x ->`) are real
+            // decisions and still count.
+            E::StabClause
+                if elixir_is_anonymous_fn_head_clause(node, ancestors)
+                    || elixir_is_bare_catchall_clause(node, code)
+                    || elixir_is_cond_default_clause(node, code, ancestors) => {}
             E::StabClause => {
                 stats.cyclomatic += 1.;
             }

--- a/src/metrics/cyclomatic/elixir.rs
+++ b/src/metrics/cyclomatic/elixir.rs
@@ -58,56 +58,78 @@ fn elixir_sole_unguarded_pattern<'a>(node: &Node<'a>) -> Option<Node<'a>> {
     patterns.next().is_none().then_some(sole)
 }
 
-/// Returns `true` when `node` is a bare catch-all `stab_clause`: a
-/// single `_` pattern with no `when` guard (`_ -> …`).
+/// Returns `true` when `node` is a construct's free default clause:
+/// a bare `_ ->` catch-all outside an anonymous fn, or an unguarded
+/// `true ->` directly under a `cond`.
 ///
-/// Elixir has no dedicated wildcard token — `_` parses as an ordinary
-/// `identifier` — so the bytes decide (grammar-dispatch §10). A named
-/// discard (`_x ->`) binds a value the body can read and keeps
-/// counting, matching Rust's bare-`_`-only `MatchArm` rule; guarded
-/// wildcards never reach the text check because
-/// [`elixir_sole_unguarded_pattern`] rejects them.
-fn elixir_is_bare_catchall_clause<'a>(node: &Node<'a>, code: &'a [u8]) -> bool {
-    use Elixir as E;
-
-    elixir_sole_unguarded_pattern(node).is_some_and(|pattern| {
-        pattern.kind_id() == E::Identifier as u16 && pattern.utf8_text(code) == Some("_")
-    })
-}
-
-/// Returns `true` when `node` is the idiomatic `true -> …` default
-/// clause of a `cond` container.
+/// Both shapes hinge on the clause's sole unguarded pattern, and
+/// [`elixir_sole_unguarded_pattern`]'s child scan allocates a cursor
+/// (the #1112 malloc) — so the pattern is extracted once here and the
+/// two shapes branch on its (kind, text), instead of every counted
+/// `stab_clause` paying the extraction twice through two independent
+/// predicates.
 ///
-/// `cond`'s final `true ->` arm is the construct's designated default
-/// — the direct analogue of `if`/`elif`/`else`'s free `else` — but
-/// the same clause under `case` is an ordinary boolean pattern match,
-/// so the exclusion is anchored to the owning construct
-/// (grammar-dispatch §8): the clause's parent must be the `do_block`
-/// of a `Call` whose target spells `cond`. A guarded `true when g ->`
-/// is a real decision and never reaches the container check.
-fn elixir_is_cond_default_clause<'a>(
+/// Bare `_ ->`: Elixir has no dedicated wildcard token — `_` parses
+/// as an ordinary `identifier` — so the bytes decide (grammar-dispatch
+/// §10). A named discard (`_x ->`) binds a value the body can read
+/// and keeps counting, matching Rust's bare-`_`-only `MatchArm` rule;
+/// guarded wildcards never reach the text check because
+/// [`elixir_sole_unguarded_pattern`] rejects them. The exclusion does
+/// NOT apply when the clause's container is an `anonymous_function`:
+/// a multi-clause `fn` is a dispatch like `case` — n clauses are n−1
+/// decisions — and its free base path is already granted by the
+/// head-clause skip (#776), so excluding a trailing `_ ->` too would
+/// leave `fn 0 -> :a; _ -> :b end` at zero decisions while the
+/// identical `case` reports one.
+///
+/// `true ->` under `cond`: the exclusion is *shape-based* — any
+/// unguarded `true ->` whose parent is the `do_block` of a `Call`
+/// spelling `cond`, whatever the arm's position. That deliberately
+/// matches the sibling convention: Rust's bare-`_` `MatchArm`
+/// exclusion is equally position-blind. The same clause under `case`
+/// is an ordinary boolean pattern match, so the exclusion is anchored
+/// to the owning construct (grammar-dispatch §8); a guarded
+/// `true when g ->` is a real decision and never reaches the
+/// container check.
+fn elixir_is_default_clause<'a>(
     node: &Node<'a>,
     code: &'a [u8],
     ancestors: Ancestors<'a, '_>,
 ) -> bool {
     use Elixir as E;
 
-    let is_literal_true = elixir_sole_unguarded_pattern(node).is_some_and(|pattern| {
-        pattern.kind_id() == E::Boolean as u16 && pattern.utf8_text(code) == Some("true")
-    });
-    if !is_literal_true {
-        return false;
-    }
-    let mut chain = ancestors.iter(node);
-    let Some((parent, _)) = chain.next() else {
+    let Some(pattern) = elixir_sole_unguarded_pattern(node) else {
         return false;
     };
-    if parent.kind_id() != E::DoBlock as u16 {
-        return false;
+    match pattern.kind_id().into() {
+        // Bare `_` catch-all — free everywhere except under an
+        // anonymous fn, whose free base path the head-clause skip
+        // already provides.
+        E::Identifier => {
+            pattern.utf8_text(code) == Some("_")
+                && ancestors
+                    .parent(node)
+                    .is_none_or(|parent| parent.kind_id() != E::AnonymousFunction as u16)
+        }
+        // Unguarded `true` — free only as `cond`'s designated
+        // default; the O(1) parent/grandparent kind checks run after
+        // the text compare so non-`true` booleans bail early.
+        E::Boolean => {
+            if pattern.utf8_text(code) != Some("true") {
+                return false;
+            }
+            let mut chain = ancestors.iter(node);
+            let Some((parent, _)) = chain.next() else {
+                return false;
+            };
+            parent.kind_id() == E::DoBlock as u16
+                && chain.next().is_some_and(|(grandparent, _)| {
+                    crate::metrics::cognitive::elixir_call_keyword(&grandparent, code)
+                        == Some("cond")
+                })
+        }
+        _ => false,
     }
-    chain.next().is_some_and(|(grandparent, _)| {
-        crate::metrics::cognitive::elixir_call_keyword(&grandparent, code) == Some("cond")
-    })
 }
 
 impl Cyclomatic for ElixirCode {
@@ -154,22 +176,26 @@ impl Cyclomatic for ElixirCode {
             // and are excluded to match the sibling family — Rust's
             // `_ =>`, Python's `case _:`, Ruby's `in _`, Kotlin's
             // `else ->`, C#'s `_ =>`, Bash's `*)`, C-family `default:`
-            // (issue #1272, lesson 11): a bare `_ ->` catch-all
-            // (any container — `case`, `receive`, and a multi-clause
-            // `fn`'s dispatch all use it as their default; a `rescue`
-            // arm's `_ ->` is likewise free, a deliberate divergence
-            // from C-family `catch (...)` — the bare-`_` rescue form
-            // is vanishingly rare and the `try` container still pays
-            // modified), and `cond`'s
-            // idiomatic `true ->` final arm (only under a `cond`
-            // container; `true ->` under `case` is an ordinary pattern
-            // and keeps counting). Guarded forms (`_ when g ->`,
-            // `true when g ->`) and named discards (`_x ->`) are real
-            // decisions and still count.
+            // (issue #1272, lesson 11): a bare `_ ->` catch-all under
+            // `case` / `receive` / `rescue` (a `rescue` arm's `_ ->`
+            // being free is a deliberate divergence from C-family
+            // `catch (...)` — the bare-`_` rescue form is vanishingly
+            // rare and the `try` container still pays modified), and
+            // any unguarded `true ->` directly under a `cond` container
+            // — shape-based, whatever the arm's position, matching
+            // Rust's position-blind bare-`_` rule; `true ->` under
+            // `case` is an ordinary pattern and keeps counting. A
+            // multi-clause `fn`'s trailing `_ ->` is NOT excluded: the
+            // head-clause skip above already grants the closure's free
+            // base path, so each 2nd+ clause — the bare catch-all
+            // included — is a real dispatch decision, keeping
+            // `fn 0 -> :a; _ -> :b end` in parity with the identical
+            // `case`. Guarded forms (`_ when g ->`, `true when g ->`)
+            // and named discards (`_x ->`) are real decisions and
+            // still count.
             E::StabClause
                 if elixir_is_anonymous_fn_head_clause(node, ancestors)
-                    || elixir_is_bare_catchall_clause(node, code)
-                    || elixir_is_cond_default_clause(node, code, ancestors) => {}
+                    || elixir_is_default_clause(node, code, ancestors) => {}
             E::StabClause => {
                 stats.cyclomatic += 1.;
             }

--- a/src/metrics/cyclomatic/irules.rs
+++ b/src/metrics/cyclomatic/irules.rs
@@ -36,6 +36,13 @@ impl Cyclomatic for IrulesCode {
             | Irules::While
             | Irules::DictFor
             | Irules::Catch
+            // `try` handlers: the grammar wraps each `on error` / `trap`
+            // group in a dedicated node (unlike Tcl's flat tokens), so each
+            // is one decision point here (issue #1266), matching `Catch`
+            // and the C-family `CatchClause`. `Try` itself and `Finally`
+            // are unconditional and stay free.
+            | Irules::OnHandler
+            | Irules::TrapHandler
             | Irules::TernaryExpr
             // Short-circuit logical operators, both symbolic and the iRules
             // keyword forms (`and`/`or`) — Tcl has no keyword forms, so these

--- a/src/metrics/cyclomatic/tcl.rs
+++ b/src/metrics/cyclomatic/tcl.rs
@@ -15,16 +15,6 @@ impl Cyclomatic for TclCode {
         _ancestors: Ancestors<'a, '_>,
         stats: &mut Stats,
     ) {
-        // Tcl `switch` is a generic `command`, not a dedicated kind, so it is
-        // matched out-of-band before the kind dispatch (issue #467). Mirroring
-        // the C-family convention (see `impl_cyclomatic_c_family`): each
-        // non-`default` arm is a decision point in standard CCN, while modified
-        // CCN collapses the whole construct to a single container decision.
-        if let Some(arms) = crate::metrics::cognitive::tcl_switch_decision_arms(node, code) {
-            stats.cyclomatic += arms as f64;
-            stats.cyclomatic_modified += 1.;
-            return;
-        }
         match node.kind_id().into() {
             Tcl::If
             | Tcl::Elseif
@@ -37,13 +27,32 @@ impl Cyclomatic for TclCode {
                 stats.cyclomatic += 1.;
                 stats.cyclomatic_modified += 1.;
             }
-            // Tcl `for` is likewise a generic `command` with no dedicated
-            // kind (issue #1264): one loop decision in both tiers, matching
-            // `Foreach`/`While` above and the dedicated iRules `For`.
-            Tcl::Command if crate::metrics::cognitive::tcl_command_is_for(node, code) => {
-                stats.cyclomatic += 1.;
-                stats.cyclomatic_modified += 1.;
-            }
+            // Tcl `switch` and `for` are generic `command`s with no dedicated
+            // kind (issues #467, #1264), so the kind dispatch above never
+            // sees them. The leading word is resolved once and dispatched on.
+            Tcl::Command => match crate::metrics::cognitive::tcl_command_name(node, code) {
+                // Mirroring the C-family convention (see
+                // `impl_cyclomatic_c_family`): each non-`default` arm is a
+                // decision point in standard CCN, while modified CCN
+                // collapses the whole construct to a single container
+                // decision. The unsupported split form yields `None` and
+                // stays uncounted in both tiers.
+                Some("switch") => {
+                    if let Some(arms) =
+                        crate::metrics::cognitive::tcl_switch_decision_arms(node, code)
+                    {
+                        stats.cyclomatic += arms as f64;
+                        stats.cyclomatic_modified += 1.;
+                    }
+                }
+                // One loop decision in both tiers, matching `Foreach`/`While`
+                // above and the dedicated iRules `For`.
+                Some("for") => {
+                    stats.cyclomatic += 1.;
+                    stats.cyclomatic_modified += 1.;
+                }
+                _ => {}
+            },
             // `try` itself is free; each `on error` handler is one decision
             // point in both tiers (issue #1266), matching `Catch` above, the
             // C-family `CatchClause`, and the iRules `OnHandler` — modified

--- a/src/metrics/cyclomatic/tcl.rs
+++ b/src/metrics/cyclomatic/tcl.rs
@@ -44,6 +44,17 @@ impl Cyclomatic for TclCode {
                 stats.cyclomatic += 1.;
                 stats.cyclomatic_modified += 1.;
             }
+            // `try` itself is free; each `on error` handler is one decision
+            // point in both tiers (issue #1266), matching `Catch` above, the
+            // C-family `CatchClause`, and the iRules `OnHandler` — modified
+            // CCN collapses only switch-like arm lists, never catch
+            // handlers. `finally` is unconditional cleanup and stays free.
+            Tcl::Try => {
+                let handlers =
+                    crate::metrics::cognitive::tcl_try_handler_bodies(node).count() as f64;
+                stats.cyclomatic += handlers;
+                stats.cyclomatic_modified += handlers;
+            }
             _ => {}
         }
     }

--- a/src/metrics/cyclomatic/tcl.rs
+++ b/src/metrics/cyclomatic/tcl.rs
@@ -37,6 +37,13 @@ impl Cyclomatic for TclCode {
                 stats.cyclomatic += 1.;
                 stats.cyclomatic_modified += 1.;
             }
+            // Tcl `for` is likewise a generic `command` with no dedicated
+            // kind (issue #1264): one loop decision in both tiers, matching
+            // `Foreach`/`While` above and the dedicated iRules `For`.
+            Tcl::Command if crate::metrics::cognitive::tcl_command_is_for(node, code) => {
+                stats.cyclomatic += 1.;
+                stats.cyclomatic_modified += 1.;
+            }
             _ => {}
         }
     }

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -3335,6 +3335,21 @@ f() {
             assert_eq!(metric.halstead.unique_operands(), 3);
             assert_eq!(metric.halstead.total_operands(), 3);
         });
+
+        // A guarded kind *inside* the interpolation: the `/` in
+        // `#{a / b}` has `binary_operator` as its parent but the
+        // `Sigil` as a further ancestor, so this input is the one
+        // discriminator between the correct parent-scoped guard and a
+        // wrong ancestor-scoped one that would swallow it.
+        //
+        // expected: operators `=`, `~`, `#{`, `/` → n1 = N1 = 4;
+        // operands `v`, `s`, `a`, `b` → n2 = N2 = 4.
+        check_metrics::<ElixirParser>("v = ~s{x #{a / b} y}\n", "foo.ex", |metric| {
+            assert_eq!(metric.halstead.unique_operators(), 4);
+            assert_eq!(metric.halstead.total_operators(), 4);
+            assert_eq!(metric.halstead.unique_operands(), 4);
+            assert_eq!(metric.halstead.total_operands(), 4);
+        });
     }
 
     #[test]

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -3225,6 +3225,119 @@ f() {
     }
 
     #[test]
+    fn elixir_sigil_delimiters_are_not_operators() {
+        // Regression: issue #1256. Sigil delimiter tokens share their
+        // kind ids with real operators (`SLASH`, `LPAREN`, `LBRACE`,
+        // …) and were classified unconditionally, so `~r/abc/`
+        // fabricated two division operators and the author's delimiter
+        // choice moved n1/N1. The parent guard suppresses them under
+        // `Sigil`; `~` stays the single per-sigil operator.
+        //
+        // expected: operators `=` × 3 and `~` × 3 → n1 = 2, N1 = 6.
+        // Without the guard the delimiters added `/` × 2, `(`, `{` →
+        // n1 = 5, N1 = 10. Operands: `a`, `~r/abc/i`, `r`, `i` (sigil
+        // modifiers), `b`, `~w(one two)`, `w`, `c`, `~s{hi}`, `s` →
+        // n2 = N2 = 10.
+        check_metrics::<ElixirParser>(
+            "a = ~r/abc/i\nb = ~w(one two)\nc = ~s{hi}\n",
+            "foo.ex",
+            |metric| {
+                assert_eq!(metric.halstead.unique_operators(), 2);
+                assert_eq!(metric.halstead.total_operators(), 6);
+                assert_eq!(metric.halstead.unique_operands(), 10);
+                assert_eq!(metric.halstead.total_operands(), 10);
+            },
+        );
+    }
+
+    #[test]
+    fn elixir_sigil_delimiter_choice_is_invariant() {
+        // Companion to the test above (#1256): two sigils differing
+        // only in delimiter are the same literal, so every delimiter
+        // choice must produce identical Halstead counts. `(` `[` `{`
+        // `<` `/` `|` are the operator-kind delimiters the guard
+        // covers; `"` and `'` never had an operator arm and pin the
+        // already-correct path.
+        //
+        // expected per variant: operators `=`, `~` → n1 = 2, N1 = 2;
+        // operands `x`, the sigil literal text, `w` (sigil name) →
+        // n2 = 3, N2 = 3.
+        for (open, close) in [
+            ("(", ")"),
+            ("[", "]"),
+            ("{", "}"),
+            ("<", ">"),
+            ("/", "/"),
+            ("|", "|"),
+            ("\"", "\""),
+            ("'", "'"),
+        ] {
+            let source = format!("x = ~w{open}one two{close}\n");
+            // `check_metrics` takes a plain `fn` and cannot capture the
+            // delimiter for the failure message; use the closure-taking
+            // `FuncSpace` helper it wraps.
+            crate::test_support::check_func_space_only::<ElixirParser, _>(
+                &source,
+                "foo.ex",
+                &[crate::Metric::Halstead],
+                |space| {
+                    let counts = [
+                        space.metrics.halstead.unique_operators(),
+                        space.metrics.halstead.total_operators(),
+                        space.metrics.halstead.unique_operands(),
+                        space.metrics.halstead.total_operands(),
+                    ];
+                    assert_eq!(counts, [2, 2, 3, 3], "delimiter pair {open} {close}");
+                },
+            );
+        }
+    }
+
+    #[test]
+    fn elixir_standalone_operators_survive_the_sigil_guard() {
+        // Control for #1256: the guard is parent-scoped, so the same
+        // token kinds outside a sigil still count. Covers every guarded
+        // kind standalone: `/` (division), `<` / `>` (comparison), `[`
+        // and `|` (list cons), `(` (call), `{` (map literal, with its
+        // `%`).
+        //
+        // expected: operators `=` × 6, `/`, `<`, `>`, `[`, `|`, `(`,
+        // `%`, `{` → n1 = 9, N1 = 14. Operands: `x`, `a`, `b`, `y`,
+        // `c`, `d`, `z`, `e`, `f`, `q`, `h`, `t`, `p`, `g`, `1`, `m`,
+        // the `k:` keyword, `2` → n2 = N2 = 18.
+        check_metrics::<ElixirParser>(
+            "x = a / b\ny = c < d\nz = e > f\nq = [h | t]\np = g(1)\nm = %{k: 2}\n",
+            "foo.ex",
+            |metric| {
+                assert_eq!(metric.halstead.unique_operators(), 9);
+                assert_eq!(metric.halstead.total_operators(), 14);
+                assert_eq!(metric.halstead.unique_operands(), 18);
+                assert_eq!(metric.halstead.total_operands(), 18);
+            },
+        );
+    }
+
+    #[test]
+    fn elixir_interpolated_sigil_keeps_inner_nodes_counting() {
+        // Interpolation inside a sigil after #1256: the `{` delimiter
+        // is suppressed (its parent is the `Sigil`), while the
+        // `interpolation` child is a separate node whose `#{` marker
+        // and inner identifier must still count — the guard must not
+        // reach past the delimiter tokens.
+        //
+        // expected: operators `=`, `~`, `#{` → n1 = N1 = 3. Operands:
+        // `v`, `s` (sigil name), `b` (interpolated identifier); the
+        // wrapping sigil is skipped (`Interpolation` child, #180) and
+        // `quoted_content` is unclassified → n2 = N2 = 3.
+        check_metrics::<ElixirParser>("v = ~s{a#{b} c}\n", "foo.ex", |metric| {
+            assert_eq!(metric.halstead.unique_operators(), 3);
+            assert_eq!(metric.halstead.total_operators(), 3);
+            assert_eq!(metric.halstead.unique_operands(), 3);
+            assert_eq!(metric.halstead.total_operands(), 3);
+        });
+    }
+
+    #[test]
     fn bash_all_expansion_kinds_skip_wrapper() {
         // Exercises every node kind tested by
         // `bash_string_has_expansion`: `simple_expansion` (`$v`),

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -466,7 +466,7 @@ mod tests {
     use std::collections::HashSet;
     use std::path::PathBuf;
 
-    use crate::test_support::check_metrics_only_shim;
+    use crate::test_support::{ast_has_kind_id, check_metrics_only_shim};
 
     use super::*;
 
@@ -3381,12 +3381,15 @@ f() {
 }",
             "foo.tcl",
             |metric| {
-                // Operands: `f`, `s`, `"hello world"` — 3 unique, 3 total.
-                // The wrapping `QuotedWord` must still contribute exactly
-                // one operand when it carries no interpolation children;
-                // dropping to 2 would mean the inert case was over-guarded.
-                assert_eq!(metric.halstead.unique_operands(), 3);
-                assert_eq!(metric.halstead.total_operands(), 3);
+                // Operands: `f`, the proc-body `braced_word`, the `set`
+                // target `s`, `"hello world"` — 4 unique, 4 total. Before
+                // #1294 this read 3/3 with `s` missing (the body operand
+                // made the count coincidentally plausible). The wrapping
+                // `QuotedWord` must still contribute exactly one operand
+                // when it carries no interpolation children; dropping to 3
+                // would mean the inert case was over-guarded.
+                assert_eq!(metric.halstead.unique_operands(), 4);
+                assert_eq!(metric.halstead.total_operands(), 4);
                 insta::assert_json_snapshot!(metric.halstead);
             },
         );
@@ -3406,11 +3409,13 @@ f() {
 }",
             "foo.tcl",
             |metric| {
-                // Operands: `f`, `x`, `y` (proc args), `s`, `$x`, `$y` — 6
-                // unique, 6 total. The wrapping `QuotedWord` contributes
-                // nothing. Pre-fix this read 7/7 (double-counted wrapper).
-                assert_eq!(metric.halstead.unique_operands(), 6);
-                assert_eq!(metric.halstead.total_operands(), 6);
+                // Operands: `f`, `x`, `y` (proc args), the proc-body
+                // `braced_word`, the `set` target `s`, `$x`, `$y` — 7
+                // unique, 7 total. The wrapping `QuotedWord` contributes
+                // nothing. Before #1294 this read 6/6 with `s` missing;
+                // before #277 the wrapper double-counted.
+                assert_eq!(metric.halstead.unique_operands(), 7);
+                assert_eq!(metric.halstead.total_operands(), 7);
                 insta::assert_json_snapshot!(metric.halstead);
             },
         );
@@ -3430,14 +3435,85 @@ f() {
 }",
             "foo.tcl",
             |metric| {
-                // Operands: `f`, `s`, `foo` — 3 unique, 3 total. The
-                // wrapping `QuotedWord` and the inert text `result: ` do
-                // not contribute extra operands. Pre-fix this read 4/4
-                // (double-counted wrapper).
-                assert_eq!(metric.halstead.unique_operands(), 3);
-                assert_eq!(metric.halstead.total_operands(), 3);
+                // Operands: `f`, the proc-body `braced_word`, the `set`
+                // target `s`, `foo` — 4 unique, 4 total. The wrapping
+                // `QuotedWord` and the inert text `result: ` do not
+                // contribute extra operands. Before #1294 this read 3/3
+                // with `s` missing; before #277 the wrapper double-counted.
+                assert_eq!(metric.halstead.unique_operands(), 4);
+                assert_eq!(metric.halstead.total_operands(), 4);
                 insta::assert_json_snapshot!(metric.halstead);
             },
+        );
+    }
+
+    /// Regression for #1294. The `set` target parses as the anonymous
+    /// `id` token (`Tcl::Id2`) — the same kind as the leaf inside a
+    /// `variable_substitution` — and the getter used to exclude that kind
+    /// wholesale, so every variable a Tcl script assigned was absent from
+    /// n2/N2. The guard is now parent-scoped: a target `id` counts, a
+    /// var-sub leaf does not. Exact occurrence counts distinguish this
+    /// fix from a regression in either direction: a re-blanketed
+    /// exclusion drops `s`/`t` (total 2), while losing the guard
+    /// double-counts the `$s` leaf as a second `s` (total 5).
+    #[test]
+    fn tcl_set_target_is_operand() {
+        let source = "set s 1\nset t $s\n";
+        let path = PathBuf::from("foo.tcl");
+        let parser = TclParser::new(source.as_bytes().to_vec(), &path, None);
+        let ops = crate::ops::ops_inner(&parser, None).expect("ops walk succeeds");
+        // expected operands: targets `s` and `t`, literal `1`, reference
+        // `$s` (wrapper only) — 4 total, each exactly once.
+        for operand in ["s", "t", "1", "$s"] {
+            assert_eq!(
+                ops.operands
+                    .iter()
+                    .filter(|o| o.as_str() == operand)
+                    .count(),
+                1,
+                "`{operand}` must be exactly one operand; operands were {:?}",
+                ops.operands
+            );
+        }
+        assert_eq!(
+            ops.operands.len(),
+            4,
+            "operands must be exactly s, t, 1, $s; got {:?}",
+            ops.operands
+        );
+
+        check_metrics::<TclParser>(source, "foo.tcl", |metric| {
+            // expected: n2 = 4 (s, t, 1, $s), N2 = 4; operators are the
+            // two `set` keywords — n1 = 1, N1 = 2.
+            assert_eq!(metric.halstead.unique_operands(), 4);
+            assert_eq!(metric.halstead.total_operands(), 4);
+            assert_eq!(metric.halstead.unique_operators(), 1);
+            assert_eq!(metric.halstead.total_operators(), 2);
+        });
+    }
+
+    /// Drift marker for #1294 (lesson 34 / grammar-dispatch §2): the
+    /// *named* `id` rule (`Tcl::Id`, kind_id 84) never surfaces at the
+    /// pinned tree-sitter-tcl — the parser emits the anonymous `Id2` in
+    /// both positions the getter guards (the `set` target and the
+    /// var-sub leaf). The `Tcl::Id` arm in `get_op_type` is therefore
+    /// defensive; if a grammar bump starts emitting 84 this fails and
+    /// the arm's classification must be re-derived instead of trusted.
+    #[test]
+    fn tcl_named_id_variant_is_unreachable() {
+        let source = "proc f {x} {\n    set s $x\n    foreach v {1 2} { puts \"$v\" }\n}\n";
+        let path = PathBuf::from("foo.tcl");
+        let parser = TclParser::new(source.as_bytes().to_vec(), &path, None);
+        // Non-vacuity: the anonymous token must be present in this parse
+        // (both the `set` target and the `$x` / `$v` leaves emit it).
+        assert!(
+            ast_has_kind_id(&parser, Tcl::Id2 as u16),
+            "expected the anonymous Tcl::Id2 token to appear in the parse",
+        );
+        assert!(
+            !ast_has_kind_id(&parser, Tcl::Id as u16),
+            "the named Tcl::Id rule surfaced; re-derive the defensive \
+             `Tcl::Id` arm in TclCode::get_op_type against the new grammar",
         );
     }
 
@@ -3987,9 +4063,9 @@ f() {
     /// interpolation child) contributes exactly **one** operand — the
     /// wrapping `QuotedWord`. Operands are `f`, `s`, `"hello world"`, and
     /// the proc-body `braced_word` (counted as an operand in the Tcl
-    /// family). iRules additionally counts the `set` target `s`, which
-    /// tree-sitter-tcl's grammar structure omits — hence n2=4 here vs Tcl's
-    /// 3. Mirrors `tcl_inert_quoted_word_counts_as_operand` (#277).
+    /// family) — n2=4, the same as Tcl since #1294 restored its `set`
+    /// target to the operand count. Mirrors
+    /// `tcl_inert_quoted_word_counts_as_operand` (#277).
     #[test]
     fn irules_inert_quoted_word_counts_as_operand() {
         let source = "proc f {} {\n    set s \"hello world\"\n}\n";

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -1364,17 +1364,17 @@ mod tests {
         // TypeScript — the four JS-family `get_op_type` impls share
         // the same template-literal handling.
         //
-        // After #313 the `: string` annotation's `String2` child also
-        // counts as an operand (text `"string"`), so unique operands
-        // are `f`, `` `hello` ``, `string` (3 each). The headline of
-        // this test — that the plain template literal contributes one
-        // operand — is unaffected.
+        // The `: string` annotation contributes no operand — its
+        // keyword counts once, as the text-keyed operator (#1261) — so
+        // the operands are `f` and `` `hello` `` (2 each). The headline
+        // of this test — that the plain template literal contributes
+        // one operand — is unaffected.
         check_metrics::<TypescriptParser>(
             "function f(): string { return `hello`; }",
             "foo.ts",
             |metric| {
-                assert_eq!(metric.halstead.unique_operands(), 3);
-                assert_eq!(metric.halstead.total_operands(), 3);
+                assert_eq!(metric.halstead.unique_operands(), 2);
+                assert_eq!(metric.halstead.total_operands(), 2);
             },
         );
     }
@@ -1385,18 +1385,17 @@ mod tests {
         // `javascript_template_string_interpolation_no_double_count`
         // for TypeScript.
         //
-        // After #313 each `: string` annotation contributes one
-        // `"string"` operand. Unique operands: `f`, `name`, `string`
-        // (3). Total operands: `f`, `name` (param), `name` (in the
-        // interpolation), `string`, `string` (5). The interpolation
+        // The `: string` annotations contribute no operands (#1261).
+        // Unique operands: `f`, `name` (2). Total operands: `f`, `name`
+        // (param), `name` (in the interpolation) (3). The interpolation
         // guard from #192 still holds — the wrapping `` `Hi ${name}!` ``
         // is `Unknown`, not double-counted.
         check_metrics::<TypescriptParser>(
             "function f(name: string): string { return `Hi ${name}!`; }",
             "foo.ts",
             |metric| {
-                assert_eq!(metric.halstead.unique_operands(), 3);
-                assert_eq!(metric.halstead.total_operands(), 5);
+                assert_eq!(metric.halstead.unique_operands(), 2);
+                assert_eq!(metric.halstead.total_operands(), 3);
             },
         );
     }
@@ -1407,14 +1406,15 @@ mod tests {
         // `javascript_template_string_plain_is_operand` for the
         // TSX (TypeScript + JSX) variant.
         //
-        // After #313 TSX's type-keyword `string` (`String3`) also
-        // counts as an operand, mirroring TS::String2.
+        // TSX's type-keyword `string` (`String3`) contributes no
+        // operand, mirroring TS::String2 (#1261): operands are `f` and
+        // `` `hello` `` (2 each).
         check_metrics::<TsxParser>(
             "function f(): string { return `hello`; }",
             "foo.tsx",
             |metric| {
-                assert_eq!(metric.halstead.unique_operands(), 3);
-                assert_eq!(metric.halstead.total_operands(), 3);
+                assert_eq!(metric.halstead.unique_operands(), 2);
+                assert_eq!(metric.halstead.total_operands(), 2);
             },
         );
     }
@@ -1425,15 +1425,15 @@ mod tests {
         // `javascript_template_string_interpolation_no_double_count`
         // for the TSX (TypeScript + JSX) variant.
         //
-        // After #313 each `: string` annotation contributes one
-        // `String3` operand; see `typescript_template_string_…` for
-        // the count derivation.
+        // The `: string` annotations contribute no `String3` operands
+        // (#1261); see `typescript_template_string_…` for the count
+        // derivation.
         check_metrics::<TsxParser>(
             "function f(name: string): string { return `Hi ${name}!`; }",
             "foo.tsx",
             |metric| {
-                assert_eq!(metric.halstead.unique_operands(), 3);
-                assert_eq!(metric.halstead.total_operands(), 5);
+                assert_eq!(metric.halstead.unique_operands(), 2);
+                assert_eq!(metric.halstead.total_operands(), 3);
             },
         );
     }
@@ -1505,8 +1505,9 @@ mod tests {
     // Verified by test-via-revert: dropping `OptionalChain` from
     // JS/MozJS, or `QMARKDOT` from TS/TSX, trips the test
     // (u_operators 6→5). This input does NOT exercise every operand
-    // alias in the per-language `operand_extras` (`Identifier2`,
-    // `String2`, `NestedIdentifier`, `MemberExpression4`); drift in
+    // alias in the per-language `operand_extras` (`Identifier2`, the
+    // JS/MozJS/TSX string-literal `String2`, `NestedIdentifier`,
+    // `MemberExpression4`); drift in
     // those is out of scope for this regression guard and would need a
     // separate fixture. The `PredefinedType` operator path (`: void`
     // double-count) is now covered by `ts_void_return_type_single_operator_453`
@@ -1531,12 +1532,14 @@ mod tests {
         check_metrics::<TsxParser>(SRC, "foo.tsx", check);
     }
 
-    // Issue #313: parity guard for the `"string"` type-keyword aliases
-    // that the TS / TSX grammars expose. `Checker::is_string` matches
-    // these aliases (#283), so `Getter::get_op_type` must also classify
-    // them — otherwise the same node disagrees between the two
-    // predicates and Halstead silently undercounts every `: string`
-    // annotation by one operand.
+    // Issue #1261 (inverting the #313 pin): the `"string"` type-keyword
+    // aliases the TS / TSX grammars expose must contribute NO operand.
+    // #313 put them in `operand_extras` for parity with the then-wider
+    // `Checker::is_string`, but the `predefined_type` wrapper already
+    // counts as the text-keyed `"string"` operator, so one `: string`
+    // token tallied as operator AND operand while `: number` counted
+    // once. #1261 drops the aliases from both `operand_extras` and
+    // `is_string`, so the keyword counts once, as the operator.
     //
     // For the input `let x: string = "y";`:
     //
@@ -1544,29 +1547,53 @@ mod tests {
     //   keyword (kind_id 135, in the type-keyword block of the enum).
     // * TSX emits `Tsx::String3` for the same role (kind_id 141).
     //
-    // After #313 both kinds are in `operand_extras` and contribute one
-    // `"string"` operand. Verified by test-via-revert: dropping
-    // `String2` from TS's `operand_extras` (or `String3` from TSX's)
-    // trips this test on `u_operands` / `operands` for the affected
-    // language.
+    // Verified by test-via-revert: restoring `String2` to TS's
+    // `operand_extras` (or `String3` to TSX's) trips this test on
+    // `u_operands` / `operands` for the affected language.
     #[test]
-    fn ts_family_string2_string3_type_keyword_parity_313() {
+    fn ts_family_type_keyword_counts_once_1261() {
         const SRC: &str = "let x: string = \"y\";";
         // Operators (n1 = 5, N1 = 5):
         //   `let`, `:`, `=`, `;`, plus `string` (PredefinedType wrapper,
         //   routed through `is_primitive` so it's keyed by its lexeme
         //   `"string"` in `primitive_operators`).
-        // Operands (n2 = 3, N2 = 3):
-        //   `x`, the `"y"` literal, and `string` (the type-keyword
-        //   child of `predefined_type`, classified via the operand
-        //   extras added by #313). Pre-fix the TS column reported
-        //   n2 = 2 / N2 = 2 because String2 fell through to `Unknown`;
-        //   the TSX column had the same gap for String3.
+        // Operands (n2 = 2, N2 = 2):
+        //   `x` and the `"y"` literal. Under #313 the type-keyword
+        //   child of `predefined_type` added a third, phantom
+        //   `"string"` operand (n2 = 3 / N2 = 3).
         let check = |m: crate::CodeMetrics| {
             assert_eq!(m.halstead.unique_operators(), 5);
             assert_eq!(m.halstead.total_operators(), 5);
-            assert_eq!(m.halstead.unique_operands(), 3);
-            assert_eq!(m.halstead.total_operands(), 3);
+            assert_eq!(m.halstead.unique_operands(), 2);
+            assert_eq!(m.halstead.total_operands(), 2);
+        };
+
+        check_metrics::<TypescriptParser>(SRC, "foo.ts", check);
+        check_metrics::<TsxParser>(SRC, "foo.tsx", check);
+    }
+
+    // Issue #1261 regression, the issue's reproducer plus a literal
+    // whose contents spell the keyword: `: string` and `: number` must
+    // contribute symmetrically — one text-keyed operator each, zero
+    // operands — while a string *literal* `"string"` stays an operand
+    // (distinct from the keyword: TS kind `String`, TSX kind `String2`,
+    // both quoted in the operand key).
+    #[test]
+    fn ts_family_string_annotation_symmetric_with_number_1261() {
+        const SRC: &str = "let x: string = \"a\";\nlet y: number = 1;\nlet s = \"string\";";
+        // Operators (n1 = 6, N1 = 13):
+        //   `let` ×3, `:` ×2, `=` ×3, `;` ×3, `string` ×1, `number` ×1.
+        //   Pre-fix N1 was identical — the wrapper operator was always
+        //   counted; the defect was the extra operand below.
+        // Operands (n2 = 6, N2 = 6):
+        //   `x`, `"a"`, `y`, `1`, `s`, `"string"` — one each. Pre-fix
+        //   the `: string` keyword added a bare `string` operand
+        //   (n2 = 7 / N2 = 7) that `: number` had no analogue of.
+        let check = |m: crate::CodeMetrics| {
+            assert_eq!(m.halstead.unique_operators(), 6);
+            assert_eq!(m.halstead.total_operators(), 13);
+            assert_eq!(m.halstead.unique_operands(), 6);
+            assert_eq!(m.halstead.total_operands(), 6);
         };
 
         check_metrics::<TypescriptParser>(SRC, "foo.ts", check);

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -1600,6 +1600,86 @@ mod tests {
         check_metrics::<TsxParser>(SRC, "foo.tsx", check);
     }
 
+    /// Drift marker for #1261 (lesson 34 / grammar-dispatch §2): the
+    /// anonymous `string` type-keyword token appears **only** as a
+    /// `predefined_type` child.
+    ///
+    /// That is the whole argument for classifying the keyword without a
+    /// parent guard — the wrapper is guaranteed to be there to carry the
+    /// operator. The two tests above measure the consequence and would
+    /// still pass if the grammar started emitting the keyword somewhere
+    /// else, as long as their own two fixtures kept their counts; this one
+    /// measures the premise, over every position #1261's dump probes
+    /// covered: annotation, parameter and return type, union member,
+    /// generic argument, and template-literal type. A string *literal*
+    /// spelling `"string"` is a different kind and must not be confused
+    /// for the keyword, so one is in the fixture too.
+    #[test]
+    fn ts_family_type_keyword_only_appears_under_predefined_type_1261() {
+        // Exercises each position the keyword can take. Valid in both
+        // grammars: no angle-bracket cast, which TSX would read as JSX.
+        const SRC: &str = "const a: string = \"string\";\n\
+                           function f(x: string): string {\n\
+                               return x;\n\
+                           }\n\
+                           type U = string | number;\n\
+                           type A = Array<string>;\n\
+                           type M = Map<string, number>;\n\
+                           type T = `id-${string}`;\n";
+        // Seven type positions: `a`, `x`, `f`'s return, the union member,
+        // `Array`'s argument, `Map`'s first argument, and the template
+        // placeholder. The `"string"` initialiser is a literal, not the
+        // keyword, and must not be among them.
+        const EXPECTED_OCCURRENCES: usize = 7;
+
+        fn keyword_occurrences<P: ParserTrait>(
+            path: &str,
+            keyword: u16,
+            predefined_type: u16,
+        ) -> usize {
+            let parser = P::new(SRC.as_bytes().to_vec(), &PathBuf::from(path), None);
+            parser
+                .root()
+                .preorder()
+                .filter(|node| node.kind_id() == keyword)
+                .inspect(|node| {
+                    assert_eq!(
+                        node.parent().map(|parent| parent.kind_id()),
+                        Some(predefined_type),
+                        "the `string` type keyword surfaced outside \
+                         `predefined_type` in {path}; the operator is carried \
+                         by the wrapper, so `get_op_type` needs a parent guard \
+                         before that arm can be trusted (#1261)",
+                    );
+                })
+                .count()
+        }
+
+        // Kind ids re-read from the generated enums, not carried over: TS
+        // `String2` = 135, TSX `String3` = 141 (TSX's `String2` = 261 is the
+        // string-literal production and stays an operand).
+        assert_eq!(
+            keyword_occurrences::<TypescriptParser>(
+                "foo.ts",
+                Typescript::String2 as u16,
+                Typescript::PredefinedType as u16,
+            ),
+            EXPECTED_OCCURRENCES,
+            "TypeScript no longer emits the `string` type keyword in every \
+             position #1261 probed",
+        );
+        assert_eq!(
+            keyword_occurrences::<TsxParser>(
+                "foo.tsx",
+                Tsx::String3 as u16,
+                Tsx::PredefinedType as u16,
+            ),
+            EXPECTED_OCCURRENCES,
+            "TSX no longer emits the `string` type keyword in every position \
+             #1261 probed",
+        );
+    }
+
     // Issue #453: a `void` return type must contribute exactly one
     // Halstead operator. The TS / TSX grammars parse `: void` as a
     // `predefined_type` wrapper around an inner `void` token. `is_primitive`

--- a/src/metrics/nexits.rs
+++ b/src/metrics/nexits.rs
@@ -317,12 +317,10 @@ impl Exit for BashCode {
 impl Exit for TclCode {
     fn compute<'a>(node: &Node<'a>, code: &'a [u8], stats: &mut Stats) {
         // Tcl has no return keyword node; `return` is a generic Command whose
-        // name field is a simple_word with text "return".
-        if node.kind_id() == Tcl::Command
-            && let Some(name) = node.child_by_field_name("name")
-            && name.kind_id() == Tcl::SimpleWord
-            && name.utf8_text(code) == Some("return")
-        {
+        // name field is a simple_word with text "return" — the same
+        // leading-word resolution the Cognitive / Cyclomatic `switch` and
+        // `for` detectors use, shared rather than restated here.
+        if crate::metrics::cognitive::tcl_command_name(node, code) == Some("return") {
             stats.exit += 1;
         }
     }

--- a/src/metrics/nom.rs
+++ b/src/metrics/nom.rs
@@ -2331,10 +2331,11 @@ outer() {
         );
     }
 
-    /// iRules counts event handlers (`when` / `on` / `trap`) and `proc`
-    /// definitions as functions; the language has no closures. A file with
-    /// two handlers and one proc reports three functions, zero closures.
-    /// Confirms the handlers-as-functions decision end to end.
+    /// iRules counts `when` event handlers and `proc` definitions as
+    /// functions; the language has no closures. A file with two handlers
+    /// and one proc reports three functions, zero closures. Confirms the
+    /// handlers-as-functions decision end to end. (`try`'s `on` / `trap`
+    /// handlers are branch points, not functions — issue #1266.)
     #[test]
     fn irules_nom_handlers_and_procs() {
         check_metrics::<IrulesParser>(
@@ -2353,6 +2354,33 @@ proc helper { x } {
                 assert_eq!(metric.nom.functions_sum(), 3);
                 assert_eq!(metric.nom.closures_sum(), 0);
                 assert_eq!(metric.nom.total(), 3);
+            },
+        );
+    }
+
+    /// iRules `try` handlers (`on error` / `trap`) are error-handler
+    /// clauses, not functions: a proc containing both must report exactly
+    /// one function (issue #1266). Before the fix each handler's dedicated
+    /// `on_handler` / `trap_handler` node was classified as a function
+    /// space, so this fixture reported three.
+    #[test]
+    fn irules_try_handlers_are_not_functions() {
+        check_metrics::<IrulesParser>(
+            "proc f {} {
+    try {
+        risky
+    } on error {msg} {
+        puts $msg
+    } trap {POSIX} {msg} {
+        puts $msg
+    }
+}
+",
+            "foo.irule",
+            |metric| {
+                assert_eq!(metric.nom.functions_sum(), 1);
+                assert_eq!(metric.nom.closures_sum(), 0);
+                assert_eq!(metric.nom.total(), 1);
             },
         );
     }

--- a/src/metrics/snapshots/big_code_analysis__metrics__halstead__tests__tcl_bitwise_ternary_string_ops.snap
+++ b/src/metrics/snapshots/big_code_analysis__metrics__halstead__tests__tcl_bitwise_ternary_string_ops.snap
@@ -5,16 +5,16 @@ expression: metric.halstead
 {
   "unique_operators": 18,
   "total_operators": 33,
-  "unique_operands": 14,
-  "total_operands": 27,
-  "length": 60,
-  "estimated_program_length": 128.36161893476807,
-  "purity_ratio": 2.139360315579468,
-  "vocabulary": 32,
-  "volume": 300.0,
-  "difficulty": 17.357142857142858,
-  "level": 0.05761316872427984,
-  "effort": 5207.142857142857,
-  "time": 289.2857142857143,
-  "bugs": 0.10014095767855698
+  "unique_operands": 17,
+  "total_operands": 30,
+  "length": 63,
+  "estimated_program_length": 144.5455183272174,
+  "purity_ratio": 2.2943733067812286,
+  "vocabulary": 35,
+  "volume": 323.1448300675329,
+  "difficulty": 15.882352941176471,
+  "level": 0.06296296296296296,
+  "effort": 5132.300242249052,
+  "time": 285.12779123605844,
+  "bugs": 0.09917908909381982
 }

--- a/src/metrics/snapshots/big_code_analysis__metrics__halstead__tests__tcl_command_substitution_quoted_word_no_double_count.snap
+++ b/src/metrics/snapshots/big_code_analysis__metrics__halstead__tests__tcl_command_substitution_quoted_word_no_double_count.snap
@@ -5,16 +5,16 @@ expression: metric.halstead
 {
   "unique_operators": 4,
   "total_operators": 5,
-  "unique_operands": 3,
-  "total_operands": 3,
-  "length": 8,
-  "estimated_program_length": 12.754887502163468,
-  "purity_ratio": 1.5943609377704335,
-  "vocabulary": 7,
-  "volume": 22.458839376460833,
+  "unique_operands": 4,
+  "total_operands": 4,
+  "length": 9,
+  "estimated_program_length": 16.0,
+  "purity_ratio": 1.7777777777777777,
+  "vocabulary": 8,
+  "volume": 27.0,
   "difficulty": 2.0,
   "level": 0.5,
-  "effort": 44.91767875292167,
-  "time": 2.495426597384537,
-  "bugs": 0.00421201861424495
+  "effort": 54.0,
+  "time": 3.0,
+  "bugs": 0.004762203155904598
 }

--- a/src/metrics/snapshots/big_code_analysis__metrics__halstead__tests__tcl_inert_quoted_word_counts_as_operand.snap
+++ b/src/metrics/snapshots/big_code_analysis__metrics__halstead__tests__tcl_inert_quoted_word_counts_as_operand.snap
@@ -5,16 +5,16 @@ expression: metric.halstead
 {
   "unique_operators": 3,
   "total_operators": 4,
-  "unique_operands": 3,
-  "total_operands": 3,
-  "length": 7,
-  "estimated_program_length": 9.509775004326936,
-  "purity_ratio": 1.3585392863324195,
-  "vocabulary": 6,
-  "volume": 18.094737505048094,
+  "unique_operands": 4,
+  "total_operands": 4,
+  "length": 8,
+  "estimated_program_length": 12.754887502163468,
+  "purity_ratio": 1.5943609377704335,
+  "vocabulary": 7,
+  "volume": 22.458839376460833,
   "difficulty": 1.5,
   "level": 0.6666666666666666,
-  "effort": 27.14210625757214,
-  "time": 1.5078947920873411,
-  "bugs": 0.0030105171772436758
+  "effort": 33.68825906469125,
+  "time": 1.871569948038403,
+  "bugs": 0.003476944758806696
 }

--- a/src/metrics/snapshots/big_code_analysis__metrics__halstead__tests__tcl_interpolated_quoted_word_no_double_count.snap
+++ b/src/metrics/snapshots/big_code_analysis__metrics__halstead__tests__tcl_interpolated_quoted_word_no_double_count.snap
@@ -5,16 +5,16 @@ expression: metric.halstead
 {
   "unique_operators": 3,
   "total_operators": 4,
-  "unique_operands": 6,
-  "total_operands": 6,
-  "length": 10,
-  "estimated_program_length": 20.264662506490403,
-  "purity_ratio": 2.0264662506490403,
-  "vocabulary": 9,
-  "volume": 31.69925001442312,
+  "unique_operands": 7,
+  "total_operands": 7,
+  "length": 11,
+  "estimated_program_length": 24.406371956566694,
+  "purity_ratio": 2.2187610869606087,
+  "vocabulary": 10,
+  "volume": 36.541209043760986,
   "difficulty": 1.5,
   "level": 0.6666666666666666,
-  "effort": 47.548875021634686,
-  "time": 2.6416041678685938,
-  "bugs": 0.004374941425395412
+  "effort": 54.81181356564148,
+  "time": 3.0451007536467487,
+  "bugs": 0.004809813015068876
 }

--- a/src/metrics/snapshots/big_code_analysis__metrics__halstead__tests__tcl_operators_and_operands.snap
+++ b/src/metrics/snapshots/big_code_analysis__metrics__halstead__tests__tcl_operators_and_operands.snap
@@ -5,16 +5,16 @@ expression: metric.halstead
 {
   "unique_operators": 10,
   "total_operators": 14,
-  "unique_operands": 10,
-  "total_operands": 15,
-  "length": 29,
-  "estimated_program_length": 66.43856189774725,
-  "purity_ratio": 2.290984893025767,
-  "vocabulary": 20,
-  "volume": 125.33591475173351,
-  "difficulty": 7.5,
-  "level": 0.13333333333333333,
-  "effort": 940.0193606380013,
-  "time": 52.223297813222295,
-  "bugs": 0.03198673734700207
+  "unique_operands": 11,
+  "total_operands": 16,
+  "length": 30,
+  "estimated_program_length": 71.27302875388389,
+  "purity_ratio": 2.375767625129463,
+  "vocabulary": 21,
+  "volume": 131.76952268336282,
+  "difficulty": 7.2727272727272725,
+  "level": 0.1375,
+  "effort": 958.3238013335477,
+  "time": 53.2402111851971,
+  "bugs": 0.03240064046533218
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -662,11 +662,11 @@ mod tests {
 
     #[test]
     fn typescript_ops() {
-        // Issue #313: the `: string` annotation's `String2` child now
-        // emits a `"string"` operand alongside the `string`
-        // primitive-typed operator (PredefinedType wrapper). Other
-        // type-keyword annotations (`: number`, `: boolean`) are not
-        // string-named kinds, so they only contribute an operator.
+        // Issue #1261: the `: string` annotation counts exactly once,
+        // as the text-keyed `string` operator (PredefinedType wrapper)
+        // — symmetric with `: number` / `: boolean`. Under #313 its
+        // `String2` child also emitted a `"string"` operand, so one
+        // source token tallied twice.
         check_ops(
             LANG::Typescript,
             "var a, b, c, avg;
@@ -697,16 +697,15 @@ mod tests {
                 "console",
                 "log",
                 "\"{}\"",
-                "string",
             ],
         );
     }
 
     #[test]
     fn typescript_function_ops() {
-        // Issue #313: see `typescript_ops` — the `string` type keyword
-        // appears as both an operator (primitive-typed) and an operand
-        // (text `"string"`) once Checker/Getter parity is enforced.
+        // Issue #1261: see `typescript_ops` — the `string` type keyword
+        // contributes only the primitive-typed operator, never a
+        // `"string"` operand.
         check_ops(
             LANG::Typescript,
             "function main() {
@@ -740,17 +739,15 @@ mod tests {
                 "console",
                 "log",
                 "\"{}\"",
-                "string",
             ],
         );
     }
 
     #[test]
     fn tsx_ops() {
-        // Issue #313: TSX exposes the `: string` type-keyword child as
-        // `String3` (vs. TS's `String2`); both are now in the operand
-        // classification, so `"string"` appears as a TSX operand for
-        // the same reason as the TS case above.
+        // Issue #1261: TSX exposes the `: string` type-keyword child as
+        // `String3` (vs. TS's `String2`); like TS, the keyword counts
+        // only as the `string` operator, never as an operand.
         check_ops(
             LANG::Tsx,
             "var a, b, c, avg;
@@ -781,15 +778,14 @@ mod tests {
                 "console",
                 "log",
                 "\"{}\"",
-                "string",
             ],
         );
     }
 
     #[test]
     fn tsx_function_ops() {
-        // Issue #313: see `tsx_ops` — TSX::String3 (type-keyword
-        // `string`) is now an operand.
+        // Issue #1261: see `tsx_ops` — TSX::String3 (type-keyword
+        // `string`) is an operator only, never an operand.
         check_ops(
             LANG::Tsx,
             "function main() {
@@ -823,7 +819,6 @@ mod tests {
                 "console",
                 "log",
                 "\"{}\"",
-                "string",
             ],
         );
     }

--- a/src/spaces_tests.rs
+++ b/src/spaces_tests.rs
@@ -2324,6 +2324,88 @@ mod nameless_construct_spaces {
         assert_class_static_block_space(LANG::Mozjs);
     }
 
+    /// Regression for #1257: a stabby lambda (`->(z) { … }` /
+    /// `->(z) do … end`) parses as a `Lambda` node that CONTAINS the
+    /// `Block` / `DoBlock` for its body, and the unconditional
+    /// `Block | DoBlock` arm in `RubyCode::is_func_space` promoted
+    /// both — the `Lambda` space plus a phantom zero-metric anonymous
+    /// Function nested inside it. The phantom inflated every
+    /// space-count consumer: per-space threshold evaluation, the
+    /// `function_spaces` average divisor (pinning per-file `min` at 0),
+    /// and the ops tree. Each stabby form must open exactly one space.
+    #[test]
+    #[cfg(feature = "ruby")]
+    fn ruby_stabby_lambda_opens_exactly_one_space() {
+        for source in [
+            "def m\n  h = ->(z) { z + 1 }\nend\n",
+            "def m\n  h = ->(z) do\n    z + 1\n  end\nend\n",
+        ] {
+            let root = analyse(LANG::Ruby, source);
+            assert_eq!(
+                shape(&root),
+                vec![
+                    (None, SpaceKind::Unit),
+                    (Some("m"), SpaceKind::Function),
+                    (Some("<anonymous>"), SpaceKind::Function),
+                ],
+                "phantom lambda-body space for {source:?}"
+            );
+        }
+    }
+
+    /// The #1257 fixture end to end: a keyword `lambda`, an iterator
+    /// block, and a `do…end` stabby lambda. The first two hang their
+    /// `Block` off a `Call` — not a `Lambda` — so the block itself must
+    /// STILL open its space; only the stabby form's own body is
+    /// suppressed. `nom` is asserted alongside because the closure
+    /// count (#465) and the space tree now share one lambda-body
+    /// predicate and must move together: 3 closures, 4 functions total.
+    #[test]
+    #[cfg(feature = "ruby")]
+    fn ruby_mixed_lambda_forms_open_one_space_each() {
+        let root = analyse(
+            LANG::Ruby,
+            "def m\n  g = lambda { |z| z + 1 }\n  [1].each { |x| x }\n  h = ->(z) do z end\nend\n",
+        );
+        assert_eq!(
+            shape(&root),
+            vec![
+                (None, SpaceKind::Unit),
+                (Some("m"), SpaceKind::Function),
+                (Some("<anonymous>"), SpaceKind::Function),
+                (Some("<anonymous>"), SpaceKind::Function),
+                (Some("<anonymous>"), SpaceKind::Function),
+            ],
+        );
+        // expected: closures = keyword lambda + each-block + stabby
+        // lambda = 3; total adds the named method `m` = 4.
+        assert_eq!(root.metrics.nom.closures_sum(), 3);
+        assert_eq!(root.metrics.nom.total(), 4);
+    }
+
+    /// A stabby lambda nested inside another's body: the inner `Lambda`
+    /// still opens its own space (its parent is the outer body block,
+    /// not a `Lambda`), nested under the outer's — one space per
+    /// lambda, no phantoms at either depth.
+    #[test]
+    #[cfg(feature = "ruby")]
+    fn ruby_nested_stabby_lambdas_open_one_space_each() {
+        let root = analyse(LANG::Ruby, "f = ->(x) { ->(y) { x + y } }\n");
+        assert_eq!(
+            shape(&root),
+            vec![
+                (None, SpaceKind::Unit),
+                (Some("<anonymous>"), SpaceKind::Function),
+                (Some("<anonymous>"), SpaceKind::Function),
+            ],
+        );
+        // `shape` flattens preorder, so pin the nesting explicitly: the
+        // inner lambda's space sits inside the outer's, not beside it.
+        assert_eq!(root.spaces.len(), 1);
+        assert_eq!(root.spaces[0].spaces.len(), 1);
+        assert!(root.spaces[0].spaces[0].spaces.is_empty());
+    }
+
     /// Sibling constructs with the same synthesised name are allowed to
     /// collide, exactly as multiple `<anonymous>` siblings already do.
     /// Pinned so the collision reads as a decision rather than an

--- a/src/spaces_tests.rs
+++ b/src/spaces_tests.rs
@@ -2377,6 +2377,13 @@ mod nameless_construct_spaces {
                 (Some("<anonymous>"), SpaceKind::Function),
             ],
         );
+        // `shape` flattens preorder, so the same list would also match a
+        // wrongly *nested* arrangement: pin the three lambda spaces as
+        // leaf siblings under `m`.
+        assert_eq!(root.spaces.len(), 1);
+        let m = &root.spaces[0];
+        assert_eq!(m.spaces.len(), 3);
+        assert!(m.spaces.iter().all(|s| s.spaces.is_empty()));
         // expected: closures = keyword lambda + each-block + stabby
         // lambda = 3; total adds the named method `m` = 4.
         assert_eq!(root.metrics.nom.closures_sum(), 3);

--- a/tests/parity/cyclomatic_cross_language_parity.rs
+++ b/tests/parity/cyclomatic_cross_language_parity.rs
@@ -238,11 +238,36 @@ fn switch_with_default_parity() {
             "irule",
         ),
     );
+    // Elixir `case` with a bare `_ ->` catch-all: the wildcard is the
+    // construct's default arm and is skipped, like Rust's `_ =>`
+    // (issue #1272). `def` must live inside a `defmodule`, which opens
+    // a Class space — the same structural offset as Java.
+    sums.insert(
+        "elixir",
+        ccn_sum(
+            LANG::Elixir,
+            r"defmodule Parity do
+  def f(x) do
+    case x do
+      1 -> :one
+      2 -> :two
+      3 -> :three
+      _ -> :other
+    end
+  end
+end
+",
+            "ex",
+        ),
+    );
     let offsets = BTreeMap::from([
         ("java", JAVA_CLASS_OFFSET),
         // C# requires every function to live inside a class, same as
         // Java — this is a language-mandated structural difference.
         ("csharp", JAVA_CLASS_OFFSET),
+        // Elixir requires every `def` to live inside a `defmodule` —
+        // the same structural difference as Java's class requirement.
+        ("elixir", JAVA_CLASS_OFFSET),
     ]);
     assert_parity("switch_with_default", &sums, &offsets);
 
@@ -389,7 +414,31 @@ f() {
             "tcl",
         ),
     );
-    let offsets = BTreeMap::from([("java", JAVA_CLASS_OFFSET), ("csharp", JAVA_CLASS_OFFSET)]);
+    // Elixir `case` with no `_ ->` fallback: every arm is a real
+    // decision and counts (issue #1272 skips only the bare wildcard).
+    // `defmodule` opens a Class space — the Java structural offset.
+    sums.insert(
+        "elixir",
+        ccn_sum(
+            LANG::Elixir,
+            r"defmodule Parity do
+  def f(x) do
+    case x do
+      1 -> :one
+      2 -> :two
+      3 -> :three
+    end
+  end
+end
+",
+            "ex",
+        ),
+    );
+    let offsets = BTreeMap::from([
+        ("java", JAVA_CLASS_OFFSET),
+        ("csharp", JAVA_CLASS_OFFSET),
+        ("elixir", JAVA_CLASS_OFFSET),
+    ]);
     assert_parity("switch_without_default", &sums, &offsets);
 
     // Anchor the absolute magnitude (lessons #6 / #23 / #468):
@@ -579,7 +628,30 @@ f() {
             "m",
         ),
     );
-    let offsets = BTreeMap::from([("java", JAVA_CLASS_OFFSET)]);
+    // Elixir has no `else if` chain keyword; `cond` is the idiomatic
+    // multi-way conditional, and its final `true ->` arm is the
+    // designated default — the analogue of the free `else`, skipped
+    // post-#1272. Three condition arms count. `defmodule` opens a
+    // Class space — the Java structural offset.
+    sums.insert(
+        "elixir",
+        ccn_sum(
+            LANG::Elixir,
+            r"defmodule Parity do
+  def f(x) do
+    cond do
+      x == 1 -> 10
+      x == 2 -> 20
+      x == 3 -> 30
+      true -> 0
+    end
+  end
+end
+",
+            "ex",
+        ),
+    );
+    let offsets = BTreeMap::from([("java", JAVA_CLASS_OFFSET), ("elixir", JAVA_CLASS_OFFSET)]);
     assert_parity("if_else_if_else_chain", &sums, &offsets);
 
     // Anchor the absolute magnitude (lessons #6 / #23 / #468):
@@ -864,7 +936,31 @@ function f($x) {
             "kt",
         ),
     );
-    let offsets = BTreeMap::from([("java", JAVA_CLASS_OFFSET), ("csharp", JAVA_CLASS_OFFSET)]);
+    // Elixir 2-arm `case` with a bare `_ ->` catch-all (issue #1272):
+    // the minimal form that catches both an over-count of the wildcard
+    // and an under-count of the explicit arm. `defmodule` opens a
+    // Class space — the Java structural offset.
+    sums.insert(
+        "elixir",
+        ccn_sum(
+            LANG::Elixir,
+            r"defmodule Parity do
+  def f(x) do
+    case x do
+      1 -> :one
+      _ -> :other
+    end
+  end
+end
+",
+            "ex",
+        ),
+    );
+    let offsets = BTreeMap::from([
+        ("java", JAVA_CLASS_OFFSET),
+        ("csharp", JAVA_CLASS_OFFSET),
+        ("elixir", JAVA_CLASS_OFFSET),
+    ]);
     assert_parity("two_arm_switch_with_wildcard", &sums, &offsets);
 
     // Anchor the absolute magnitude (lessons #6 / #23 / #468):

--- a/tests/parity/halstead_set_target_parity.rs
+++ b/tests/parity/halstead_set_target_parity.rs
@@ -1,0 +1,69 @@
+//! Tcl / iRules parity test for the Halstead classification of a `set`
+//! target versus a `variable_substitution` leaf.
+//!
+//! Both grammars emit the same `id` kind for a standalone assignment
+//! target (`set s …` → `s`) and for the leaf inside `$s`, so the getter
+//! must tell them apart by parent, not by kind. iRules always did;
+//! Tcl carried a blanket kind exclusion instead, which silently dropped
+//! every assigned variable from `n2`/`N2` (#1294). The two dialects had
+//! drifted in opposite directions — this fixture keeps them agreeing.
+
+#[cfg(all(feature = "tcl", feature = "irules"))]
+use big_code_analysis::{Ast, LANG, MetricsOptions, Ops, Source, analyze};
+
+/// One occurrence per operand, flattened across nested spaces so the
+/// assertion does not depend on where each dialect opens spaces.
+#[cfg(all(feature = "tcl", feature = "irules"))]
+fn flatten_operands(ops: &Ops, out: &mut Vec<String>) {
+    out.extend(ops.operands.iter().cloned());
+    for space in &ops.spaces {
+        flatten_operands(space, out);
+    }
+}
+
+// A parity claim needs both dialects, so the test is absent (not
+// vacuously green, not spuriously red) unless both features are on.
+#[cfg(all(feature = "tcl", feature = "irules"))]
+#[test]
+fn set_target_counts_as_operand_in_both_dialects() {
+    // `s` appears as a `set` target and (wrapped) as `$s`; `t` only as a
+    // target. Pre-#1294 Tcl reported neither `s` nor `t`.
+    let source = "set s 1\nset t $s\n";
+
+    for (lang, ext) in [(LANG::Tcl, "tcl"), (LANG::Irules, "irule")] {
+        let name = format!("parity.{ext}");
+
+        let ops = Ast::parse(Source::new(lang, source.as_bytes()).with_name(Some(name.clone())))
+            .unwrap_or_else(|e| panic!("{lang:?}: parse failed: {e}"))
+            .ops()
+            .unwrap_or_else(|e| panic!("{lang:?}: ops failed: {e}"));
+        let mut operands = Vec::new();
+        flatten_operands(&ops, &mut operands);
+
+        // Exact occurrence counts distinguish the fix from a regression
+        // in either direction: a blanket kind exclusion drops `s` and
+        // `t` entirely, while losing the parent guard double-counts the
+        // `$s` leaf as a second `s`.
+        for operand in ["s", "t", "1", "$s"] {
+            assert_eq!(
+                operands.iter().filter(|o| o.as_str() == operand).count(),
+                1,
+                "{lang:?}: `{operand}` must be exactly one operand; got {operands:?}",
+            );
+        }
+        assert_eq!(
+            operands.len(),
+            4,
+            "{lang:?}: operands must be exactly s, t, 1, $s; got {operands:?}",
+        );
+
+        let space = analyze(
+            Source::new(lang, source.as_bytes()).with_name(Some(name)),
+            MetricsOptions::default(),
+        )
+        .unwrap_or_else(|e| panic!("{lang:?}: analyze failed: {e}"));
+        // expected: n2 = 4 (s, t, 1, $s), N2 = 4 in both dialects.
+        assert_eq!(space.metrics.halstead.unique_operands(), 4, "{lang:?}");
+        assert_eq!(space.metrics.halstead.total_operands(), 4, "{lang:?}");
+    }
+}

--- a/tests/parity/main.rs
+++ b/tests/parity/main.rs
@@ -9,6 +9,7 @@ mod cpp_mozcpp_parity;
 mod cyclomatic_cross_language_parity;
 mod exit_cross_language_parity;
 mod functions_metrics_parity;
+mod halstead_set_target_parity;
 mod nargs_cross_language_parity;
 mod ops_metrics_space_parity;
 mod space_span_containment;

--- a/tests/parity/ops_metrics_space_parity.rs
+++ b/tests/parity/ops_metrics_space_parity.rs
@@ -139,8 +139,14 @@ pub(super) fn fixture(lang: LANG) -> (&'static str, &'static str) {
              return $g($a) + 1;\n}\n",
             "php",
         ),
+        // The stabby lambda exercises the #1257 lambda-body gate: the
+        // `Lambda` wrapper opens the space and its own `Block` must
+        // not. Both walks reach the gate through
+        // `is_func_space_with_code`, so a caller reverted to the
+        // byte-less `is_func_space` (the #1130 shape) would re-open
+        // the phantom body space on one side only and diverge here.
         LANG::Ruby => (
-            "def f(a)\n  g = lambda { |b| b * 2 }\n  g.call(a) + 1\nend\n",
+            "def f(a)\n  g = lambda { |b| b * 2 }\n  h = ->(b) { b + 1 }\n  g.call(a) + 1\nend\n",
             "rb",
         ),
         LANG::Groovy => (


### PR DESCRIPTION
Fixes seven metric-correctness bugs across Tcl, iRules, Elixir, Ruby, and
TypeScript/TSX, plus the review findings that surfaced while auditing those
fixes.

## Issues fixed

| Issue | Defect |
|-------|--------|
| #1294 | Tcl `set` targets were absent from Halstead operands — the anonymous `id` kind was excluded wholesale on the false premise that it only appears inside `$var` substitutions |
| #1264 | Tcl `for` loops scored zero decisions; the grammar has no `for` rule, so the loop parses as a generic `command` |
| #1266 | Tcl `try … on error` handlers scored zero in both complexity metrics; iRules handlers additionally opened spurious anonymous function spaces, inflating `nom` |
| #1272 | Elixir bare `_ ->` catch-alls and `cond`'s `true ->` default arm inflated cyclomatic, unlike every sibling language's default arm |
| #1256 | Elixir sigil delimiters counted as ordinary Halstead operators, so `~r/abc/` fabricated two division operators and the delimiter choice moved `n1`/`N1` |
| #1257 | A Ruby stabby lambda opened a phantom second function space for its own body block |
| #1261 | TS/TSX `: string` counted as both a Halstead operator and an operand, while `: number` / `: boolean` counted once |

## Review findings fixed on top

An eight-angle review of the branch found four genuine behaviour bugs in the
fixes above — three of them sibling walks the original fixes' own rationale
required sweeping:

- **Elixir ABC counted sigil delimiters as conditions** (`~s<hi>` scored
  `conditions = 2`, `~s(hi)` scored 0). The #1256 parent guard reached only the
  Halstead getter.
- **`fn 0 -> :a; _ -> :b end` contributed zero decisions.** The #776
  anonymous-fn head-clause skip and #1272's new wildcard skip composed, so a
  two-way dispatch was invisible to CCN where the identical `case` counted 1.
  The batch's own test had pinned this as intended; it is inverted with a
  case-parity rationale.
- **Ruby cognitive double-charged stabby-lambda nesting** (`->(a){ if a … }`
  scored 3 against `lambda { |a| if a … }`'s 2) — the third consumer of the
  container+leaf pair #1257 unified, left unswept.
- **The `cond` `true ->` exclusion is shape-based, not positional.** Kept
  (it matches Rust's position-blind bare-`_` convention) and the docs and
  CHANGELOG corrected to say so, rather than silently disagreeing with the code.

Quality work in the same pass: Tcl command names now resolve once per node
instead of up to four times per walk (`nexits` and ABC reuse the shared helper
rather than open-coding or index-slicing it); the try-handler scan replaces a
two-flag state machine with a pairwise children scan; Ruby's checker override
derives from one kind list instead of restating it; and drift markers pin the
two grammar premises these fixes rest on — iRules handler kinds appear only
under `try`, and the TS/TSX `string` keyword token only under `predefined_type`.

## Not fixed here

Ruby regex and Perl match delimiters fabricate division operators the same way
Elixir sigils did (`bca ops` on `x = /abc/` reports `/` with no division
present). That is pre-existing rather than introduced by this branch, so it is
filed as #1312 with `FIXME(#1312)` anchors at both getter arms instead of being
folded into this PR.

## Validation

`make pre-commit` reports `BCA_GATE: pass (gate=pre-commit)` on the branch tip.
Every fix additionally ran the `simplify-rust`, `rust-optimize`, `review`, and
`audit-tests` skills with remediation, and every new test was watched failing
against the pre-fix logic by perturbation. No integration-snapshot churn: the
corpora are C-family and JavaScript only, so none of these languages is
represented there.

One gap worth naming: batch-level patch coverage was not measured against the
~98% project baseline. Each fix was authored under the requirement that every
changed line be exercised, but no `cargo llvm-cov` comparison was run.
