### PR TITLE
deps: bump tree-sitter from 0.26.11 to 0.26.12

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -718,7 +718,7 @@ half of that rationale fits it too. The exemption is about unification
 pressure and the runtime has none — the lockfile shows 25 crates
 depending on `tree-sitter-language` against one external dependent
 (`tree-sitter-perl`) for `tree-sitter` — and every manifest here already
-pins it at `=0.26.11` with the workspace resolving. Its ABI version is
+pins it at `=0.26.12` with the workspace resolving. Its ABI version is
 also what each vendored `parser.c` was generated against, so an
 accidental bump is precisely the drift the gate exists to catch.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -508,6 +508,21 @@ for historical reference.
 
 ### Changed
 
+- The `tree-sitter` runtime is `=0.26.12`, up one upstream patch
+  release, pinned in lockstep across the root manifest, `enums`, and
+  the five vendored `bca-tree-sitter-*` crates. `tree_sitter` is
+  re-exported from the library root, so the resolved version is visible
+  to consumers. Nothing in the release reaches this workspace's
+  behaviour: `include/tree_sitter/api.h` and the Rust bindings are
+  byte-identical to `0.26.11`, so `TREE_SITTER_LANGUAGE_VERSION` stays
+  at 15 and the vendored `parser.c` sources are unaffected, as is the
+  `Send + Sync` argument the PyO3 bindings rest on. The three C fixes
+  are an error-recovery restart when the parser is already in
+  `ERROR_STATE`, a `has_later_named_siblings` correction in the tree
+  cursor, and query-anchor semantics for skipped quantifiers — the
+  last inert here, since this workspace uses no tree-sitter query API.
+  No metric value moves.
+
 - Ruby's and Elixir's `#{` interpolation opener no longer counts as a
   Halstead operator. Unlike PHP's `{`, which aliases the
   compound-statement brace and was fabricating a block (see Fixed),

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4465,9 +4465,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.11"
+version = "0.26.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df"
+checksum = "83c567a8e18ae93f20982c90370b16fd24023aeaf52f6052b96957ab253a0fec"
 dependencies = [
  "cc",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ authors = [
 # entries via `.workspace = true`, so any grammar bump here MUST be
 # applied to enums/Cargo.toml in lockstep (see recreate-grammars.sh).
 [workspace.dependencies]
-tree-sitter = "=0.26.11"
+tree-sitter = "=0.26.12"
 tree-sitter-bash = "=0.25.1"
 tree-sitter-c-sharp = "=0.23.5"
 tree-sitter-elixir = "=0.3.5"

--- a/big-code-analysis-py/src/node.rs
+++ b/big-code-analysis-py/src/node.rs
@@ -55,7 +55,7 @@
 //! the iterator's own keep-alive.
 //!
 //! `tree_sitter::Tree`, `Node`, and `TreeCursor` are `Send + Sync` under
-//! the pinned `=0.26.11`, so the pyclasses are sendable (no `unsendable`)
+//! the pinned `=0.26.12`, so the pyclasses are sendable (no `unsendable`)
 //! and compose with `ThreadPoolExecutor` fan-out like [`PyAst`] itself.
 
 use big_code_analysis::tree_sitter::{Node as TsNode, TreeCursor};

--- a/enums/Cargo.lock
+++ b/enums/Cargo.lock
@@ -472,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.11"
+version = "0.26.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df"
+checksum = "83c567a8e18ae93f20982c90370b16fd24023aeaf52f6052b96957ab253a0fec"
 dependencies = [
  "cc",
  "regex",

--- a/enums/Cargo.toml
+++ b/enums/Cargo.toml
@@ -26,7 +26,7 @@ askama = "^0.16"
 # [workspace.dependencies]. They MUST be kept in lockstep with the
 # matching block in ../Cargo.toml when grammars are bumped
 # (see recreate-grammars.sh).
-tree-sitter = "=0.26.11"
+tree-sitter = "=0.26.12"
 tree-sitter-bash = "=0.25.1"
 tree-sitter-c-sharp = "=0.23.5"
 tree-sitter-elixir = "=0.3.5"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -621,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.11"
+version = "0.26.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df"
+checksum = "83c567a8e18ae93f20982c90370b16fd24023aeaf52f6052b96957ab253a0fec"
 dependencies = [
  "cc",
  "regex",

--- a/tree-sitter-ccomment/Cargo.lock
+++ b/tree-sitter-ccomment/Cargo.lock
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.11"
+version = "0.26.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df"
+checksum = "83c567a8e18ae93f20982c90370b16fd24023aeaf52f6052b96957ab253a0fec"
 dependencies = [
  "cc",
  "regex",

--- a/tree-sitter-ccomment/Cargo.toml
+++ b/tree-sitter-ccomment/Cargo.toml
@@ -56,4 +56,4 @@ tree-sitter-language="0.1.0"
 cc = "^1.2"
 
 [dev-dependencies]
-tree-sitter = "=0.26.11"
+tree-sitter = "=0.26.12"

--- a/tree-sitter-mozcpp/Cargo.lock
+++ b/tree-sitter-mozcpp/Cargo.lock
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.11"
+version = "0.26.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df"
+checksum = "83c567a8e18ae93f20982c90370b16fd24023aeaf52f6052b96957ab253a0fec"
 dependencies = [
  "cc",
  "regex",

--- a/tree-sitter-mozcpp/Cargo.toml
+++ b/tree-sitter-mozcpp/Cargo.toml
@@ -68,4 +68,4 @@ tree-sitter-cpp = "=0.23.4"
 build = ["tree-sitter-cpp"]
 
 [dev-dependencies]
-tree-sitter = "=0.26.11"
+tree-sitter = "=0.26.12"

--- a/tree-sitter-mozjs/Cargo.lock
+++ b/tree-sitter-mozjs/Cargo.lock
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.11"
+version = "0.26.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df"
+checksum = "83c567a8e18ae93f20982c90370b16fd24023aeaf52f6052b96957ab253a0fec"
 dependencies = [
  "cc",
  "regex",

--- a/tree-sitter-mozjs/Cargo.toml
+++ b/tree-sitter-mozjs/Cargo.toml
@@ -70,4 +70,4 @@ tree-sitter-javascript = "=0.25.0"
 build = ["tree-sitter-javascript"]
 
 [dev-dependencies]
-tree-sitter = "=0.26.11"
+tree-sitter = "=0.26.12"

--- a/tree-sitter-preproc/Cargo.lock
+++ b/tree-sitter-preproc/Cargo.lock
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.11"
+version = "0.26.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df"
+checksum = "83c567a8e18ae93f20982c90370b16fd24023aeaf52f6052b96957ab253a0fec"
 dependencies = [
  "cc",
  "regex",

--- a/tree-sitter-preproc/Cargo.toml
+++ b/tree-sitter-preproc/Cargo.toml
@@ -56,4 +56,4 @@ tree-sitter-language="0.1.0"
 cc = "^1.2"
 
 [dev-dependencies]
-tree-sitter = "=0.26.11"
+tree-sitter = "=0.26.12"

--- a/tree-sitter-tcl/Cargo.lock
+++ b/tree-sitter-tcl/Cargo.lock
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.11"
+version = "0.26.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df"
+checksum = "83c567a8e18ae93f20982c90370b16fd24023aeaf52f6052b96957ab253a0fec"
 dependencies = [
  "cc",
  "regex",

--- a/tree-sitter-tcl/Cargo.toml
+++ b/tree-sitter-tcl/Cargo.toml
@@ -67,4 +67,4 @@ tree-sitter-language = "0.1.0"
 cc = "^1.2"
 
 [dev-dependencies]
-tree-sitter = "=0.26.11"
+tree-sitter = "=0.26.12"

--- a/utils/check-excluded-manifests.py
+++ b/utils/check-excluded-manifests.py
@@ -127,7 +127,7 @@ LINTS_EXEMPT_CRATES = frozenset(
 # is about unification pressure, and the runtime has none: the lockfile
 # shows 25 crates depending on `tree-sitter-language` but only one
 # external crate (`tree-sitter-perl`) depending on `tree-sitter`, and
-# every manifest here already pins it at `=0.26.11` with the workspace
+# every manifest here already pins it at `=0.26.12` with the workspace
 # resolving. The runtime's ABI version is also what a grammar's
 # generated `parser.c` is built against, so an accidental bump is
 # exactly the drift this gate exists to catch.


### PR DESCRIPTION
Takes the `tree-sitter` runtime from `=0.26.11` to `=0.26.12` across
every manifest and lockfile in one commit.

## Why one PR instead of eight

Dependabot opened this bump once per manifest: #1334 (root), #1333
(`/fuzz`), #1331 (`/enums`, which also edits all five vendored
manifests), #1329, #1328, #1327, #1322, #1321. The runtime is `=`-pinned
in **seven** manifests and locked in **eight** lockfiles, and
`utils/check-excluded-manifests.py` requires every one of them to agree.
Merging them serially would leave each intermediate commit with a split
pin — red on the gate, and unresolvable for anyone who checked out that
commit. #1331 also overlaps five of its siblings, so the sequence has no
conflict-free ordering.

This branch supersedes all eight. Closing them in favour of it.

## The release does not reach this workspace's behaviour

Diffed the two published crates directly:

| Surface | Result |
|---------|--------|
| `include/tree_sitter/api.h` | **byte-identical** |
| Rust bindings | **byte-identical** |
| `TREE_SITTER_LANGUAGE_VERSION` | 15, unchanged (min compatible 13) |
| C sources | 3 files, 36 lines |

Because the ABI constants and the header are unchanged, the vendored
`parser.c` sources stay valid against the runtime — the drift
`check-excluded-manifests.py` exists to catch is not present. Because
the Rust bindings are unchanged, the `Send + Sync` argument that
`big-code-analysis-py/src/node.rs` rests on is unaffected.

The three C fixes:

- **`parser.c`** — restart error recovery when the parser is already in
  `ERROR_STATE`. The only change with any plausible reach here, and it
  applies to malformed input.
- **`tree_cursor.c`** — a later *anonymous* sibling no longer settles
  `has_later_named_siblings`.
- **`query.c`** — anchor semantics for skipped quantifiers. Inert: this
  workspace uses no tree-sitter query API (no `Query::new`, no
  `QueryCursor`).

Each lockfile moved exactly this one package; no edge was re-pointed.

## Verification

`make pre-commit` → `BCA_GATE: pass (gate=pre-commit)`

- **5,364 Rust tests pass (10 skipped)** and **363 Python tests pass
  (1 xfailed)** — the same totals `main` carries, so nothing was gained
  or lost.
- **No metric value moved.** The working tree is free of `.snap.new`
  and the `big-code-analysis-output` submodule is clean at its recorded
  SHA `c6840dce`, so no integration snapshot shifted and no submodule
  bump is owed.
- `make fuzz-check` passes separately, since `fuzz/Cargo.lock` sits
  outside the `make pre-commit` DAG. The fuzz targets build against
  0.26.12 under ASan on nightly.

## Also updated

The three in-tree references naming the old pin, each a one-token
in-place edit: the rationale prose in `AGENTS.md` and in
`utils/check-excluded-manifests.py`, and the sendability note in
`big-code-analysis-py/src/node.rs`. The historical `CHANGELOG.md` entry
recording the 0.26.9 → 0.26.11 bump is left as written.

`tree_sitter` is re-exported from the library root, so the resolved
version is visible to consumers and the bump is recorded under
`## [Unreleased]` → `### Changed`. Per `STABILITY.md` a runtime bump
rides a minor release; no public API shape changes.

Grammar pins are untouched — all twenty remain at their `=X.Y.Z`
versions.
