### PR TITLE
fix(getter): literal delimiters fabricate operators

### DIFF
--- a/.bca-baseline.toml
+++ b/.bca-baseline.toml
@@ -825,7 +825,7 @@ value = 53745.73829541664
 path = "src/getter/perl.rs"
 qualified = "PerlCode::get_op_type"
 metric = "halstead.effort"
-value = 85258.94234296979
+value = 89041.25632378942
 
 [[entry]]
 path = "src/getter/php.rs"

--- a/.bca-baseline.toml
+++ b/.bca-baseline.toml
@@ -807,25 +807,25 @@ value = 5.0
 path = "src/getter/bash.rs"
 qualified = "BashCode::get_op_type"
 metric = "halstead.effort"
-value = 64170.027458982564
+value = 59128.4908004283
 
 [[entry]]
 path = "src/getter/elixir.rs"
 qualified = "ElixirCode::get_op_type"
 metric = "halstead.effort"
-value = 74457.74988084711
+value = 69065.79907514916
 
 [[entry]]
 path = "src/getter/irules.rs"
 qualified = "IrulesCode::get_op_type"
 metric = "halstead.effort"
-value = 53163.06867422894
+value = 53745.73829541664
 
 [[entry]]
 path = "src/getter/perl.rs"
 qualified = "PerlCode::get_op_type"
 metric = "halstead.effort"
-value = 91534.67237440146
+value = 85258.94234296979
 
 [[entry]]
 path = "src/getter/php.rs"
@@ -843,7 +843,7 @@ value = 48346.66496041094
 path = "src/getter/ruby.rs"
 qualified = "RubyCode::get_op_type"
 metric = "halstead.effort"
-value = 100458.58684134025
+value = 93711.92421824159
 
 [[entry]]
 path = "src/metrics/abc/csharp.rs"

--- a/.bca-baseline.toml
+++ b/.bca-baseline.toml
@@ -831,7 +831,7 @@ value = 85258.94234296979
 path = "src/getter/php.rs"
 qualified = "PhpCode::get_op_type"
 metric = "halstead.effort"
-value = 71190.04074846079
+value = 84318.81385575322
 
 [[entry]]
 path = "src/getter/python.rs"
@@ -843,7 +843,7 @@ value = 48346.66496041094
 path = "src/getter/ruby.rs"
 qualified = "RubyCode::get_op_type"
 metric = "halstead.effort"
-value = 93711.92421824159
+value = 93042.67141704941
 
 [[entry]]
 path = "src/metrics/abc/csharp.rs"

--- a/.rustfmt-bail-baseline.txt
+++ b/.rustfmt-bail-baseline.txt
@@ -106,27 +106,27 @@
 # carried a 252-character match arm.
 
 enums/src/macros.rs 1
-src/getter.rs 2
+src/getter.rs 3
 src/getter/bash.rs 3
 src/getter/c.rs 3
-src/getter/cpp.rs 6
+src/getter/cpp.rs 7
 src/getter/csharp.rs 5
-src/getter/elixir.rs 2
+src/getter/elixir.rs 3
 src/getter/go.rs 1
-src/getter/groovy.rs 4
-src/getter/irules.rs 5
+src/getter/groovy.rs 5
+src/getter/irules.rs 6
 src/getter/java.rs 2
 src/getter/kotlin.rs 4
 src/getter/lua.rs 3
-src/getter/mozcpp.rs 6
+src/getter/mozcpp.rs 7
 src/getter/objc.rs 3
-src/getter/perl.rs 2
+src/getter/perl.rs 3
 src/getter/php.rs 8
 src/getter/python.rs 7
-src/getter/ruby.rs 2
-src/getter/tcl.rs 5
+src/getter/ruby.rs 3
+src/getter/tcl.rs 6
 src/macros/mod.rs 38
-src/metrics/abc/elixir.rs 5
+src/metrics/abc/elixir.rs 6
 src/metrics/abc/perl.rs 8
 src/metrics/abc/php.rs 9
 src/metrics/cognitive/perl.rs 8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -508,16 +508,19 @@ for historical reference.
 
 ### Changed
 
