### PR TITLE
fix(dev-env): give the container its own Python venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1353,7 +1353,14 @@ lint:
 # `.SHELLFLAGS := -eu -o pipefail -c`.
 py-clean:
 	@echo "Removing Python build artifacts..."
-	@rm -rf "$(BCA_PY_DIR)/.venv"
+	@# `.venv` is a bind-mount point inside the dev container
+	@# (see dev-env-run), and a mount point cannot be unlinked:
+	@# plain `rm -rf` would abort the recipe with EBUSY. Empty it in
+	@# place when the directory itself refuses to go away.
+	@rm -rf "$(BCA_PY_DIR)/.venv" 2>/dev/null || \
+	  { find "$(BCA_PY_DIR)/.venv" -mindepth 1 -maxdepth 1 \
+	      -exec rm -rf {} + && \
+	    echo "  .venv is a mount point; emptied it in place."; }
 	@rm -rf "$(BCA_PY_DIR)/.pytest_cache"
 	@rm -rf "$(BCA_PY_DIR)/.mypy_cache"
 	@rm -rf "$(BCA_PY_DIR)/.ruff_cache"
@@ -2095,6 +2102,25 @@ DEV_IMAGE      := big-code-analysis-dev:latest
 DEV_CONTAINER  := big-code-analysis-dev
 DEV_MOUNT      := /home/dev/source/big-code-analysis
 
+# The container needs its own big-code-analysis-py/.venv. A venv records
+# absolute interpreter paths in every console-script shebang and in
+# pyvenv.cfg, so the one directory cannot serve both sides of the bind
+# mount: whichever environment ran `uv sync` last owns it, and the other
+# gets `bad interpreter: .../.venv/bin/python: No such file or directory`
+# from every py-* recipe. Mounting a host-side directory over that path
+# keeps the in-container path spelled `.venv`, so none of the recipes
+# that resolve `$(BCA_PY_DIR)/.venv/bin/*` need to know this exists.
+# Ownership lines up because dev-env-build passes the caller's UID/GID.
+#
+# The cache outlives the container while the container's home — and the
+# uv-managed interpreter the venv points at — does not, so after
+# `dev-env-rm` + `dev-env-run` a stale venv can name a missing
+# interpreter. uv's remediation is to delete and recreate `.venv`, which
+# cannot work on a mount point; empty the cache dir on the host instead.
+# See docker/README.md.
+DEV_VENV       := $(or $(XDG_CACHE_HOME),$(HOME)/.cache)/big-code-analysis-dev/py-venv
+DEV_PY_VENV    := $(DEV_MOUNT)/big-code-analysis-py/.venv
+
 dev-env-build:
 	docker build \
 	  --build-arg USER_UID=$(shell id -u) \
@@ -2103,13 +2129,24 @@ dev-env-build:
 	  --file $(BASE_DIR)Dockerfile "$(BASE_DIR)"
 
 dev-env-run:
+	mkdir -p "$(DEV_VENV)"
+	@# Pre-create the mount target too. Docker mounts the repo first and
+	@# then creates the deeper target if it is missing — as root, and on
+	@# the host, since that path lives inside the bind-mounted checkout.
+	@# A contributor who has not yet run `make py-bootstrap` on the host
+	@# would otherwise find a root-owned `.venv` in their working tree
+	@# and host-side `uv sync` failing with permission denied.
+	mkdir -p "$(BCA_PY_DIR)/.venv"
 	docker run --detach --init \
 	  --name $(DEV_CONTAINER) \
 	  --volume "$(BASE_DIR):$(DEV_MOUNT)" \
+	  --volume "$(DEV_VENV):$(DEV_PY_VENV)" \
 	  --env ANTHROPIC_API_KEY \
 	  --env CODEGRAPH_LLM_API_KEY \
 	  $(DEV_IMAGE) sleep infinity
 	@echo "Started $(DEV_CONTAINER). Open a shell with: make dev-env-shell"
+	@echo "Run 'make py-bootstrap' inside it once to populate $(DEV_PY_VENV)"
+	@echo "  (backed by $(DEV_VENV) on the host)."
 
 dev-env-shell:
 	docker exec --interactive --tty --workdir $(DEV_MOUNT) $(DEV_CONTAINER) bash

