### PR TITLE
fix(dev-env): silence the undefined XDG_CACHE_HOME warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2118,6 +2118,13 @@ DEV_MOUNT      := /home/dev/source/big-code-analysis
 # interpreter. uv's remediation is to delete and recreate `.venv`, which
 # cannot work on a mount point; empty the cache dir on the host instead.
 # See docker/README.md.
+#
+# Default XDG_CACHE_HOME to empty so the `:=` expansion below does not
+# trip `--warn-undefined-variables` when it is unset (the common case
+# off XDG-configured desktops); an environment value still wins, since
+# `?=` only assigns when undefined. Without this the warning fires once
+# per recursive sub-make -- 45 times in one `make pre-commit`.
+XDG_CACHE_HOME ?=
 DEV_VENV       := $(or $(XDG_CACHE_HOME),$(HOME)/.cache)/big-code-analysis-dev/py-venv
 DEV_PY_VENV    := $(DEV_MOUNT)/big-code-analysis-py/.venv
 


### PR DESCRIPTION
Follow-up to #1340. Not a behaviour bug — a warning that #1340's new
variable emits on every recursive `make` for anyone without
`XDG_CACHE_HOME` set.

## Problem

212455cd added

```make
DEV_VENV := $(or $(XDG_CACHE_HOME),$(HOME)/.cache)/big-code-analysis-dev/py-venv
```

and line 11 of the same file sets
`MAKEFLAGS += --warn-undefined-variables`. Reading an unset
`XDG_CACHE_HOME` trips it:

```text
Makefile:2121: warning: undefined variable 'XDG_CACHE_HOME'
```

The variable is unset on any system that has not opted into the XDG
cache location, which is the default on macOS and common on Linux.

**Why it is easy to miss.** `MAKEFLAGS` reaches recursive sub-makes,
not the parse that set it, so the top-level `make help` prints nothing
and only sub-makes warn. It is quiet exactly where you would check by
hand and loud where it matters:

| Invocation | Warnings |
|------------|---------:|
| `make help` | 0 |
| `make worktree-setup` | 1 |
| `make pre-commit` | **45** |

## Fix

Default the variable to empty so the `:=` expansion has something
defined to read. This is the idiom the file already uses for
`BCA_SINCE` a few hundred lines up, with the same reasoning:

```make
XDG_CACHE_HOME ?=
```

`?=` only assigns when undefined, so an environment value still wins
and `DEV_VENV` keeps both of its intended resolutions. Verified:

| `XDG_CACHE_HOME` | `DEV_VENV` |
|---|---|
| unset | `$(HOME)/.cache/big-code-analysis-dev/py-venv` |
| `/custom/cache` | `/custom/cache/big-code-analysis-dev/py-venv` |

No recipe, mount, or documented path changes; `docker/README.md`
already describes both cases correctly.

## Verification

`make pre-commit` → `BCA_GATE: pass (gate=pre-commit)`, with **zero**
`undefined variable` lines in the log, down from 45.
