### PR TITLE
docs: record lessons 91 and 92 and two rules

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -368,3 +368,36 @@ single non-listed language (`--features go`) is the reproducer.
 
 Note the union is over *features*, not languages: `LANG::Tsx` rides
 `feature = "typescript"`, so a seven-row table can need only six.
+
+## Assert a whole-run invariant in the run, not in a fixture list
+
+When a change establishes an invariant that holds at the end of *every*
+execution of a hot path — a scratch structure fully drained, a stack
+balanced, a counter back at zero — a `debug_assert!` on that path
+recruits the entire test corpus as input. A named test covers the
+fixtures you thought of; the assertion covers every language, every
+corpus file, and every integration suite that happens to run the path,
+which is a different order of coverage for one line.
+
+This matters most when the invariant has more than one owner. #1375's
+nesting-slot lifetime is enforced in two places — the walk's
+`exclude_tests` prune arm and `propagate_nesting_to_children` — so a
+third `continue` added later would leak with nothing to notice. The
+targeted test names four seeding paths; the `debug_assert!` covered
+3,590 lib tests plus every integration suite on the first run, which is
+what actually established the invariant across all twenty languages.
+
+Both, not either:
+
+- The **named test** is the regression test `AGENTS.md` requires, it is
+  what you verify by revert, and it survives into release builds via an
+  `observation::counter!`. It also documents *which* paths seed state,
+  which an assertion cannot say.
+- The **`debug_assert!`** generalises it for free, and is compiled out
+  of release, so an O(1) check on a per-walk path costs nothing shipped.
+  Keep it O(1): a per-node assertion is how the exact ancestor-chain
+  check went quadratic (`make chain-audit`, #1122).
+
+The assertion earns its place only if the suite actually exercises the
+path under `cfg(debug_assertions)` — which `make pre-commit` does. An
+assertion that only a release build reaches is lesson #80.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -766,6 +766,17 @@ Treat the pinned version as fixed:
   gh issue create --title "Title" --label "bug" --body-file /tmp/issue-body.md
   ```
 
+- **Re-verify a deferred issue's premises before building on them.**
+  A deferral records the code as it stood when the issue was filed,
+  and both halves age: the measurement it rests on may never have
+  been taken, and a later change may have decided its central design
+  question the other way. Neither shows up as a contradiction — the
+  issue and its resolution plan still read as coherent. Check each
+  cited path, and check whether anything shipped since already
+  answers the question. #1158 proposed an output-ordering contract
+  that #1303 had shipped the opposite of, complete with tests, and
+  its own go/no-go measurement had never been run; when run, it
+  closed the issue. This is the issue-tracker form of lesson #84.
 - Do not push (`git push`, `git push --force`) or open pull
   requests (`gh pr create`) without explicit user instruction.
   This rule covers **publishing code** only — it does **not**

--- a/docs/development/lessons_learned.md
+++ b/docs/development/lessons_learned.md
@@ -134,6 +134,8 @@ number and the higher number stays as a redirect.
 | [88](#88-a-text-scan-that-does-not-lex-the-language-measures-noise) | A text scan that does not lex the language measures noise |
 | [89](#89-a-positive-enumeration-and-a-negative-filter-differ-on-what-neither-names) | A positive enumeration and a negative filter differ on what neither names |
 | [90](#90-re-reading-a-single-consumption-source-yields-empty-not-an-error) | A re-read of a consumable source yields empty, not an error |
+| [91](#91-a-gate-can-filter-out-its-own-subject-before-the-check-runs) | A gate can filter out its own subject before the check runs |
+| [92](#92-an-optimizations-rationale-can-encode-the-waste-it-optimizes-for) | An optimization's rationale can encode the waste it optimizes for |
 
 ---
 
@@ -3542,5 +3544,80 @@ the project had exempted. The fix materializes the list once, before
 the walk, and carries it out in `CheckWalk::seeds`; the pre-existing
 regression test for #497 passed throughout, because it spelled the
 seed list as a file.
+
+---
+
+## 91. A gate can filter out its own subject before the check runs
+
+**Lesson:** When you add a dependency or supply-chain gate, prove it
+fails by reintroducing the condition it guards and watching it go red.
+A tool that builds a filtered view of its input before applying your
+rules can drop the very artifact a rule names, leaving an entry that is
+syntactically valid, semantically correct, and permanently silent. When
+the tool's view is derived, guard the raw artifact instead — the
+lockfile, the manifest — and record at the site where the dead entry
+would go why it is not there.
+
+A config entry reads as coverage. A future maintainer greps `deny.toml`,
+finds the crate and the version range spelled out, and stops looking;
+the tool exits 0, which is the same output it gives when the tree is
+genuinely clean. Nothing distinguishes "no violation" from "the subject
+was never in scope", and the gap opens precisely when the guard matters,
+because the condition that reintroduces the vulnerable crate is also the
+condition that puts it back beyond the filter.
+
+**cargo-deny cannot guard `h2 0.3.27`** (RUSTSEC-2026-0258, Scorecard
+alert #776; `3df3b2c3`, `b60943b5` — direct pushes to `main`, no PR).
+The crate reached the tree only through `actix-web`'s default `http2`
+feature, and no patched 0.3 release exists, so the fix was to drop the
+feature: `bca-web` binds plaintext and actix negotiates HTTP/2 only over
+TLS ALPN. The obvious belt-and-braces guard, a `[bans] deny` on
+`h2 <0.4.16`, turned out to be dead by construction — krates, cargo-deny's
+graph builder, filters the crate out before the advisory and ban checks
+run (`-L debug` logs `filtered h2 0.3.27`), on 0.19 and on the 0.20 that
+CI's action bundles. Re-enabling `actix-web/http2` under both versions
+left cargo-deny silent. The working guard reads `Cargo.lock` directly
+from a test, and `deny.toml` carries a comment where the entry would
+have been, naming the reproduction so the next reader does not add one.
+
+---
+
+## 92. An optimization's rationale can encode the waste it optimizes for
+
+**Lesson:** When a collection is pre-sized to its input, ask whether it
+needs to reach that size before optimizing for it — a reserve is
+evidence that somebody measured the final size, never evidence the
+growth was necessary. And attribute a resource peak by bisecting the
+run: one metric at a time, one output destination at a time, one worker
+count at a time. Reading the code ranks hypotheses it cannot
+discriminate, because every allocation you suspect really is there.
+
+A leak stated as a steady state stops looking like a leak. The sentence
+justifying the reserve asserts the growth as a fact, so review checks
+the arithmetic — is `descendant_count` the right size? — rather than the
+premise, and the premise is the bug. Nothing else flags it either: the
+retained entries are dead, so no metric value, snapshot, or exit status
+moves whether they are freed or kept.
+
+**The nesting map's reserve was sized to the leak it should have
+prevented** (#1069, fixed in #1375 / PR #1377). `NestingMap` carries one
+`Nesting` per node id, seeded by the parent, read once by the node's own
+`Cognitive::compute`, read once more when its children are seeded — and
+then never removed. #1069 measured that it "converges on one entry per
+visited node", and reserved `descendant_count()` up front to skip the
+doubling chain, which is a real speedup for a growth that should not
+have existed. On a 28 MB generated tree-sitter `parser.c` that was
+540 MB of a 1,265 MB peak. Freeing each slot in its last reader leaves
+the live set bounded by the traversal stack: 735 MB, and 3.3 s against
+5.1 s.
+
+**All three hypotheses in the issue were wrong** (#1375). It proposed
+the reorder buffer, a path list materialized twice, and glibc arena
+retention. Selection settled it in minutes where code reading had not:
+`dump` (parse only) measured 722 MB and every non-cognitive metric
+723–725 MB against cognitive's 1,264 MB, `--output-dir` matched stdout
+byte-for-byte in peak — ruling out both the wire clone and the reorder
+buffer — and `bca check`, which has no reorder buffer at all, still
+peaked at 4.5 GB on the same tree.
 
 ---

--- a/docs/development/lessons_learned.md
+++ b/docs/development/lessons_learned.md
@@ -3570,8 +3570,12 @@ condition that puts it back beyond the filter.
 alert #776; `3df3b2c3`, `b60943b5` — direct pushes to `main`, no PR).
 The crate reached the tree only through `actix-web`'s default `http2`
 feature, and no patched 0.3 release exists, so the fix was to drop the
-feature: `bca-web` binds plaintext and actix negotiates HTTP/2 only over
-TLS ALPN. The obvious belt-and-braces guard, a `[bans] deny` on
+feature: this daemon reaches the network through a plain
+`HttpServer::bind`, which serves HTTP/1.x only. Note the reason is that
+call and not a property of actix — `bind_auto_h2c` speaks plaintext
+HTTP/2 without TLS, and is itself `#[cfg(feature = "http2")]`, so
+dropping the feature removes the H2C entry point along with the
+vulnerable crate. The obvious belt-and-braces guard, a `[bans] deny` on
 `h2 <0.4.16`, turned out to be dead by construction — krates, cargo-deny's
 graph builder, filters the crate out before the advisory and ban checks
 run (`-L debug` logs `filtered h2 0.3.27`), on 0.19 and on the 0.20 that
@@ -3601,9 +3605,14 @@ moves whether they are freed or kept.
 
 **The nesting map's reserve was sized to the leak it should have
 prevented** (#1069, fixed in #1375 / PR #1377). `NestingMap` carries one
-`Nesting` per node id, seeded by the parent, read once by the node's own
-`Cognitive::compute`, read once more when its children are seeded — and
-then never removed. #1069 measured that it "converges on one entry per
+`Nesting` per node id, seeded by the parent, read by the node's own
+`Cognitive::compute`, and read a last time when its children are seeded
+— but never removed. The two shapes that skip that last read are the
+ones the fix has to handle separately: a leaf returned early on
+`children.is_empty()`, and an `exclude_tests`-pruned node reached
+neither `compute` nor propagation, so freeing in the last reader means
+dropping the leaf bail-out and adding a removal on the prune arm.
+Issue #1069 measured that the map "converges on one entry per
 visited node", and reserved `descendant_count()` up front to skip the
 doubling chain, which is a real speedup for a growth that should not
 have existed. On a 28 MB generated tree-sitter `parser.c` that was
@@ -3611,13 +3620,16 @@ have existed. On a 28 MB generated tree-sitter `parser.c` that was
 the live set bounded by the traversal stack: 735 MB, and 3.3 s against
 5.1 s.
 
-**All three hypotheses in the issue were wrong** (#1375). It proposed
-the reorder buffer, a path list materialized twice, and glibc arena
-retention. Selection settled it in minutes where code reading had not:
-`dump` (parse only) measured 722 MB and every non-cognitive metric
-723–725 MB against cognitive's 1,264 MB, `--output-dir` matched stdout
-byte-for-byte in peak — ruling out both the wire clone and the reorder
-buffer — and `bca check`, which has no reorder buffer at all, still
-peaked at 4.5 GB on the same tree.
+**Every suspect the issue named turned out to be secondary** (#1375).
+It listed the per-file working set, the `OrderedStdout` reorder buffer,
+and glibc arena retention — none of them wrong to suspect, and the last
+demonstrably real, since `MALLOC_ARENA_MAX=1` did lower the peak to
+3.4 GB. None was the dominant term, and code reading could not say so,
+because every allocation on the list is genuinely there. Selection
+could: `dump` (parse only) measured 722 MB and every non-cognitive
+metric 723–725 MB against cognitive's 1,264 MB, `--output-dir` came
+within a megabyte of stdout — 1,266 against 1,265 MB, ruling out both
+the wire clone and the reorder buffer — and `bca check`, which has no
+reorder buffer at all, still peaked at 4.5 GB on the same tree.
 
 ---


### PR DESCRIPTION
Two lessons and two rules from the 2026-08-29/30 window. Both lessons
name a mechanism nothing in the file covers; both non-qualifying
takeaways were routed to rules instead, per the file's own "standing
obligations live in rules, not here" preamble.

## Lesson 91 — a gate can filter out its own subject before the check runs

The belt-and-braces guard for RUSTSEC-2026-0258 would be a `[bans] deny`
on `h2 <0.4.16`. It is dead by construction: krates, cargo-deny's graph
builder, filters the crate out before the advisory and ban checks run
(`-L debug` logs `filtered h2 0.3.27`), on 0.19 and on the 0.20 that
CI's action bundles. Re-enabling `actix-web/http2` under both versions
left cargo-deny silent — so the entry would have looked like coverage
and could never have fired.

What makes it worth an entry is the shape: a config entry naming the
crate and the version range reads as a guard to every future
maintainer, and the tool exits 0, which is exactly what it prints when
the tree is genuinely clean. The working guard reads `Cargo.lock` from a
test, and `deny.toml` carries a comment where the dead entry would have
gone.

Cited by commit hash rather than PR — both are direct pushes verified
reachable on `main` with no PR, which is the one case the skill's
guardrail permits.

## Lesson 92 — an optimization's rationale can encode the waste it optimizes for

#1069 measured that the cognitive nesting map "converges on one entry
per visited node" and reserved `descendant_count()` up front to skip the
doubling chain. That is a genuine speedup — for growth that should not
have existed. The slot is dead after its children are seeded and was
never removed, so the reserve was sized to the leak: 540 MB of a
1,265 MB peak on a 28 MB generated `parser.c`, fixed in #1375 / PR
#1377.

The second mechanism is how it was found. All three hypotheses in the
issue (reorder buffer, path list materialized twice, glibc arenas) were
wrong, and code reading could not discriminate them because every
allocation suspected really is present. Bisecting by selection settled
it: `dump` measured 722 MB and every non-cognitive metric 723–725 MB
against cognitive's 1,264 MB, `--output-dir` matched stdout in peak, and
`bca check` — which has no reorder buffer at all — still peaked at
4.5 GB.

## Routed to rules instead

- **`AGENTS.md`**, GitHub workflow: re-verify a deferred issue's
  premises before building on them. #1158 proposed an output-ordering
  contract that #1303 had shipped the opposite of, with tests, and its
  own go/no-go measurement had never been run; running it closed the
  issue. This is the issue-tracker form of lesson 84.
- **`.claude/rules/testing.md`**: assert a whole-run invariant in the
  run, not in a fixture list. A `debug_assert!` at the end of a hot path
  recruits the entire corpus as input — 3,590 lib tests plus every
  integration suite, against the four fixtures a named test lists — and
  that is what established #1375's invariant across all twenty
  languages. Both guards, not either, and keep the assertion O(1): a
  per-node one is how the exact ancestor-chain check went quadratic
  (#1122).

## Notes

- Entries are 34 and 38 lines, inside the 45-line single-mechanism and
  ~60-line two-mechanism budgets. `rumdl` passes; both index anchors
  resolve.
- Numbering appends at 91/92, so no existing citation moves.
- Not done, and flagged rather than acted on: a one-clause merge of the
  `parser_cache` doc-claim instance into lesson 84 (one more instance of
  a mechanism it already documents with eight), and lesson 59's 81-line
  overrun against the 75-line stop.