--- a/docker/README.md
+++ b/docker/README.md
@@ -60,6 +60,37 @@ The container mounts this repository at
 (`id -u` / `id -g`) so files written in the mounted checkout keep the right
 ownership on the host.
 
+One directory inside that checkout is deliberately *not* shared:
+`big-code-analysis-py/.venv`. `make dev-env-run` mounts
+`~/.cache/big-code-analysis-dev/py-venv` over it (`$XDG_CACHE_HOME` wins
+where it is set), so the container gets its own virtualenv. A venv records absolute interpreter paths in
+`pyvenv.cfg` and in every console-script shebang, so a single directory
+cannot serve both sides of the bind mount — whichever environment ran
+`uv sync` last owns it, and the other gets
+
+```text
+bash: .venv/bin/mypy: /…/.venv/bin/python: bad interpreter
+```
+
+from `py-typecheck`, `py-test`, `py-stubtest` and friends. Because the
+in-container path is still spelled `.venv`, no `py-*` recipe needs to
+know about the split. Run `make py-bootstrap` once inside the container
+to populate it; the host's own venv contents are untouched.
+
+The cache directory outlives the container, but the container's home —
+and with it the uv-managed interpreter the venv points at — does not. So
+after a `make dev-env-rm` / `make dev-env-run` cycle the cached venv can
+name an interpreter that no longer exists, and uv cannot repair it in
+place because a mount point cannot be deleted. Reset it from the host:
+
+```bash
+rm -rf ~/.cache/big-code-analysis-dev/py-venv/*
+```
+
+then `make py-bootstrap` inside the container again. For the same reason
+`make py-clean` empties `.venv` in place rather than removing it when it
+is the mount point.
+
 ## Authentication
 
 Claude Code state lives in the container's home directory, which persists


### PR DESCRIPTION
## Problem

The host and the dev container bind-mount the same checkout, so they
contended for a single `big-code-analysis-py/.venv`. A venv records
absolute interpreter paths in `pyvenv.cfg` and in every console-script
shebang, so one directory cannot serve both sides:

```text
bash: .venv/bin/mypy: /home/dev/source/…/.venv/bin/python: bad interpreter
```

Whichever environment ran `uv sync` last owned it and the other got that
from `py-typecheck`, `py-test` and `py-stubtest`. `make worktree-setup` on
the host is enough to take ownership, so the two silently broke each
other — which is how this surfaced.

## Fix

`dev-env-run` mounts a host cache directory over that path, so each side
gets its own virtualenv. The in-container path is still spelled `.venv`,
so **none of the fourteen recipe lines resolving
`$(BCA_PY_DIR)/.venv/bin/*` change** and no gate mechanism is
refactored. Ownership lines up through the UID/GID build args
`dev-env-build` already passes.

Two consequences of the nested mount, both handled:

- **Docker creates a missing deeper mount target itself — as root, and
  on the host,** since the path sits inside the bind mount. Verified in
  an isolated scratch mount: without a pre-created directory the host
  gets a root-owned `.venv` and host-side `uv sync` fails with
  permission denied. `dev-env-run` pre-creates it.
- **A mount point cannot be unlinked,** so `py-clean`'s `rm -rf` aborted
  the recipe with `EBUSY` inside the container, taking `distclean` with
  it. It now empties the directory in place when removal fails.
  Unchanged on the host, where `.venv` is an ordinary directory: removed
  as before, exit 0, and no mount-point message.

`docker/README.md` documents the split, the symptom it prevents, and the
host-side reset for a stale cached venv after a `dev-env-rm` /
`dev-env-run` cycle (the cache outlives the container, but the
uv-managed interpreter it names does not).

## Verification

- `make pre-commit` → `BCA_GATE: pass`
- `make py-typecheck` passing **in the container and on the host
  simultaneously** — mypy 32 files, pyright 0 errors on both sides. That
  state was previously impossible.
- Container recreated from scratch against the final Makefile; container
  `make py-clean` exits 0; host `.venv` intact and user-owned.
- `py-clean` exercised against a populated directory, an absent one, and
  a real mount point — exit 0 in all three.

Scope: dev tooling only. No library, CLI, or web code is touched.