-- Ruby's `#{` interpolation opener no longer counts as a Halstead
-  operator. Unlike PHP's `{`, which aliases the compound-statement
-  brace and was fabricating a block (see Fixed), Ruby's is a token of
-  its own and nothing was miscounted — this is a deliberate change of
-  rule, so that the five interpolating languages agree. Kotlin, C# and
-  Groovy already declined to count theirs; an interpolation opener is
-  spelling rather than an operation, and the interpolated expression's
-  own operators are counted either way. Ruby Halstead operator counts
-  drop for every literal that interpolates: string, symbol, regex,
-  heredoc and subshell (#1314).
+- Ruby's and Elixir's `#{` interpolation opener no longer counts as a
+  Halstead operator. Unlike PHP's `{`, which aliases the
+  compound-statement brace and was fabricating a block (see Fixed),
+  `#{` is a token of its own and nothing was miscounted — this is a
+  deliberate change of rule, so that the six interpolating languages
+  agree. Kotlin, C# and Groovy already declined to count theirs; an
+  interpolation opener is spelling rather than an operation, and the
+  interpolated expression's own operators are counted either way. Ruby
+  and Elixir spell the marker with the same token, so leaving either
+  counted would have made the two disagree on one construct. Halstead
+  operator counts drop for every literal that interpolates: Ruby
+  strings, symbols, regexes, heredocs and subshells, and Elixir
+  strings, charlists and sigils (#1314).
 - The `enums` generator's `sanitize_string` / `get_token_names` lost their
   `escape: bool` parameter. No production caller passed `true`: #862
   established that the JSON generator, the last one, was double-escaping

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,34 @@ for historical reference.
   standalone `a / b` division still counts. Ruby and Perl Halstead
   operator counts drop accordingly (#1312). The remaining eight
   languages with this defect are tracked in #1314.
+- Literal delimiters fabricated operators in eight more languages, the
+  rest of the class #1256 and #1312 fixed. A JavaScript, TypeScript,
+  TSX or MozJS regex spelled both delimiters `/`; a Groovy slashy
+  string spelled its closer `/`; a C++ or MozC++ raw string spelled its
+  `R"(` opener `(`; and a Tcl or iRules braced *word* spelled its `{`
+  the way a script block does. Each reported an operation absent from
+  the source, and each moved with the author's choice of delimiter. All
+  are now parent-guarded to `Unknown` under the literal wrapper, so a
+  real division, call or block still counts (#1314).
+- JavaScript-family regex literals contributed **no operand** either —
+  `Regex` was in neither the operator nor the operand arm, so `/abc/g`
+  reached the Halstead vocabulary from neither side. It now counts as
+  one operand, matching Ruby's `regex` and Elixir's sigils. `n2`/`N2`
+  rise for JS-family code containing regex literals (#1314).
+- Perl's five pattern wrappers all scored zero, and are now split by
+  what they are: `/abc/`, `m/abc/` and `qr/abc/` are pattern *values*
+  and count as one operand each, while `s///` and `tr///` (with its
+  `y///` synonym) are operations applied to a target and count as
+  operators, rendered in `bca ops` as `s///` and `tr///`. Perl
+  `n1`/`N1`/`n2`/`N2` all move for code using patterns (#1314).
+- PHP string-interpolation openers fabricated a block operator. `{` is
+  both the compound-statement brace and the complex-interpolation
+  opener, so `"{$x}"` inflated the same `{}` vocabulary entry a real
+  block uses — the worst case of the five interpolating languages, and
+  the only one where the two share a token. Guarded in all four
+  positions the grammar puts it (`encapsed_string`, `heredoc_body`,
+  `shell_command_expression`, and the deprecated `"${x}"` form's
+  `dynamic_variable_name`); a real block still counts (#1314).
 - Every `bca` subcommand man page omitted the CLI's global options
   (`-w`/`--warnings`, `--report-skipped`), and `bca-vcs-commit.1` /
   `bca-vcs-trend.1` additionally omitted the whole vcs history-tuning
@@ -480,6 +508,16 @@ for historical reference.
 
 ### Changed
 
+- Ruby's `#{` interpolation opener no longer counts as a Halstead
+  operator. Unlike PHP's `{`, which aliases the compound-statement
+  brace and was fabricating a block (see Fixed), Ruby's is a token of
+  its own and nothing was miscounted — this is a deliberate change of
+  rule, so that the five interpolating languages agree. Kotlin, C# and
+  Groovy already declined to count theirs; an interpolation opener is
+  spelling rather than an operation, and the interpolated expression's
+  own operators are counted either way. Ruby Halstead operator counts
+  drop for every literal that interpolates: string, symbol, regex,
+  heredoc and subshell (#1314).
 - The `enums` generator's `sanitize_string` / `get_token_names` lost their
   `escape: bool` parameter. No production caller passed `true`: #862
   established that the JSON generator, the last one, was double-escaping

--- a/big-code-analysis-book/src/metrics.md
+++ b/big-code-analysis-book/src/metrics.md
@@ -531,6 +531,21 @@ basis; the rules deliberately exclude pure layout punctuation like
 parentheses and statement separators, which is why the Halstead
 totals are *not* the same as the Tokens count.
 
+Two classification rules are worth knowing because they are choices
+rather than consequences, and because several grammars spell the
+tokens involved the same way they spell real operators:
+
+- **A literal's own delimiters are not operators.** A JavaScript
+  regex, a Groovy slashy string, a C++ raw string, a Tcl braced word
+  and a Perl or Ruby pattern each contribute *one operand* — the
+  literal — and no operator for the punctuation around it. Otherwise
+  the score would move with the author's choice of delimiter, which
+  says nothing about the code.
+- **A string-interpolation opener is not an operator.** `"{$x}"` in
+  PHP, `"#{x}"` in Ruby, `"${x}"` in Kotlin and Groovy and `$"{x}"`
+  in C# all count the interpolated expression's own operators and
+  nothing for the opener itself.
+
 ### Derived metrics
 
 Halstead then derives a small zoo of formulas. big-code-analysis

--- a/big-code-analysis-book/src/metrics.md
+++ b/big-code-analysis-book/src/metrics.md
@@ -542,9 +542,9 @@ tokens involved the same way they spell real operators:
   the score would move with the author's choice of delimiter, which
   says nothing about the code.
 - **A string-interpolation opener is not an operator.** `"{$x}"` in
-  PHP, `"#{x}"` in Ruby, `"${x}"` in Kotlin and Groovy and `$"{x}"`
-  in C# all count the interpolated expression's own operators and
-  nothing for the opener itself.
+  PHP, `"#{x}"` in Ruby and Elixir, `"${x}"` in Kotlin and Groovy and
+  `$"{x}"` in C# all count the interpolated expression's own operators
+  and nothing for the opener itself.
 
 ### Derived metrics
 

--- a/src/checker/go.rs
+++ b/src/checker/go.rs
@@ -38,9 +38,6 @@ impl Checker for GoCode {
 
     #[inline]
     fn is_else_if<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>) -> bool {
-        node.kind_id() == Go::IfStatement
-            && ancestors
-                .parent(node)
-                .is_some_and(|p| p.kind_id() == Go::IfStatement)
+        node.kind_id() == Go::IfStatement && ancestors.parent_has_kind(node, Go::IfStatement as u16)
     }
 }

--- a/src/getter.rs
+++ b/src/getter.rs
@@ -92,6 +92,15 @@ macro_rules! get_operator {
 // #192): a bare `` `...` `` mirrors a `"..."` operand, but an
 // interpolated template must yield `Unknown` because its inner
 // `TemplateSubstitution` expressions are walked separately.
+//
+// The `Regex` arms are shared the same way (issue #1314), and for the
+// same reason: all four grammars spell a regex literal identically —
+// a `regex` wrapper whose two delimiters are `SLASH`, the kind id real
+// division uses — so neither arm has a per-language delta to hoist to
+// a call site. Only the ids differ (`SLASH` 87/81/90/87, `Regex`
+// 224/250/264/225) and the macro names both through the enum, so no
+// invocation mentions either. See the arms themselves for the
+// fabrication and the missing-operand halves.
 macro_rules! impl_js_family_get_op_type {
     (
         $lang:ident,
@@ -99,17 +108,8 @@ macro_rules! impl_js_family_get_op_type {
         operand_extras: [$($operand_extra:ident),* $(,)?]
         $(, predefined_void: $predefined_type:ident)? $(,)?
     ) => {
-        fn get_op_type<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> HalsteadType {
+        fn get_op_type<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>) -> HalsteadType {
             use $lang::*;
-
-            // FIXME(#1314): two defects in the regex literal, identical
-            // across all four callers so they stay in the macro body
-            // rather than at each invocation. A `Regex`'s two delimiters
-            // are `SLASH`, so `/abc/g` fabricates a division (the class
-            // #1256 fixed for Elixir and #1312 for Ruby/Perl — parent-
-            // guard them to `Unknown` under `Regex`). And `Regex` is in
-            // neither the operator nor the operand arm below, so the
-            // literal itself contributes no operand at all.
 
             // TS/TSX only: a `void` return / parameter type is parsed as a
             // `predefined_type` wrapper around an inner `void` token. Both
@@ -136,6 +136,40 @@ macro_rules! impl_js_family_get_op_type {
             )?
 
             match node.kind_id().into() {
+                // Regex delimiter punctuation. A `regex` literal spells
+                // both of its delimiters with the same kind id real
+                // division uses, so `const a = /abc/g;` reported a `/`
+                // operator with no division in the source and n1/N1
+                // counted the literal's punctuation as arithmetic
+                // (#1314, the JS-family sibling of Elixir #1256 and
+                // Ruby/Perl #1312). The `Regex` node itself is the
+                // operand (below), so the delimiters are suppressed
+                // exactly when their parent is that node — the
+                // compound-leaf guard of grammar-dispatch section 5.
+                //
+                // Parent, not ancestor, for correctness by
+                // construction rather than by observation: unlike
+                // Ruby's `#{…}`, a JS regex admits no nested
+                // expression at all (`regex_pattern` and `regex_flags`
+                // are leaves), so no fixture can tell this guard from
+                // an ancestor-scanning one. The halstead test
+                // `js_regex_delimiter_guard_is_parent_scoped_is_unobservable`
+                // records that, and pins the grammar property it rests
+                // on, rather than implying coverage the suite lacks.
+                //
+                // `SLASH2` — the aliased regex-start token every one of
+                // these grammars carries — needs no arm: it is absent
+                // from the operator list below, so it already lands on
+                // `Unknown`, which is what a delimiter should be. That
+                // is the one place this differs from Ruby's guard,
+                // where `SLASH2` had to be moved off the arithmetic arm.
+                SLASH
+                    if ancestors
+                        .parent(node)
+                        .is_some_and(|p| p.kind_id() == Regex as u16) =>
+                {
+                    HalsteadType::Unknown
+                }
                 Export | Import | Import2 | Extends | DOT | From | LPAREN | COMMA | As | STAR
                 | GTGT | GTGTGT | COLON | Return | Delete | Throw | Break | Continue | If
                 | Else | Switch | Case | Default | Async | Do | For | In | Of | While | Try
@@ -154,9 +188,20 @@ macro_rules! impl_js_family_get_op_type {
                 // code (#695).
                 | Set | Get
                 $(| $op_extra)* => HalsteadType::Operator,
+                // `Regex` is the literal's own node and contributes one
+                // operand, the way Ruby's `Regex` and Elixir's `Sigil`
+                // do. It was in neither arm before #1314, so `/abc/g`
+                // reached the vocabulary from *neither* side: a
+                // fabricated `/` operator and no operand at all. Its
+                // `regex_pattern` / `regex_flags` children stay
+                // unclassified, so the wrapper cannot double-count
+                // them, and no interpolation is possible inside a JS
+                // regex — hence a plain arm here rather than the
+                // `string_operand_type` dispatch the template literal
+                // below needs.
                 Identifier | MemberExpression | MemberExpression2 | MemberExpression3
                 | PropertyIdentifier | String | Number | True | False | Null | This | Super
-                | Undefined
+                | Undefined | Regex
                 $(| $operand_extra)* => HalsteadType::Operand,
                 // A `` `...` `` is a string literal; without interpolation it
                 // mirrors `"..."` and contributes one operand. When it has a

--- a/src/getter.rs
+++ b/src/getter.rs
@@ -164,9 +164,7 @@ macro_rules! impl_js_family_get_op_type {
                 // is the one place this differs from Ruby's guard,
                 // where `SLASH2` had to be moved off the arithmetic arm.
                 SLASH
-                    if ancestors
-                        .parent(node)
-                        .is_some_and(|p| p.kind_id() == Regex as u16) =>
+                    if ancestors.parent_has_kind(node, Regex as u16) =>
                 {
                     HalsteadType::Unknown
                 }

--- a/src/getter/bash.rs
+++ b/src/getter/bash.rs
@@ -111,9 +111,7 @@ impl Getter for BashCode {
             // `variable_substitution`.
             Bash::VariableName | Bash::VariableName2 | Bash::VariableName3
             | Bash::SpecialVariableName | Bash::SpecialVariableName2 => {
-                if ancestors
-                    .parent(node)
-                    .is_some_and(|p| p.kind_id() == Bash::SimpleExpansion as u16)
+                if ancestors.parent_has_kind(node, Bash::SimpleExpansion as u16)
                 {
                     HalsteadType::Unknown
                 } else {

--- a/src/getter/bash.rs
+++ b/src/getter/bash.rs
@@ -111,8 +111,7 @@ impl Getter for BashCode {
             // `variable_substitution`.
             Bash::VariableName | Bash::VariableName2 | Bash::VariableName3
             | Bash::SpecialVariableName | Bash::SpecialVariableName2 => {
-                if ancestors.parent_has_kind(node, Bash::SimpleExpansion as u16)
-                {
+                if ancestors.parent_has_kind(node, Bash::SimpleExpansion as u16) {
                     HalsteadType::Unknown
                 } else {
                     HalsteadType::Operand

--- a/src/getter/cpp.rs
+++ b/src/getter/cpp.rs
@@ -84,12 +84,31 @@ impl Getter for CppCode {
         // folding to its pair glyph in `get_operator_id_as_str`. The
         // invariant is pinned by `second_alias_opener_collapses_to_base_kind_id`
         // in `metrics/halstead.rs` (issue #768).
-        //
-        // FIXME(#1314): a raw string's `R"(` delimiter is an `LPAREN`
-        // child of `RawStringLiteral`, so `R"(raw)"` fabricates a
-        // call — the class #1256 fixed for Elixir and #1312 for
-        // Ruby/Perl. Parent-guard it to `Unknown`; `mozcpp` too.
         match node.kind_id().into() {
+            // Raw-string delimiter punctuation. A `raw_string_literal`
+            // carries its `R"(` opener as a bare `LPAREN` child — the
+            // kind id a call or a grouping uses — so `R"(raw)"`
+            // reported a `()` operator with no call in the source
+            // (#1314, the C++ sibling of Elixir #1256 and Ruby/Perl
+            // #1312). The literal is already an operand (below), so the
+            // delimiter is suppressed exactly when its parent is that
+            // node — the compound-leaf guard of grammar-dispatch
+            // section 5. Verified across `R"(x)"`, the custom-delimiter
+            // `R"tag(x)tag"` (which adds a `raw_string_delimiter` but
+            // keeps the same `(`), and the `LR` / `u8R` prefixed forms;
+            // the closing `)` needs no arm because #695 dropped every
+            // closer from the operator set.
+            //
+            // Parent, not ancestor. That distinction is unobservable
+            // here — `raw_string_content` is a leaf, so no `LPAREN` is
+            // ever a deeper descendant of a raw string — but parent
+            // scoping is correct by construction and keeps this arm the
+            // same shape as its siblings. `mozcpp` carries the twin.
+            LPAREN
+                if ancestors.parent_has_kind(node, RawStringLiteral as u16) =>
+            {
+                HalsteadType::Unknown
+            }
             DOT | DOTSTAR | LPAREN | LPAREN2 | COMMA | STAR | GTGT | COLON | SEMI | Return
             | Break | Continue | If | Else | Switch | Case | Default | For | While | Goto | Do
             | Delete | New | Try | Try2 | Catch | Throw | EQ | AMPAMP | PIPEPIPE | DASH

--- a/src/getter/cpp.rs
+++ b/src/getter/cpp.rs
@@ -130,12 +130,13 @@ impl Getter for CppCode {
             | Signed | Unsigned | Long | Short => HalsteadType::Operator,
             Identifier | TypeIdentifier | FieldIdentifier | RawStringLiteral | StringLiteral
             | NumberLiteral | True | False | Null | DOTDOTDOT => HalsteadType::Operand,
-            NamespaceIdentifier => match ancestors.parent(node) {
-                Some(parent) if matches!(parent.kind_id().into(), NamespaceDefinition) => {
-                    HalsteadType::Operand
-                }
-                _ => HalsteadType::Unknown,
-            },
+            // A namespace identifier is an operand only where it
+            // *names* a namespace; the same kind also spells the
+            // qualifier in `ns::thing`, which the final arm leaves
+            // `Unknown` (#1096).
+            NamespaceIdentifier if ancestors.parent_has_kind(node, NamespaceDefinition as u16) => {
+                HalsteadType::Operand
+            }
             _ => HalsteadType::Unknown,
         }
     }

--- a/src/getter/elixir.rs
+++ b/src/getter/elixir.rs
@@ -185,7 +185,7 @@ impl Getter for ElixirCode {
             | E::LPAREN | E::LPAREN2 | E::LBRACE
             | E::LBRACK | E::LBRACK2 | E::LTLT | E::GTGT
             | E::COMMA | E::SEMI | E::COLON | E::COLONCOLON | E::DOT
-            | E::DOTDOT | E::DOTDOTDOT | E::PERCENT | E::HASHLBRACE | E::AT
+            | E::DOTDOT | E::DOTDOTDOT | E::PERCENT | E::AT
             // Arithmetic / unary
             | E::PLUS | E::DASH | E::STAR | E::STARSTAR | E::SLASH
             // Comparison
@@ -218,11 +218,18 @@ impl Getter for ElixirCode {
             // the interpolated expressions are already walked and counted
             // as operands in their own right; counting the wrapping
             // literal as well would double-count the inner identifiers'
-            // contribution (issue #180). The `#{` marker is classified
-            // as an operator via `HASHLBRACE` (the closing `}` is not —
-            // #695 removed every closing-delimiter arm), so an
-            // interpolated literal still adds operator weight without
-            // inflating `N2`.
+            // contribution (issue #180).
+            //
+            // The `#{` marker itself contributes nothing. It was an
+            // operator via `HASHLBRACE` until #1314, which settled the
+            // rule across every interpolating language: an
+            // interpolation opener is spelling, not an operation, and
+            // the interpolated expression's own operators are counted
+            // either way. Elixir spells the marker with the *same*
+            // token as Ruby, so leaving it counted here would have made
+            // the two disagree on one construct — the divergence that
+            // rule exists to remove. Elixir Halstead operator counts
+            // drop for interpolated strings, charlists and sigils.
             E::String | E::Charlist | E::Sigil => {
                 Self::string_operand_type(node, &[E::Interpolation as u16])
             }

--- a/src/getter/elixir.rs
+++ b/src/getter/elixir.rs
@@ -160,9 +160,7 @@ impl Getter for ElixirCode {
             // a sigil (division `a / b`, comparison `<`, pipe `|`) fall
             // through to the operator arm and still count.
             E::SLASH | E::LPAREN | E::LBRACE | E::LBRACK | E::LT | E::GT | E::PIPE
-                if ancestors
-                    .parent(node)
-                    .is_some_and(|p| p.kind_id() == E::Sigil as u16) =>
+                if ancestors.parent_has_kind(node, E::Sigil as u16) =>
             {
                 HalsteadType::Unknown
             }

--- a/src/getter/groovy.rs
+++ b/src/getter/groovy.rs
@@ -125,9 +125,7 @@ impl Getter for GroovyCode {
             // `UnaryExpression` wrapping the same `StringLiteral`, so
             // its `~` still counts.
             SLASH
-                if ancestors
-                    .parent(node)
-                    .is_some_and(|p| p.kind_id() == StringLiteral as u16) =>
+                if ancestors.parent_has_kind(node, StringLiteral as u16) =>
             {
                 HalsteadType::Unknown
             }

--- a/src/getter/groovy.rs
+++ b/src/getter/groovy.rs
@@ -80,7 +80,7 @@ impl Getter for GroovyCode {
         }
     }
 
-    fn get_op_type<'a>(node: &Node<'a>, _ancestors: Ancestors<'a, '_>) -> HalsteadType {
+    fn get_op_type<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>) -> HalsteadType {
         use Groovy::*;
         // Mirrors `JavaCode`'s minimal classification — modifiers
         // (`Public`, `Static`, …), declaration keywords (`Class`,
@@ -97,12 +97,40 @@ impl Getter for GroovyCode {
         // `NumberLiteral` is the new grammar's consolidated numeric
         // literal — the prior grammar split numbers by radix
         // (Hex/Octal/Binary/Decimal Integer/Float).
-        //
-        // FIXME(#1314): a slashy string's closing delimiter is a
-        // `SLASH` child of `StringLiteral`, so `def b = /xyz/`
-        // fabricates a division — the class #1256 fixed for Elixir
-        // and #1312 for Ruby/Perl. Parent-guard it to `Unknown`.
         match node.kind_id().into() {
+            // Slashy-string delimiter punctuation. A slashy string
+            // (`/xyz/`) is a `StringLiteral` whose closing delimiter is
+            // a `SLASH` — the kind id real division uses — so
+            // `def b = /xyz/` reported a `/` operator with no division
+            // in the source (#1314, the Groovy sibling of Elixir #1256
+            // and Ruby/Perl #1312). Only the *closer* is a child: the
+            // grammar folds the opening `/` into the literal's own
+            // span, so this fabricated one `/` per literal rather than
+            // Ruby's two. The `StringLiteral` is already the operand
+            // (below), so the delimiter is suppressed exactly when its
+            // parent is that node — the compound-leaf guard of
+            // grammar-dispatch section 5.
+            //
+            // Parent, not ancestor, and here that distinction is
+            // *observable*: a GString interpolation inside a slashy
+            // string (`/x${a / b}y/`) puts a real division under a
+            // `StringLiteral` ancestor, and an ancestor-scanning guard
+            // would swallow it. Pinned by
+            // `groovy_slashy_guard_is_parent_scoped_not_ancestor_scoped`.
+            //
+            // The other string forms need no arm: `'plain'` is a
+            // childless leaf, `"dq"` closes with `"` (134), and
+            // dollar-slashy `$/…/$` closes with `/$` (144) — none of
+            // which this match classifies. `~/ab.c/` is a
+            // `UnaryExpression` wrapping the same `StringLiteral`, so
+            // its `~` still counts.
+            SLASH
+                if ancestors
+                    .parent(node)
+                    .is_some_and(|p| p.kind_id() == StringLiteral as u16) =>
+            {
+                HalsteadType::Unknown
+            }
             // Control-flow + keyword operators (mirrors Java's set,
             // minus tokens that no longer exist in the dekobon grammar
             // — `This`, `VoidType`, `Throws2`).

--- a/src/getter/irules.rs
+++ b/src/getter/irules.rs
@@ -20,10 +20,10 @@ impl Getter for IrulesCode {
     fn get_op_type<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>) -> HalsteadType {
         match node.kind_id().into() {
             // Braced-word delimiter punctuation — the twin of the Tcl
-            // arm, which carries the derivation (#1314). The same
-            // discriminator holds at this grammar's own ids: handler
-            // and `if` bodies are `BracedWord` (132), conditions are
-            // `Expr` (141), and only the value form is
+            // arm, which carries the derivation and both caveats
+            // (#1314). The same split holds at this grammar's own ids:
+            // handler and `if` bodies are `BracedWord` (132),
+            // conditions are `Expr` (141), and only the value form is
             // `BracedWordSimple` (133).
             Irules::LBRACE
                 if ancestors.parent_has_kind(node, Irules::BracedWordSimple as u16) =>

--- a/src/getter/irules.rs
+++ b/src/getter/irules.rs
@@ -129,8 +129,7 @@ impl Getter for IrulesCode {
             // target from n2/N2 (#1294). (`Id2` here is a different,
             // non-surfacing token.)
             Irules::Id => {
-                if ancestors.parent_has_kind(node, Irules::VariableSubstitution as u16)
-                {
+                if ancestors.parent_has_kind(node, Irules::VariableSubstitution as u16) {
                     HalsteadType::Unknown
                 } else {
                     HalsteadType::Operand

--- a/src/getter/irules.rs
+++ b/src/getter/irules.rs
@@ -18,10 +18,18 @@ impl Getter for IrulesCode {
     }
 
     fn get_op_type<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>) -> HalsteadType {
-        // FIXME(#1314): a braced *word* carries its `{` as an
-        // `LBRACE` child and fabricates a block; see the Tcl
-        // sibling, which carries the same gap.
         match node.kind_id().into() {
+            // Braced-word delimiter punctuation — the twin of the Tcl
+            // arm, which carries the derivation (#1314). The same
+            // discriminator holds at this grammar's own ids: handler
+            // and `if` bodies are `BracedWord` (132), conditions are
+            // `Expr` (141), and only the value form is
+            // `BracedWordSimple` (133).
+            Irules::LBRACE
+                if ancestors.parent_has_kind(node, Irules::BracedWordSimple as u16) =>
+            {
+                HalsteadType::Unknown
+            }
             // Anonymous keyword tokens (the `*2` aliases are the keyword
             // literals; the unsuffixed high-id variants are the statement
             // nodes counted by the branching metrics, not here).
@@ -121,9 +129,7 @@ impl Getter for IrulesCode {
             // target from n2/N2 (#1294). (`Id2` here is a different,
             // non-surfacing token.)
             Irules::Id => {
-                if ancestors
-                    .parent(node)
-                    .is_some_and(|p| p.kind_id() == Irules::VariableSubstitution as u16)
+                if ancestors.parent_has_kind(node, Irules::VariableSubstitution as u16)
                 {
                     HalsteadType::Unknown
                 } else {

--- a/src/getter/mozcpp.rs
+++ b/src/getter/mozcpp.rs
@@ -109,12 +109,13 @@ impl Getter for MozcppCode {
             | Signed | Unsigned | Long | Short => HalsteadType::Operator,
             Identifier | TypeIdentifier | FieldIdentifier | RawStringLiteral | StringLiteral
             | NumberLiteral | True | False | Null | DOTDOTDOT => HalsteadType::Operand,
-            NamespaceIdentifier => match ancestors.parent(node) {
-                Some(parent) if matches!(parent.kind_id().into(), NamespaceDefinition) => {
-                    HalsteadType::Operand
-                }
-                _ => HalsteadType::Unknown,
-            },
+            // A namespace identifier is an operand only where it
+            // *names* a namespace; the same kind also spells the
+            // qualifier in `ns::thing`, which the final arm leaves
+            // `Unknown` (#1096).
+            NamespaceIdentifier if ancestors.parent_has_kind(node, NamespaceDefinition as u16) => {
+                HalsteadType::Operand
+            }
             _ => HalsteadType::Unknown,
         }
     }

--- a/src/getter/mozcpp.rs
+++ b/src/getter/mozcpp.rs
@@ -76,11 +76,18 @@ impl Getter for MozcppCode {
 
         // `LPAREN2` is a defensive arm (collapsed to `LPAREN` before
         // `kind_id()`; #768, see the Cpp note).
-        //
-        // FIXME(#1314): a raw string's `R"(` delimiter is an `LPAREN`
-        // child of `RawStringLiteral` and fabricates a call; see the
-        // Cpp sibling, which carries the same gap.
         match node.kind_id().into() {
+            // Raw-string delimiter punctuation — the twin of the Cpp
+            // arm, which carries the derivation (#1314). `.mozcpp` owns
+            // no file extension, so nothing routes to it and it gets no
+            // integration-snapshot coverage; the parity assertion in
+            // `tests/parity/cpp_mozcpp_parity.rs` is what keeps this
+            // clone from drifting.
+            LPAREN
+                if ancestors.parent_has_kind(node, RawStringLiteral as u16) =>
+            {
+                HalsteadType::Unknown
+            }
             DOT | DOTSTAR | LPAREN | LPAREN2 | COMMA | STAR | GTGT | COLON | SEMI | Return
             | Break | Continue | If | Else | Switch | Case | Default | For | While | Goto | Do
             | Delete | New | Try | Try2 | Catch | Throw | EQ | AMPAMP | PIPEPIPE | DASH

--- a/src/getter/perl.rs
+++ b/src/getter/perl.rs
@@ -29,15 +29,9 @@ impl Getter for PerlCode {
             // the Perl sibling of Elixir #1256). Suppress them exactly
             // when their parent is the literal — the compound-leaf
             // guard of grammar-dispatch §5 — which leaves the bare form
-            // contributing what its four synonyms already contribute.
-            //
-            // FIXME(#1314): what all five contribute is *nothing* — no
-            // Perl regex wrapper is in the operand arm below, so the
-            // literal itself never counts, unlike Ruby's `Regex` and
-            // Elixir's `Sigil`. Promoting only the bare form would
-            // score `/abc/` at one operand and its synonyms at zero,
-            // so it is the same gap #1314 records for the JS family
-            // and wants closed across all five wrappers at once.
+            // contributing what its three synonyms already contribute
+            // (#1314 made that "one operand" rather than "nothing";
+            // see the pattern-value arm below).
             P::SLASH
                 if ancestors.parent_has_kind(node, P::PatternMatcher as u16) =>
             {
@@ -66,6 +60,21 @@ impl Getter for PerlCode {
             | P::AMPEQ | P::PIPEEQ | P::CARETEQ | P::LTLTEQ | P::GTGTEQ | P::AMPAMPEQ
             | P::PIPEPIPEEQ | P::SLASHSLASHEQ | P::DOTEQ | P::XEQ
             | P::LTEQGT | P::AMPDOTEQ | P::PIPEDOTEQ | P::CARETDOTEQ | P::Isa
+            // Substitution and transliteration. These are *operations
+            // applied to a target*, not pattern values, so they are
+            // operators while the three pattern spellings below are
+            // operands (#1314). `y///` is a synonym of `tr///` and
+            // shares `TransliterationTrOrY`, so the two fold to one
+            // entry, which is what synonyms should do.
+            //
+            // Their pattern and replacement text is invisible to this
+            // grammar either way: `bca dump` shows
+            // `substitution_pattern_s` emitting only the `s` keyword
+            // and its `start` / `separator` / `end` delimiters, with no
+            // content node, so nothing is lost by not treating them as
+            // values. `get_operator_id_as_str` below renders them
+            // `s///` and `tr///` rather than as raw kind names.
+            | P::SubstitutionPatternS | P::TransliterationTrOrY
                 => HalsteadType::Operator,
             // Operands: identifiers and literals. Non-interpolating
             // string literals (`'…'`, `q{…}`) are leaf operands; the
@@ -92,13 +101,57 @@ impl Getter for PerlCode {
             // it is interpolation-capable, so it joins the same
             // dispatch — inert heredocs are one operand, interpolating
             // heredocs let the inner variables carry the count.
+            // The pattern *values* — `/abc/`, `m/abc/`, `qr/abc/` —
+            // join the same dispatch (#1314). `m/abc/` is exactly
+            // `/abc/` and `qr/abc/` is the same pattern as a value, so
+            // all three must score alike; that equality is what
+            // `perl_every_pattern_value_spelling_scores_alike` protects
+            // and why #1312 declined to promote the bare form on its
+            // own. Promoting the three together closes the gap without
+            // reintroducing the spelling sensitivity: each contributes
+            // one operand, matching Ruby's `Regex` and Elixir's
+            // `Sigil`. `s///` and `tr///` are *not* here — they are
+            // operations applied to a target and sit in the operator
+            // arm above.
+            //
+            // Sharing the string dispatch is not incidental, which is
+            // why the arms are merged rather than duplicated: the bare
+            // form keeps an interpolated variable inside an
+            // unclassified `regex_pattern_content`, but `m/$x/` and
+            // `qr/$x/` emit a real `Interpolation` whose
+            // `scalar_variable` is already counted. A plain operand arm
+            // would score `/$x/` at one operand and `m/$x/` at two —
+            // the very divergence the equality above exists to prevent.
             P::StringDoubleQuoted | P::StringQqQuoted | P::BacktickQuoted
-            | P::CommandQxQuoted | P::HeredocBodyStatement => {
+            | P::CommandQxQuoted | P::HeredocBodyStatement
+            | P::PatternMatcher | P::PatternMatcherM | P::RegexPatternQr => {
                 Self::string_operand_type(node, &[P::Interpolation as u16])
             }
             _ => HalsteadType::Unknown,
         }
     }
 
-    get_operator!(Perl);
+    /// Folds paired delimiters to one glyph, and names the two
+    /// pattern *operations* after their source spelling.
+    ///
+    /// Hand-written rather than `get_operator!(Perl)` because
+    /// `SubstitutionPatternS` and `TransliterationTrOrY` are named
+    /// nodes rather than punctuation tokens (#1314): the macro's
+    /// fallback renders a kind's own name, so `bca ops` would list
+    /// `substitution_pattern_s` and `transliteration_tr_or_y` among
+    /// the operators, which reads as a bug rather than as `s///`.
+    /// `tr///` covers `y///` too — one kind, one glyph, because they
+    /// are synonyms.
+    #[inline]
+    fn get_operator_id_as_str(id: u16) -> &'static str {
+        let typ = id.into();
+        match typ {
+            Perl::LPAREN => "()",
+            Perl::LBRACK => "[]",
+            Perl::LBRACE => "{}",
+            Perl::SubstitutionPatternS => "s///",
+            Perl::TransliterationTrOrY => "tr///",
+            _ => typ.into(),
+        }
+    }
 }

--- a/src/getter/perl.rs
+++ b/src/getter/perl.rs
@@ -39,9 +39,7 @@ impl Getter for PerlCode {
             // so it is the same gap #1314 records for the JS family
             // and wants closed across all five wrappers at once.
             P::SLASH
-                if ancestors
-                    .parent(node)
-                    .is_some_and(|p| p.kind_id() == P::PatternMatcher as u16) =>
+                if ancestors.parent_has_kind(node, P::PatternMatcher as u16) =>
             {
                 HalsteadType::Unknown
             }

--- a/src/getter/perl.rs
+++ b/src/getter/perl.rs
@@ -67,12 +67,15 @@ impl Getter for PerlCode {
             // shares `TransliterationTrOrY`, so the two fold to one
             // entry, which is what synonyms should do.
             //
-            // Their pattern and replacement text is invisible to this
-            // grammar either way: `bca dump` shows
-            // `substitution_pattern_s` emitting only the `s` keyword
-            // and its `start` / `separator` / `end` delimiters, with no
-            // content node, so nothing is lost by not treating them as
-            // values. `get_operator_id_as_str` below renders them
+            // Their *literal* pattern and replacement text is
+            // invisible either way: `bca dump` shows `s/a/b/` emitting
+            // only the `s` keyword and its `start` / `separator` /
+            // `end` delimiters, with no content node, so classifying
+            // them as operators loses nothing that treating them as
+            // values would have kept. An *interpolated* `s/$x/$y/` does
+            // emit `Interpolation` children, and those count as
+            // operands under either choice — so the reason for the
+            // split is the semantic one above, not this. `get_operator_id_as_str` below renders them
             // `s///` and `tr///` rather than as raw kind names.
             | P::SubstitutionPatternS | P::TransliterationTrOrY
                 => HalsteadType::Operator,

--- a/src/getter/php.rs
+++ b/src/getter/php.rs
@@ -40,13 +40,14 @@ impl Getter for PhpCode {
             // An interpolation opener is spelling, not an operation:
             // the interpolated expression's own operators are already
             // counted, and no reader performs a `{`. Measured across
-            // the five interpolating languages here, `[n1, N1]` on one
+            // the six interpolating languages here, `[n1, N1]` on one
             // fixture with and without an interpolation: kotlin
             // [5,7]->[5,7], csharp [8,11]->[8,11], groovy's `${` (142)
             // absent from its operator arm, ruby [1,2]->[2,3], php
-            // [2,4]->[3,5]. Three of five already declined to count it;
-            // this arm and the Ruby `#{` drop in the same commit make
-            // it five of five.
+            // [2,4]->[3,5], and elixir counting it through the same
+            // `HASHLBRACE` token as Ruby. Three of six already
+            // declined to count it; this arm plus the Ruby and Elixir
+            // `#{` drops on this branch make it six of six.
             //
             // Four parents, not one. The opener is a direct child of
             // `encapsed_string` (`"{$y}"`), of `heredoc_body` — the

--- a/src/getter/php.rs
+++ b/src/getter/php.rs
@@ -30,15 +30,56 @@ impl Getter for PhpCode {
 
     fn get_op_type<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>) -> HalsteadType {
         use Php::*;
-        // FIXME(#1314): `LBRACE` is both the compound-statement
-        // brace and the complex-interpolation opener (documented
-        // below for the operand decision), so `"dq {$y} end"`
-        // fabricates a block. Unlike #1312's Ruby/Perl mirrors this
-        // needs a policy call first: Kotlin's `${` and C#'s
-        // `interpolation_brace` are distinct kinds and are not
-        // counted, while Ruby's `#{` is. Settle the rule across all
-        // four before guarding here.
         match node.kind_id().into() {
+            // String-interpolation opener. `LBRACE` is *both* the
+            // compound-statement brace and the complex-interpolation
+            // opener, so `"dq {$y} end"` reported a `{}` operator —
+            // and reported it against the same vocabulary entry a real
+            // block uses, which no other language does (#1314).
+            //
+            // An interpolation opener is spelling, not an operation:
+            // the interpolated expression's own operators are already
+            // counted, and no reader performs a `{`. Measured across
+            // the five interpolating languages here, `[n1, N1]` on one
+            // fixture with and without an interpolation: kotlin
+            // [5,7]->[5,7], csharp [8,11]->[8,11], groovy's `${` (142)
+            // absent from its operator arm, ruby [1,2]->[2,3], php
+            // [2,4]->[3,5]. Three of five already declined to count it;
+            // this arm and the Ruby `#{` drop in the same commit make
+            // it five of five.
+            //
+            // Four parents, not one. The opener is a direct child of
+            // `encapsed_string` (`"{$y}"`), of `heredoc_body` — the
+            // body, not `heredoc` — of `shell_command_expression`
+            // (`` `ls {$y}` ``), and of `dynamic_variable_name`, which
+            // covers both the in-string `"${y}"` form and a bare
+            // `${$y}` variable-variable. `"${y}"` is deprecated as of
+            // PHP 8.2 and removed in 9.0, but the grammar still parses
+            // it and it is still in the wild.
+            //
+            // Parent, not ancestor, and PHP is one of only two
+            // languages in #1314 where that is observable: a closure
+            // inside an interpolation (`"{$o->m(function() { … })}"`)
+            // puts a compound-statement brace under an
+            // `encapsed_string` ancestor. Pinned by
+            // `php_interpolation_guard_is_parent_scoped_not_ancestor_scoped`.
+            //
+            // A literal brace in string text (`"lit { brace"`) never
+            // reaches here — the grammar folds it into `string_content`
+            // — so nothing is over-suppressed.
+            LBRACE
+                if matches!(
+                    ancestors.parent(node).map(|p| p.kind_id().into()),
+                    Some(
+                        EncapsedString
+                            | HeredocBody
+                            | ShellCommandExpression
+                            | DynamicVariableName
+                    )
+                ) =>
+            {
+                HalsteadType::Unknown
+            }
             // Operator: control-flow keywords
             If | Else | Elseif | Endif
             | Switch | Case | Default | Endswitch

--- a/src/getter/ruby.rs
+++ b/src/getter/ruby.rs
@@ -45,9 +45,7 @@ impl Getter for RubyCode {
             // outside a `Regex`, it now falls to `Unknown` rather than
             // being counted as a division.
             R::SLASH | R::SLASH2
-                if ancestors
-                    .parent(node)
-                    .is_some_and(|p| p.kind_id() == R::Regex as u16) =>
+                if ancestors.parent_has_kind(node, R::Regex as u16) =>
             {
                 HalsteadType::Unknown
             }

--- a/src/getter/ruby.rs
+++ b/src/getter/ruby.rs
@@ -67,9 +67,22 @@ impl Getter for RubyCode {
             | R::Undef2 | R::Alias2
             // Logical / definedness keywords
             | R::And | R::Or | R::Not | R::DefinedQMARK
-            // Structural punctuation acting as operators. Only the
-            // *opening* delimiter counts (the pair folds to one glyph in
-            // `get_operator_id_as_str`); the former closing arms
+            // Structural punctuation acting as operators. `HASHLBRACE`
+            // — the `#{` interpolation opener — was here until #1314
+            // and is deliberately gone: an interpolation opener is
+            // spelling rather than an operation, the interpolated
+            // expression's own operators being counted already. Unlike
+            // PHP's `{`, Ruby's is a token of its own, so it needs no
+            // parent guard; dropping the arm is the whole change, and
+            // it applies to every literal that interpolates — string,
+            // symbol, regex, heredoc, subshell. See the PHP sibling in
+            // `src/getter/php.rs` for the cross-language measurement
+            // this policy rests on. This half is a behaviour change,
+            // not a fabrication fix: Ruby Halstead operator counts drop
+            // for interpolated literals.
+            //
+            // Only the *opening* delimiter counts (the pair folds to
+            // one glyph in `get_operator_id_as_str`); the former closing arms
             // (`RPAREN`/`RPAREN2`/`RBRACE`/`RBRACK`) double-counted every
             // balanced pair, inflating n1/N1 (#695). The `LBRACKRBRACK` /
             // `LBRACKRBRACKEQ` indexer *method names* below (`def [](i)`)
@@ -81,7 +94,7 @@ impl Getter for RubyCode {
             | R::LPAREN | R::LPAREN2
             | R::LBRACE | R::LBRACK | R::LBRACK2 | R::LBRACK3
             | R::COMMA | R::SEMI | R::DOT | R::COLONCOLON | R::COLONCOLON2 | R::AMPDOT
-            | R::COLON | R::COLON2 | R::HASHLBRACE | R::DASHGT
+            | R::COLON | R::COLON2 | R::DASHGT
             // Method-name operator markers (`def +@`, `def -@`, `def ~@`)
             // and indexer methods.
             | R::PLUSAT | R::DASHAT | R::TILDEAT

--- a/src/getter/tcl.rs
+++ b/src/getter/tcl.rs
@@ -47,7 +47,7 @@ impl Getter for TclCode {
             // Guarding that kind too would drop every real block, so
             // closing it needs command-name recognition
             // (grammar-dispatch §9) rather than another kind arm —
-            // tracked separately. iRules carries the twin.
+            // FIXME(#1318). iRules carries the twin.
             Tcl::LBRACE
                 if ancestors.parent_has_kind(node, Tcl::BracedWordSimple as u16) =>
             {

--- a/src/getter/tcl.rs
+++ b/src/getter/tcl.rs
@@ -24,21 +24,30 @@ impl Getter for TclCode {
             // when its parent is that node — the compound-leaf guard of
             // grammar-dispatch section 5.
             //
-            // The discriminator is clean, and that is what makes a
-            // kind-scoped guard safe here where it would not be
-            // elsewhere: every *script* body is a `BracedWord` (88) —
-            // verified across `proc`, `if`, `catch`, `eval`, `after`
-            // and `uplevel` — an `if`/`while` condition is an `Expr`
-            // (97), and a `proc` parameter list is `Arguments` (94).
-            // All three keep their braces as operators.
+            // A *script* body is a `BracedWord` (88) — verified across
+            // `proc`, `if`, `catch`, `eval`, `after` and `uplevel` — an
+            // `if`/`while` condition is an `Expr` (97), and a `proc`
+            // parameter list is `Arguments` (94). All three keep their
+            // braces as operators, which is what makes keying the guard
+            // on `BracedWordSimple` safe.
             //
-            // Parent, not ancestor, though the distinction is
-            // unobservable: a braced word contains only `SimpleWord`s
-            // and nested `BracedWordSimple`s, so every `{` below one
-            // has it as an immediate parent, and no script body ever
-            // nests inside a value word. Parent scoping is correct by
-            // construction and keeps this arm the shape of its
-            // siblings. iRules carries the twin.
+            // Parent, not ancestor, and here the distinction is
+            // *observable*: the grammar parses a `[…]` command
+            // substitution inside a braced word, so
+            // `set z {x [if {$q} {puts w}] v}` nests an `Expr` and a
+            // `BracedWord` — each with its own `{` — under a
+            // `BracedWordSimple` ancestor. An ancestor scan swallows
+            // both. Pinned by
+            // `tcl_braced_word_guard_is_parent_scoped_not_ancestor_scoped`.
+            //
+            // What this arm does *not* reach: the grammar emits
+            // `BracedWordSimple` only in the value slot of the commands
+            // it special-cases, so `lappend x {a b}` parses its literal
+            // as a `BracedWord` script and still fabricates a `{}`.
+            // Guarding that kind too would drop every real block, so
+            // closing it needs command-name recognition
+            // (grammar-dispatch §9) rather than another kind arm —
+            // tracked separately. iRules carries the twin.
             Tcl::LBRACE
                 if ancestors.parent_has_kind(node, Tcl::BracedWordSimple as u16) =>
             {

--- a/src/getter/tcl.rs
+++ b/src/getter/tcl.rs
@@ -120,8 +120,7 @@ impl Getter for TclCode {
             // listed defensively so a grammar bump that starts emitting it
             // classifies it identically.
             Tcl::Id | Tcl::Id2 => {
-                if ancestors.parent_has_kind(node, Tcl::VariableSubstitution as u16)
-                {
+                if ancestors.parent_has_kind(node, Tcl::VariableSubstitution as u16) {
                     HalsteadType::Unknown
                 } else {
                     HalsteadType::Operand

--- a/src/getter/tcl.rs
+++ b/src/getter/tcl.rs
@@ -13,13 +13,37 @@ impl Getter for TclCode {
     }
 
     fn get_op_type<'a>(node: &Node<'a>, ancestors: Ancestors<'a, '_>) -> HalsteadType {
-        // FIXME(#1314): a braced *word* carries its `{` as an
-        // `LBRACE` child, so the value `{braced word}` fabricates a
-        // block — the class #1256 fixed for Elixir and #1312 for
-        // Ruby/Perl. Only `BracedWordSimple` is the value form
-        // (script bodies are `BracedWord`, `expr` bodies `Expr`), so
-        // parent-guarding on it is safe; iRules carries the same gap.
         match node.kind_id().into() {
+            // Braced-word delimiter punctuation. A braced *word* — a
+            // literal value such as `set a {braced word}` — carries its
+            // `{` as an `LBRACE` child, the kind id a real block uses,
+            // so the value reported a `{}` operator with no block in
+            // the source (#1314, the Tcl sibling of Elixir #1256 and
+            // Ruby/Perl #1312). `BracedWordSimple` is already an
+            // operand (below), so the delimiter is suppressed exactly
+            // when its parent is that node — the compound-leaf guard of
+            // grammar-dispatch section 5.
+            //
+            // The discriminator is clean, and that is what makes a
+            // kind-scoped guard safe here where it would not be
+            // elsewhere: every *script* body is a `BracedWord` (88) —
+            // verified across `proc`, `if`, `catch`, `eval`, `after`
+            // and `uplevel` — an `if`/`while` condition is an `Expr`
+            // (97), and a `proc` parameter list is `Arguments` (94).
+            // All three keep their braces as operators.
+            //
+            // Parent, not ancestor, though the distinction is
+            // unobservable: a braced word contains only `SimpleWord`s
+            // and nested `BracedWordSimple`s, so every `{` below one
+            // has it as an immediate parent, and no script body ever
+            // nests inside a value word. Parent scoping is correct by
+            // construction and keeps this arm the shape of its
+            // siblings. iRules carries the twin.
+            Tcl::LBRACE
+                if ancestors.parent_has_kind(node, Tcl::BracedWordSimple as u16) =>
+            {
+                HalsteadType::Unknown
+            }
             // Anonymous keyword tokens (control-flow and declaration keywords).
             Tcl::Proc
             | Tcl::If2
@@ -96,9 +120,7 @@ impl Getter for TclCode {
             // listed defensively so a grammar bump that starts emitting it
             // classifies it identically.
             Tcl::Id | Tcl::Id2 => {
-                if ancestors
-                    .parent(node)
-                    .is_some_and(|p| p.kind_id() == Tcl::VariableSubstitution as u16)
+                if ancestors.parent_has_kind(node, Tcl::VariableSubstitution as u16)
                 {
                     HalsteadType::Unknown
                 } else {

--- a/src/metrics/abc/elixir.rs
+++ b/src/metrics/abc/elixir.rs
@@ -211,9 +211,7 @@ impl Abc for ElixirCode {
             // `LBRACE` / `LBRACK` / `PIPE`), none has an arm in this
             // impl, so `LT` / `GT` are the only overlap to guard.
             E::LT | E::GT
-                if ancestors
-                    .parent(node)
-                    .is_some_and(|p| p.kind_id() == E::Sigil as u16) => {}
+                if ancestors.parent_has_kind(node, E::Sigil as u16) => {}
             // Comparison operator tokens. `Elixir::LT` / `Elixir::GT`
             // reach here only outside a sigil (the guard arm above
             // consumes the delimiter case); Elixir has no Go-style

--- a/src/metrics/abc/kotlin.rs
+++ b/src/metrics/abc/kotlin.rs
@@ -239,10 +239,7 @@ impl Abc for KotlinCode {
             // else-clause and `when`'s `else ->` entry. Only count it
             // when it belongs to an `if_expression`; the `WhenEntry`
             // wrapper above already covers the `when` case.
-            Else if ancestors
-                .parent(node)
-                .is_some_and(|p| p.kind_id() == IfExpression) =>
-            {
+            Else if ancestors.parent_has_kind(node, IfExpression as u16) => {
                 stats.conditions += 1.;
             }
             // `<` and `>` may appear as type-argument brackets

--- a/src/metrics/cognitive/kotlin.rs
+++ b/src/metrics/cognitive/kotlin.rs
@@ -60,9 +60,7 @@ impl Cognitive for KotlinCode {
                 // which is `O(depth)` — one climb per `else` keeps the
                 // metric quadratic on a deeply nested `if`/`else` chain,
                 // the shape #1062 exists to make linear.
-                let in_when = ancestors
-                    .parent(node)
-                    .is_some_and(|p| p.kind_id() == WhenEntry);
+                let in_when = ancestors.parent_has_kind(node, WhenEntry as u16);
                 if !in_when {
                     increment_by_one(stats);
                 }

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -872,6 +872,39 @@ mod tests {
     }
 
     #[test]
+    fn cpp_raw_string_delimiter_is_not_an_operator() {
+        // Regression: issue #1314, the C++ sibling of Elixir #1256 and
+        // Ruby/Perl #1312. A `raw_string_literal` carries its `R"(`
+        // opener as a bare `LPAREN` child — the kind id a call uses —
+        // so `auto a = R"(raw)";` reported a `()` operator with no call
+        // in the source.
+        //
+        // The fixture holds both sides at once: two raw strings and one
+        // real call. A guard widened past the literal would drop
+        // `f(a)`'s parenthesis and fail here rather than silently
+        // passing.
+        //
+        // The second literal uses the custom-delimiter form to pin that
+        // shape too — it adds a `raw_string_delimiter` child but keeps
+        // the same `(` — and its distinct text makes n2 differ from N2.
+        //
+        // expected: operators `;` × 3, `=` × 3, `int`, `()` × 1 →
+        // n1 = 4, N1 = 8. Operands the two literals, `a` × 2, `b`, `c`,
+        // `f` → n2 = 6, N2 = 7. Before the guard the two openers added
+        // two more `()` → N1 = 10.
+        check_metrics::<CppParser>(
+            "auto a = R\"(raw)\";\nauto b = R\"tag(raw)tag\";\nint c = f(a);\n",
+            "foo.cpp",
+            |metric| {
+                assert_eq!(metric.halstead.unique_operators(), 4);
+                assert_eq!(metric.halstead.total_operators(), 8);
+                assert_eq!(metric.halstead.unique_operands(), 6);
+                assert_eq!(metric.halstead.total_operands(), 7);
+            },
+        );
+    }
+
+    #[test]
     fn rust_operators_and_operands() {
         check_metrics::<RustParser>(
             "fn main() {
@@ -3938,6 +3971,18 @@ f() {
 }",
             "foo.tcl",
             |metric| {
+                // Anchored per the snapshot policy in AGENTS.md, which
+                // this call predates. N1 fell 33 → 31 with #1314: the
+                // `if` condition's `{x}` and `{y}` are braced *words*,
+                // so their openers stopped fabricating a `{}` operator.
+                // n1 is unchanged at 18 because the `{}` entry survives
+                // on the proc body and the `expr` braces — which is
+                // exactly why the fabrication was invisible in n1 and
+                // is the reason to assert N1 as well (#1294).
+                assert_eq!(metric.halstead.unique_operators(), 18);
+                assert_eq!(metric.halstead.total_operators(), 31);
+                assert_eq!(metric.halstead.unique_operands(), 17);
+                assert_eq!(metric.halstead.total_operands(), 30);
                 insta::assert_json_snapshot!(metric.halstead);
             },
         );
@@ -4106,6 +4151,61 @@ f() {
             !ast_has_kind_id(&parser, Tcl::Id as u16),
             "the named Tcl::Id rule surfaced; re-derive the defensive \
              `Tcl::Id` arm in TclCode::get_op_type against the new grammar",
+        );
+    }
+
+    #[test]
+    fn tcl_braced_word_delimiter_is_not_an_operator() {
+        // Regression: issue #1314, the Tcl sibling of Elixir #1256 and
+        // Ruby/Perl #1312. A braced *word* — a literal value, not a
+        // script — carries its `{` as an `LBRACE` child, the kind id a
+        // real block uses, so `set a {braced word}` reported a `{}`
+        // operator with no block in the source.
+        //
+        // expected: operator `set` × 3 → n1 = 1, N1 = 3. Operands
+        // `a`, `b`, `c`, `$a`, `{braced word}` × 2 and its inner
+        // `braced` / `word` × 2 each → n2 = 7, N2 = 10. (The inner
+        // words counting alongside the word that contains them is a
+        // separate, pre-existing defect filed off #1314; this test
+        // pins today's totals rather than endorsing them.) Before the
+        // guard the two openers added `{}` → n1 = 2, N1 = 5.
+        check_metrics::<TclParser>(
+            "set a {braced word}\nset b {braced word}\nset c $a\n",
+            "foo.tcl",
+            |metric| {
+                assert_eq!(metric.halstead.unique_operators(), 1);
+                assert_eq!(metric.halstead.total_operators(), 3);
+                assert_eq!(metric.halstead.unique_operands(), 7);
+                assert_eq!(metric.halstead.total_operands(), 10);
+            },
+        );
+    }
+
+    #[test]
+    fn tcl_script_bodies_keep_their_braces() {
+        // Control for #1314, and the reason a kind-scoped guard is safe
+        // in Tcl where it would not be elsewhere: the grammar gives the
+        // literal and the block *different* kinds. A `proc` body, an
+        // `if` body and an `if` condition are `BracedWord` (88) and
+        // `Expr` (97); only the value form is `BracedWordSimple` (89).
+        // This fixture nests a braced word inside a real script body,
+        // so a guard that keyed on the brace alone would drop the
+        // block's `{}` and fail here.
+        //
+        // expected: operators `proc`, `set` × 2, `if`, `>`, and `{}`
+        // × 4 (the proc parameter list, the proc body, the `if`
+        // condition, the `if` body) → n1 = 5, N1 = 9. Operands `p`,
+        // `x`, `a`, `{v w}`, `v`, `w`, `$x`, `1`, `b`, `{y}`, `y` and
+        // the second `x` occurrence → n2 = N2 = 13.
+        check_metrics::<TclParser>(
+            "proc p {x} {\n  set a {v w}\n  if {$x > 1} { set b {y} }\n}\n",
+            "foo.tcl",
+            |metric| {
+                assert_eq!(metric.halstead.unique_operators(), 5);
+                assert_eq!(metric.halstead.total_operators(), 9);
+                assert_eq!(metric.halstead.unique_operands(), 13);
+                assert_eq!(metric.halstead.total_operands(), 13);
+            },
         );
     }
 
@@ -4921,6 +5021,36 @@ f() {
             bare_var, 1,
             "bare $x must be exactly one operand (inner id leaf not double-counted); operands were {:?}",
             ops.operands
+        );
+    }
+
+    #[test]
+    fn irules_braced_word_delimiter_is_not_an_operator() {
+        // Regression: issue #1314. The iRules twin of
+        // `tcl_braced_word_delimiter_is_not_an_operator` — the two
+        // getters are deliberate clones, so the guard lands in both and
+        // is asserted in both.
+        //
+        // One fixture covers the guard and its control: `{braced word}`
+        // and `{y}` are values whose openers must not count, while the
+        // handler body, the `if` condition and the `if` body are
+        // `BracedWord` / `Expr` and must keep theirs. A guard keyed on
+        // the brace alone would take `{}` out of the operator set
+        // entirely and fail here.
+        //
+        // expected: operators `when`, `set` × 2, `if`, `contains`,
+        // `[]`, `{}` × 3 → n1 = 6, N1 = 9. Every operand is distinct →
+        // n2 = N2 = 12. Before the guard the two value openers added
+        // two more `{}` occurrences → N1 = 11.
+        check_metrics::<IrulesParser>(
+            "when HTTP_REQUEST {\n  set a {braced word}\n  if {[HTTP::uri] contains \"x\"} { set b {y} }\n}\n",
+            "foo.irule",
+            |metric| {
+                assert_eq!(metric.halstead.unique_operators(), 6);
+                assert_eq!(metric.halstead.total_operators(), 9);
+                assert_eq!(metric.halstead.unique_operands(), 12);
+                assert_eq!(metric.halstead.total_operands(), 12);
+            },
         );
     }
 

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -2834,36 +2834,43 @@ mod tests {
         // with no division in the source.
         //
         // expected: operators `$` (the `scalar_variable` sigil), `=~`
-        // and `;` → n1 = N1 = 3. Operand `$s` → n2 = N2 = 1; the
-        // `PatternMatcher` wrapper is not classified (see
-        // `perl_every_pattern_spelling_scores_alike`). Before the guard
-        // the two delimiters added `/` → n1 = 4, N1 = 5.
+        // and `;` → n1 = N1 = 3. Operands `$s` and the `/abc/` pattern
+        // → n2 = N2 = 2. Before the guard the two delimiters added `/`
+        // → n1 = 4, N1 = 5; the pattern operand arrived with #1314,
+        // which promoted all three pattern spellings together (see
+        // `perl_every_pattern_value_spelling_scores_alike`).
         check_metrics::<PerlParser>("$s =~ /abc/;\n", "foo.pl", |metric| {
             assert_eq!(metric.halstead.unique_operators(), 3);
             assert_eq!(metric.halstead.total_operators(), 3);
-            assert_eq!(metric.halstead.unique_operands(), 1);
-            assert_eq!(metric.halstead.total_operands(), 1);
+            assert_eq!(metric.halstead.unique_operands(), 2);
+            assert_eq!(metric.halstead.total_operands(), 2);
         });
     }
 
     #[test]
-    fn perl_every_pattern_spelling_scores_alike() {
-        // Companion to the test above (#1312). `m/abc/` is exactly
-        // `/abc/` in Perl, and the delimiter pair is free, so all of
-        // these must score identically. The suffixed forms already did
-        // before the fix: `bca dump` shows `m//`, `qr//`, `s///`,
-        // `tr///` and `y///` using the dedicated `StartDelimiter` /
-        // `SeparatorDelimiter` / `EndDelimiter` kinds, which no arm in
-        // `PerlCode::get_op_type` classifies — so they are here as
-        // no-change guards, and the bare row is the one the guard
-        // moved onto the same footing.
+    fn perl_every_pattern_value_spelling_scores_alike() {
+        // Companion to the test above (#1312, extended by #1314).
+        // `m/abc/` is exactly `/abc/` in Perl and `qr/abc/` is the same
+        // pattern as a value, so the three spellings of a pattern
+        // *value* must score identically whatever delimiters they use.
         //
-        // That shared footing is also why this fix deliberately does
-        // *not* take up the issue's suggestion to classify
-        // `PatternMatcher` as an operand for parity with Ruby's `Regex`
-        // and Elixir's `Sigil`: doing it for the bare form alone would
-        // score `/abc/` at one operand and its four synonyms at zero,
+        // Until #1314 they scored alike at *zero*: no Perl pattern
+        // wrapper was in the operand arm, so the literal never counted,
+        // unlike Ruby's `Regex` and Elixir's `Sigil`. #1312 declined to
+        // promote the bare form on its own precisely because that would
+        // have scored `/abc/` at one operand and its synonyms at zero,
         // reintroducing the spelling sensitivity this test pins.
+        // Promoting all three together closes the gap and keeps the
+        // equality, which is what this test now asserts.
+        //
+        // `s///` and `tr///` are deliberately *not* rows here any more.
+        // They are operations applied to a target rather than pattern
+        // values, so #1314 made them operators; their own equality is
+        // pinned by `perl_every_pattern_operation_spelling_scores_alike`
+        // below. Splitting the one loop in two is the substantive
+        // disagreement #1314 had with the reasoning recorded here: this
+        // test governs *synonyms*, and `s///` is not a synonym of
+        // `/abc/`.
         //
         // The fixture matches twice against one variable so that no two
         // of `[n1, N1, n2, N2]` are equal. A square tuple would leave
@@ -2873,17 +2880,83 @@ mod tests {
         //
         // expected per variant: operators `$` × 2 (one per
         // `scalar_variable`), `=~` × 2, `and`, `;` → n1 = 4, N1 = 6.
-        // The pattern contributes no operator (that is the point) and
-        // no operand (see the note above); operand `$s` twice → n2 = 1,
-        // N2 = 2.
-        for pattern in [
-            "/abc/", "m/abc/", "m{abc}", "qr/abc/", "s/a/b/", "s{a}{b}", "tr/a/b/", "y/a/b/",
-        ] {
+        // The pattern contributes no *operator* — that is #1312's half
+        // — and one operand, so with `$s` twice and the pattern twice
+        // → n2 = 2, N2 = 4.
+        for pattern in ["/abc/", "m/abc/", "m{abc}", "qr/abc/"] {
             assert_halstead_counts::<PerlParser>(
                 &format!("$s =~ {pattern} and $s =~ {pattern};\n"),
                 "foo.pl",
-                [4, 6, 1, 2],
+                [4, 6, 2, 4],
                 &format!("pattern {pattern}"),
+            );
+        }
+    }
+
+    #[test]
+    fn perl_every_pattern_operation_spelling_scores_alike() {
+        // The other half of the split (#1314). Substitution and
+        // transliteration are operations applied to a target, so they
+        // are operators — and like the value spellings, their delimiter
+        // choice must not move the count. `y///` is a synonym of
+        // `tr///` and shares `TransliterationTrOrY`, so the two fold to
+        // one operator entry, which is why all four rows agree on n1.
+        //
+        // expected per variant: operators `$` × 2, `=~` × 2, `and`,
+        // `;`, and the operation itself × 2 → n1 = 5, N1 = 8. The
+        // pattern and replacement text is invisible to this grammar —
+        // `substitution_pattern_s` emits only its keyword and
+        // delimiters, no content node — so the sole operand is `$s`,
+        // twice → n2 = 1, N2 = 2.
+        for pattern in ["s/a/b/", "s{a}{b}", "tr/a/b/", "y/a/b/"] {
+            assert_halstead_counts::<PerlParser>(
+                &format!("$s =~ {pattern} and $s =~ {pattern};\n"),
+                "foo.pl",
+                [5, 8, 1, 2],
+                &format!("pattern {pattern}"),
+            );
+        }
+    }
+
+    #[test]
+    fn perl_interpolated_pattern_operands_agree_but_operators_do_not() {
+        // Two things at once (#1314), because they are the same
+        // measurement: why the three pattern-value spellings route
+        // through `string_operand_type` rather than a plain operand
+        // arm, and what that routing does *not* fix.
+        //
+        // `m/$x/` and `qr/$x/` emit a real `Interpolation` wrapping a
+        // `scalar_variable`, while the bare form keeps its `$x` inside
+        // an unclassified `regex_pattern_content`. So:
+        //
+        // * Operands agree at n2 = N2 = 2 (`$s` plus one contribution
+        //   from the pattern) only because of the interpolation guard.
+        //   A plain operand arm would count the wrapper *and* the inner
+        //   `$x` for the suffixed forms — n2 = 3 — reintroducing
+        //   through the back door the divergence
+        //   `perl_every_pattern_value_spelling_scores_alike` exists to
+        //   prevent. Which node carries the one operand still differs
+        //   by spelling: the wrapper for the bare form, the inner `$x`
+        //   for the other two.
+        // * Operators do *not* agree: the exposed `scalar_variable`
+        //   brings a `$` sigil, an operator here, that the bare form
+        //   has no node for. N1 is 3 for `/$x/` and 4 for the other
+        //   two.
+        //
+        // The operator asymmetry is a grammar gap this classifier
+        // cannot repair — there is nothing to classify in the bare
+        // form — so it is pinned rather than papered over, the same
+        // treatment `perl_division_emits_no_slash_token` gives the
+        // missing division token. A bump that starts exposing the bare
+        // form's interpolation turns this red, at which point the
+        // expectations above need re-deriving.
+        assert_halstead_counts::<PerlParser>("$s =~ /$x/;\n", "foo.pl", [3, 3, 2, 2], "bare /$x/");
+        for pattern in ["m/$x/", "qr/$x/"] {
+            assert_halstead_counts::<PerlParser>(
+                &format!("$s =~ {pattern};\n"),
+                "foo.pl",
+                [3, 4, 2, 2],
+                &format!("suffixed {pattern}"),
             );
         }
     }

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -466,7 +466,7 @@ mod tests {
     use std::collections::HashSet;
     use std::path::PathBuf;
 
-    use crate::test_support::{ast_has_kind_id, check_metrics_only_shim};
+    use crate::test_support::{ast_has_kind_id, check_metrics_only_shim, for_each_node_with_chain};
 
     use super::*;
 
@@ -1470,6 +1470,115 @@ mod tests {
                 assert_eq!(metric.halstead.unique_operands(), 2);
                 assert_eq!(metric.halstead.total_operands(), 3);
             },
+        );
+    }
+
+    /// The JS-family regex fixture, asserted against all four grammars.
+    ///
+    /// `impl_js_family_get_op_type!` is instantiated four times against
+    /// four distinct `kind_id` enums (`SLASH` 87/81/90/87, `Regex`
+    /// 224/250/264/225), so each expansion is a separate compiled arm
+    /// and a drift in one grammar is invisible if only one is checked
+    /// (grammar-dispatch section 11).
+    fn assert_js_family_counts(source: &str, expected: [u64; 4]) {
+        assert_halstead_counts::<JavascriptParser>(source, "foo.js", expected, "javascript");
+        assert_halstead_counts::<MozjsParser>(source, "foo.jsm", expected, "mozjs");
+        assert_halstead_counts::<TypescriptParser>(source, "foo.ts", expected, "typescript");
+        assert_halstead_counts::<TsxParser>(source, "foo.tsx", expected, "tsx");
+    }
+
+    #[test]
+    fn js_family_regex_delimiters_are_not_operators() {
+        // Regression: issue #1314, the JS-family sibling of Elixir
+        // #1256 and Ruby/Perl #1312. A `regex` literal spells both of
+        // its delimiters `SLASH` — the kind id real division uses — so
+        // `const a = /abc/g;` reported a `/` operator with no division
+        // in the source, and n1/N1 counted the literal's punctuation as
+        // arithmetic.
+        //
+        // The same fixture pins the second, independent half: `Regex`
+        // was in neither arm, so the literal contributed no operand
+        // either and reached the vocabulary from *neither* side.
+        //
+        // expected: operators `const`, `=`, `;`, `let` → n1 = 4;
+        // `const` `=` `;` on line 1, `let` `=` `;` on line 2, `=` `;`
+        // on line 3 → N1 = 8. Operands `a`, `/abc/g`, `b` → n2 = 3,
+        // with `a` used three times and `b` twice → N2 = 6.
+        //
+        // Before the fix: n1 = 5 and N1 = 10 (the two fabricated `/`),
+        // n2 = 2 and N2 = 5 (no operand for the literal).
+        //
+        // The four values are deliberately distinct so no transposition
+        // of the unique-vs-total axes inside `assert_halstead_counts`
+        // can pass (#1312).
+        assert_js_family_counts("const a = /abc/g;\nlet b = a;\nb = a;\n", [4, 8, 3, 6]);
+    }
+
+    #[test]
+    fn js_family_division_survives_the_regex_guard() {
+        // Control for #1314: the guard is scoped to a `Regex` parent,
+        // so real division must still count. This fixture holds both
+        // sides at once — two divisions and one regex literal — so a
+        // guard widened to every `SLASH` fails here rather than
+        // silently passing the test above.
+        //
+        // expected: operators `const`, `=`, `;`, `/` → n1 = 4; two
+        // `const`, two `=`, two `;` and two `/` → N1 = 8. Operands
+        // `q`, `a`, `b`, `c`, `r`, `/x/` → n2 = N2 = 6.
+        assert_js_family_counts("const q = a / b / c;\nconst r = /x/;\n", [4, 8, 6, 6]);
+    }
+
+    #[test]
+    fn js_regex_delimiter_guard_is_parent_scoped_is_unobservable() {
+        // Companion to the two above, and a statement of what they do
+        // *not* cover. Ruby's guard has
+        // `ruby_regex_guard_is_parent_scoped_not_ancestor_scoped`
+        // because a division inside `#{…}` sits under a `Regex`
+        // ancestor without being its child. No JS fixture can do that:
+        // a regex literal admits no nested expression at all, its
+        // `regex_pattern` and `regex_flags` children being leaves. So
+        // the ancestor-scoped mutant of this guard — the one #1256's
+        // post-mortem says survives every ordinary fixture — is
+        // unobservable here. Measured, not assumed.
+        //
+        // Rather than write a fixture that would pass under both
+        // spellings and read as coverage, pin the grammar property the
+        // claim rests on: within a fixture that puts a division, a
+        // template substitution and a regex in one file, every `SLASH`
+        // reachable *below* a `Regex` is its immediate child. Should a
+        // bump start nesting expressions inside a regex, this turns red
+        // and the distinction becomes both observable and worth a real
+        // test.
+        let source = b"const a = /abc/g;\nconst q = x / y;\nconst t = `p ${x / y} ${/zz/} q`;\n";
+        let mut slashes_below_a_regex = 0;
+        let visited = for_each_node_with_chain::<crate::langs::JavascriptCode>(
+            source,
+            |node: &Node<'_>, chain| {
+                if node.kind_id() != Javascript::SLASH as u16 {
+                    return;
+                }
+                let regex_id = Javascript::Regex as u16;
+                let Some(depth) = chain.iter().position(|a| a.kind_id() == regex_id) else {
+                    return;
+                };
+                slashes_below_a_regex += 1;
+                assert_eq!(
+                    depth,
+                    chain.len() - 1,
+                    "a SLASH at row {} has a Regex ancestor that is not its parent, so the \
+                     parent-vs-ancestor mutant is now observable and needs a real test",
+                    node.start_row()
+                );
+            },
+        );
+        assert!(visited > 20, "fixture is too small to prove much");
+        // Without this the assertion above is vacuous whenever the
+        // fixture stops containing a regex at all — the failure mode a
+        // filter that matches nothing always has.
+        assert_eq!(
+            slashes_below_a_regex, 4,
+            "expected the two regex literals' four delimiters; the fixture no longer \
+             exercises what this test claims"
         );
     }
 

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -1582,36 +1582,74 @@ mod tests {
         // bump start nesting expressions inside a regex, this turns red
         // and the distinction becomes both observable and worth a real
         // test.
+        //
+        // Checked against all four grammars, not just JavaScript: the
+        // guard is instantiated four times against four distinct enums,
+        // and the property this test exists to watch could hold in one
+        // and lapse in another.
         let source = b"const a = /abc/g;\nconst q = x / y;\nconst t = `p ${x / y} ${/zz/} q`;\n";
-        let mut slashes_below_a_regex = 0;
-        let visited = for_each_node_with_chain::<crate::langs::JavascriptCode>(
+        assert_regex_slashes_are_immediate_children::<crate::langs::JavascriptCode>(
             source,
-            |node: &Node<'_>, chain| {
-                if node.kind_id() != Javascript::SLASH as u16 {
-                    return;
-                }
-                let regex_id = Javascript::Regex as u16;
-                let Some(depth) = chain.iter().position(|a| a.kind_id() == regex_id) else {
-                    return;
-                };
-                slashes_below_a_regex += 1;
-                assert_eq!(
-                    depth,
-                    chain.len() - 1,
-                    "a SLASH at row {} has a Regex ancestor that is not its parent, so the \
-                     parent-vs-ancestor mutant is now observable and needs a real test",
-                    node.start_row()
-                );
-            },
+            Javascript::SLASH as u16,
+            Javascript::Regex as u16,
+            "javascript",
         );
-        assert!(visited > 20, "fixture is too small to prove much");
+        assert_regex_slashes_are_immediate_children::<crate::langs::MozjsCode>(
+            source,
+            Mozjs::SLASH as u16,
+            Mozjs::Regex as u16,
+            "mozjs",
+        );
+        assert_regex_slashes_are_immediate_children::<crate::langs::TypescriptCode>(
+            source,
+            Typescript::SLASH as u16,
+            Typescript::Regex as u16,
+            "typescript",
+        );
+        assert_regex_slashes_are_immediate_children::<crate::langs::TsxCode>(
+            source,
+            Tsx::SLASH as u16,
+            Tsx::Regex as u16,
+            "tsx",
+        );
+    }
+
+    /// Asserts every `slash` token below a `regex` node in `source` is
+    /// that node's *immediate* child, for one grammar.
+    ///
+    /// Backs `js_regex_delimiter_guard_is_parent_scoped_is_unobservable`
+    /// — see there for why the property is worth pinning.
+    fn assert_regex_slashes_are_immediate_children<L: crate::traits::LanguageInfo>(
+        source: &[u8],
+        slash: u16,
+        regex: u16,
+        label: &str,
+    ) {
+        let mut slashes_below_a_regex = 0;
+        let visited = for_each_node_with_chain::<L>(source, |node: &Node<'_>, chain| {
+            if node.kind_id() != slash {
+                return;
+            }
+            let Some(depth) = chain.iter().position(|a| a.kind_id() == regex) else {
+                return;
+            };
+            slashes_below_a_regex += 1;
+            assert_eq!(
+                depth,
+                chain.len() - 1,
+                "{label}: a slash at row {} has a regex ancestor that is not its parent, so \
+                 the parent-vs-ancestor mutant is now observable and needs a real test",
+                node.start_row()
+            );
+        });
+        assert!(visited > 20, "{label}: fixture is too small to prove much");
         // Without this the assertion above is vacuous whenever the
         // fixture stops containing a regex at all — the failure mode a
         // filter that matches nothing always has.
         assert_eq!(
             slashes_below_a_regex, 4,
-            "expected the two regex literals' four delimiters; the fixture no longer \
-             exercises what this test claims"
+            "{label}: expected the two regex literals' four delimiters; the fixture no \
+             longer exercises what this test claims"
         );
     }
 
@@ -2940,8 +2978,8 @@ mod tests {
         //   for the other two.
         // * Operators do *not* agree: the exposed `scalar_variable`
         //   brings a `$` sigil, an operator here, that the bare form
-        //   has no node for. N1 is 3 for `/$x/` and 4 for the other
-        //   two.
+        //   has no node for. Over two matches N1 is 6 for `/$x/` and
+        //   8 for the other two.
         //
         // The operator asymmetry is a grammar gap this classifier
         // cannot repair — there is nothing to classify in the bare
@@ -2950,12 +2988,20 @@ mod tests {
         // missing division token. A bump that starts exposing the bare
         // form's interpolation turns this red, at which point the
         // expectations above need re-deriving.
-        assert_halstead_counts::<PerlParser>("$s =~ /$x/;\n", "foo.pl", [3, 3, 2, 2], "bare /$x/");
+        // Each fixture matches twice, so `N1 > n1` and `N2 > n2` and no
+        // row is a square tuple that a transposition inside
+        // `assert_halstead_counts` could pass (#1312).
+        assert_halstead_counts::<PerlParser>(
+            "$s =~ /$x/ and $s =~ /$x/;\n",
+            "foo.pl",
+            [4, 6, 2, 4],
+            "bare /$x/",
+        );
         for pattern in ["m/$x/", "qr/$x/"] {
             assert_halstead_counts::<PerlParser>(
-                &format!("$s =~ {pattern};\n"),
+                &format!("$s =~ {pattern} and $s =~ {pattern};\n"),
                 "foo.pl",
-                [3, 4, 2, 2],
+                [4, 8, 2, 4],
                 &format!("suffixed {pattern}"),
             );
         }
@@ -3677,16 +3723,18 @@ f() {
         // child), so `name` is the only repeated operand:
         // u_operands = 4 (def, greet, name, msg), N2 = 5. Without the
         // fix, the wrapping literal would also count → u_operands = 5,
-        // N2 = 6. Operators: `do`, `end`, `(`, `=`, `#{` → u = N = 5.
+        // N2 = 6. Operators: `do`, `end`, `(`, `=` → u = N = 4.
         // Only the *opening* delimiters count after #695, so the `)`
-        // and the `}` interpolation closer no longer add operators (the
-        // `(` and `#{` openers still do); before #695 this was 7.
+        // and the `}` interpolation closer add no operator; #1314 then
+        // dropped the `#{` opener too, on the rule that an
+        // interpolation opener is spelling rather than an operation
+        // (was 5 here, and 7 before #695).
         check_metrics::<ElixirParser>(
             "def greet(name) do\n  msg = \"Hi #{name}\"\nend\n",
             "foo.ex",
             |metric| {
-                assert_eq!(metric.halstead.unique_operators(), 5);
-                assert_eq!(metric.halstead.total_operators(), 5);
+                assert_eq!(metric.halstead.unique_operators(), 4);
+                assert_eq!(metric.halstead.total_operators(), 4);
                 assert_eq!(metric.halstead.unique_operands(), 4);
                 assert_eq!(metric.halstead.total_operands(), 5);
                 insta::assert_json_snapshot!(metric.halstead);
@@ -3891,17 +3939,18 @@ f() {
     fn elixir_interpolated_sigil_keeps_inner_nodes_counting() {
         // Interpolation inside a sigil after #1256: the `{` delimiter
         // is suppressed (its parent is the `Sigil`), while the
-        // `interpolation` child is a separate node whose `#{` marker
-        // and inner identifier must still count — the guard must not
-        // reach past the delimiter tokens.
+        // `interpolation` child is a separate node whose inner
+        // identifier must still count — the guard must not reach past
+        // the delimiter tokens.
         //
-        // expected: operators `=`, `~`, `#{` → n1 = N1 = 3. Operands:
+        // expected: operators `=`, `~` → n1 = N1 = 2. Operands:
         // `v`, `s` (sigil name), `b` (interpolated identifier); the
         // wrapping sigil is skipped (`Interpolation` child, #180) and
-        // `quoted_content` is unclassified → n2 = N2 = 3.
+        // `quoted_content` is unclassified → n2 = N2 = 3. The `#{`
+        // marker was a third operator until #1314 dropped it.
         check_metrics::<ElixirParser>("v = ~s{a#{b} c}\n", "foo.ex", |metric| {
-            assert_eq!(metric.halstead.unique_operators(), 3);
-            assert_eq!(metric.halstead.total_operators(), 3);
+            assert_eq!(metric.halstead.unique_operators(), 2);
+            assert_eq!(metric.halstead.total_operators(), 2);
             assert_eq!(metric.halstead.unique_operands(), 3);
             assert_eq!(metric.halstead.total_operands(), 3);
         });
@@ -3912,11 +3961,13 @@ f() {
         // discriminator between the correct parent-scoped guard and a
         // wrong ancestor-scoped one that would swallow it.
         //
-        // expected: operators `=`, `~`, `#{`, `/` → n1 = N1 = 4;
-        // operands `v`, `s`, `a`, `b` → n2 = N2 = 4.
+        // expected: operators `=`, `~`, `/` → n1 = N1 = 3 (the `#{`
+        // opener stopped counting with #1314); operands `v`, `s`, `a`,
+        // `b` → n2 = N2 = 4. The division is what this row is for, and
+        // it still counts — the ancestor-scoped mutant drops it.
         check_metrics::<ElixirParser>("v = ~s{x #{a / b} y}\n", "foo.ex", |metric| {
-            assert_eq!(metric.halstead.unique_operators(), 4);
-            assert_eq!(metric.halstead.total_operators(), 4);
+            assert_eq!(metric.halstead.unique_operators(), 3);
+            assert_eq!(metric.halstead.total_operators(), 3);
             assert_eq!(metric.halstead.unique_operands(), 4);
             assert_eq!(metric.halstead.total_operands(), 4);
         });
@@ -4278,6 +4329,58 @@ f() {
                 assert_eq!(metric.halstead.total_operators(), 9);
                 assert_eq!(metric.halstead.unique_operands(), 13);
                 assert_eq!(metric.halstead.total_operands(), 13);
+            },
+        );
+    }
+
+    #[test]
+    fn tcl_braced_word_guard_is_parent_scoped_not_ancestor_scoped() {
+        // The input that separates the parent-scoped guard from the
+        // ancestor-scanning mutant. I first recorded this distinction
+        // as *unobservable* in Tcl, reasoning that a braced word holds
+        // only simple words and nested braced words. `bca dump` says
+        // otherwise: the grammar parses a `[…]` command substitution
+        // inside a braced word, and the `if` inside it brings an `Expr`
+        // condition and a `BracedWord` body, each with its own `{`,
+        // both of them non-immediate descendants of the
+        // `BracedWordSimple`. An ancestor scan swallows both.
+        //
+        // (Real Tcl does not substitute inside braces — this is the
+        // grammar modelling structure it will not evaluate. What the
+        // classifier sees is what the metric reports, so it is the
+        // right fixture regardless.)
+        //
+        // expected: operators `set`, `[]`, `if`, and `{}` × 2 (the
+        // `if` condition's `Expr` and its `BracedWord` body; the outer
+        // value word's own `{` is suppressed) → n1 = 4, N1 = 5.
+        // Operands `z`, `x`, `$q`, `puts`, `w`, `v` and the two braced
+        // words → n2 = N2 = 8. Under the ancestor-scoped mutant both
+        // surviving braces vanish: n1 = 3, N1 = 3.
+        check_metrics::<TclParser>("set z {x [if {$q} {puts w}] v}\n", "foo.tcl", |metric| {
+            assert_eq!(metric.halstead.unique_operators(), 4);
+            assert_eq!(metric.halstead.total_operators(), 5);
+            assert_eq!(metric.halstead.unique_operands(), 8);
+            assert_eq!(metric.halstead.total_operands(), 8);
+        });
+    }
+
+    #[test]
+    fn irules_braced_word_guard_is_parent_scoped_not_ancestor_scoped() {
+        // The iRules twin of the test above — the two getters are
+        // clones, so the mutant must fail in both.
+        //
+        // expected: operators `when`, `set`, `[]`, `if`, `{}` × 3 (the
+        // handler body, the `if` condition and the `if` body) → n1 = 5,
+        // N1 = 7. Operands `HTTP_REQUEST`, `z`, `x`, `$q`, `log`, `w`,
+        // `v` and the braced words → n2 = N2 = 10.
+        check_metrics::<IrulesParser>(
+            "when HTTP_REQUEST {\n  set z {x [if {$q} {log w}] v}\n}\n",
+            "foo.irule",
+            |metric| {
+                assert_eq!(metric.halstead.unique_operators(), 5);
+                assert_eq!(metric.halstead.total_operators(), 7);
+                assert_eq!(metric.halstead.unique_operands(), 10);
+                assert_eq!(metric.halstead.total_operands(), 10);
             },
         );
     }

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -2182,34 +2182,33 @@ mod tests {
             }",
             "foo.groovy",
             |metric| {
-                // Each Groovy-specific operator kind contributes one
-                // distinct entry to the operator set. The 20-operator
-                // floor breaks down as: 16 Groovy-specific tokens
-                // exercised by the fixture (`?:`, `?.`, `??.`, `*.`,
-                // `.&`, `.@`, `===`, `!==`, `<=>`, `=~`, `==~`, `..<`,
-                // `<..`, `<..<`, `as`, `?[`) plus a handful of
-                // ambient Java-shaped operators the fixture also
-                // uses (`def`, `=`, `{`, `(`, `,`, `return`). A
-                // grammar regression that drops one of the 16
-                // Groovy-specific tokens would push the count below
-                // this floor.
                 // Exact pin: with the dekobon Groovy grammar this
                 // fixture exercises 16 Groovy-specific tokens (`?:`,
                 // `?.`, `??.`, `*.`, `.&`, `.@`, `===`, `!==`, `<=>`,
                 // `=~`, `==~`, `..<`, `<..`, `<..<`, `as`, `?[`) plus
-                // 7 ambient Java-shaped operators the fixture also
-                // uses (`def`, `=`, `,`, `{`, `(`, `[`, `return`),
-                // for a total of 23 distinct operator kinds. A
-                // regression that drops any one of the 16 #247
-                // operators would push the count below 23 and fail
-                // this assertion. The complementary AST walk below
-                // pins each #247 operator's identity individually so
-                // a grammar change that adds an unrelated operator
-                // (lifting `u_operators` to 24) still flags the loss
-                // of a #247 operator at the per-token level.
+                // 6 ambient Java-shaped operators the fixture also
+                // uses (`def`, `=`, `,`, `{}`, `()`, `return`), for a
+                // total of 22 distinct operator kinds. A regression
+                // that drops any one of the 16 #247 operators would
+                // push the count below 22 and fail this assertion. The
+                // complementary AST walk below pins each #247
+                // operator's identity individually so a grammar change
+                // that adds an unrelated operator (lifting
+                // `u_operators` to 23) still flags the loss of a #247
+                // operator at the per-token level.
+                //
+                // Was 23 until #1314. The extra entry was a `/` — the
+                // fixture's two slashy literals (`/pat/`, `/^pat\$/`)
+                // each spelled their closing delimiter with the
+                // division kind, and the arm now guards them. The
+                // enumeration above was wrong in two ways at that
+                // count: it listed an ambient `[`, which this fixture
+                // never emits (`list?[0]` is the single `?[` token),
+                // and omitted the fabricated `/` that made up the
+                // difference. Both are corrected here.
                 assert_eq!(
                     metric.halstead.unique_operators(),
-                    23,
+                    22,
                     "u_operators changed; check whether a #247 operator was dropped or an unrelated operator added (and update the comment / token list above accordingly)",
                 );
             },
@@ -2276,6 +2275,111 @@ mod tests {
             assert_eq!(metric.halstead.total_operands(), 2);
         });
         assert_ops_operands::<GroovyParser>(src, "foo.groovy", 2, vec!["f", "\"plain\""]);
+    }
+
+    #[test]
+    fn groovy_slashy_string_delimiter_is_not_an_operator() {
+        // Regression: issue #1314, the Groovy sibling of Elixir #1256
+        // and Ruby/Perl #1312. A slashy string is a `StringLiteral`
+        // whose closing delimiter is a `SLASH` — the kind id real
+        // division uses — so `def b = /xyz/` reported a `/` operator
+        // with no division in the source. Only the closer is a child
+        // (the grammar folds the opening `/` into the literal's span),
+        // so this fabricated one `/` per literal rather than Ruby's two.
+        //
+        // expected: operators `def` × 3, `=` × 3 → n1 = 2, N1 = 6.
+        // Operands `b`, `/xyz/` × 2, `c`, `s` → n2 = 4, N2 = 6. Before
+        // the guard the two closers added `/` → n1 = 3, N1 = 8.
+        check_metrics::<GroovyParser>(
+            "def b = /xyz/\ndef c = /xyz/\ndef s = b\n",
+            "foo.groovy",
+            |metric| {
+                assert_eq!(metric.halstead.unique_operators(), 2);
+                assert_eq!(metric.halstead.total_operators(), 6);
+                assert_eq!(metric.halstead.unique_operands(), 4);
+                assert_eq!(metric.halstead.total_operands(), 6);
+            },
+        );
+    }
+
+    #[test]
+    fn groovy_division_survives_the_slashy_guard() {
+        // Control for #1314: the guard is scoped to a `StringLiteral`
+        // parent, so real division must still count. Both sides are in
+        // one fixture — two divisions and one slashy literal — so a
+        // guard widened to every `SLASH` fails here rather than
+        // silently passing the test above.
+        //
+        // expected: operators `def` × 2, `=` × 2, `/` × 2 → n1 = 3,
+        // N1 = 6. Operands `q`, `a`, `b`, `c`, `r`, `/x/` → n2 = N2 = 6.
+        check_metrics::<GroovyParser>("def q = a / b / c\ndef r = /x/\n", "foo.groovy", |metric| {
+            assert_eq!(metric.halstead.unique_operators(), 3);
+            assert_eq!(metric.halstead.total_operators(), 6);
+            assert_eq!(metric.halstead.unique_operands(), 6);
+            assert_eq!(metric.halstead.total_operands(), 6);
+        });
+    }
+
+    #[test]
+    fn groovy_slashy_guard_is_parent_scoped_not_ancestor_scoped() {
+        // The input that separates the parent-scoped guard from the
+        // ancestor-scanning mutant of it — the mutant #1256's
+        // post-mortem says survives every ordinary fixture. Groovy is
+        // one of only two languages in #1314 where such an input
+        // exists at all: a slashy string may carry a GString
+        // interpolation, so `/x${a / b}y/` puts a real division under a
+        // `StringLiteral` *ancestor* while its parent is the
+        // `binary_expression`. An ancestor scan swallows it; the parent
+        // check leaves it alone. (The JS, C++ and Tcl/iRules guards
+        // have no such input — see
+        // `js_regex_delimiter_guard_is_parent_scoped_is_unobservable`.)
+        //
+        // expected: operators `def` × 2, `=` × 2, `/` (the
+        // interpolated division) → n1 = 3, N1 = 5. The wrapping literal
+        // is not an operand — it carries an interpolation, so
+        // `string_operand_type` yields `Unknown` and the inner
+        // expression's operands carry the count (#454) — leaving `r`,
+        // `a`, `b`, `s` → n2 = 4, with `a` twice → N2 = 5. Under the
+        // ancestor-scoped mutant the division vanishes: n1 = 2, N1 = 4.
+        check_metrics::<GroovyParser>(
+            "def r = /x${a / b}y/\ndef s = a\n",
+            "foo.groovy",
+            |metric| {
+                assert_eq!(metric.halstead.unique_operators(), 3);
+                assert_eq!(metric.halstead.total_operators(), 5);
+                assert_eq!(metric.halstead.unique_operands(), 4);
+                assert_eq!(metric.halstead.total_operands(), 5);
+            },
+        );
+    }
+
+    #[test]
+    fn groovy_every_string_spelling_scores_alike() {
+        // Companion to the three above (#1314). Groovy has five ways to
+        // write an inert one-character string, and the choice is
+        // spelling rather than semantics, so all five must score
+        // identically. Before the guard the two slashy forms reported
+        // an extra `/` operator that the other three did not — the
+        // author's delimiter choice moved n1/N1.
+        //
+        // The dollar-slashy and quoted forms are no-change controls:
+        // `$/…/$` closes with `/$` (kind 144) and `"…"` with `"` (134),
+        // neither of which the operator arm classifies. `'x'` is a
+        // childless leaf. The escaped-slash row is the one that would
+        // regress if the guard were ever narrowed to a literal whose
+        // *only* child is the closer.
+        //
+        // expected per spelling: operators `def` × 3, `=` × 3 → n1 = 2,
+        // N1 = 6; operands `a`, the literal, `b`, `c` → n2 = 4, with
+        // `a` used three times → N2 = 6.
+        for literal in ["/x/", "$/x/$", "'x'", "\"x\"", r"/esc\/aped/"] {
+            assert_halstead_counts::<GroovyParser>(
+                &format!("def a = {literal}\ndef b = a\ndef c = a\n"),
+                "foo.groovy",
+                [2, 6, 4, 6],
+                &format!("literal {literal}"),
+            );
+        }
     }
 
     #[test]

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -4290,9 +4290,10 @@ f() {
         // `a`, `b`, `c`, `$a`, `{braced word}` × 2 and its inner
         // `braced` / `word` × 2 each → n2 = 7, N2 = 10. (The inner
         // words counting alongside the word that contains them is a
-        // separate, pre-existing defect filed off #1314; this test
-        // pins today's totals rather than endorsing them.) Before the
-        // guard the two openers added `{}` → n1 = 2, N1 = 5.
+        // separate, pre-existing defect, filed off #1314 as #1317;
+        // this test pins today's totals rather than endorsing them.)
+        // Before the guard the two openers added `{}` → n1 = 2,
+        // N1 = 5.
         check_metrics::<TclParser>(
             "set a {braced word}\nset b {braced word}\nset c $a\n",
             "foo.tcl",
@@ -4318,9 +4319,16 @@ f() {
         //
         // expected: operators `proc`, `set` × 2, `if`, `>`, and `{}`
         // × 4 (the proc parameter list, the proc body, the `if`
-        // condition, the `if` body) → n1 = 5, N1 = 9. Operands `p`,
-        // `x`, `a`, `{v w}`, `v`, `w`, `$x`, `1`, `b`, `{y}`, `y` and
-        // the second `x` occurrence → n2 = N2 = 13.
+        // condition, the `if` body) → n1 = 5, N1 = 9. Operands, all
+        // distinct → n2 = N2 = 13: the words `p`, `x`, `a`, `v`, `w`,
+        // `$x`, `1`, `b`, `y`, the two braced *words* `{v w}` and
+        // `{y}`, and — the part worth noting — the two *script* bodies
+        // `{\n  set a …\n}` and `{ set b {y} }`, which are
+        // `BracedWord` operands in their own right. A script body
+        // therefore counts twice over: once as this operand and once
+        // as the `{}` operator above. That is pre-existing and not
+        // what this test guards; it is spelled out so the count is
+        // re-derivable.
         check_metrics::<TclParser>(
             "proc p {x} {\n  set a {v w}\n  if {$x > 1} { set b {y} }\n}\n",
             "foo.tcl",

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -4561,6 +4561,139 @@ f() {
     }
 
     #[test]
+    fn php_interpolation_opener_is_not_an_operator() {
+        // Regression: issue #1314. `Php::LBRACE` is *both* the
+        // compound-statement brace and the complex-interpolation
+        // opener, so `"dq {$y} end"` reported a `{}` operator — and
+        // reported it against the same vocabulary entry a real block
+        // uses, which no other language does.
+        //
+        // expected: operators `=` × 2, `;` × 2 → n1 = 2, N1 = 4.
+        // Operands `$s`, `$t`, `$y` × 2 → n2 = 3, N2 = 4. Before the
+        // guard the two openers added `{}` → n1 = 3, N1 = 6.
+        check_metrics::<PhpParser>(
+            "<?php\n$s = \"dq {$y} end\";\n$t = \"dq {$y} end\";\n",
+            "foo.php",
+            |metric| {
+                assert_eq!(metric.halstead.unique_operators(), 2);
+                assert_eq!(metric.halstead.total_operators(), 4);
+                assert_eq!(metric.halstead.unique_operands(), 3);
+                assert_eq!(metric.halstead.total_operands(), 4);
+            },
+        );
+    }
+
+    #[test]
+    fn php_interpolation_opener_guard_covers_every_wrapper() {
+        // The opener is a direct child of four distinct parents, and
+        // each is an independent leg of the guard (grammar-dispatch
+        // section 11) — a fixture covering only `encapsed_string`
+        // leaves the other three dead.
+        //
+        // Row 2 is a heredoc, whose brace hangs off `heredoc_body`
+        // rather than `heredoc`; row 3 is a backtick
+        // `shell_command_expression`; row 4 is a bare `${$y}`
+        // variable-variable, whose brace belongs to
+        // `dynamic_variable_name` and which is the one position that
+        // is not inside a string at all.
+        //
+        // expected per row: operators `=` × 2, `;` × 2 → n1 = 2,
+        // N1 = 4; three distinct operands with one repeated → n2 = 3,
+        // N2 = 4.
+        for (label, source) in [
+            (
+                "encapsed_string",
+                "<?php\n$s = \"dq {$y} end\";\n$t = \"dq {$y} end\";\n",
+            ),
+            (
+                "heredoc_body and shell_command_expression",
+                "<?php\n$h = <<<EOT\na {$y} b\nEOT;\n$b = `ls {$y}`;\n",
+            ),
+            ("dynamic_variable_name", "<?php\n$q = ${$y};\n$r = ${$y};\n"),
+        ] {
+            assert_halstead_counts::<PhpParser>(source, "foo.php", [2, 4, 3, 4], label);
+        }
+    }
+
+    #[test]
+    fn php_every_interpolation_spelling_scores_alike() {
+        // The policy stated as a test (#1314). PHP writes one
+        // interpolation three ways; the choice is spelling, so all
+        // three must score identically. Before the guard the two
+        // braced forms reported a `{}` the bare `$y` form did not.
+        //
+        // `"${y}"` is deprecated as of PHP 8.2 and removed in 9.0, but
+        // the pinned grammar still parses it and it is still in the
+        // wild, so it stays a row here.
+        //
+        // The fixture deliberately omits a `$y = …` declaration: with
+        // one, the bare and `{$y}` forms key their operand as `$y` and
+        // collapse into the declaration's entry while `${y}` keys as
+        // `${y}` and does not, so n2 would differ for a reason that has
+        // nothing to do with this guard.
+        //
+        // expected per spelling: operators `=` × 2, `;` × 2 → n1 = 2,
+        // N1 = 4; operands `$s`, `$t`, the interpolated reference × 2
+        // → n2 = 3, N2 = 4.
+        for literal in ["\"a $y b\"", "\"a {$y} b\"", "\"a ${y} b\""] {
+            assert_halstead_counts::<PhpParser>(
+                &format!("<?php\n$s = {literal};\n$t = {literal};\n"),
+                "foo.php",
+                [2, 4, 3, 4],
+                &format!("interpolation {literal}"),
+            );
+        }
+    }
+
+    #[test]
+    fn php_compound_statement_brace_still_counts() {
+        // Control for #1314: the guard is scoped to the four
+        // interpolating wrappers, so a real block keeps its `{}`. A
+        // guard widened to every `LBRACE` would take `{}` out of the
+        // operator set entirely and fail here.
+        //
+        // expected: operators `function`, `()`, `{}` × 2, `if`,
+        // `return`, `;` → n1 = 6, N1 = 8. Operands `f`, `1`, `2` →
+        // n2 = N2 = 3.
+        check_metrics::<PhpParser>(
+            "<?php\nfunction f() { if (1) { return 2; } }\n",
+            "foo.php",
+            |metric| {
+                assert_eq!(metric.halstead.unique_operators(), 6);
+                assert_eq!(metric.halstead.total_operators(), 8);
+                assert_eq!(metric.halstead.unique_operands(), 3);
+                assert_eq!(metric.halstead.total_operands(), 3);
+            },
+        );
+    }
+
+    #[test]
+    fn php_interpolation_guard_is_parent_scoped_not_ancestor_scoped() {
+        // The input that separates the parent-scoped guard from the
+        // ancestor-scanning mutant — the mutant #1256's post-mortem
+        // says survives every ordinary fixture. PHP is one of only two
+        // languages in #1314 where such an input exists: a closure
+        // inside a complex interpolation puts a *compound-statement*
+        // brace under an `encapsed_string` ancestor while its parent is
+        // the `compound_statement`. An ancestor scan swallows it.
+        //
+        // expected: operators `=`, `;` × 2, `->`, `()` × 2, `function`,
+        // `{}`, `return` → n1 = 7, N1 = 9. Operands `$s`, `$o`, `m`,
+        // `1` → n2 = N2 = 4. Under the ancestor-scoped mutant the
+        // closure's brace vanishes: n1 = 6, N1 = 8.
+        check_metrics::<PhpParser>(
+            "<?php\n$s = \"{$o->m(function() { return 1; })}\";\n",
+            "foo.php",
+            |metric| {
+                assert_eq!(metric.halstead.unique_operators(), 7);
+                assert_eq!(metric.halstead.total_operators(), 9);
+                assert_eq!(metric.halstead.unique_operands(), 4);
+                assert_eq!(metric.halstead.total_operands(), 4);
+            },
+        );
+    }
+
+    #[test]
     fn elixir_operators_and_operands() {
         // Exercises every Halstead family classified in Elixir's
         // `get_op_type`: control-flow keywords (`do`, `end`, `fn`),
@@ -4772,15 +4905,20 @@ f() {
         // `Regex` as a further ancestor, so an ancestor scan would
         // swallow it. Every other fixture in this file passes under
         // both spellings. Two interpolations, so the mutant moves both
-        // n1 (3 → 2) and N1 (5 → 3).
+        // n1 (2 → 1) and N1 (3 → 1).
         //
-        // expected: operators `=`, `#{` × 2, `/` × 2 → n1 = 3, N1 = 5.
-        // Operands `w`, `p`, `q`, `r`, `t` → n2 = N2 = 5; the wrapping
-        // `Regex` is skipped because it carries an `Interpolation`
-        // child (the #180 double-count guard).
+        // expected: operators `=`, `/` × 2 → n1 = 2, N1 = 3. Operands
+        // `w`, `p`, `q`, `r`, `t` → n2 = N2 = 5; the wrapping `Regex`
+        // is skipped because it carries an `Interpolation` child (the
+        // #180 double-count guard).
+        //
+        // Was n1 = 3, N1 = 5 until #1314 dropped `#{` from the operator
+        // arm. The mutant still moves both axes, so this fixture is as
+        // discriminating as it was — it just no longer counts the two
+        // interpolation openers alongside the two divisions.
         check_metrics::<RubyParser>("w = /a#{p / q}c#{r / t}b/\n", "foo.rb", |metric| {
-            assert_eq!(metric.halstead.unique_operators(), 3);
-            assert_eq!(metric.halstead.total_operators(), 5);
+            assert_eq!(metric.halstead.unique_operators(), 2);
+            assert_eq!(metric.halstead.total_operators(), 3);
             assert_eq!(metric.halstead.unique_operands(), 5);
             assert_eq!(metric.halstead.total_operands(), 5);
         });
@@ -4813,6 +4951,55 @@ f() {
                 "Ruby::SLASH must be the delimiter kind for `{source}`"
             );
         }
+    }
+
+    #[test]
+    fn ruby_interpolation_opener_is_not_an_operator() {
+        // Behaviour change, not a fabrication fix: #1314 drops
+        // `HASHLBRACE` from Ruby's operator arm. `#{` is a token of its
+        // own here — unlike PHP's `{`, which aliases the
+        // compound-statement brace — so nothing was being miscounted;
+        // the question was whether an interpolation opener is an
+        // operation at all, and across the five interpolating languages
+        // three already said no. Ruby Halstead operator counts drop for
+        // interpolated literals as a result.
+        //
+        // Asserted as an invariance: the interpolated and plain
+        // spellings of one string must now score identically, which is
+        // the policy rather than a magic number. Before the change the
+        // interpolated row was n1 = 2, N1 = 3.
+        //
+        // expected per row: operator `=` × 2 → n1 = 1, N1 = 2; operands
+        // `s`, `t`, and the literal's content contribution × 2 →
+        // n2 = 3, N2 = 4.
+        for literal in ["\"a #{y} b\"", "\"a b\""] {
+            assert_halstead_counts::<RubyParser>(
+                &format!("s = {literal}\nt = {literal}\n"),
+                "foo.rb",
+                [1, 2, 3, 4],
+                &format!("literal {literal}"),
+            );
+        }
+    }
+
+    #[test]
+    fn ruby_interpolation_opener_drop_covers_every_literal() {
+        // `HASHLBRACE` is one arm, but it fires under every Ruby
+        // literal that interpolates, so the drop is not specific to
+        // double-quoted strings. A symbol and a regex — two literals
+        // whose `#{…}` reaches the same token — must contribute no
+        // operator for the opener either.
+        //
+        // expected: operator `=` × 3 → n1 = 1, N1 = 3. Operands `y`,
+        // `1`, `a`, `b`, plus the two interpolated `y` references →
+        // n2 = 4, N2 = 6. Before the change each `#{` added one →
+        // n1 = 2, N1 = 5.
+        check_metrics::<RubyParser>("y = 1\na = :\"s#{y}\"\nb = /r#{y}/\n", "foo.rb", |metric| {
+            assert_eq!(metric.halstead.unique_operators(), 1);
+            assert_eq!(metric.halstead.total_operators(), 3);
+            assert_eq!(metric.halstead.unique_operands(), 4);
+            assert_eq!(metric.halstead.total_operands(), 6);
+        });
     }
 
     /// Comprehensive iRules Halstead test exercising every operator family

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -4766,12 +4766,12 @@ f() {
         // section 11) — a fixture covering only `encapsed_string`
         // leaves the other three dead.
         //
-        // Row 2 is a heredoc, whose brace hangs off `heredoc_body`
-        // rather than `heredoc`; row 3 is a backtick
-        // `shell_command_expression`; row 4 is a bare `${$y}`
-        // variable-variable, whose brace belongs to
-        // `dynamic_variable_name` and which is the one position that
-        // is not inside a string at all.
+        // One row per parent, so a failure names the leg that broke.
+        // The heredoc's brace hangs off `heredoc_body` rather than
+        // `heredoc`; the backtick form is `shell_command_expression`;
+        // and the bare `${$y}` variable-variable is a
+        // `dynamic_variable_name`, the one position that is not inside
+        // a string at all.
         //
         // expected per row: operators `=` × 2, `;` × 2 → n1 = 2,
         // N1 = 4; three distinct operands with one repeated → n2 = 3,
@@ -4782,8 +4782,12 @@ f() {
                 "<?php\n$s = \"dq {$y} end\";\n$t = \"dq {$y} end\";\n",
             ),
             (
-                "heredoc_body and shell_command_expression",
-                "<?php\n$h = <<<EOT\na {$y} b\nEOT;\n$b = `ls {$y}`;\n",
+                "heredoc_body",
+                "<?php\n$h = <<<EOT\na {$y} b\nEOT;\n$i = <<<EOT\na {$y} b\nEOT;\n",
+            ),
+            (
+                "shell_command_expression",
+                "<?php\n$b = `ls {$y}`;\n$c = `ls {$y}`;\n",
             ),
             ("dynamic_variable_name", "<?php\n$q = ${$y};\n$r = ${$y};\n"),
         ] {

--- a/src/metrics/loc/lua.rs
+++ b/src/metrics/loc/lua.rs
@@ -37,9 +37,7 @@ impl Loc for LuaCode {
             // string nodes, so we guard on the parent kind to avoid skipping them there.
             Lua::DASHDASH | Lua::CommentContent | Lua::CommentContent2 => {}
             Lua::LBRACKLBRACK | Lua::RBRACKRBRACK
-                if ancestors
-                    .parent(node)
-                    .is_some_and(|p| p.kind_id() == Lua::Comment) => {}
+                if ancestors.parent_has_kind(node, Lua::Comment as u16) => {}
 
             Lua::Comment => {
                 add_cloc_lines(stats, start, end);

--- a/src/metrics/snapshots/big_code_analysis__metrics__halstead__tests__elixir_interpolated_string_no_double_count.snap
+++ b/src/metrics/snapshots/big_code_analysis__metrics__halstead__tests__elixir_interpolated_string_no_double_count.snap
@@ -3,18 +3,18 @@ source: src/metrics/halstead.rs
 expression: metric.halstead
 ---
 {
-  "unique_operators": 5,
-  "total_operators": 5,
+  "unique_operators": 4,
+  "total_operators": 4,
   "unique_operands": 4,
   "total_operands": 5,
-  "length": 10,
-  "estimated_program_length": 19.60964047443681,
-  "purity_ratio": 1.960964047443681,
-  "vocabulary": 9,
-  "volume": 31.69925001442312,
-  "difficulty": 3.125,
-  "level": 0.32,
-  "effort": 99.06015629507226,
-  "time": 5.503342016392903,
-  "bugs": 0.007136381924287368
+  "length": 9,
+  "estimated_program_length": 16.0,
+  "purity_ratio": 1.7777777777777777,
+  "vocabulary": 8,
+  "volume": 27.0,
+  "difficulty": 2.5,
+  "level": 0.4,
+  "effort": 67.5,
+  "time": 3.75,
+  "bugs": 0.005526047247960579
 }

--- a/src/metrics/snapshots/big_code_analysis__metrics__halstead__tests__tcl_bitwise_ternary_string_ops.snap
+++ b/src/metrics/snapshots/big_code_analysis__metrics__halstead__tests__tcl_bitwise_ternary_string_ops.snap
@@ -4,17 +4,17 @@ expression: metric.halstead
 ---
 {
   "unique_operators": 18,
-  "total_operators": 33,
+  "total_operators": 31,
   "unique_operands": 17,
   "total_operands": 30,
-  "length": 63,
+  "length": 61,
   "estimated_program_length": 144.5455183272174,
-  "purity_ratio": 2.2943733067812286,
+  "purity_ratio": 2.3695986611019246,
   "vocabulary": 35,
-  "volume": 323.1448300675329,
+  "volume": 312.88626403364293,
   "difficulty": 15.882352941176471,
   "level": 0.06296296296296296,
-  "effort": 5132.300242249052,
-  "time": 285.12779123605844,
-  "bugs": 0.09917908909381982
+  "effort": 4969.370075828447,
+  "time": 276.0761153238026,
+  "bugs": 0.09706879512049184
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -579,6 +579,24 @@ impl<'tree, 'chain> Ancestors<'tree, 'chain> {
         }
     }
 
+    /// Whether `node`'s parent has kind id `kind`.
+    ///
+    /// The compound-leaf guard of `.claude/rules/grammar-dispatch.md`
+    /// section 5 asks this and nothing else: a delimiter or keyword
+    /// token is suppressed *only* directly under the construct that
+    /// owns it, never under an arbitrary ancestor. Seventeen dispatch
+    /// arms across `getter`, `checker` and the metric walkers spelled
+    /// it out as `.parent(node).is_some_and(|p| p.kind_id() == X as
+    /// u16)`, which wraps onto four rustfmt lines inside a match guard
+    /// and buries the question under the plumbing.
+    ///
+    /// A `false` when `node` has no parent is the answer every one of
+    /// those call sites wants: a root node's token is not inside the
+    /// construct, so it is not suppressed.
+    pub(crate) fn parent_has_kind(self, node: &Node<'tree>, kind: u16) -> bool {
+        self.parent(node).is_some_and(|p| p.kind_id() == kind)
+    }
+
     /// The sibling immediately before `node`, or `None` when `node` is
     /// its parent's first child or has no parent.
     ///

--- a/src/node.rs
+++ b/src/node.rs
@@ -584,11 +584,14 @@ impl<'tree, 'chain> Ancestors<'tree, 'chain> {
     /// The compound-leaf guard of `.claude/rules/grammar-dispatch.md`
     /// section 5 asks this and nothing else: a delimiter or keyword
     /// token is suppressed *only* directly under the construct that
-    /// owns it, never under an arbitrary ancestor. Seventeen dispatch
+    /// owns it, never under an arbitrary ancestor. Eleven dispatch
     /// arms across `getter`, `checker` and the metric walkers spelled
     /// it out as `.parent(node).is_some_and(|p| p.kind_id() == X as
     /// u16)`, which wraps onto four rustfmt lines inside a match guard
-    /// and buries the question under the plumbing.
+    /// and buries the question under the plumbing; #1314 added six more
+    /// and folded all seventeen onto this. The same shape survives in
+    /// `impl_is_else_if_parent_clause!` (`src/checker.rs`), which
+    /// spells its binding `|parent|` and was left alone.
     ///
     /// A `false` when `node` has no parent is the answer every one of
     /// those call sites wants: a root node's token is not inside the

--- a/src/node.rs
+++ b/src/node.rs
@@ -589,9 +589,11 @@ impl<'tree, 'chain> Ancestors<'tree, 'chain> {
     /// it out as `.parent(node).is_some_and(|p| p.kind_id() == X as
     /// u16)`, which wraps onto four rustfmt lines inside a match guard
     /// and buries the question under the plumbing; #1314 added six more
-    /// and folded all seventeen onto this. The same shape survives in
-    /// `impl_is_else_if_parent_clause!` (`src/checker.rs`), which
-    /// spells its binding `|parent|` and was left alone.
+    /// and folded all seventeen onto this. Three sites spelling their
+    /// binding `|parent|` were left alone and would each fit:
+    /// `impl_is_else_if_parent_clause!` (`src/checker.rs`),
+    /// `is_stabby_lambda_body` (`src/checker/ruby.rs`) and
+    /// `is_useful_comment` (`src/checker/rust.rs`, a let-chain).
     ///
     /// A `false` when `node` has no parent is the answer every one of
     /// those call sites wants: a root node's token is not inside the

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -456,6 +456,34 @@ mod tests {
     }
 
     #[test]
+    fn perl_pattern_operations_render_as_source_spellings() {
+        // #1314 classifies `s///` and `tr///` as Halstead operators.
+        // They are *named* nodes rather than punctuation tokens, so the
+        // `get_operator!` macro's fallback would render each kind's own
+        // name — `substitution_pattern_s`, `transliteration_tr_or_y` —
+        // into `bca ops`, which reads as a bug rather than as Perl.
+        // `PerlCode::get_operator_id_as_str` is hand-written to map
+        // them, and this is what pins that mapping: the counts alone
+        // cannot see it.
+        //
+        // `y///` is a synonym of `tr///` and shares one kind, so the
+        // two source spellings collapse to a single `tr///` entry —
+        // asserted here by the *absence* of a `y///` row in an
+        // exhaustive expectation, not by a negative assertion.
+        //
+        // The trailing `/pat/` keeps a pattern *value* in the fixture,
+        // so the test also shows the split: the operation spellings are
+        // operators while the value is an operand.
+        check_ops(
+            LANG::Perl,
+            "$s =~ s/a/b/;\n$s =~ tr/c/d/;\n$s =~ y/e/f/;\n$t = /pat/;",
+            "foo.pl",
+            &mut ["$", ";", "=", "=~", "s///", "tr///"],
+            &mut ["$s", "$t", "/pat/"],
+        );
+    }
+
+    #[test]
     fn python_function_ops() {
         check_ops(
             LANG::Python,

--- a/tests/parity/cpp_mozcpp_parity.rs
+++ b/tests/parity/cpp_mozcpp_parity.rs
@@ -96,3 +96,45 @@ fn cpp_and_mozcpp_agree_on_plain_cpp() {
         "fixture should exercise assignments and branches: {cpp:?}"
     );
 }
+
+#[test]
+fn cpp_and_mozcpp_agree_on_raw_string_delimiters() {
+    // #1314 guards `LPAREN` under a `RawStringLiteral` parent in both
+    // `CppCode::get_op_type` and its `MozcppCode` clone. Mozcpp owns no
+    // file extension, so nothing else exercises its copy — this is the
+    // whole coverage the clone has.
+    //
+    // The fixture pairs two raw strings with a real call, so the
+    // assertion below separates "the delimiter stopped counting" from
+    // "every `(` stopped counting": a guard widened past the literal
+    // would drop `f(a)`'s parenthesis too and take N1 to 7.
+    let source = "auto a = R\"(raw)\";\nauto b = R\"tag(raw)tag\";\nint c = f(a);\n";
+
+    let cpp = metric_sums(LANG::Cpp, source, "cpp");
+    let mozcpp = metric_sums(LANG::Mozcpp, source, "cpp");
+    assert_eq!(
+        cpp, mozcpp,
+        "Cpp and Mozcpp must agree on raw-string delimiter classification"
+    );
+
+    let get = |key: &str| {
+        cpp.iter()
+            .find(|(k, _)| *k == key)
+            .map_or_else(|| panic!("metric_sums omitted {key}: {cpp:?}"), |(_, v)| *v)
+    };
+    // Operators: `;` x 3, `=` x 3, `int`, and the one `()` from `f(a)`
+    // -> N1 = 8. Before the guard the two raw-string openers added two
+    // more `()` -> N1 = 10.
+    assert_eq!(
+        get("halstead.operators"),
+        8,
+        "raw-string openers must not count, and the real call must: {cpp:?}"
+    );
+    // Operands: the two raw-string literals (distinct text), `a` twice,
+    // `b`, `c`, `f` -> N2 = 7.
+    assert_eq!(
+        get("halstead.operands"),
+        7,
+        "both raw-string literals must still count as operands: {cpp:?}"
+    );
+}


### PR DESCRIPTION
Fixes #1314

A literal wrapper's delimiter token shares its `kind_id` with a real
operator, so the generic operator arm classified it. The count then
reported an operation that appears nowhere in the source, and it moved
with the author's choice of delimiter — spelling, not semantics. This is
the third instalment of a class already fixed twice: #1256 (Elixir
sigils) and #1312 (Ruby regex, Perl bare match). Every dispatch touched
here carried a `FIXME(#1314)` anchor left by #1312.

Two secondary defects rode along: the JS-family `Regex` literal was in
*neither* the operator nor the operand arm, so `/abc/g` contributed
nothing at all; and Perl's five pattern wrappers all scored zero.

## What changed

| Language | Guard |
|---|---|
| javascript / mozjs / typescript / tsx | `SLASH` under `Regex` → `Unknown`; `Regex` added to the operand arm |
| groovy | `SLASH` under `StringLiteral` (slashy strings) |
| cpp / mozcpp | `LPAREN` under `RawStringLiteral` |
| tcl / irules | `LBRACE` under `BracedWordSimple` |
| php | `LBRACE` under four interpolation parents |
| ruby / elixir | `HASHLBRACE` dropped from the operator arm |
| perl | pattern wrappers split by semantics (below) |

Each guard is parent-scoped, never ancestor-scoped — the compound-leaf
rule of `grammar-dispatch.md` §5.

**One deliberate behaviour change, called out separately in the
changelog.** Ruby and Elixir stop counting `#{` as an operator. This is
policy, not a fabrication repair, so Halstead operator counts drop for
every interpolated string, symbol, regex, heredoc and subshell in those
two languages. The rule is now uniform: measured across the six
interpolating languages, three already declined to count the opener
(kotlin, csharp, groovy); this makes it six of six.

## Five corrections to the issue's plan

Each verified with `bca dump` before acting, per "do not assume the
issue is accurate":

1. **PHP needs four parent kinds, not one.** The opener is a direct
   child of `encapsed_string`, `heredoc_body` (the *body*, not
   `heredoc`), `shell_command_expression` **and**
   `dynamic_variable_name`. The issue named only the first, which would
   have left three of four legs fabricating.
2. **Elixir had to join.** The issue scoped the interpolation change to
   Ruby, but Elixir counts `#{` through the same `HASHLBRACE` token —
   found by the review pass, after the changelog already stated the rule
   as universal.
3. **Perl's pattern values cannot be plain operands.** `/$x/` keeps its
   variable inside an unclassified `regex_pattern_content`, but `m/$x/`
   and `qr/$x/i` emit a real `interpolation` that is already counted. A
   plain operand arm scores the two spellings differently — reintroducing
   the exact sensitivity `perl_every_pattern_spelling_scores_alike`
   exists to pin. All three route through `string_operand_type`.
   `s///` and `tr///`/`y///` are operations, not values, so they land in
   the operator arm with hand-written `s///` / `tr///` glyphs (otherwise
   `bca ops` prints raw kind names, which reads as a bug).
4. **The parent-vs-ancestor mutant is observable in four languages, not
   two.** This is the mutant #1256's post-mortem says survives every
   ordinary fixture, so it decides where a test is real. My own first
   draft had Tcl/iRules as unobservable; the review disproved it —
   `set z {x [if {$q} {puts w}] v}` nests an `Expr` and a `BracedWord`,
   each with its own `{`, under a `BracedWordSimple` ancestor. Tests
   added for groovy, php, tcl and irules. It is genuinely unobservable
   in JS and C++ (both contents are leaves); that is stated in the
   comments rather than faked with a fixture that discriminates nothing.
5. **Snapshot churn was 41 files, not the ~337 a regex estimate
   suggested.**

## Testing

~20 new tests in `src/metrics/halstead.rs`, one in `src/ops.rs`, one in
`tests/parity/cpp_mozcpp_parity.rs` (mozcpp owns no file extension, so
that parity test is its only coverage).

Every arm is proved load-bearing. A **scripted 14-case perturbation
sweep** — file read into memory once and restored in a `finally`, never
`git checkout --`, per `testing.md` — deletes each guard and widens
parent to ancestor. All 14 now fail at least one named test. Two
initially failed nothing and were fixed rather than explained away: the
mozcpp arm (covered by a parity test the sweep wasn't running) and the
Perl glyph rendering (genuinely untested — now pinned).

Patch coverage: `cargo llvm-cov` confirms every added production line is
covered; the one uncovered added line is an `assert_eq!` failure-message
argument. Project figure 98.19%.

Existing tests that moved were re-derived by hand, not pasted. Two were
themselves wrong: `groovy_dekobon_operator_coverage_247` enumerated an
ambient `[` that never appears and omitted the fabricated `/`.

`make pre-commit` → `BCA_GATE: pass`, run against this worktree.

The issue's original evidence table was re-probed against a freshly
built binary: every fabricated operator is gone and no real one
vanished.

## Review

`simplify-rust`, `rust-optimize`, `review` and `audit-tests` all ran.
The review pass produced items 2 and 4 above plus the finding that the
Tcl fix is partial; `audit-tests` caught a PHP test with three rows for
four parents.

`Ancestors::parent_has_kind` (`src/node.rs`) folds 17 copies of the
parent-check idiom onto one helper. It was introduced to resolve
`clippy::too_many_lines` on `IrulesCode::get_op_type` without the
workspace's first `too_many_lines` allow, and it *lowered*
`halstead.effort` in four of five affected baseline entries.

The `.rustfmt-bail-baseline.txt` bump is a ratchet in the harmless
direction: the guard arms are shorter, so rustfmt has less to re-wrap
inside matches that already bail.

## Follow-ups filed, not fixed here

- #1317 — Tcl/iRules braced words double-count their inner words.
- #1318 — Tcl/iRules braced literals still fabricate a block outside the
  special-cased commands. Closing it needs command-name recognition
  (`grammar-dispatch.md` §9), not another kind arm; anchored with a
  `FIXME` at the arm.

## Submodule

`tests/repositories/big-code-analysis-output` is pushed
(`377a5ae1..c6840dce` on its `main`) and the parent records that exact
SHA, so a fresh clone resolves.
