### PR TITLE
deps: bump tree-sitter from 0.26.12 to 0.26.13

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -728,7 +728,7 @@ half of that rationale fits it too. The exemption is about unification
 pressure and the runtime has none — the lockfile shows 25 crates
 depending on `tree-sitter-language` against one external dependent
 (`tree-sitter-perl`) for `tree-sitter` — and every manifest here already
-pins it at `=0.26.12` with the workspace resolving. Its ABI version is
+pins it at `=0.26.13` with the workspace resolving. Its ABI version is
 also what each vendored `parser.c` was generated against, so an
 accidental bump is precisely the drift the gate exists to catch.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,21 @@ for historical reference.
 
 ## [Unreleased]
 
+### Changed
+
+- The `tree-sitter` runtime is `=0.26.13`, up one upstream patch
+  release, pinned in lockstep across the root manifest, `enums`, the
+  five vendored `bca-tree-sitter-*` crates, and the `fuzz` lockfile.
+  `include/tree_sitter/api.h` is unchanged, so
+  `TREE_SITTER_LANGUAGE_VERSION` stays at 15 and the vendored `parser.c`
+  sources are unaffected; the Rust binding differs only by a dropped
+  `#[must_use]`, so the `Send + Sync` argument the PyO3 bindings rest on
+  is untouched. The C changes are an error-recovery fix that nests the
+  children of a re-parsed error under one `ERROR` node instead of
+  splicing them into the parent, and two query fixes (an exact-length
+  `MISSING` match and a corrected alternative-step skip) that nothing
+  here uses.
+
 ## [2.2.0] - 2026-08-29
 
 One entry below is marked **(breaking)**: the Python bindings'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1822,7 +1822,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c91d8cffac8849493a82233811bd02b2b183b8cf39bf704de0fa0841b737595"
 dependencies = [
  "bstr",
- "hashbrown 0.17.1",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -4118,7 +4118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4455,9 +4455,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.12"
+version = "0.26.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c567a8e18ae93f20982c90370b16fd24023aeaf52f6052b96957ab253a0fec"
+checksum = "17ebdd3a5a7e28a1890b876fdbd0c3c0fe0a6336cffaa104f11b9f720c9daa29"
 dependencies = [
  "cc",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ authors = [
 # entries via `.workspace = true`, so any grammar bump here MUST be
 # applied to enums/Cargo.toml in lockstep (see recreate-grammars.sh).
 [workspace.dependencies]
-tree-sitter = "=0.26.12"
+tree-sitter = "=0.26.13"
 tree-sitter-bash = "=0.25.1"
 tree-sitter-c-sharp = "=0.23.5"
 tree-sitter-elixir = "=0.3.5"

--- a/big-code-analysis-py/src/node.rs
+++ b/big-code-analysis-py/src/node.rs
@@ -55,7 +55,7 @@
 //! the iterator's own keep-alive.
 //!
 //! `tree_sitter::Tree`, `Node`, and `TreeCursor` are `Send + Sync` under
-//! the pinned `=0.26.12`, so the pyclasses are sendable (no `unsendable`)
+//! the pinned `=0.26.13`, so the pyclasses are sendable (no `unsendable`)
 //! and compose with `ThreadPoolExecutor` fan-out like [`PyAst`] itself.
 //! That version literal is a premise, not decoration — the layouts and
 //! the `&mut self` on `Tree::edit` are what make the argument above

--- a/enums/Cargo.lock
+++ b/enums/Cargo.lock
@@ -472,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.12"
+version = "0.26.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c567a8e18ae93f20982c90370b16fd24023aeaf52f6052b96957ab253a0fec"
+checksum = "17ebdd3a5a7e28a1890b876fdbd0c3c0fe0a6336cffaa104f11b9f720c9daa29"
 dependencies = [
  "cc",
  "regex",

--- a/enums/Cargo.toml
+++ b/enums/Cargo.toml
@@ -26,7 +26,7 @@ askama = "^0.16"
 # [workspace.dependencies]. They MUST be kept in lockstep with the
 # matching block in ../Cargo.toml when grammars are bumped
 # (see recreate-grammars.sh).
-tree-sitter = "=0.26.12"
+tree-sitter = "=0.26.13"
 tree-sitter-bash = "=0.25.1"
 tree-sitter-c-sharp = "=0.23.5"
 tree-sitter-elixir = "=0.3.5"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -621,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.12"
+version = "0.26.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c567a8e18ae93f20982c90370b16fd24023aeaf52f6052b96957ab253a0fec"
+checksum = "17ebdd3a5a7e28a1890b876fdbd0c3c0fe0a6336cffaa104f11b9f720c9daa29"
 dependencies = [
  "cc",
  "regex",

--- a/tree-sitter-ccomment/Cargo.lock
+++ b/tree-sitter-ccomment/Cargo.lock
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.12"
+version = "0.26.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c567a8e18ae93f20982c90370b16fd24023aeaf52f6052b96957ab253a0fec"
+checksum = "17ebdd3a5a7e28a1890b876fdbd0c3c0fe0a6336cffaa104f11b9f720c9daa29"
 dependencies = [
  "cc",
  "regex",

--- a/tree-sitter-ccomment/Cargo.toml
+++ b/tree-sitter-ccomment/Cargo.toml
@@ -56,4 +56,4 @@ tree-sitter-language="0.1.0"
 cc = "^1.2"
 
 [dev-dependencies]
-tree-sitter = "=0.26.12"
+tree-sitter = "=0.26.13"

--- a/tree-sitter-mozcpp/Cargo.lock
+++ b/tree-sitter-mozcpp/Cargo.lock
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.12"
+version = "0.26.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c567a8e18ae93f20982c90370b16fd24023aeaf52f6052b96957ab253a0fec"
+checksum = "17ebdd3a5a7e28a1890b876fdbd0c3c0fe0a6336cffaa104f11b9f720c9daa29"
 dependencies = [
  "cc",
  "regex",

--- a/tree-sitter-mozcpp/Cargo.toml
+++ b/tree-sitter-mozcpp/Cargo.toml
@@ -68,4 +68,4 @@ tree-sitter-cpp = "=0.23.4"
 build = ["tree-sitter-cpp"]
 
 [dev-dependencies]
-tree-sitter = "=0.26.12"
+tree-sitter = "=0.26.13"

--- a/tree-sitter-mozjs/Cargo.lock
+++ b/tree-sitter-mozjs/Cargo.lock
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.12"
+version = "0.26.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c567a8e18ae93f20982c90370b16fd24023aeaf52f6052b96957ab253a0fec"
+checksum = "17ebdd3a5a7e28a1890b876fdbd0c3c0fe0a6336cffaa104f11b9f720c9daa29"
 dependencies = [
  "cc",
  "regex",

--- a/tree-sitter-mozjs/Cargo.toml
+++ b/tree-sitter-mozjs/Cargo.toml
@@ -70,4 +70,4 @@ tree-sitter-javascript = "=0.25.0"
 build = ["tree-sitter-javascript"]
 
 [dev-dependencies]
-tree-sitter = "=0.26.12"
+tree-sitter = "=0.26.13"

--- a/tree-sitter-preproc/Cargo.lock
+++ b/tree-sitter-preproc/Cargo.lock
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.12"
+version = "0.26.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c567a8e18ae93f20982c90370b16fd24023aeaf52f6052b96957ab253a0fec"
+checksum = "17ebdd3a5a7e28a1890b876fdbd0c3c0fe0a6336cffaa104f11b9f720c9daa29"
 dependencies = [
  "cc",
  "regex",

--- a/tree-sitter-preproc/Cargo.toml
+++ b/tree-sitter-preproc/Cargo.toml
@@ -56,4 +56,4 @@ tree-sitter-language="0.1.0"
 cc = "^1.2"
 
 [dev-dependencies]
-tree-sitter = "=0.26.12"
+tree-sitter = "=0.26.13"

--- a/tree-sitter-tcl/Cargo.lock
+++ b/tree-sitter-tcl/Cargo.lock
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.12"
+version = "0.26.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c567a8e18ae93f20982c90370b16fd24023aeaf52f6052b96957ab253a0fec"
+checksum = "17ebdd3a5a7e28a1890b876fdbd0c3c0fe0a6336cffaa104f11b9f720c9daa29"
 dependencies = [
  "cc",
  "regex",

--- a/tree-sitter-tcl/Cargo.toml
+++ b/tree-sitter-tcl/Cargo.toml
@@ -67,4 +67,4 @@ tree-sitter-language = "0.1.0"
 cc = "^1.2"
 
 [dev-dependencies]
-tree-sitter = "=0.26.12"
+tree-sitter = "=0.26.13"

--- a/utils/check-excluded-manifests.py
+++ b/utils/check-excluded-manifests.py
@@ -127,7 +127,7 @@ LINTS_EXEMPT_CRATES = frozenset(
 # is about unification pressure, and the runtime has none: the lockfile
 # shows 25 crates depending on `tree-sitter-language` but only one
 # external crate (`tree-sitter-perl`) depending on `tree-sitter`, and
-# every manifest here already pins it at `=0.26.12` with the workspace
+# every manifest here already pins it at `=0.26.13` with the workspace
 # resolving. The runtime's ABI version is also what a grammar's
 # generated `parser.c` is built against, so an accidental bump is
 # exactly the drift this gate exists to catch.


### PR DESCRIPTION
Consolidates the eight per-manifest dependabot bumps of `tree-sitter` 0.26.12 → 0.26.13 (#1364, #1365, #1366, #1367, #1368, #1369, #1371, #1372).

The runtime is `=`-pinned in eight manifests that must move together: each dependabot PR alone fails `check-excluded-manifests` (split pin) and `make fuzz-check` (`--locked` against a stale `fuzz/Cargo.lock`). This branch bumps the root manifest, `enums`, the five vendored grammar crates, all eight lockfiles, the version cited by the PyO3 safety argument in `node.rs`, and adds the CHANGELOG entry.

Upstream delta reviewed: `api.h` unchanged (language ABI 15), Rust binding differs by one dropped `#[must_use]`, C changes are an error-recovery nesting fix and two query fixes. `make pre-commit` passes locally.
