### PR TITLE
test(features): gate language-specific tests on their Cargo features

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -9,9 +9,9 @@ name: Fuzz
 # reasoning the `coverage` job in ci.yml records for staying on stable.
 # Here the flag simply is not set, so a nightly lint is a warning.
 #
-# The consequence is worth stating plainly: this workflow is not in the
-# `ci` aggregator's `needs:`, so it is advisory until branch protection
-# names it.
+# This workflow is not in the `ci` aggregator's `needs:`, so it is
+# advisory — by decision, not by omission. The rationale and what would
+# reverse it are in docs/development/fuzzing.md, "Advisory, by decision".
 #
 # See docs/development/fuzzing.md.
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -351,12 +351,17 @@ repos:
         pass_filenames: false
 
       # Lockstep version invariant — every owned crate and every
-      # `=<v>` internal-dep pin must match the workspace version.
-      # See RELEASING.md "Lockstep version policy".
+      # `=<v>` internal-dep pin must match the workspace version, and
+      # each workspace-excluded crate's own `Cargo.lock` must record
+      # its path packages at the versions their manifests declare.
+      # `Cargo.lock` is in the trigger set for the latter: a commit
+      # that *only* refreshes those lockfiles must still be checked,
+      # and it touches no manifest (#1234). See RELEASING.md "Lockstep
+      # version policy".
       - id: check-versions
         name: check-versions
         language: system
-        files: '(Cargo\.toml|/Cargo\.toml|/bindings/rust/README\.md|^README\.md|^STABILITY\.md|big-code-analysis-book/src/library/(quick-start|cargo-features|stability)\.md|big-code-analysis-book/src/recipes/ci\.md|utils/check-versions\.py)$'
+        files: '(Cargo\.(toml|lock)|/Cargo\.(toml|lock)|/bindings/rust/README\.md|^README\.md|^STABILITY\.md|big-code-analysis-book/src/library/(quick-start|cargo-features|stability)\.md|big-code-analysis-book/src/recipes/ci\.md|utils/check-versions\.py)$'
         entry: python3 utils/check-versions.py
         pass_filenames: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,21 @@ for historical reference.
 
 ### Fixed
 
+- **`make fuzz-smoke` now runs every fuzz target and reports all of the
+  failing ones**, instead of aborting on the first crash (#1235). The
+  recipe runs under `.SHELLFLAGS := -eu`, so a crashing
+  `cargo fuzz run` ended the loop and the later targets never ran — and
+  `fuzz-smoke` is what the quarterly `fuzz.yml` cron invokes, the run
+  nobody is watching, so a quarter that produced three unrelated crashes
+  reported one and rediscovered the rest only after it was fixed. The
+  loop now collects per-target status, exits non-zero at the end naming
+  each failing target, and prints the `make fuzz-run` reproduction
+  command. `fuzz-replay`, the per-PR gate, deliberately keeps stopping
+  at the first failure. The fuzz workflow's advisory (non-required)
+  status is now recorded as a decision, with its rationale and the
+  measured cost of the alternative, in
+  [`docs/development/fuzzing.md`](docs/development/fuzzing.md).
+
 - **A `::`-qualified Tcl or iRules command now resolves to the core
   command it names** in every metric, not just the ones reading the
   braced-word slot table. `::switch` *is* `switch` — a leading `::` names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,9 +162,11 @@ for historical reference.
   (#1281). The cyclomatic, cognitive, nargs and exit suites had
   hand-maintained language lists that had fallen behind the roster:
   Ruby, Lua, Perl, Go and Elixir were missing from families they can
-  express, `LANG::C` appeared in none of them (every row labelled `"c"`
-  actually parsed `LANG::Cpp`), and the omission had already masked a
-  real divergence — the Elixir catch-all CCN bug fixed in #1272. The
+  express, and `LANG::C` appeared in none of the cyclomatic, cognitive
+  or nargs families — every row labelled `"c"` there actually parsed
+  `LANG::Cpp`, and only the exit suite carried a genuine `LANG::C` row.
+  The omission had already masked a real divergence: the Elixir
+  catch-all CCN bug fixed in #1272. The
   restructure adds 107 measured fixture rows across 11 families and
   records a reason at every `None` arm, replacing `nargs`'s false "every
   supported language …" prose list and `nexits`'s asserted "all 23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,19 @@ for historical reference.
 
 ### Fixed
 
+- **The 24 `alterator_string_flattening` cases are now gated on their own
+  grammar features**, so a build that enables only some of the eight
+  languages they cover leaves the rest *absent* rather than failing
+  (#1415). Each case parses through `Ast::parse(…).expect(…)`, which
+  panics when that row's grammar is compiled out, and the module is
+  declared ungated — so any feature set short of the full eight red-Xed
+  up to 24 tests that read as a defect in whatever was being changed.
+  The file-local `flatten_cases!` macro now takes a per-row feature
+  literal and emits `#[cfg(feature = …)]` on each generated test, which
+  is what a table spanning eight grammars needs: the whole-module gate
+  its single-grammar siblings use can name only one feature. The
+  `--all-features` test population is unchanged.
+
 - **`make fuzz-smoke` now runs every fuzz target and reports all of the
   failing ones**, instead of aborting on the first crash (#1235). The
   recipe runs under `.SHELLFLAGS := -eu`, so a crashing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,29 @@ for historical reference.
 
 ### Fixed
 
+- **The five hand-listed cross-language parity suites now key their
+  fixtures on an exhaustive `match` over `LANG`**, so a new language
+  cannot be added without deciding whether it spells each construct
+  (#1281). The cyclomatic, cognitive, nargs and exit suites had
+  hand-maintained language lists that had fallen behind the roster:
+  Ruby, Lua, Perl, Go and Elixir were missing from families they can
+  express, `LANG::C` appeared in none of them (every row labelled `"c"`
+  actually parsed `LANG::Cpp`), and the omission had already masked a
+  real divergence — the Elixir catch-all CCN bug fixed in #1272. The
+  restructure adds 107 measured fixture rows across 11 families and
+  records a reason at every `None` arm, replacing `nargs`'s false "every
+  supported language …" prose list and `nexits`'s asserted "all 23
+  languages" claim with a compiler-enforced one. None of the new rows
+  moved a metric: all 107 were at parity when added.
+- **The same five suites no longer panic under a reduced feature set.**
+  Each measured its fixtures through `analyze(…).expect(…)` with no
+  `is_enabled()` filter, so any build short of the language a row named
+  died on `LanguageDisabled` rather than skipping the row — 13 of 19
+  parity tests failed under `--no-default-features --features go`, which
+  reads as a defect in whatever was being changed. The four table-driven
+  suites now skip disabled languages, and the two-grammar
+  `cpp_mozcpp_parity` is gated on `cpp` *and* `mozcpp` at compile time.
+  The `--all-features` test population is unchanged.
 - **The 24 `alterator_string_flattening` cases are now gated on their own
   grammar features**, so a build that enables only some of the eight
   languages they cover leaves the rest *absent* rather than failing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,20 @@ for historical reference.
   aggregate diverges from the CLI accessor; nothing in the workspace
   reads the flag, so this is a correction to a published description
   rather than a behaviour change.
+- `make check-versions` now also gates the workspace-excluded crates'
+  lockfiles, failing when a `Cargo.lock` under `enums/`, `fuzz/`, or a
+  vendored `tree-sitter-*` leaf records a path package at a version its
+  manifest no longer declares (#1234). `cargo update --workspace` — the
+  refresh `RELEASING.md` calls mandatory during a bump — reaches only
+  the root lockfile, and every gate that consumes the others passes
+  `--locked`, so a bump that skipped them turned `make enums-check`,
+  `fuzz-check`, or `release-check` red on a later, unrelated commit. The
+  failure now names the lockfile, the package, both versions, and the
+  `cargo update --manifest-path` line that repairs it. The candidate
+  list is derived from the root manifest's `[workspace] exclude` array
+  rather than from the gate's existing lockstep-version tuple, which
+  omits `fuzz` (deliberately version `0.0.0`) and so would have missed
+  one of the two lockfiles that motivated the change.
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,27 @@ for historical reference.
 
 ### Fixed
 
+- **Twenty-five cross-language test sweeps no longer fail spuriously
+  under a reduced feature set** (#1286, #1411). Each carried a loud
+  non-vacuity guard (`checked > 0`, `assert_fixtures_present`) without
+  the `#[cfg(any(feature = …))]` union that makes the test *absent*
+  rather than failing when none of its fixture languages is compiled
+  in, so a contributor building a subset read the guard as a defect in
+  whatever they were changing: 12 such tests failed under
+  `--no-default-features --features go` and 9 under
+  `--features rust,typescript`, now 0 in both. Four sweeps had the
+  inverse problem — a filter and no guard, so they passed having
+  asserted nothing — and four more were not a plain union:
+  `nargs`'s comment-in-parameter-list sweep drove two **disjoint**
+  fixture populations from one conjunctive guard (no union satisfies
+  it; it is now two tests, one per population), its C-family
+  return-type sweep needed the *intersection* of three tables rather
+  than their union, `cognitive`'s function-depth sweep had neither the
+  filter nor the guard and handed disabled grammars to the parser, and
+  `abc`'s keyword-negation module holds a third, Lua-only test that a
+  module gate naming only the other two would have silently dropped
+  from a Lua build. The `--all-features` test population is unchanged
+  but for that deliberate one-into-two split.
 - **The five hand-listed cross-language parity suites now key their
   fixtures on an exhaustive `match` over `LANG`**, so a new language
   cannot be added without deciding whether it spells each construct

--- a/Makefile
+++ b/Makefile
@@ -1228,17 +1228,36 @@ fuzz-check:
 	  echo "nightly toolchain or cargo-fuzz not found; skipping fuzz-check"; \
 	fi
 
+# The loop collects failures instead of stopping at the first, because
+# this is what the quarterly cron runs and nobody is watching it. A hunt
+# that trips over three unrelated crashes should report three; stopping
+# at the first hides the other two until the quarter after the fix, and
+# the artifact upload in fuzz.yml already globs every target's
+# reproducer. `.SHELLFLAGS` carries `-e`, but a command on the left of
+# `||` is not a fatal failure under it, so the run survives a crashing
+# target and still exits non-zero at the end.
+#
+# `fuzz-replay` below keeps the opposite shape deliberately: it is the
+# per-PR gate, where one broken seed is already enough to stop the
+# merge, and the seconds saved by not replaying the rest are the point.
 fuzz-smoke:
 	@if rustup toolchain list 2>/dev/null | grep -q '^nightly' && \
 	    command -v cargo-fuzz >/dev/null 2>&1; then \
 	  $(FUZZ_REQUIRE_SYMBOLIZER); \
+	  failed=""; \
 	  for t in $$(cargo +nightly fuzz list); do \
 	    echo "Fuzzing $$t for $(FUZZ_RUNS) runs..."; \
 	    mkdir -p $(FUZZ_WORK)/"$$t"; \
 	    $(FUZZ_CC_ENV) $(FUZZ_RUN_ENV) cargo +nightly fuzz run --target $(FUZZ_HOST_TRIPLE) "$$t" \
 	      $(FUZZ_WORK)/"$$t" $(BASE_DIR)fuzz/corpus/"$$t" \
-	      -- -runs=$(FUZZ_RUNS) -timeout=$(FUZZ_TIMEOUT); \
+	      -- -runs=$(FUZZ_RUNS) -timeout=$(FUZZ_TIMEOUT) \
+	      || failed="$$failed $$t"; \
 	  done; \
+	  if [ -n "$$failed" ]; then \
+	    echo "fuzz-smoke: failing targets:$$failed"; \
+	    echo "reproduce with: make fuzz-run FUZZ_TARGET=<target> FUZZ_INPUT=fuzz/artifacts/<target>/<file>"; \
+	    exit 1; \
+	  fi; \
 	else \
 	  echo "nightly toolchain or cargo-fuzz not found; skipping fuzz-smoke"; \
 	fi

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -581,6 +581,14 @@ the leaf at the old version: `make release-check` dry-runs them with
 `cargo publish --locked`, which refuses to touch the stale lockfile and
 fails the gate (the v2.2.0 cut hit exactly this).
 
+You no longer have to remember this step unprompted. `make
+check-versions` compares every path package recorded in those seven
+lockfiles against the version its manifest declares, so a bump that
+skips one fails in the release-prep commit — naming the lockfile, the
+package, and both versions — instead of surfacing later as a `--locked`
+error inside an unrelated commit's `enums-check`, `fuzz-check`, or
+`release-check` (#1234).
+
 Regenerate the committed man pages in the same release-prep commit:
 
 ```bash

--- a/docs/development/fuzzing.md
+++ b/docs/development/fuzzing.md
@@ -139,9 +139,17 @@ on unrelated PRs.
 ### Advisory, by decision
 
 The fuzz job is **not** a required check, and that is a choice rather
-than an oversight. `main` carries no branch protection at all today, so
-nothing in this repository blocks a merge on a CI result; the open
-question was whether the fuzz job should be the first to.
+than an oversight. `main`'s `protect-main` ruleset requires signed
+commits and linear history, and forbids deletion and force-pushes, but
+it names no required status checks — so no CI result blocks a merge
+today, and the open question was whether the fuzz job should be the
+first to.
+
+Check that with `gh api repos/:owner/:repo/rules/branches/main`, not
+with `gh api repos/:owner/:repo/branches/main/protection`. The latter
+reads only the legacy branch-protection API and answers `404 Branch not
+protected` for a branch governed by a ruleset, which is exactly how this
+section came to claim in its first draft that `main` was unprotected.
 
 It should not be, yet. Requiring it puts 15m48s — the measured cost of
 one run — in front of every pull request touching `src/`, `fuzz/`, a
@@ -150,14 +158,17 @@ hunt. It also promotes a nightly-toolchain hiccup or a flaky
 `cargo-fuzz` install into a merge blocker, on the one workflow whose
 reason for living outside `ci.yml` is that nightly moves underneath it.
 And a red cron is not silent: the scheduled run files a GitHub issue
-naming the reproducers (the `File issue on a scheduled-run crash` step
-in `.github/workflows/fuzz.yml`), so the hunt already reports itself
-without branch protection.
+linking the run and the uploaded `fuzz-artifacts` bundle (the `File
+issue on a scheduled-run crash` step in `.github/workflows/fuzz.yml`),
+so the hunt already reports itself without a required check. The issue
+body carries the `make fuzz-run` template rather than the failing
+target names; those are in the job log, which the summary line above
+now lists in full.
 
 What would change the answer is evidence that the job is boring — a few
 quarterly crons in a row going red only for real crashes, never for
-toolchain flakes. Revisit it then, together with whatever else `main`
-gets protected with.
+toolchain flakes. Revisit it then, by adding a `required_status_checks`
+rule to the existing ruleset.
 
 ## Running locally
 

--- a/docs/development/fuzzing.md
+++ b/docs/development/fuzzing.md
@@ -118,6 +118,12 @@ then **replays the committed seeds** — the regression question, answered
 in seconds. The quarterly cron does the **hunt**, at 200 000 runs per
 target.
 
+The two halves also differ in what they do after a crash. `fuzz-replay`
+stops at the first one, because a pull request is already blocked by it.
+`fuzz-smoke` runs every remaining target and fails at the end naming all
+of them: nobody is watching the cron, and a run that reports one of
+three crashes hides the other two until the quarter after the fix.
+
 That split is a correction, and the numbers are why. The job first ran
 11 targets x 10 000 mutations on every pull-request push: 156 s to build
 and 977 s to fuzz, nine times over one pull request, 96 minutes of runner
@@ -130,9 +136,28 @@ cargo-fuzz needs nightly and `ci.yml` sets `RUSTFLAGS: "-D warnings"`
 workflow-wide; pairing the two turns every new nightly lint into a red X
 on unrelated PRs.
 
-One consequence is worth stating: the fuzz workflow is **not** in the
-`ci` aggregator's `needs:`, so it is advisory until branch protection
-names it.
+### Advisory, by decision
+
+The fuzz job is **not** a required check, and that is a choice rather
+than an oversight. `main` carries no branch protection at all today, so
+nothing in this repository blocks a merge on a CI result; the open
+question was whether the fuzz job should be the first to.
+
+It should not be, yet. Requiring it puts 15m48s — the measured cost of
+one run — in front of every pull request touching `src/`, `fuzz/`, a
+manifest or a grammar, to gate a build-and-replay pass rather than a
+hunt. It also promotes a nightly-toolchain hiccup or a flaky
+`cargo-fuzz` install into a merge blocker, on the one workflow whose
+reason for living outside `ci.yml` is that nightly moves underneath it.
+And a red cron is not silent: the scheduled run files a GitHub issue
+naming the reproducers (the `File issue on a scheduled-run crash` step
+in `.github/workflows/fuzz.yml`), so the hunt already reports itself
+without branch protection.
+
+What would change the answer is evidence that the job is boring — a few
+quarterly crons in a row going red only for real crashes, never for
+toolchain flakes. Revisit it then, together with whatever else `main`
+gets protected with.
 
 ## Running locally
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,9 +149,15 @@ mod macros;
 // module's metric budget on test-only code (#1066).
 #[cfg(test)]
 mod test_support;
-// Drift guard for the crate-level `## Supported Languages` list above.
+// Gated on the four grammars its tables name, so a build enabling none
+// of them drops the module rather than tripping its `checked > 0`
+// non-vacuity guard (`.claude/rules/testing.md`, #1286). The guard then
+// covers only the residual case where `is_enabled` stops agreeing with
+// the feature it compiled under.
 #[cfg(test)]
+#[cfg(any(feature = "c", feature = "cpp", feature = "mozcpp", feature = "objc"))]
 mod c_family_space_names_tests;
+// Drift guard for the crate-level `## Supported Languages` list above.
 #[cfg(test)]
 mod lib_docs_tests;
 #[cfg(test)]

--- a/src/metrics/abc.rs
+++ b/src/metrics/abc.rs
@@ -11594,7 +11594,26 @@ function f(int $a, int $b): int {
 /// operand is the only input that discriminates the first defect and
 /// the negated operand the only one that discriminates the second —
 /// existing ternary fixtures use neither.
+// Gated on the union of the features [`ternary_comment_invariance::cases`]
+// has a row for, so a build enabling none of them — `--no-default-features
+// --features go` — drops both tests rather than tripping their
+// `checked > 0` guards (`.claude/rules/testing.md`, #1286). Both tests
+// read the same table, so one gate on the module is exact for each.
 #[cfg(test)]
+#[cfg(any(
+    feature = "c",
+    feature = "cpp",
+    feature = "csharp",
+    feature = "groovy",
+    feature = "java",
+    feature = "javascript",
+    feature = "mozcpp",
+    feature = "mozjs",
+    feature = "objc",
+    feature = "perl",
+    feature = "php",
+    feature = "typescript"
+))]
 mod ternary_comment_invariance {
     use crate::test_support::metrics_verbatim;
     use crate::{LANG, MetricsOptions};
@@ -11723,7 +11742,19 @@ mod ternary_comment_invariance {
 /// They are exercised here so a future edit cannot regress them
 /// silently. Python counts `not` through its own dispatcher arm and has
 /// no `!` spelling to compare against.
+// Gated on the union of every row below — the three `pairs` languages
+// plus Lua, whose test is separate — so a build enabling none of them
+// drops the module instead of failing its guards
+// (`.claude/rules/testing.md`, #1286 / #1411). The three tests do *not*
+// share a row set, so each carries its own narrower gate: a Lua-only
+// build must not be asked to run the Ruby/Perl baselines.
 #[cfg(test)]
+#[cfg(any(
+    feature = "elixir",
+    feature = "lua",
+    feature = "perl",
+    feature = "ruby"
+))]
 mod keyword_negation_parity {
     use crate::test_support::metrics_verbatim;
     use crate::{LANG, MetricsOptions};
@@ -11735,6 +11766,7 @@ mod keyword_negation_parity {
     }
 
     /// `(bang_form, keyword_form)` pairs that must score identically.
+    #[cfg(any(feature = "elixir", feature = "perl", feature = "ruby"))]
     fn pairs(lang: LANG) -> Option<Vec<(String, String)>> {
         let build =
             |t: &str| -> (String, String) { (t.replace("{NOT}", "!"), t.replace("{NOT}", "not ")) };
@@ -11757,6 +11789,7 @@ mod keyword_negation_parity {
     }
 
     #[test]
+    #[cfg(any(feature = "elixir", feature = "perl", feature = "ruby"))]
     fn the_not_keyword_scores_like_bang() {
         let mut checked = 0;
         for lang in LANG::into_enum_iter() {
@@ -11786,6 +11819,7 @@ mod keyword_negation_parity {
     /// `a ? (!b) : (!c)` is four: the `?` marker, the condition `a` in
     /// boolean context, and one per negated branch operand.
     #[test]
+    #[cfg(any(feature = "perl", feature = "ruby"))]
     fn the_baseline_values_are_one_and_four() {
         let mut checked = 0;
         for (lang, guard, ternary) in [
@@ -11816,10 +11850,17 @@ mod keyword_negation_parity {
     /// Lua's only negation keyword is `not`, so it has no `!` twin to
     /// compare against — its guard is that the keyword counts at all.
     #[test]
+    #[cfg(feature = "lua")]
     fn lua_counts_its_only_negation_keyword() {
-        if !LANG::Lua.is_enabled() {
-            return;
-        }
+        // Was a silent `if !is_enabled() { return; }`, which made the
+        // whole test a no-op rather than absent whenever the runtime
+        // check and the feature disagreed. The `cfg` above is the
+        // absence half; this is the loud residual half (#1286).
+        assert!(
+            LANG::Lua.is_enabled(),
+            "compiled under `feature = \"lua\"` but `LANG::Lua` reports disabled; \
+             this test asserted nothing"
+        );
         assert_eq!(
             conditions(
                 LANG::Lua,

--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -10736,7 +10736,25 @@ end",
     /// / `method_declaration` and the grammar allows neither inside a
     /// function body, so the surcharge is unreachable there — a nested
     /// Go function is a `func_literal`, which takes the `lambda` path.
+    // Gated on the union of the rows below. Unlike its siblings this
+    // test had *neither* half of the rule: the rows were swept without
+    // an `is_enabled` filter, so a disabled grammar reached
+    // `Ast::parse`, which cannot produce a tree for one — the gate alone
+    // would still leave it failing under `--features c`, a subset the
+    // gate admits. All three pieces landed together (#1286).
     #[test]
+    #[cfg(any(
+        feature = "bash",
+        feature = "c",
+        feature = "irules",
+        feature = "javascript",
+        feature = "lua",
+        feature = "mozcpp",
+        feature = "mozjs",
+        feature = "objc",
+        feature = "ruby",
+        feature = "typescript"
+    ))]
     fn function_depth_surcharge_holds_across_languages() {
         use crate::test_support::metrics_verbatim;
 
@@ -10787,7 +10805,11 @@ end",
         const TCL_NESTED: &str =
             "proc outer {x} {\nproc inner {y} {\nif {$y > 0} {\nputs positive\n}\n}\n}\n";
 
-        let rows = [
+        // Filtered rather than swept whole: `parses_cleanly` and
+        // `cognitive_of` both hand the row to the parser, and a grammar
+        // this build did not compile in has none, so an unfiltered
+        // sweep fails on every feature subset that omits one row.
+        let rows: Vec<(LANG, &str, &str)> = [
             (LANG::C, C_FLAT, C_NESTED),
             (LANG::Objc, OBJC_FLAT, OBJC_NESTED),
             (LANG::Mozcpp, CPP_FLAT, CPP_NESTED),
@@ -10799,7 +10821,17 @@ end",
             (LANG::Lua, LUA_FLAT, LUA_NESTED),
             (LANG::Bash, BASH_FLAT, BASH_NESTED),
             (LANG::Irules, TCL_FLAT, TCL_NESTED),
-        ];
+        ]
+        .into_iter()
+        .filter(|&(lang, ..)| lang.is_enabled())
+        .collect();
+        // The non-vacuity half: the `cfg` above makes the test absent
+        // when no row's feature is on, so reaching here with an empty
+        // sweep means `is_enabled` stopped agreeing with it.
+        assert!(
+            !rows.is_empty(),
+            "no language enabled; this test asserted nothing"
+        );
 
         // Whole vectors rather than a per-row `assert_eq!`: when this
         // shared walk breaks it breaks for every language at once, and
@@ -10930,7 +10962,11 @@ end",
 /// function boundaries) rather than a value that moves with any
 /// unrelated re-tuning. The absolute is pinned too, so a regression
 /// moving both equally still fails.
+// Gated on the union of the three languages `cases()` has a row for, so
+// a build enabling none of them drops the module rather than tripping
+// its `checked > 0` guard (`.claude/rules/testing.md`, #1286).
 #[cfg(test)]
+#[cfg(any(feature = "java", feature = "javascript", feature = "kotlin"))]
 mod nameless_construct_boundaries {
     use crate::test_support::space_verbatim;
     use crate::{FuncSpace, LANG, MetricsOptions};

--- a/src/metrics/container_scope_tests.rs
+++ b/src/metrics/container_scope_tests.rs
@@ -473,7 +473,31 @@ end
 ///
 /// The positive half of the contract, and the guard against "fixing"
 /// #1197 by disabling the metric everywhere.
+// The four `FIXTURES` sweeps carry the narrower union of that table's
+// own rows, rather than inheriting the module's wider one: a build
+// enabling only `bash`, `lua` or `c` reaches the module for the
+// no-member-construct test below, and `FIXTURES` is empty there, so an
+// ungated sweep would trip `assert_fixtures_present` on a configuration
+// it has nothing to say about.
 #[test]
+#[cfg(any(
+    feature = "cpp",
+    feature = "csharp",
+    feature = "elixir",
+    feature = "go",
+    feature = "groovy",
+    feature = "java",
+    feature = "javascript",
+    feature = "kotlin",
+    feature = "mozcpp",
+    feature = "mozjs",
+    feature = "objc",
+    feature = "php",
+    feature = "python",
+    feature = "ruby",
+    feature = "rust",
+    feature = "typescript"
+))]
 fn containers_emit_npm_and_npa() {
     assert_fixtures_present(FIXTURES);
     for fixture in FIXTURES {
@@ -521,6 +545,24 @@ fn containers_emit_npm_and_npa() {
 /// function spaces here and are covered by the same sweep, as are C#'s
 /// expression-bodied property and indexer.
 #[test]
+#[cfg(any(
+    feature = "cpp",
+    feature = "csharp",
+    feature = "elixir",
+    feature = "go",
+    feature = "groovy",
+    feature = "java",
+    feature = "javascript",
+    feature = "kotlin",
+    feature = "mozcpp",
+    feature = "mozjs",
+    feature = "objc",
+    feature = "php",
+    feature = "python",
+    feature = "ruby",
+    feature = "rust",
+    feature = "typescript"
+))]
 fn function_spaces_emit_neither() {
     assert_fixtures_present(FIXTURES);
     for fixture in FIXTURES {
@@ -559,6 +601,24 @@ fn function_spaces_emit_neither() {
 /// it would have left `npm` / `npa` disagreeing with `wmc` about a root
 /// the three metrics share a [`MetricScope`](crate::metric_catalog::MetricScope).
 #[test]
+#[cfg(any(
+    feature = "cpp",
+    feature = "csharp",
+    feature = "elixir",
+    feature = "go",
+    feature = "groovy",
+    feature = "java",
+    feature = "javascript",
+    feature = "kotlin",
+    feature = "mozcpp",
+    feature = "mozjs",
+    feature = "objc",
+    feature = "php",
+    feature = "python",
+    feature = "ruby",
+    feature = "rust",
+    feature = "typescript"
+))]
 fn the_file_root_keeps_its_rollup() {
     assert_fixtures_present(FIXTURES);
     for fixture in FIXTURES {
@@ -623,6 +683,24 @@ fn the_file_root_keeps_its_rollup() {
 /// there is no set for a space to fall out of. (`.claude/rules/testing.md`:
 /// "review the selector as carefully as the assertion".)
 #[test]
+#[cfg(any(
+    feature = "cpp",
+    feature = "csharp",
+    feature = "elixir",
+    feature = "go",
+    feature = "groovy",
+    feature = "java",
+    feature = "javascript",
+    feature = "kotlin",
+    feature = "mozcpp",
+    feature = "mozjs",
+    feature = "objc",
+    feature = "php",
+    feature = "python",
+    feature = "ruby",
+    feature = "rust",
+    feature = "typescript"
+))]
 fn no_space_is_emitted_with_an_unknown_kind() {
     assert_fixtures_present(FIXTURES);
     for fixture in FIXTURES {

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -33,7 +33,31 @@ pub mod tokens;
 /// Weighted Methods per Class.
 pub mod wmc;
 
+// Gated on the union of the features its `FIXTURES` rows carry, so a
+// build enabling none of them drops the module rather than tripping
+// `assert_fixtures_present` — a failure that reads as a defect in
+// whatever was being changed (`.claude/rules/testing.md`, #1286). The
+// tests the module already gates individually all name a subset of this
+// list.
 #[cfg(test)]
+#[cfg(any(
+    feature = "cpp",
+    feature = "csharp",
+    feature = "elixir",
+    feature = "go",
+    feature = "groovy",
+    feature = "java",
+    feature = "javascript",
+    feature = "kotlin",
+    feature = "mozcpp",
+    feature = "mozjs",
+    feature = "objc",
+    feature = "php",
+    feature = "python",
+    feature = "ruby",
+    feature = "rust",
+    feature = "typescript"
+))]
 #[path = "container_scope_tests.rs"]
 mod container_scope_tests;
 

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -33,14 +33,18 @@ pub mod tokens;
 /// Weighted Methods per Class.
 pub mod wmc;
 
-// Gated on the union of the features its `FIXTURES` rows carry, so a
-// build enabling none of them drops the module rather than tripping
-// `assert_fixtures_present` — a failure that reads as a defect in
-// whatever was being changed (`.claude/rules/testing.md`, #1286). The
-// tests the module already gates individually all name a subset of this
-// list.
+// Gated on the union of every feature any test in the module names —
+// the `FIXTURES` rows plus the `bash` / `lua` / `c` row set that
+// `a_language_with_no_member_construct_emits_neither_block` uses. The
+// narrower `FIXTURES` union belongs on the four tests that read
+// `FIXTURES`, not here: a module gate is an outer `cfg`, so naming only
+// the `FIXTURES` features would delete that Bash/Lua/C test from a build
+// enabling exactly the languages it exists to cover
+// (`.claude/rules/testing.md`, #1286).
 #[cfg(test)]
 #[cfg(any(
+    feature = "bash",
+    feature = "c",
     feature = "cpp",
     feature = "csharp",
     feature = "elixir",
@@ -49,6 +53,7 @@ pub mod wmc;
     feature = "java",
     feature = "javascript",
     feature = "kotlin",
+    feature = "lua",
     feature = "mozcpp",
     feature = "mozjs",
     feature = "objc",

--- a/src/metrics/nargs.rs
+++ b/src/metrics/nargs.rs
@@ -4370,7 +4370,19 @@ when HTTP_REQUEST { log local0. \"hit\" }
 /// were checked and are correct — each overrides `compute` with its own
 /// closure-parameter shape — and the JS family reaches the right answer
 /// through the singular `parameter` field.
+// Gated on the union of the languages `cases()` has a row for, so a
+// build enabling none of them drops the module rather than tripping its
+// `checked > 0` guard (`.claude/rules/testing.md`, #1286). The
+// closure-channel test below reads a strict subset of that table and so
+// carries its own narrower gate.
 #[cfg(test)]
+#[cfg(any(
+    feature = "csharp",
+    feature = "java",
+    feature = "javascript",
+    feature = "mozjs",
+    feature = "typescript"
+))]
 mod lambda_parenthesisation_parity {
     use crate::test_support::metrics_verbatim;
     use crate::{LANG, MetricsOptions};
@@ -4460,11 +4472,14 @@ mod lambda_parenthesisation_parity {
     /// Asserting the channel per language rather than globally keeps
     /// this test from encoding that as a bug.
     #[test]
+    #[cfg(any(feature = "csharp", feature = "java"))]
     fn a_bare_lambda_stays_in_the_closure_channel() {
-        for lang in [LANG::Java, LANG::Csharp] {
-            if !lang.is_enabled() {
-                continue;
-            }
+        let mut checked = 0;
+        for lang in [LANG::Java, LANG::Csharp]
+            .into_iter()
+            .filter(LANG::is_enabled)
+        {
+            checked += 1;
             let [bare, ..] = cases(lang).expect("both languages have cases");
             assert_eq!(
                 args(lang, bare),
@@ -4472,6 +4487,13 @@ mod lambda_parenthesisation_parity {
                 "{lang:?}: the lambda's argument must be billed to closure_args"
             );
         }
+        // Two rows against the module's five-feature gate, so this test
+        // needs the narrower `cfg` above; the guard then covers the
+        // residual `is_enabled` disagreement (#1286).
+        assert!(
+            checked > 0,
+            "neither java nor csharp is enabled; this test asserted nothing"
+        );
     }
 }
 
@@ -4681,45 +4703,87 @@ mod comments_in_parameter_lists {
         })
     }
 
-    #[test]
-    fn a_comment_in_a_parameter_list_is_not_a_parameter() {
-        let (mut repaired, mut guards) = (0, 0);
+    /// Sweeps one fixture table, reporting every row that miscounted and
+    /// failing differently when the table ran empty.
+    ///
+    /// The two populations are swept by two tests rather than one
+    /// because they are **disjoint**, and a single test could not be
+    /// gated (#1286): its guard was the conjunction `repaired > 0 &&
+    /// guards > 0`, which no union of the two tables satisfies —
+    /// `--features rust` supplies a repaired row and no guard row,
+    /// `--features go` the reverse. Split, each test's `cfg` is exactly
+    /// its own table's languages and each guard stays loud. The shared
+    /// collect-then-report shape lives here so the split costs no
+    /// duplication.
+    fn sweep(table: impl Fn(LANG) -> Option<&'static [(&'static str, (u64, u64))]>, what: &str) {
+        let mut checked = 0;
         let mut failures = Vec::new();
         for lang in LANG::into_enum_iter().filter(LANG::is_enabled) {
-            for (table, counter) in [
-                (repaired_cases(lang), &mut repaired),
-                (already_correct_cases(lang), &mut guards),
-            ] {
-                for (source, expected) in table.unwrap_or_default() {
-                    *counter += 1;
-                    let got = args(lang, source);
-                    // Collected rather than asserted inline so a revert of
-                    // any one of the four loops shows every language it
-                    // broke, not just the alphabetically first. The branch
-                    // carries no formatting — a line that runs only on
-                    // failure can never be covered, so the report is built
-                    // once, below, from the raw tuples.
-                    if got != *expected {
-                        failures.push((lang, source, *expected, got));
-                    }
+            for (source, expected) in table(lang).unwrap_or_default() {
+                checked += 1;
+                let got = args(lang, source);
+                // Collected rather than asserted inline so a revert of
+                // any one of the four loops shows every language it
+                // broke, not just the alphabetically first. The branch
+                // carries no formatting — a line that runs only on
+                // failure can never be covered, so the report is built
+                // once, below, from the raw tuples.
+                if got != *expected {
+                    failures.push((lang, source, *expected, got));
                 }
             }
         }
         // Bound eagerly and interpolated by name: an `assert!` argument is
         // evaluated only when the assertion fires, so spelling these out
         // as arguments would leave two more never-executed lines behind.
-        let (failed, total) = (failures.len(), repaired + guards);
+        let failed = failures.len();
         assert!(
             failures.is_empty(),
-            "{failed}/{total} fixtures counted a comment as a parameter: {failures:#?}"
+            "{failed}/{checked} {what} fixtures counted a comment as a parameter: {failures:#?}"
         );
-        // Both tallies, so a table that stopped being reached — a renamed
+        // The tally, so a table that stopped being reached — a renamed
         // `LANG` variant, a feature that stopped being enabled — fails
         // here rather than passing vacuously.
         assert!(
-            repaired > 0 && guards > 0,
-            "no fixture ran (repaired={repaired}, guards={guards}); this test asserted nothing"
+            checked > 0,
+            "no {what} fixture ran; this test asserted nothing"
         );
+    }
+
+    #[test]
+    #[cfg(any(
+        feature = "c",
+        feature = "cpp",
+        feature = "csharp",
+        feature = "elixir",
+        feature = "groovy",
+        feature = "java",
+        feature = "javascript",
+        feature = "kotlin",
+        feature = "mozcpp",
+        feature = "mozjs",
+        feature = "objc",
+        feature = "php",
+        feature = "python",
+        feature = "ruby",
+        feature = "rust",
+        feature = "typescript"
+    ))]
+    fn a_comment_in_a_repaired_parameter_list_is_not_a_parameter() {
+        sweep(repaired_cases, "repaired");
+    }
+
+    #[test]
+    #[cfg(any(
+        feature = "go",
+        feature = "groovy",
+        feature = "kotlin",
+        feature = "lua",
+        feature = "objc",
+        feature = "perl"
+    ))]
+    fn a_positive_parameter_filter_still_ignores_a_comment() {
+        sweep(already_correct_cases, "already-correct");
     }
 
     /// Tcl — and iRules, which shares the shape — reports **4** for a
@@ -4800,7 +4864,9 @@ mod comments_in_parameter_lists {
     /// what would break if a grammar bump moved the comment inside the
     /// field.
     #[test]
+    #[cfg(any(feature = "csharp", feature = "java"))]
     fn a_comment_on_a_bare_lambda_parameter_changes_nothing() {
+        let mut checked = 0;
         for (lang, commented, bare) in [
             (
                 LANG::Java,
@@ -4816,6 +4882,7 @@ mod comments_in_parameter_lists {
         .into_iter()
         .filter(|(lang, ..)| lang.is_enabled())
         {
+            checked += 1;
             let got = args(lang, commented);
             assert_eq!(
                 got,
@@ -4830,10 +4897,25 @@ mod comments_in_parameter_lists {
                 "{lang:?}: a bare lambda parameter is one closure argument"
             );
         }
+        // The non-vacuity half the `cfg` above does not cover: a
+        // zero-iteration loop here means `is_enabled` stopped agreeing
+        // with the feature this compiled under (#1286).
+        assert!(
+            checked > 0,
+            "neither java nor csharp is enabled; this test asserted nothing"
+        );
     }
 }
 
+// The guard below is a *conjunction* over three tables, so the gate is
+// their intersection rather than their union: `cpp_only_shapes` is the
+// narrowest at `Cpp | Mozcpp`, and both other tables include those two,
+// so `any(cpp, mozcpp)` is exactly the set of feature configurations in
+// which all three tallies can be non-zero (#1286). A plain union would
+// re-admit the spurious failure — `--features c` supplies shared and
+// attributed rows but no `cpp_only` one.
 #[cfg(test)]
+#[cfg(any(feature = "cpp", feature = "mozcpp"))]
 mod c_family_return_type_declarators {
     use crate::test_support::space_verbatim;
     use crate::{LANG, MetricsOptions};

--- a/src/spaces_tests.rs
+++ b/src/spaces_tests.rs
@@ -2533,7 +2533,36 @@ fn walk_frees_every_cognitive_nesting_slot() {
     }
 }
 
+// The sweep below covers every `LANG` variant, so its row set is every
+// language feature there is and its non-vacuity guard is only reachable
+// in a build that compiled none of them. Gated so that build drops the
+// test rather than failing it (`.claude/rules/testing.md`, #1286).
 #[cfg(test)]
+#[cfg(any(
+    feature = "bash",
+    feature = "c",
+    feature = "c-family-helpers",
+    feature = "cpp",
+    feature = "csharp",
+    feature = "elixir",
+    feature = "go",
+    feature = "groovy",
+    feature = "irules",
+    feature = "java",
+    feature = "javascript",
+    feature = "kotlin",
+    feature = "lua",
+    feature = "mozcpp",
+    feature = "mozjs",
+    feature = "objc",
+    feature = "perl",
+    feature = "php",
+    feature = "python",
+    feature = "ruby",
+    feature = "rust",
+    feature = "tcl",
+    feature = "typescript"
+))]
 mod empty_root_contract {
     use crate::{LANG, MetricsOptions, Source, SpaceKind, analyze};
 
@@ -2554,11 +2583,13 @@ mod empty_root_contract {
         // supported language families.
         let inputs: &[&[u8]] = &[b"", b"   \n\t\n", b"// just a comment\n", b"/* block */\n"];
 
+        let mut checked = 0;
         for lang in LANG::into_enum_iter() {
             if !lang.is_enabled() {
                 continue;
             }
             for src in inputs {
+                checked += 1;
                 let space = analyze(Source::new(lang, src), MetricsOptions::default())
                     .unwrap_or_else(|err| {
                         panic!(
@@ -2577,5 +2608,16 @@ mod empty_root_contract {
                 );
             }
         }
+        // Counts language/input *pairs* rather than languages, so an
+        // emptied `inputs` fails here too — the outer loop would
+        // otherwise still run once per language while asserting
+        // nothing. The `cfg` above makes the no-language build drop this
+        // test; the two states it cannot see are that emptied table and
+        // an `is_enabled` that stopped agreeing with the features this
+        // compiled under (#1286).
+        assert!(
+            checked > 0,
+            "no language/input pair ran; this test asserted nothing"
+        );
     }
 }

--- a/tests/grammars/alterator_string_flattening.rs
+++ b/tests/grammars/alterator_string_flattening.rs
@@ -16,12 +16,29 @@
 //! leaf carries the full quoted text — only the `alterate` arm produces a
 //! childless node whose value is `"hi"`.
 #![allow(missing_docs)]
+// Every case below is gated on its own grammar feature, so a build that
+// enables none of the eight leaves the helpers they share with no caller
+// at all. The relaxation is scoped to exactly that configuration, so a
+// genuinely dead helper still fails the `--all-features` leg.
+#![cfg_attr(
+    not(any(
+        feature = "csharp",
+        feature = "elixir",
+        feature = "irules",
+        feature = "lua",
+        feature = "mozcpp",
+        feature = "objc",
+        feature = "ruby",
+        feature = "tcl",
+    )),
+    allow(dead_code)
+)]
 
 use big_code_analysis::{Ast, AstCfg, AstNode, LANG, Source};
 
-/// Dumps `code` for `lang` and returns the root AST node. Runs only under
-/// builds where `lang`'s grammar feature is enabled (the `--all-features`
-/// test leg); the `feature-matrix` legs merely `cargo check` this file.
+/// Dumps `code` for `lang` and returns the root AST node. Every caller is
+/// a `#[cfg(feature = …)]`-gated case, so `lang`'s grammar is compiled in
+/// whenever this runs and the parse cannot fail for want of a feature.
 fn dump_root(lang: LANG, code: &str, file_name: &str) -> AstNode {
     let cfg = AstCfg {
         id: String::new(),
@@ -30,7 +47,7 @@ fn dump_root(lang: LANG, code: &str, file_name: &str) -> AstNode {
         span: false,
     };
     Ast::parse(Source::new(lang, code.as_bytes()).with_name(Some(file_name.to_owned())))
-        .expect("language feature enabled under --all-features")
+        .expect("case gated on this language's grammar feature")
         .dump(cfg)
         .root
         .expect("source parses to a root AST node")
@@ -52,13 +69,25 @@ fn assert_flattened(lang: LANG, code: &str, file_name: &str, literal: &str) {
     );
 }
 
-/// Emits one `#[test]` per `name: lang, code, file, literal;` case, each
-/// asserting the literal survives `alterate` as a single verbatim leaf.
-/// Mirrors the `roundtrip_tests!` pattern in `src/language_enum_roundtrip.rs`.
+/// Emits one `#[test]` per `name: feature, lang, code, file, literal;`
+/// case, each asserting the literal survives `alterate` as a single
+/// verbatim leaf. Mirrors the `roundtrip_tests!` pattern in
+/// `src/language_enum_roundtrip.rs`.
+///
+/// The feature literal is per row rather than one gate on the module
+/// because the table spans eight grammars: a whole-module
+/// `#[cfg(feature = …)]` — the shape the single-grammar siblings
+/// `c_grammar_metrics` and `mozcpp_grammar_metrics` use — can name only
+/// one of them. A row whose grammar is absent must be *absent* too, not
+/// merely failing: without the gate every row panicked in `dump_root`
+/// under any feature set short of the full eight, which reads as a
+/// defect in whatever was being changed (`.claude/rules/testing.md`,
+/// "Gate a feature-gated fixture table on the union of its rows").
 macro_rules! flatten_cases {
-    ($($name:ident: $lang:expr, $code:expr, $file:expr, $lit:expr;)*) => {
+    ($($name:ident: $feat:literal, $lang:expr, $code:expr, $file:expr, $lit:expr;)*) => {
         $(
             #[test]
+            #[cfg(feature = $feat)]
             fn $name() {
                 assert_flattened($lang, $code, $file, $lit);
             }
@@ -67,11 +96,11 @@ macro_rules! flatten_cases {
 }
 
 flatten_cases! {
-    objc_flattens_string_literal: LANG::Objc, "int f(void) { const char *s = \"hi\"; return 0; }", "f.m", "\"hi\"";
-    mozcpp_flattens_string_literal: LANG::Mozcpp, "int f() { const char *s = \"hi\"; return 0; }", "f.cpp", "\"hi\"";
-    csharp_flattens_string_literal: LANG::Csharp, "class C { void M() { string s = \"hi\"; } }", "f.cs", "\"hi\"";
-    lua_flattens_string_literal: LANG::Lua, "local s = \"hi\"", "f.lua", "\"hi\"";
-    tcl_flattens_quoted_word: LANG::Tcl, "set s \"hi\"", "f.tcl", "\"hi\"";
+    objc_flattens_string_literal: "objc", LANG::Objc, "int f(void) { const char *s = \"hi\"; return 0; }", "f.m", "\"hi\"";
+    mozcpp_flattens_string_literal: "mozcpp", LANG::Mozcpp, "int f() { const char *s = \"hi\"; return 0; }", "f.cpp", "\"hi\"";
+    csharp_flattens_string_literal: "csharp", LANG::Csharp, "class C { void M() { string s = \"hi\"; } }", "f.cs", "\"hi\"";
+    lua_flattens_string_literal: "lua", LANG::Lua, "local s = \"hi\"", "f.lua", "\"hi\"";
+    tcl_flattens_quoted_word: "tcl", LANG::Tcl, "set s \"hi\"", "f.tcl", "\"hi\"";
     // In valid iRules a quoted word only appears inside an event handler's
     // `{ … }` body. Until #1381 `alterate` flattened that body as a single
     // `braced_word` leaf, so the only verbatim text in the whole dump was
@@ -79,28 +108,28 @@ flatten_cases! {
     // valid input. The handler body is a script now, so the arm this file
     // is about is finally what this row tests — the same claim its Tcl
     // twin above makes.
-    irules_flattens_quoted_word: LANG::Irules, "when HTTP_REQUEST { set s \"hi\" }", "f.irule", "\"hi\"";
+    irules_flattens_quoted_word: "irules", LANG::Irules, "when HTTP_REQUEST { set s \"hi\" }", "f.irule", "\"hi\"";
     // The Tcl half of the same claim. `tcl_flattens_quoted_word` above
     // reaches the literal at statement level, where the body guard has
     // nothing to do — verified by perturbation: deleting the Tcl guard
     // failed no test until this row existed, while the iRules twin failed
     // on its own because iRules has no statement level to test from.
-    tcl_flattens_quoted_word_inside_a_proc_body: LANG::Tcl, "proc p {} { puts \"hi\" }", "f.tcl", "\"hi\"";
+    tcl_flattens_quoted_word_inside_a_proc_body: "tcl", LANG::Tcl, "proc p {} { puts \"hi\" }", "f.tcl", "\"hi\"";
     // The braced *value* half of the same rule: `lappend`'s argument is a
     // literal, so it keeps the flattening a script body gives up. Without
     // it the #1381 guard would read as "braced words are never flattened",
     // which is the opposite over-correction.
-    tcl_flattens_braced_value: LANG::Tcl, "lappend x {a b}\n", "f.tcl", "{a b}";
-    irules_flattens_braced_value: LANG::Irules, "lappend b {x y}\n", "f.irule", "{x y}";
+    tcl_flattens_braced_value: "tcl", LANG::Tcl, "lappend x {a b}\n", "f.tcl", "{a b}";
+    irules_flattens_braced_value: "irules", LANG::Irules, "lappend b {x y}\n", "f.irule", "{x y}";
     // The value slots of a construct `is_value_braced_word` classifies
     // whole as script-taking. Without `is_braced_literal_slot` the dump
     // rendered `{my proc}` as a command named `my` and `{a b}` as a
     // command named `a` — the literal's text survived only inside a
     // subtree the source does not contain.
-    tcl_flattens_braced_proc_name: LANG::Tcl, "proc {my proc} {} {}\n", "f.tcl", "{my proc}";
-    tcl_flattens_namespace_argument: LANG::Tcl, "namespace export {a b}\n", "f.tcl", "{a b}";
-    irules_flattens_braced_proc_name: LANG::Irules, "proc {my proc} {} {}\n", "f.irule", "{my proc}";
-    irules_flattens_namespace_argument: LANG::Irules, "namespace export {a b}\n", "f.irule", "{a b}";
+    tcl_flattens_braced_proc_name: "tcl", LANG::Tcl, "proc {my proc} {} {}\n", "f.tcl", "{my proc}";
+    tcl_flattens_namespace_argument: "tcl", LANG::Tcl, "namespace export {a b}\n", "f.tcl", "{a b}";
+    irules_flattens_braced_proc_name: "irules", LANG::Irules, "proc {my proc} {} {}\n", "f.irule", "{my proc}";
+    irules_flattens_namespace_argument: "irules", LANG::Irules, "namespace export {a b}\n", "f.irule", "{a b}";
     // The *value* argument of a command whose other arguments are
     // scripts (#1381 review). Each of these was flattened before #1381
     // and became a nested `command` under it, so the dump grew a
@@ -110,15 +139,15 @@ flatten_cases! {
     // `Checker::is_string_with_code` in `checker.rs` — this file can
     // only observe the positive, since a flattened leaf is what it
     // looks for.
-    tcl_flattens_after_delay: LANG::Tcl, "after {100} {puts a}\n", "f.tcl", "{100}";
-    tcl_flattens_time_count: LANG::Tcl, "time {puts b} {5}\n", "f.tcl", "{5}";
-    tcl_flattens_uplevel_level: LANG::Tcl, "uplevel {1} {puts c}\n", "f.tcl", "{1}";
-    tcl_flattens_switch_subject: LANG::Tcl, "switch {foo} {p {puts d}}\n", "f.tcl", "{foo}";
-    tcl_flattens_namespace_eval_name: LANG::Tcl, "namespace eval {my ns} {puts e}\n", "f.tcl", "{my ns}";
-    irules_flattens_after_delay: LANG::Irules, "after {100} {log a}\n", "f.irule", "{100}";
-    irules_flattens_time_count: LANG::Irules, "time {log b} {5}\n", "f.irule", "{5}";
-    irules_flattens_uplevel_level: LANG::Irules, "uplevel {1} {log c}\n", "f.irule", "{1}";
-    irules_flattens_namespace_eval_name: LANG::Irules, "namespace eval {my ns} {log d}\n", "f.irule", "{my ns}";
-    ruby_flattens_string_literal: LANG::Ruby, "s = \"hi\"\n", "f.rb", "\"hi\"";
-    elixir_flattens_string_literal: LANG::Elixir, "s = \"hi\"\n", "f.ex", "\"hi\"";
+    tcl_flattens_after_delay: "tcl", LANG::Tcl, "after {100} {puts a}\n", "f.tcl", "{100}";
+    tcl_flattens_time_count: "tcl", LANG::Tcl, "time {puts b} {5}\n", "f.tcl", "{5}";
+    tcl_flattens_uplevel_level: "tcl", LANG::Tcl, "uplevel {1} {puts c}\n", "f.tcl", "{1}";
+    tcl_flattens_switch_subject: "tcl", LANG::Tcl, "switch {foo} {p {puts d}}\n", "f.tcl", "{foo}";
+    tcl_flattens_namespace_eval_name: "tcl", LANG::Tcl, "namespace eval {my ns} {puts e}\n", "f.tcl", "{my ns}";
+    irules_flattens_after_delay: "irules", LANG::Irules, "after {100} {log a}\n", "f.irule", "{100}";
+    irules_flattens_time_count: "irules", LANG::Irules, "time {log b} {5}\n", "f.irule", "{5}";
+    irules_flattens_uplevel_level: "irules", LANG::Irules, "uplevel {1} {log c}\n", "f.irule", "{1}";
+    irules_flattens_namespace_eval_name: "irules", LANG::Irules, "namespace eval {my ns} {log d}\n", "f.irule", "{my ns}";
+    ruby_flattens_string_literal: "ruby", LANG::Ruby, "s = \"hi\"\n", "f.rb", "\"hi\"";
+    elixir_flattens_string_literal: "elixir", LANG::Elixir, "s = \"hi\"\n", "f.ex", "\"hi\"";
 }

--- a/tests/parity/cognitive_cross_language_parity.rs
+++ b/tests/parity/cognitive_cross_language_parity.rs
@@ -22,6 +22,13 @@
 //! side; this test ensures the cognitive side never quietly drifts
 //! along the same axis.
 //!
+//! The fixture table is an exhaustive `match` on [`LANG`], so adding a
+//! language variant fails to compile until someone decides whether its
+//! grammar models a switch-like construct; a language that does not says
+//! so with `None`, and the reason lives at the arm. Before #1281 the
+//! list was hand-maintained and had fallen behind the roster — Ruby and
+//! Elixir were absent, and the row labelled `c` parsed `LANG::Cpp`.
+//!
 //! The test uses `cognitive_max()` (space-stacking-independent) so
 //! Java's mandatory wrapping class does not skew the comparison —
 //! no per-language offset is required.
@@ -35,208 +42,179 @@ fn cognitive_max(lang: LANG, source: &str, ext: &str) -> f64 {
         Source::new(lang, source.as_bytes()).with_name(Some(name)),
         MetricsOptions::default(),
     )
-    .expect("parser produced no FuncSpace for parity fixture");
+    .unwrap_or_else(|e| panic!("{lang:?}: analyze failed: {e}"));
     space.metrics.cognitive.cognitive_max() as f64
 }
 
-// A 2-arm switch/match with one explicit arm plus a wildcard /
-// `default` arm contributes one decision point in cognitive
-// complexity (the switch itself); the explicit arm adds no extra
-// nesting and the fallback is silent. Expected `cognitive_max()` is
-// therefore `1` for every language whose grammar models the
-// construct as a `switch`/`match`.
+/// Returns `(source, extension)` for a language whose grammar models a
+/// switch-like construct with a wildcard / `default` arm, or `None` for
+/// one that does not.
+///
+/// Every `Some` row spells the same shape: a function whose whole body
+/// is a two-arm switch — one explicit arm plus a fallback.
+fn fixture(lang: LANG) -> Option<(&'static str, &'static str)> {
+    // Exhaustive per-language dispatch table: one arm per LANG variant
+    // is the point of this function, so a new language cannot be added
+    // without deciding whether it has a switch-like construct. The
+    // repo's own `.bcaignore` excludes `./tests/**`, so this marker is
+    // for the per-edit `bca check` hook rather than for the self-scan
+    // gate.
+    // bca: suppress(cyclomatic)
+    let row = match lang {
+        LANG::Rust => (
+            "fn f(x: u8) -> &'static str {\n    match x {\n        1 => \"one\",\n        \
+             _ => \"other\",\n    }\n}\n",
+            "rs",
+        ),
+        // One arm for the whole C family: the fixture is plain C, which
+        // all four grammars accept unchanged. Objective-C reaches it
+        // through a free C `function_definition`, valid in a `.m` file.
+        LANG::C | LANG::Cpp | LANG::Mozcpp | LANG::Objc => (
+            "void f(int x) {\n    switch (x) {\n        case 1: break;\n        \
+             default: break;\n    }\n}\n",
+            "c",
+        ),
+        LANG::Java => (
+            "class Parity {\n    static void f(int x) {\n        switch (x) {\n            \
+             case 1: break;\n            default: break;\n        }\n    }\n}\n",
+            "java",
+        ),
+        LANG::Csharp => (
+            "class Parity {\n    static void F(int x) {\n        switch (x) {\n            \
+             case 1: break;\n            default: break;\n        }\n    }\n}\n",
+            "cs",
+        ),
+        LANG::Javascript | LANG::Mozjs => (
+            "function f(x) {\n    switch (x) {\n        case 1: break;\n        \
+             default: break;\n    }\n}\n",
+            "js",
+        ),
+        LANG::Typescript => (
+            "function f(x: number) {\n    switch (x) {\n        case 1: break;\n        \
+             default: break;\n    }\n}\n",
+            "ts",
+        ),
+        LANG::Tsx => (
+            "function f(x: number) {\n    switch (x) {\n        case 1: break;\n        \
+             default: break;\n    }\n}\n",
+            "tsx",
+        ),
+        LANG::Php => (
+            "<?php\nfunction f($x) {\n    switch ($x) {\n        case 1: break;\n        \
+             default: break;\n    }\n}\n",
+            "php",
+        ),
+        LANG::Groovy => (
+            "def f(x) {\n    switch (x) {\n        case 1: break\n        default: break\n    }\n}\n",
+            "groovy",
+        ),
+        // Kotlin spells the same construct `when`.
+        LANG::Kotlin => (
+            "fun f(x: Int): String {\n    return when (x) {\n        1 -> \"one\"\n        \
+             else -> \"other\"\n    }\n}\n",
+            "kt",
+        ),
+        LANG::Go => (
+            "package p\nfunc f(x int) string {\n    switch x {\n    case 1:\n        \
+             return \"one\"\n    default:\n        return \"other\"\n    }\n}\n",
+            "go",
+        ),
+        // Python's structural-pattern `match`; `case _` is the wildcard.
+        LANG::Python => (
+            "def f(x):\n    match x:\n        case 1:\n            return 'one'\n        \
+             case _:\n            return 'other'\n",
+            "py",
+        ),
+        // Ruby spells the construct `case`/`when`, with `else` as the
+        // fallback arm.
+        LANG::Ruby => (
+            "def f(x)\n  case x\n  when 1 then \"one\"\n  else \"other\"\n  end\nend\n",
+            "rb",
+        ),
+        // Elixir's `case` with a bare `_ ->` catch-all (#1272). `def`
+        // must live inside a `defmodule`, but `cognitive_max()` reads
+        // the function space, so the module adds no offset.
+        LANG::Elixir => (
+            "defmodule Parity do\n  def f(x) do\n    case x do\n      1 -> :one\n      \
+             _ -> :other\n    end\n  end\nend\n",
+            "ex",
+        ),
+        LANG::Bash => (
+            "f() {\n  case \"$1\" in\n    one) echo one ;;\n    *) echo other ;;\n  esac\n}\n",
+            "sh",
+        ),
+        // Tcl spells the construct as a generic `switch` command and
+        // iRules as a dedicated node (#467); both contribute one
+        // decision point with the `default` arm free, so one fixture
+        // text serves both.
+        LANG::Tcl => (
+            "proc f {x} {\n    switch $x {\n        1 { return one }\n        \
+             default { return other }\n    }\n}\n",
+            "tcl",
+        ),
+        LANG::Irules => (
+            "proc f {x} {\n    switch $x {\n        1 { return one }\n        \
+             default { return other }\n    }\n}\n",
+            "irule",
+        ),
+        // No switch-like construct to score. Lua has none at all — the
+        // idiomatic form is an `if`/`elseif` chain. Perl's `given`/`when`
+        // was always experimental and was removed from the language in
+        // 5.42; the pinned grammar does not model it (verified: the
+        // construct parses to ERROR nodes), so a fixture using it would
+        // pin the parse failure rather than the metric. The two
+        // C-family helper grammars parse fragments and have no
+        // statements at all.
+        LANG::Lua | LANG::Perl | LANG::Ccomment | LANG::Preproc => return None,
+    };
+    Some(row)
+}
 
 #[test]
 fn two_arm_wildcard_switch_cognitive_parity() {
-    let rust = cognitive_max(
-        LANG::Rust,
-        r#"fn f(x: u8) -> &'static str {
-    match x {
-        1 => "one",
-        _ => "other",
-    }
-}
-"#,
-        "rs",
-    );
-    let c = cognitive_max(
-        LANG::Cpp,
-        r"void f(int x) {
-    switch (x) {
-        case 1: break;
-        default: break;
-    }
-}
-",
-        "c",
-    );
-    let java = cognitive_max(
-        LANG::Java,
-        r"class Parity {
-    static void f(int x) {
-        switch (x) {
-            case 1: break;
-            default: break;
-        }
-    }
-}
-",
-        "java",
-    );
-    let javascript = cognitive_max(
-        LANG::Javascript,
-        r"function f(x) {
-    switch (x) {
-        case 1: break;
-        default: break;
-    }
-}
-",
-        "js",
-    );
-    let typescript = cognitive_max(
-        LANG::Typescript,
-        r"function f(x: number) {
-    switch (x) {
-        case 1: break;
-        default: break;
-    }
-}
-",
-        "ts",
-    );
-    let php = cognitive_max(
-        LANG::Php,
-        r"<?php
-function f($x) {
-    switch ($x) {
-        case 1: break;
-        default: break;
-    }
-}
-",
-        "php",
-    );
-    let csharp = cognitive_max(
-        LANG::Csharp,
-        r"class Parity {
-    static void F(int x) {
-        switch (x) {
-            case 1: break;
-            default: break;
-        }
-    }
-}
-",
-        "cs",
-    );
-    // Kotlin spells the same construct `when`; Go's `switch` shares
-    // the same node category.
-    let kotlin = cognitive_max(
-        LANG::Kotlin,
-        r#"fun f(x: Int): String {
-    return when (x) {
-        1 -> "one"
-        else -> "other"
-    }
-}
-"#,
-        "kt",
-    );
-    let go = cognitive_max(
-        LANG::Go,
-        r#"package p
-func f(x int) string {
-    switch x {
-    case 1:
-        return "one"
-    default:
-        return "other"
-    }
-}
-"#,
-        "go",
-    );
-    let bash = cognitive_max(
-        LANG::Bash,
-        "f() {\n  case \"$1\" in\n    one) echo one ;;\n    *) echo other ;;\n  esac\n}\n",
-        "sh",
-    );
-    let python = cognitive_max(
-        LANG::Python,
-        "def f(x):\n    match x:\n        case 1:\n            return 'one'\n        case _:\n            return 'other'\n",
-        "py",
-    );
-    let groovy = cognitive_max(
-        LANG::Groovy,
-        r"def f(x) {
-    switch (x) {
-        case 1: break
-        default: break
-    }
-}
-",
-        "groovy",
-    );
-    // Tcl spells the construct as a generic `switch` command; the structure
-    // adds one cognitive decision point, the `default` arm is free (issue #467).
-    let tcl = cognitive_max(
-        LANG::Tcl,
-        r"proc f {x} {
-    switch $x {
-        1 { return one }
-        default { return other }
-    }
-}
-",
-        "tcl",
-    );
-    // iRules spells `switch` as a dedicated node, but the cognitive
-    // contribution is the same: one decision point, the `default` arm free.
-    let irules = cognitive_max(
-        LANG::Irules,
-        r"proc f {x} {
-    switch $x {
-        1 { return one }
-        default { return other }
-    }
-}
-",
-        "irule",
-    );
-    // Objective-C uses a free C `function_definition` (valid in a `.m`
-    // file); its `switch_statement` is the single decision point and the
-    // `default:` arm is free, matching the family.
-    let objc = cognitive_max(
-        LANG::Objc,
-        r"void f(int x) {
-    switch (x) {
-        case 1: break;
-        default: break;
-    }
-}
-",
-        "m",
-    );
-
-    // expected: one explicit arm + wildcard/default in a single
-    // switch/match contributes one cognitive decision point.
+    // expected: a two-arm switch/match with one explicit arm plus a
+    // wildcard/`default` contributes exactly one cognitive decision
+    // point — the switch itself. Hand-derived: the construct is +1 at
+    // nesting depth 0, the explicit arm adds no nesting of its own, and
+    // the fallback is silent.
     let expected = 1.0;
-    assert_eq!(rust, expected, "rust");
-    assert_eq!(c, expected, "c");
-    assert_eq!(java, expected, "java");
-    assert_eq!(javascript, expected, "javascript");
-    assert_eq!(typescript, expected, "typescript");
-    assert_eq!(php, expected, "php");
-    assert_eq!(csharp, expected, "csharp");
-    assert_eq!(kotlin, expected, "kotlin");
-    assert_eq!(go, expected, "go");
-    assert_eq!(bash, expected, "bash");
-    assert_eq!(python, expected, "python");
-    assert_eq!(groovy, expected, "groovy");
-    assert_eq!(tcl, expected, "tcl");
-    assert_eq!(irules, expected, "irules");
-    assert_eq!(objc, expected, "objc");
+
+    let mut checked = 0;
+    for lang in LANG::into_enum_iter() {
+        if !lang.is_enabled() {
+            continue;
+        }
+        let Some((source, ext)) = fixture(lang) else {
+            continue;
+        };
+        checked += 1;
+        let got = cognitive_max(lang, source, ext);
+        assert_eq!(
+            got, expected,
+            "{lang:?}: cognitive_max {got} != expected {expected}",
+        );
+    }
+
+    // A table that lost its rows is a real, feature-independent
+    // regression, so assert it directly. A build whose enabled
+    // languages have no switch-like construct legitimately checks
+    // nothing — the state a `#[cfg]`-gated-out module would be in — so
+    // `checked > 0` is deliberately not asserted: making it safe would
+    // need a hand-maintained feature union naming every `Some` arm,
+    // which is the drift this restructure removed (#1281).
+    assert!(
+        LANG::into_enum_iter().any(|lang| fixture(lang).is_some()),
+        "the fixture table has no rows at all, so this test cannot fail",
+    );
+    // Re-derive the count independently of the loop, so a `continue`
+    // added above cannot quietly drop rows.
+    let eligible = LANG::into_enum_iter()
+        .filter(|lang| lang.is_enabled() && fixture(*lang).is_some())
+        .count();
+    assert_eq!(
+        checked, eligible,
+        "the loop checked {checked} languages but {eligible} enabled languages have a fixture",
+    );
 }
 
 /// A function *declared inside a closure* must score the same as the
@@ -330,8 +308,15 @@ fn a_function_declared_inside_a_closure_scores_the_same_as_outside() {
             "{lang:?}: the baseline itself moved, so the equality above proves nothing",
         );
     }
-    assert!(
-        checked > 0,
-        "at least one language feature must be enabled for this test to mean anything"
+    // An empty `cases` table is a real, feature-independent regression;
+    // a build enabling only languages absent from it legitimately checks
+    // nothing. Asserting `checked > 0` conflated the two and failed
+    // spuriously under, for example, `--no-default-features --features
+    // go` (#1281).
+    assert!(!cases.is_empty(), "the case table has no rows at all");
+    let eligible = cases.iter().filter(|case| case.0.is_enabled()).count();
+    assert_eq!(
+        checked, eligible,
+        "the loop checked {checked} languages but {eligible} enabled languages have a case",
     );
 }

--- a/tests/parity/cpp_mozcpp_parity.rs
+++ b/tests/parity/cpp_mozcpp_parity.rs
@@ -20,9 +20,16 @@
 //! The fixture deliberately exercises the constructs that regression
 //! touched: `new` allocation, a compound assignment, the `<=>` spaceship,
 //! and a `try` / `catch` pair, plus ordinary branches and returns.
+//!
+//! Both grammars must be compiled in for any of this to mean
+//! anything, so every item below is gated on the pair. Without the
+//! gate a reduced-feature build did not skip these tests, it panicked
+//! inside `analyze`'s `LanguageDisabled` error (#1281).
 
+#[cfg(all(feature = "cpp", feature = "mozcpp"))]
 use big_code_analysis::{LANG, MetricsOptions, Source, analyze};
 
+#[cfg(all(feature = "cpp", feature = "mozcpp"))]
 /// Headline integer metric sums for one parse of `source` as `lang`.
 fn metric_sums(lang: LANG, source: &str, ext: &str) -> Vec<(&'static str, u64)> {
     let name = format!("parity.{ext}");
@@ -30,7 +37,7 @@ fn metric_sums(lang: LANG, source: &str, ext: &str) -> Vec<(&'static str, u64)> 
         Source::new(lang, source.as_bytes()).with_name(Some(name)),
         MetricsOptions::default(),
     )
-    .expect("parser produced a FuncSpace");
+    .unwrap_or_else(|e| panic!("{lang:?}: analyze failed: {e}"));
     let m = &space.metrics;
     vec![
         ("cyclomatic", m.cyclomatic.cyclomatic_sum()),
@@ -45,6 +52,7 @@ fn metric_sums(lang: LANG, source: &str, ext: &str) -> Vec<(&'static str, u64)> 
     ]
 }
 
+#[cfg(all(feature = "cpp", feature = "mozcpp"))]
 /// The value `metric_sums` recorded for `key`, panicking with the whole
 /// row set when the key is absent.
 ///
@@ -60,6 +68,7 @@ fn metric(sums: &[(&'static str, u64)], key: &str) -> u64 {
     )
 }
 
+#[cfg(all(feature = "cpp", feature = "mozcpp"))]
 #[test]
 fn cpp_and_mozcpp_agree_on_plain_cpp() {
     // Plain C++: `new` / compound-assign / `<=>` / `try`-`catch` are all
@@ -108,6 +117,7 @@ fn cpp_and_mozcpp_agree_on_plain_cpp() {
     );
 }
 
+#[cfg(all(feature = "cpp", feature = "mozcpp"))]
 #[test]
 fn cpp_and_mozcpp_agree_on_raw_string_delimiters() {
     // #1314 guards `LPAREN` under a `RawStringLiteral` parent in both
@@ -146,6 +156,7 @@ fn cpp_and_mozcpp_agree_on_raw_string_delimiters() {
     );
 }
 
+#[cfg(all(feature = "cpp", feature = "mozcpp"))]
 #[test]
 fn cpp_and_mozcpp_agree_on_this() {
     // #1361 added `This` to the operand arm of both `CppCode::get_op_type`

--- a/tests/parity/cyclomatic_cross_language_parity.rs
+++ b/tests/parity/cyclomatic_cross_language_parity.rs
@@ -23,15 +23,23 @@
 //! prescribes a cross-language parity test for this metric. That is
 //! what this file is.
 //!
-//! For every construct family below the test builds a
-//! `BTreeMap<&str, f64>` keyed by language with its standard-CCN sum, then
-//! asserts every value is equal **after subtracting a small set of
-//! explicitly-documented per-language offsets** that account for
-//! intrinsic, language-mandated structural differences (e.g. Java's
-//! requirement that every function live inside a class, which adds a
-//! `FuncSpace` and therefore +1 to every sum). On failure the full
-//! before/after maps are printed so any drift and the language that
-//! drifted are immediately visible.
+//! Each construct family below is an exhaustive `match` on [`LANG`]
+//! returning a [`Fixture`]: one arm per variant, so adding a language
+//! fails to compile until someone decides whether it spells the family's
+//! construct, and a language that does not says so with `None` and a
+//! reason at the arm. Before #1281 the families were hand-maintained
+//! `BTreeMap` inserts that had fallen behind the roster — Ruby, Lua,
+//! Perl and Go were absent from families they can express, and every row
+//! labelled `"c"` actually parsed [`LANG::Cpp`].
+//!
+//! [`check_family`] then builds a `BTreeMap<&str, f64>` keyed by
+//! language with its standard-CCN sum and asserts every value is equal
+//! **after subtracting a small set of explicitly-documented per-language
+//! offsets** that account for intrinsic, language-mandated structural
+//! differences (e.g. Java's requirement that every function live inside
+//! a class, which adds a `FuncSpace` and therefore +1 to every sum). On
+//! failure the full before/after maps are printed so any drift and the
+//! language that drifted are immediately visible.
 //!
 //! Each offset must be either (a) a structural language requirement
 //! that cannot be removed by rewriting the fixture, or (b) a
@@ -57,19 +65,58 @@ fn ccn_sum(lang: LANG, source: &str, ext: &str) -> f64 {
         Source::new(lang, source.as_bytes()).with_name(Some(name)),
         MetricsOptions::default(),
     )
-    .expect("parser produced no FuncSpace for parity fixture");
+    .unwrap_or_else(|e| panic!("{lang:?}: analyze failed: {e}"));
     space.metrics.cyclomatic.cyclomatic_sum() as f64
 }
 
-/// Java requires every function to live inside a class, which the
-/// FuncSpace traversal counts as an extra space and so adds +1 to every
-/// CCN sum. This is a language-mandated structural difference, not a
-/// metric bug.
-const JAVA_CLASS_OFFSET: f64 = 1.0;
+/// Some languages cannot spell a free function: Java and C# require a
+/// wrapping class, Elixir a wrapping `defmodule`. The `FuncSpace`
+/// traversal counts that container as an extra space and so adds +1 to
+/// every CCN sum. This is a language-mandated structural difference, not
+/// a metric bug, and it is the only offset any family uses.
+const CONTAINER_SPACE_OFFSET: f64 = 1.0;
+
+/// One language's fixture for a construct family.
+struct Fixture {
+    /// Source spelling the family's construct in this language.
+    source: &'static str,
+    /// Extension used to name the parsed unit. It reaches the file-level
+    /// space name and no metric, so it is cosmetic — but it keeps a
+    /// failure message readable.
+    ext: &'static str,
+    /// Structural spaces the language forces around the fixture, removed
+    /// before comparing. Living on the fixture rather than in a separate
+    /// table keeps the offset next to the source that causes it.
+    offset: f64,
+}
+
+/// A fixture whose function sits at file scope, so nothing is subtracted.
+fn flat(source: &'static str, ext: &'static str) -> Fixture {
+    Fixture {
+        source,
+        ext,
+        offset: 0.0,
+    }
+}
+
+/// A fixture whose language requires the function to live inside a class
+/// or module, worth [`CONTAINER_SPACE_OFFSET`].
+fn in_container(source: &'static str, ext: &'static str) -> Fixture {
+    Fixture {
+        source,
+        ext,
+        offset: CONTAINER_SPACE_OFFSET,
+    }
+}
 
 /// Asserts every language in `sums` reports the same CCN value after
 /// subtracting `offsets[lang]` (default 0). Both maps and the
 /// normalised values are printed on failure so the drift is obvious.
+///
+/// This alone is **not** a sufficient check: a build with one enabled
+/// language reaches it with a single-entry map, which has one unique
+/// value by construction. [`assert_normalised`] is what pins the
+/// magnitude, and every family calls both.
 #[track_caller]
 fn assert_parity(family: &str, sums: &BTreeMap<&str, f64>, offsets: &BTreeMap<&str, f64>) {
     let normalised: BTreeMap<&str, f64> = sums
@@ -105,23 +152,85 @@ fn assert_normalised(
     }
 }
 
+/// Measures every enabled language that has a row in `fixture`, then
+/// runs both halves of the family's claim: mutual agreement
+/// ([`assert_parity`]) and absolute magnitude ([`assert_normalised`]).
+///
+/// One driver for all eight families is what makes "every family still
+/// pins its magnitude" structural rather than something a reviewer has
+/// to re-check per family.
+#[track_caller]
+fn check_family(family: &str, expected: f64, fixture: fn(LANG) -> Option<Fixture>) {
+    let mut sums = BTreeMap::new();
+    let mut offsets = BTreeMap::new();
+
+    for lang in LANG::into_enum_iter() {
+        if !lang.is_enabled() {
+            continue;
+        }
+        let Some(row) = fixture(lang) else {
+            continue;
+        };
+        sums.insert(lang.name(), ccn_sum(lang, row.source, row.ext));
+        if row.offset != 0.0 {
+            offsets.insert(lang.name(), row.offset);
+        }
+    }
+
+    // A table that lost its rows is a real, feature-independent
+    // regression, so assert it directly. A build whose enabled languages
+    // cannot all spell this family's construct legitimately checks
+    // nothing — the state a `#[cfg]`-gated-out module would be in — so
+    // a non-empty `sums` is deliberately not asserted: making that safe
+    // would need a hand-maintained feature union naming every `Some`
+    // arm, which is the drift this restructure removed (#1281).
+    assert!(
+        LANG::into_enum_iter().any(|lang| fixture(lang).is_some()),
+        "{family}: the fixture table has no rows at all, so it cannot fail",
+    );
+    // Re-derive the count independently of the loop above, so a
+    // `continue` added there cannot quietly drop rows.
+    let eligible = LANG::into_enum_iter()
+        .filter(|lang| lang.is_enabled() && fixture(*lang).is_some())
+        .count();
+    assert_eq!(
+        sums.len(),
+        eligible,
+        "{family}: measured {} languages but {eligible} enabled languages have a fixture",
+        sums.len(),
+    );
+    if sums.is_empty() {
+        // Nothing enabled can spell this construct. `assert_parity`
+        // would see zero distinct values and report drift, so a build
+        // that measured nothing would fail as though it had found a
+        // disagreement.
+        return;
+    }
+
+    assert_parity(family, &sums, &offsets);
+    assert_normalised(&sums, &offsets, expected, family);
+}
+
 // --- Family 1: switch / match with fallback arm ----------------------------
 //
-// Three semantically equivalent fixtures, each defining a single function
-// that switches an integer against three explicit arms plus a fallback
-// (`default:` in C/Java, `_ =>` in Rust). Standard CCN counts the three
-// explicit arms and skips the fallback (Rust treats bare `_ =>` like
-// C-family `default:` after #106 / `a54b073`).
+// Semantically equivalent fixtures, each defining a single function that
+// switches an integer against three explicit arms plus a fallback
+// (`default:` in C-family, `_ =>` in Rust, `else` in Ruby/Kotlin).
+// Standard CCN counts the three explicit arms and skips the fallback
+// (Rust treats bare `_ =>` like C-family `default:` after #106 /
+// `a54b073`).
 //
 // Per-language post-offset expectation: unit(1) + fn(1) + 3 explicit arms = 5.
 
-#[test]
-fn switch_with_default_parity() {
-    let mut sums = BTreeMap::new();
-    sums.insert(
-        "rust",
-        ccn_sum(
-            LANG::Rust,
+fn switch_with_default(lang: LANG) -> Option<Fixture> {
+    // Exhaustive per-language dispatch table: one arm per LANG variant
+    // is the point of this function, so a new language cannot be added
+    // without deciding whether it spells the construct. The repo's own
+    // `.bcaignore` excludes `./tests/**`, so this marker is for the
+    // per-edit `bca check` hook rather than for the self-scan gate.
+    // bca: suppress(cyclomatic)
+    let row = match lang {
+        LANG::Rust => flat(
             r#"fn f(x: u8) -> &'static str {
     match x {
         1 => "one",
@@ -133,11 +242,11 @@ fn switch_with_default_parity() {
 "#,
             "rs",
         ),
-    );
-    sums.insert(
-        "c",
-        ccn_sum(
-            LANG::Cpp,
+        // One arm for the whole C family: the fixture is plain C, which
+        // all four grammars accept unchanged. Objective-C reaches it
+        // through a free C `function_definition`, valid in a `.m` file,
+        // so it needs no container offset either.
+        LANG::C | LANG::Cpp | LANG::Mozcpp | LANG::Objc => flat(
             r"void f(int x) {
     switch (x) {
         case 1: break;
@@ -149,11 +258,7 @@ fn switch_with_default_parity() {
 ",
             "c",
         ),
-    );
-    sums.insert(
-        "java",
-        ccn_sum(
-            LANG::Java,
+        LANG::Java => in_container(
             r"class Parity {
     static void f(int x) {
         switch (x) {
@@ -167,12 +272,8 @@ fn switch_with_default_parity() {
 ",
             "java",
         ),
-    );
-    // C# switch-expression with discard arm `_ =>` (issue #282).
-    sums.insert(
-        "csharp",
-        ccn_sum(
-            LANG::Csharp,
+        // C# switch-expression with discard arm `_ =>` (issue #282).
+        LANG::Csharp => in_container(
             r#"class Parity {
     static string f(int x) => x switch {
         1 => "one",
@@ -184,12 +285,8 @@ fn switch_with_default_parity() {
 "#,
             "cs",
         ),
-    );
-    // Kotlin `when` with `else ->` arm (issue #282).
-    sums.insert(
-        "kotlin",
-        ccn_sum(
-            LANG::Kotlin,
+        // Kotlin `when` with `else ->` arm (issue #282).
+        LANG::Kotlin => flat(
             r#"fun f(x: Int): String = when (x) {
     1 -> "one"
     2 -> "two"
@@ -199,14 +296,133 @@ fn switch_with_default_parity() {
 "#,
             "kt",
         ),
-    );
-    // Tcl `switch` is a generic command whose non-`default` arms are the
-    // decision points; `default` is free, matching the C-family `default:`
-    // (issue #467). Procs are top-level, so no class offset.
-    sums.insert(
-        "tcl",
-        ccn_sum(
-            LANG::Tcl,
+        LANG::Javascript | LANG::Mozjs => flat(
+            r"function f(x) {
+    switch (x) {
+        case 1: break;
+        case 2: break;
+        case 3: break;
+        default: break;
+    }
+}
+",
+            "js",
+        ),
+        LANG::Typescript => flat(
+            r"function f(x: number) {
+    switch (x) {
+        case 1: break;
+        case 2: break;
+        case 3: break;
+        default: break;
+    }
+}
+",
+            "ts",
+        ),
+        LANG::Tsx => flat(
+            r"function f(x: number) {
+    switch (x) {
+        case 1: break;
+        case 2: break;
+        case 3: break;
+        default: break;
+    }
+}
+",
+            "tsx",
+        ),
+        LANG::Php => flat(
+            r"<?php
+function f($x) {
+    switch ($x) {
+        case 1: break;
+        case 2: break;
+        case 3: break;
+        default: break;
+    }
+}
+",
+            "php",
+        ),
+        // Python's structural-pattern `match`; `case _` is the wildcard.
+        LANG::Python => flat(
+            r"def f(x):
+    match x:
+        case 1:
+            return 'one'
+        case 2:
+            return 'two'
+        case 3:
+            return 'three'
+        case _:
+            return 'other'
+",
+            "py",
+        ),
+        LANG::Go => flat(
+            r#"package p
+func f(x int) string {
+    switch x {
+    case 1:
+        return "one"
+    case 2:
+        return "two"
+    case 3:
+        return "three"
+    default:
+        return "other"
+    }
+}
+"#,
+            "go",
+        ),
+        // Ruby spells the construct `case`/`when` with `else` as the
+        // fallback arm, and `def` is top-level, so no container offset.
+        LANG::Ruby => flat(
+            r#"def f(x)
+  case x
+  when 1 then "one"
+  when 2 then "two"
+  when 3 then "three"
+  else "other"
+  end
+end
+"#,
+            "rb",
+        ),
+        LANG::Groovy => flat(
+            r"def f(x) {
+    switch (x) {
+        case 1: break
+        case 2: break
+        case 3: break
+        default: break
+    }
+}
+",
+            "groovy",
+        ),
+        // Bash's `*)` is the catch-all arm and is free, matching the
+        // C-family `default:`; each explicit arm counts exactly once
+        // after the #107 / `e668f14` fix.
+        LANG::Bash => flat(
+            r#"#!/bin/bash
+f() {
+    case "$1" in
+        one)   echo 1 ;;
+        two)   echo 2 ;;
+        three) echo 3 ;;
+        *)     echo 0 ;;
+    esac
+}
+"#,
+            "sh",
+        ),
+        // Tcl `switch` is a generic command whose non-`default` arms are
+        // the decision points; `default` is free, matching the C-family
+        // `default:` (issue #467). Procs are top-level, so no offset.
+        LANG::Tcl => flat(
             r"proc f {x} {
     switch $x {
         1 { return one }
@@ -218,14 +434,10 @@ fn switch_with_default_parity() {
 ",
             "tcl",
         ),
-    );
-    // iRules `switch` is a dedicated node (unlike Tcl's command form), but
-    // counts the same: 3 non-`default` arms, fallback free. Procs are
-    // top-level, so no class offset.
-    sums.insert(
-        "irules",
-        ccn_sum(
-            LANG::Irules,
+        // iRules `switch` is a dedicated node (unlike Tcl's command
+        // form), but counts the same: 3 non-`default` arms, fallback
+        // free.
+        LANG::Irules => flat(
             r"proc f {x} {
     switch $x {
         1 { return one }
@@ -237,15 +449,10 @@ fn switch_with_default_parity() {
 ",
             "irule",
         ),
-    );
-    // Elixir `case` with a bare `_ ->` catch-all: the wildcard is the
-    // construct's default arm and is skipped, like Rust's `_ =>`
-    // (issue #1272). `def` must live inside a `defmodule`, which opens
-    // a Class space — the same structural offset as Java.
-    sums.insert(
-        "elixir",
-        ccn_sum(
-            LANG::Elixir,
+        // Elixir `case` with a bare `_ ->` catch-all: the wildcard is
+        // the construct's default arm and is skipped, like Rust's
+        // `_ =>` (issue #1272).
+        LANG::Elixir => in_container(
             r"defmodule Parity do
   def f(x) do
     case x do
@@ -259,32 +466,33 @@ end
 ",
             "ex",
         ),
-    );
-    let offsets = BTreeMap::from([
-        ("java", JAVA_CLASS_OFFSET),
-        // C# requires every function to live inside a class, same as
-        // Java — this is a language-mandated structural difference.
-        ("csharp", JAVA_CLASS_OFFSET),
-        // Elixir requires every `def` to live inside a `defmodule` —
-        // the same structural difference as Java's class requirement.
-        ("elixir", JAVA_CLASS_OFFSET),
-    ]);
-    assert_parity("switch_with_default", &sums, &offsets);
+        // No switch-like construct to count. Lua has none at all — the
+        // idiomatic multi-way form is an `if`/`elseif` chain, covered by
+        // `if_else_if_else_chain`. Perl's `given`/`when` was always
+        // experimental and was removed from the language in 5.42; the
+        // pinned grammar does not model it (verified: the construct
+        // parses to ERROR nodes), so a fixture using it would pin the
+        // parse failure rather than the metric. The two C-family helper
+        // grammars parse fragments — a comment body, a preprocessor
+        // directive — and have no statements at all.
+        LANG::Lua | LANG::Perl | LANG::Ccomment | LANG::Preproc => return None,
+    };
+    Some(row)
+}
 
+#[test]
+fn switch_with_default_parity() {
     // Anchor the absolute magnitude, not just mutual agreement (lessons
     // #6 / #23 / #468): a symmetric regression that dropped or added +1
     // across every language would still satisfy `assert_parity`. Pin the
     // hand-derived spec value: unit(1) + fn(1) + 3 explicit arms = 5
-    // (fallback skipped post-#106), Java/C# normalised by JAVA_CLASS_OFFSET.
-    assert_normalised(&sums, &offsets, 5.0, "switch_with_default");
+    // (fallback skipped post-#106).
+    check_family("switch_with_default", 5.0, switch_with_default);
 }
 
 // --- Family 2: switch / case / match without fallback ----------------------
 //
-// Three explicit arms, no semantic fallback. Bash joins this family
-// because `case…esac` semantics count each arm exactly once after the
-// #107 / `e668f14` fix; with no `*)` arm there is no asymmetry between
-// Bash and C-family.
+// Three explicit arms, no semantic fallback.
 //
 // Rust requires exhaustive matching, so its fixture still includes a
 // bare `_ => {}` arm — but post-#106 (`a54b073`) bare wildcards are
@@ -294,13 +502,11 @@ end
 //
 // Per-language post-offset expectation: unit(1) + fn(1) + 3 arms = 5.
 
-#[test]
-fn switch_without_default_parity() {
-    let mut sums = BTreeMap::new();
-    sums.insert(
-        "rust",
-        ccn_sum(
-            LANG::Rust,
+fn switch_without_default(lang: LANG) -> Option<Fixture> {
+    // Exhaustive per-language dispatch table; see `switch_with_default`.
+    // bca: suppress(cyclomatic)
+    let row = match lang {
+        LANG::Rust => flat(
             r"fn f(x: u8) {
     match x {
         1 => {}
@@ -312,11 +518,7 @@ fn switch_without_default_parity() {
 ",
             "rs",
         ),
-    );
-    sums.insert(
-        "c",
-        ccn_sum(
-            LANG::Cpp,
+        LANG::C | LANG::Cpp | LANG::Mozcpp | LANG::Objc => flat(
             r"void f(int x) {
     switch (x) {
         case 1: break;
@@ -327,11 +529,7 @@ fn switch_without_default_parity() {
 ",
             "c",
         ),
-    );
-    sums.insert(
-        "java",
-        ccn_sum(
-            LANG::Java,
+        LANG::Java => in_container(
             r"class Parity {
     static void f(int x) {
         switch (x) {
@@ -344,29 +542,10 @@ fn switch_without_default_parity() {
 ",
             "java",
         ),
-    );
-    sums.insert(
-        "bash",
-        ccn_sum(
-            LANG::Bash,
-            r#"#!/bin/bash
-f() {
-    case "$1" in
-        one)   echo 1 ;;
-        two)   echo 2 ;;
-        three) echo 3 ;;
-    esac
-}
-"#,
-            "sh",
-        ),
-    );
-    // C# switch *statement* (not expression — switch expressions require
-    // exhaustiveness so cannot express "no default"). Issue #282.
-    sums.insert(
-        "csharp",
-        ccn_sum(
-            LANG::Csharp,
+        // C# switch *statement* (not expression — switch expressions
+        // require exhaustiveness so cannot express "no default").
+        // Issue #282.
+        LANG::Csharp => in_container(
             r"class Parity {
     static void f(int x) {
         switch (x) {
@@ -379,13 +558,10 @@ f() {
 ",
             "cs",
         ),
-    );
-    // Kotlin `when` used as a statement does not require an `else` arm
-    // (only `when` as an expression with sealed types does). Issue #282.
-    sums.insert(
-        "kotlin",
-        ccn_sum(
-            LANG::Kotlin,
+        // Kotlin `when` used as a statement does not require an `else`
+        // arm (only `when` as an expression with sealed types does).
+        // Issue #282.
+        LANG::Kotlin => flat(
             r"fun f(x: Int) {
     when (x) {
         1 -> { }
@@ -396,13 +572,117 @@ f() {
 ",
             "kt",
         ),
-    );
-    // Tcl `switch` with no `default` arm: all three arms are decision
-    // points (issue #467). Procs are top-level, so no class offset.
-    sums.insert(
-        "tcl",
-        ccn_sum(
-            LANG::Tcl,
+        LANG::Javascript | LANG::Mozjs => flat(
+            r"function f(x) {
+    switch (x) {
+        case 1: break;
+        case 2: break;
+        case 3: break;
+    }
+}
+",
+            "js",
+        ),
+        LANG::Typescript => flat(
+            r"function f(x: number) {
+    switch (x) {
+        case 1: break;
+        case 2: break;
+        case 3: break;
+    }
+}
+",
+            "ts",
+        ),
+        LANG::Tsx => flat(
+            r"function f(x: number) {
+    switch (x) {
+        case 1: break;
+        case 2: break;
+        case 3: break;
+    }
+}
+",
+            "tsx",
+        ),
+        LANG::Php => flat(
+            r"<?php
+function f($x) {
+    switch ($x) {
+        case 1: break;
+        case 2: break;
+        case 3: break;
+    }
+}
+",
+            "php",
+        ),
+        // Python's `match` is not required to be exhaustive, so the
+        // wildcard arm can simply be omitted.
+        LANG::Python => flat(
+            r"def f(x):
+    match x:
+        case 1:
+            return 'one'
+        case 2:
+            return 'two'
+        case 3:
+            return 'three'
+",
+            "py",
+        ),
+        LANG::Go => flat(
+            r"package p
+func f(x int) {
+    switch x {
+    case 1:
+    case 2:
+    case 3:
+    }
+}
+",
+            "go",
+        ),
+        LANG::Ruby => flat(
+            r#"def f(x)
+  case x
+  when 1 then "one"
+  when 2 then "two"
+  when 3 then "three"
+  end
+end
+"#,
+            "rb",
+        ),
+        LANG::Groovy => flat(
+            r"def f(x) {
+    switch (x) {
+        case 1: break
+        case 2: break
+        case 3: break
+    }
+}
+",
+            "groovy",
+        ),
+        // Bash joins this family because `case…esac` semantics count
+        // each arm exactly once after the #107 / `e668f14` fix; with no
+        // `*)` arm there is no asymmetry between Bash and the C family.
+        LANG::Bash => flat(
+            r#"#!/bin/bash
+f() {
+    case "$1" in
+        one)   echo 1 ;;
+        two)   echo 2 ;;
+        three) echo 3 ;;
+    esac
+}
+"#,
+            "sh",
+        ),
+        // Tcl / iRules `switch` with no `default` arm: all three arms
+        // are decision points (issue #467).
+        LANG::Tcl => flat(
             r"proc f {x} {
     switch $x {
         1 { return one }
@@ -413,14 +693,21 @@ f() {
 ",
             "tcl",
         ),
-    );
-    // Elixir `case` with no `_ ->` fallback: every arm is a real
-    // decision and counts (issue #1272 skips only the bare wildcard).
-    // `defmodule` opens a Class space — the Java structural offset.
-    sums.insert(
-        "elixir",
-        ccn_sum(
-            LANG::Elixir,
+        LANG::Irules => flat(
+            r"proc f {x} {
+    switch $x {
+        1 { return one }
+        2 { return two }
+        3 { return three }
+    }
+}
+",
+            "irule",
+        ),
+        // Elixir `case` with no `_ ->` fallback: every arm is a real
+        // decision and counts (issue #1272 skips only the bare
+        // wildcard).
+        LANG::Elixir => in_container(
             r"defmodule Parity do
   def f(x) do
     case x do
@@ -433,35 +720,32 @@ end
 ",
             "ex",
         ),
-    );
-    let offsets = BTreeMap::from([
-        ("java", JAVA_CLASS_OFFSET),
-        ("csharp", JAVA_CLASS_OFFSET),
-        ("elixir", JAVA_CLASS_OFFSET),
-    ]);
-    assert_parity("switch_without_default", &sums, &offsets);
+        // No switch-like construct; see `switch_with_default` for why.
+        LANG::Lua | LANG::Perl | LANG::Ccomment | LANG::Preproc => return None,
+    };
+    Some(row)
+}
 
+#[test]
+fn switch_without_default_parity() {
     // Anchor the absolute magnitude (lessons #6 / #23 / #468):
     // unit(1) + fn(1) + 3 arms = 5 (no fallback to count; Rust's bare
     // `_ => {}` skipped post-#106, Bash arms count once post-#107).
-    assert_normalised(&sums, &offsets, 5.0, "switch_without_default");
+    check_family("switch_without_default", 5.0, switch_without_default);
 }
 
 // --- Family 3: if / else if / else chain -----------------------------------
 //
 // A three-condition chain (one `if`, two `else if`, one `else`). Each
-// condition contributes one decision point. JavaScript and Python join
-// here; Bash uses `elif` which is counted via `ElifClause`.
+// condition contributes one decision point; the trailing `else` is free.
 //
-// Per-language expectation: unit(1) + fn(1) + 3 conditions = 5.
+// Per-language post-offset expectation: unit(1) + fn(1) + 3 conditions = 5.
 
-#[test]
-fn if_else_if_else_chain_parity() {
-    let mut sums = BTreeMap::new();
-    sums.insert(
-        "rust",
-        ccn_sum(
-            LANG::Rust,
+fn if_else_if_else_chain(lang: LANG) -> Option<Fixture> {
+    // Exhaustive per-language dispatch table; see `switch_with_default`.
+    // bca: suppress(cyclomatic)
+    let row = match lang {
+        LANG::Rust => flat(
             r"fn f(x: i32) -> i32 {
     if x == 1 {
         10
@@ -476,11 +760,7 @@ fn if_else_if_else_chain_parity() {
 ",
             "rs",
         ),
-    );
-    sums.insert(
-        "c",
-        ccn_sum(
-            LANG::Cpp,
+        LANG::C | LANG::Cpp | LANG::Mozcpp | LANG::Objc => flat(
             r"int f(int x) {
     if (x == 1) {
         return 10;
@@ -495,11 +775,7 @@ fn if_else_if_else_chain_parity() {
 ",
             "c",
         ),
-    );
-    sums.insert(
-        "java",
-        ccn_sum(
-            LANG::Java,
+        LANG::Java => in_container(
             r"class Parity {
     static int f(int x) {
         if (x == 1) {
@@ -516,11 +792,39 @@ fn if_else_if_else_chain_parity() {
 ",
             "java",
         ),
-    );
-    sums.insert(
-        "javascript",
-        ccn_sum(
-            LANG::Javascript,
+        LANG::Csharp => in_container(
+            r"class Parity {
+    static int F(int x) {
+        if (x == 1) {
+            return 10;
+        } else if (x == 2) {
+            return 20;
+        } else if (x == 3) {
+            return 30;
+        } else {
+            return 0;
+        }
+    }
+}
+",
+            "cs",
+        ),
+        LANG::Kotlin => flat(
+            r"fun f(x: Int): Int {
+    if (x == 1) {
+        return 10
+    } else if (x == 2) {
+        return 20
+    } else if (x == 3) {
+        return 30
+    } else {
+        return 0
+    }
+}
+",
+            "kt",
+        ),
+        LANG::Javascript | LANG::Mozjs => flat(
             r"function f(x) {
     if (x === 1) {
         return 10;
@@ -535,11 +839,55 @@ fn if_else_if_else_chain_parity() {
 ",
             "js",
         ),
-    );
-    sums.insert(
-        "python",
-        ccn_sum(
-            LANG::Python,
+        LANG::Typescript => flat(
+            r"function f(x: number): number {
+    if (x === 1) {
+        return 10;
+    } else if (x === 2) {
+        return 20;
+    } else if (x === 3) {
+        return 30;
+    } else {
+        return 0;
+    }
+}
+",
+            "ts",
+        ),
+        LANG::Tsx => flat(
+            r"function f(x: number): number {
+    if (x === 1) {
+        return 10;
+    } else if (x === 2) {
+        return 20;
+    } else if (x === 3) {
+        return 30;
+    } else {
+        return 0;
+    }
+}
+",
+            "tsx",
+        ),
+        // PHP spells the middle links `elseif` (a dedicated node rather
+        // than a nested `if` inside an else clause).
+        LANG::Php => flat(
+            r"<?php
+function f($x) {
+    if ($x == 1) {
+        return 10;
+    } elseif ($x == 2) {
+        return 20;
+    } elseif ($x == 3) {
+        return 30;
+    } else {
+        return 0;
+    }
+}
+",
+            "php",
+        ),
+        LANG::Python => flat(
             r"def f(x):
     if x == 1:
         return 10
@@ -552,11 +900,87 @@ fn if_else_if_else_chain_parity() {
 ",
             "py",
         ),
-    );
-    sums.insert(
-        "bash",
-        ccn_sum(
-            LANG::Bash,
+        LANG::Go => flat(
+            r"package p
+func f(x int) int {
+    if x == 1 {
+        return 10
+    } else if x == 2 {
+        return 20
+    } else if x == 3 {
+        return 30
+    } else {
+        return 0
+    }
+}
+",
+            "go",
+        ),
+        // Ruby spells the middle links `elsif`.
+        LANG::Ruby => flat(
+            r"def f(x)
+  if x == 1
+    10
+  elsif x == 2
+    20
+  elsif x == 3
+    30
+  else
+    0
+  end
+end
+",
+            "rb",
+        ),
+        // Lua spells them `elseif`, one keyword.
+        LANG::Lua => flat(
+            r"function f(x)
+    if x == 1 then
+        return 10
+    elseif x == 2 then
+        return 20
+    elseif x == 3 then
+        return 30
+    else
+        return 0
+    end
+end
+",
+            "lua",
+        ),
+        // Perl spells them `elsif`, like Ruby.
+        LANG::Perl => flat(
+            r"sub f {
+    my ($x) = @_;
+    if ($x == 1) {
+        return 10;
+    } elsif ($x == 2) {
+        return 20;
+    } elsif ($x == 3) {
+        return 30;
+    } else {
+        return 0;
+    }
+}
+",
+            "pl",
+        ),
+        LANG::Groovy => flat(
+            r"def f(x) {
+    if (x == 1) {
+        return 10
+    } else if (x == 2) {
+        return 20
+    } else if (x == 3) {
+        return 30
+    } else {
+        return 0
+    }
+}
+",
+            "groovy",
+        ),
+        LANG::Bash => flat(
             r#"#!/bin/bash
 f() {
     if [ "$1" -eq 1 ]; then
@@ -572,71 +996,27 @@ f() {
 "#,
             "sh",
         ),
-    );
-    sums.insert(
-        "groovy",
-        ccn_sum(
-            LANG::Groovy,
-            r"def f(x) {
-    if (x == 1) {
-        return 10
-    } else if (x == 2) {
-        return 20
-    } else if (x == 3) {
-        return 30
-    } else {
-        return 0
-    }
+        // Tcl and iRules both have a dedicated `elseif`; each is a
+        // decision and the trailing `else` is free.
+        LANG::Tcl => flat(
+            r"proc f {x} {
+    if { $x == 1 } { return 10 } elseif { $x == 2 } { return 20 } elseif { $x == 3 } { return 30 } else { return 0 }
 }
 ",
-            "groovy",
+            "tcl",
         ),
-    );
-    // iRules has a dedicated `elseif` node; each `elseif` is a decision and
-    // the trailing `else` is free, matching the family. Proc is top-level,
-    // so no class offset.
-    sums.insert(
-        "irules",
-        ccn_sum(
-            LANG::Irules,
+        LANG::Irules => flat(
             r"proc f {x} {
     if { $x == 1 } { return 10 } elseif { $x == 2 } { return 20 } elseif { $x == 3 } { return 30 } else { return 0 }
 }
 ",
             "irule",
         ),
-    );
-    // Objective-C uses a free C `function_definition` (valid in a `.m`
-    // file), which is top-level, so no class offset. Each `else if`
-    // condition is a decision, the trailing `else` is free.
-    sums.insert(
-        "objc",
-        ccn_sum(
-            LANG::Objc,
-            r"int f(int x) {
-    if (x == 1) {
-        return 10;
-    } else if (x == 2) {
-        return 20;
-    } else if (x == 3) {
-        return 30;
-    } else {
-        return 0;
-    }
-}
-",
-            "m",
-        ),
-    );
-    // Elixir has no `else if` chain keyword; `cond` is the idiomatic
-    // multi-way conditional, and its final `true ->` arm is the
-    // designated default — the analogue of the free `else`, skipped
-    // post-#1272. Three condition arms count. `defmodule` opens a
-    // Class space — the Java structural offset.
-    sums.insert(
-        "elixir",
-        ccn_sum(
-            LANG::Elixir,
+        // Elixir has no `else if` chain keyword; `cond` is the idiomatic
+        // multi-way conditional, and its final `true ->` arm is the
+        // designated default — the analogue of the free `else`, skipped
+        // post-#1272. Three condition arms count.
+        LANG::Elixir => in_container(
             r"defmodule Parity do
   def f(x) do
     cond do
@@ -650,33 +1030,37 @@ end
 ",
             "ex",
         ),
-    );
-    let offsets = BTreeMap::from([("java", JAVA_CLASS_OFFSET), ("elixir", JAVA_CLASS_OFFSET)]);
-    assert_parity("if_else_if_else_chain", &sums, &offsets);
+        // The two C-family helper grammars parse fragments and have no
+        // statements at all.
+        LANG::Ccomment | LANG::Preproc => return None,
+    };
+    Some(row)
+}
 
+#[test]
+fn if_else_if_else_chain_parity() {
     // Anchor the absolute magnitude (lessons #6 / #23 / #468):
-    // unit(1) + fn(1) + 3 conditions = 5 (one `if`, two `else if`/`elif`;
-    // the trailing `else` is not a decision point). This family caught
-    // the #229 Python over-count, so pinning the value also guards the
-    // `parent_grandparent_match` fix from a symmetric regression.
-    assert_normalised(&sums, &offsets, 5.0, "if_else_if_else_chain");
+    // unit(1) + fn(1) + 3 conditions = 5 (one `if`, two
+    // `else if`/`elif`/`elsif`/`elseif`; the trailing `else` is not a
+    // decision point). This family caught the #229 Python over-count, so
+    // pinning the value also guards the `parent_grandparent_match` fix
+    // from a symmetric regression.
+    check_family("if_else_if_else_chain", 5.0, if_else_if_else_chain);
 }
 
 // --- Family 4: single `if` with no `else` ----------------------------------
 //
 // The simplest decision form: one branching condition, no else clause.
 // No else clause means none of the per-language `else`/elif
-// idiosyncrasies apply.
+// idiosyncrasies apply, so every language with an `if` belongs here.
 //
 // Per-language post-offset expectation: unit(1) + fn(1) + 1 if = 3.
 
-#[test]
-fn single_if_no_else_parity() {
-    let mut sums = BTreeMap::new();
-    sums.insert(
-        "rust",
-        ccn_sum(
-            LANG::Rust,
+fn single_if_no_else(lang: LANG) -> Option<Fixture> {
+    // Exhaustive per-language dispatch table; see `switch_with_default`.
+    // bca: suppress(cyclomatic)
+    let row = match lang {
+        LANG::Rust => flat(
             r"fn f(x: i32) {
     if x == 1 {
         let _ = x;
@@ -685,11 +1069,7 @@ fn single_if_no_else_parity() {
 ",
             "rs",
         ),
-    );
-    sums.insert(
-        "c",
-        ccn_sum(
-            LANG::Cpp,
+        LANG::C | LANG::Cpp | LANG::Mozcpp | LANG::Objc => flat(
             r"void f(int x) {
     if (x == 1) {
         x = x;
@@ -698,11 +1078,7 @@ fn single_if_no_else_parity() {
 ",
             "c",
         ),
-    );
-    sums.insert(
-        "java",
-        ccn_sum(
-            LANG::Java,
+        LANG::Java => in_container(
             r"class Parity {
     static void f(int x) {
         if (x == 1) {
@@ -713,11 +1089,27 @@ fn single_if_no_else_parity() {
 ",
             "java",
         ),
-    );
-    sums.insert(
-        "javascript",
-        ccn_sum(
-            LANG::Javascript,
+        LANG::Csharp => in_container(
+            r"class Parity {
+    static void F(int x) {
+        if (x == 1) {
+            x = x;
+        }
+    }
+}
+",
+            "cs",
+        ),
+        LANG::Kotlin => flat(
+            r"fun f(x: Int) {
+    if (x == 1) {
+        println(x)
+    }
+}
+",
+            "kt",
+        ),
+        LANG::Javascript | LANG::Mozjs => flat(
             r"function f(x) {
     if (x === 1) {
         return x;
@@ -726,22 +1118,89 @@ fn single_if_no_else_parity() {
 ",
             "js",
         ),
-    );
-    sums.insert(
-        "python",
-        ccn_sum(
-            LANG::Python,
+        LANG::Typescript => flat(
+            r"function f(x: number) {
+    if (x === 1) {
+        return x;
+    }
+}
+",
+            "ts",
+        ),
+        LANG::Tsx => flat(
+            r"function f(x: number) {
+    if (x === 1) {
+        return x;
+    }
+}
+",
+            "tsx",
+        ),
+        LANG::Php => flat(
+            r"<?php
+function f($x) {
+    if ($x == 1) {
+        echo $x;
+    }
+}
+",
+            "php",
+        ),
+        LANG::Python => flat(
             r"def f(x):
     if x == 1:
         return x
 ",
             "py",
         ),
-    );
-    sums.insert(
-        "bash",
-        ccn_sum(
-            LANG::Bash,
+        LANG::Go => flat(
+            r"package p
+func f(x int) {
+    if x == 1 {
+        g(x)
+    }
+}
+",
+            "go",
+        ),
+        LANG::Ruby => flat(
+            r"def f(x)
+  if x == 1
+    x
+  end
+end
+",
+            "rb",
+        ),
+        LANG::Lua => flat(
+            r"function f(x)
+    if x == 1 then
+        return x
+    end
+end
+",
+            "lua",
+        ),
+        LANG::Perl => flat(
+            r"sub f {
+    my ($x) = @_;
+    if ($x == 1) {
+        return $x;
+    }
+}
+",
+            "pl",
+        ),
+        LANG::Groovy => flat(
+            r"def f(x) {
+    if (x == 1) {
+        println x
+    }
+}
+",
+            "groovy",
+        ),
+        LANG::Bash => flat(
             r#"#!/bin/bash
 f() {
     if [ "$1" -eq 1 ]; then
@@ -751,42 +1210,48 @@ f() {
 "#,
             "sh",
         ),
-    );
-    sums.insert(
-        "groovy",
-        ccn_sum(
-            LANG::Groovy,
-            r"def f(x) {
-    if (x == 1) {
-        println x
-    }
+        LANG::Tcl => flat(
+            r"proc f {x} {
+    if { $x == 1 } { return $x }
 }
 ",
-            "groovy",
+            "tcl",
         ),
-    );
-    // Objective-C free C function (top-level, no class offset): a single
-    // `if` with no `else` is one decision point.
-    sums.insert(
-        "objc",
-        ccn_sum(
-            LANG::Objc,
-            r"void f(int x) {
-    if (x == 1) {
-        x = x;
-    }
+        LANG::Irules => flat(
+            r"proc f {x} {
+    if { $x == 1 } { return $x }
 }
 ",
-            "m",
+            "irule",
         ),
-    );
-    let offsets = BTreeMap::from([("java", JAVA_CLASS_OFFSET)]);
-    assert_parity("single_if_no_else", &sums, &offsets);
+        // Elixir's `if` is a macro-shaped `Call` rather than a keyword
+        // statement (#275), so this row is also the one that would
+        // notice the `Exit`-style callee-text match falling out of the
+        // cyclomatic impl.
+        LANG::Elixir => in_container(
+            r"defmodule Parity do
+  def f(x) do
+    if x == 1 do
+      x
+    end
+  end
+end
+",
+            "ex",
+        ),
+        // The two C-family helper grammars parse fragments and have no
+        // statements at all.
+        LANG::Ccomment | LANG::Preproc => return None,
+    };
+    Some(row)
+}
 
+#[test]
+fn single_if_no_else_parity() {
     // Anchor the absolute magnitude (lessons #6 / #23 / #468):
     // unit(1) + fn(1) + 1 if = 3. No else clause, so no per-language
     // else/elif idiosyncrasy contributes.
-    assert_normalised(&sums, &offsets, 3.0, "single_if_no_else");
+    check_family("single_if_no_else", 3.0, single_if_no_else);
 }
 
 // --- Family 5: 2-arm switch / match with wildcard / default ---------------
@@ -802,13 +1267,11 @@ f() {
 //
 // Per-language post-offset expectation: unit(1) + fn(1) + 1 arm = 3.
 
-#[test]
-fn two_arm_switch_with_wildcard_parity() {
-    let mut sums = BTreeMap::new();
-    sums.insert(
-        "rust",
-        ccn_sum(
-            LANG::Rust,
+fn two_arm_switch_with_wildcard(lang: LANG) -> Option<Fixture> {
+    // Exhaustive per-language dispatch table; see `switch_with_default`.
+    // bca: suppress(cyclomatic)
+    let row = match lang {
+        LANG::Rust => flat(
             r#"fn f(x: u8) -> &'static str {
     match x {
         1 => "one",
@@ -818,11 +1281,7 @@ fn two_arm_switch_with_wildcard_parity() {
 "#,
             "rs",
         ),
-    );
-    sums.insert(
-        "c",
-        ccn_sum(
-            LANG::Cpp,
+        LANG::C | LANG::Cpp | LANG::Mozcpp | LANG::Objc => flat(
             r"void f(int x) {
     switch (x) {
         case 1: break;
@@ -832,11 +1291,7 @@ fn two_arm_switch_with_wildcard_parity() {
 ",
             "c",
         ),
-    );
-    sums.insert(
-        "java",
-        ccn_sum(
-            LANG::Java,
+        LANG::Java => in_container(
             r"class Parity {
     static void f(int x) {
         switch (x) {
@@ -848,11 +1303,27 @@ fn two_arm_switch_with_wildcard_parity() {
 ",
             "java",
         ),
-    );
-    sums.insert(
-        "javascript",
-        ccn_sum(
-            LANG::Javascript,
+        // C# switch-expression with discard arm (issue #282).
+        LANG::Csharp => in_container(
+            r#"class Parity {
+    static string f(int x) => x switch {
+        1 => "one",
+        _ => "other"
+    };
+}
+"#,
+            "cs",
+        ),
+        // Kotlin `when` with `else ->` arm (issue #282).
+        LANG::Kotlin => flat(
+            r#"fun f(x: Int): String = when (x) {
+    1 -> "one"
+    else -> "other"
+}
+"#,
+            "kt",
+        ),
+        LANG::Javascript | LANG::Mozjs => flat(
             r"function f(x) {
     switch (x) {
         case 1: break;
@@ -862,11 +1333,7 @@ fn two_arm_switch_with_wildcard_parity() {
 ",
             "js",
         ),
-    );
-    sums.insert(
-        "typescript",
-        ccn_sum(
-            LANG::Typescript,
+        LANG::Typescript => flat(
             r"function f(x: number) {
     switch (x) {
         case 1: break;
@@ -876,11 +1343,17 @@ fn two_arm_switch_with_wildcard_parity() {
 ",
             "ts",
         ),
-    );
-    sums.insert(
-        "php",
-        ccn_sum(
-            LANG::Php,
+        LANG::Tsx => flat(
+            r"function f(x: number) {
+    switch (x) {
+        case 1: break;
+        default: break;
+    }
+}
+",
+            "tsx",
+        ),
+        LANG::Php => flat(
             r"<?php
 function f($x) {
     switch ($x) {
@@ -891,59 +1364,71 @@ function f($x) {
 ",
             "php",
         ),
-    );
-    sums.insert(
-        "python",
-        ccn_sum(
-            LANG::Python,
+        LANG::Python => flat(
             "def f(x):\n    match x:\n        case 1:\n            return 'one'\n        case _:\n            return 'other'\n",
             "py",
         ),
-    );
-    sums.insert(
-        "bash",
-        ccn_sum(
-            LANG::Bash,
+        LANG::Go => flat(
+            r#"package p
+func f(x int) string {
+    switch x {
+    case 1:
+        return "one"
+    default:
+        return "other"
+    }
+}
+"#,
+            "go",
+        ),
+        LANG::Ruby => flat(
+            r#"def f(x)
+  case x
+  when 1 then "one"
+  else "other"
+  end
+end
+"#,
+            "rb",
+        ),
+        LANG::Groovy => flat(
+            r"def f(x) {
+    switch (x) {
+        case 1: break
+        default: break
+    }
+}
+",
+            "groovy",
+        ),
+        LANG::Bash => flat(
             "#!/bin/bash\nf() {\n    case \"$1\" in\n        one) echo 1 ;;\n        *)   echo 0 ;;\n    esac\n}\n",
             "sh",
         ),
-    );
-    // C# switch-expression with discard arm (issue #282).
-    sums.insert(
-        "csharp",
-        ccn_sum(
-            LANG::Csharp,
-            r#"class Parity {
-    static string f(int x) => x switch {
-        1 => "one",
-        _ => "other"
-    };
+        LANG::Tcl => flat(
+            r"proc f {x} {
+    switch $x {
+        1 { return one }
+        default { return other }
+    }
 }
-"#,
-            "cs",
+",
+            "tcl",
         ),
-    );
-    // Kotlin `when` with `else ->` arm (issue #282).
-    sums.insert(
-        "kotlin",
-        ccn_sum(
-            LANG::Kotlin,
-            r#"fun f(x: Int): String = when (x) {
-    1 -> "one"
-    else -> "other"
+        LANG::Irules => flat(
+            r"proc f {x} {
+    switch $x {
+        1 { return one }
+        default { return other }
+    }
 }
-"#,
-            "kt",
+",
+            "irule",
         ),
-    );
-    // Elixir 2-arm `case` with a bare `_ ->` catch-all (issue #1272):
-    // the minimal form that catches both an over-count of the wildcard
-    // and an under-count of the explicit arm. `defmodule` opens a
-    // Class space — the Java structural offset.
-    sums.insert(
-        "elixir",
-        ccn_sum(
-            LANG::Elixir,
+        // Elixir 2-arm `case` with a bare `_ ->` catch-all (issue
+        // #1272): the minimal form that catches both an over-count of
+        // the wildcard and an under-count of the explicit arm.
+        LANG::Elixir => in_container(
             r"defmodule Parity do
   def f(x) do
     case x do
@@ -955,41 +1440,44 @@ end
 ",
             "ex",
         ),
-    );
-    let offsets = BTreeMap::from([
-        ("java", JAVA_CLASS_OFFSET),
-        ("csharp", JAVA_CLASS_OFFSET),
-        ("elixir", JAVA_CLASS_OFFSET),
-    ]);
-    assert_parity("two_arm_switch_with_wildcard", &sums, &offsets);
+        // No switch-like construct; see `switch_with_default` for why.
+        LANG::Lua | LANG::Perl | LANG::Ccomment | LANG::Preproc => return None,
+    };
+    Some(row)
+}
 
+#[test]
+fn two_arm_switch_with_wildcard_parity() {
     // Anchor the absolute magnitude (lessons #6 / #23 / #468):
     // unit(1) + fn(1) + 1 explicit arm = 3 (the wildcard/`default` is
     // skipped). This is the canonical lesson-11 trigger (#106): pinning
     // the value guards against both an over-count of the wildcard and an
     // under-count of the explicit arm shifting symmetrically.
-    assert_normalised(&sums, &offsets, 3.0, "two_arm_switch_with_wildcard");
+    check_family(
+        "two_arm_switch_with_wildcard",
+        3.0,
+        two_arm_switch_with_wildcard,
+    );
 }
 
-// --- Family 6: do-while loop ---------------------------------------------
+// --- Family 6: trailing-condition loop -----------------------------------
 //
-// A single `do { … } while (cond)` loop must contribute exactly one
-// decision point in every language that exposes the construct. In the
+// A loop whose body runs before its condition is tested — `do { … }
+// while (cond)` in the C family, `repeat … until` in Lua, `begin … end
+// while` in Ruby — must contribute exactly one decision point. In the
 // C-family cyclomatic impls this fires via the inner `while` keyword
 // token (`Cpp::While`, `Java::While`, `Groovy::While`), which is the
 // same token used for a standalone `while` loop — listing the
 // `DoStatement` node itself would double-count (regression for issue
 // #284's incorrect fix proposal).
 //
-// Per-language post-offset expectation: unit(1) + fn(1) + do(1) = 3.
+// Per-language post-offset expectation: unit(1) + fn(1) + loop(1) = 3.
 
-#[test]
-fn do_while_loop_parity() {
-    let mut sums = BTreeMap::new();
-    sums.insert(
-        "c",
-        ccn_sum(
-            LANG::Cpp,
+fn do_while_loop(lang: LANG) -> Option<Fixture> {
+    // Exhaustive per-language dispatch table; see `switch_with_default`.
+    // bca: suppress(cyclomatic)
+    let row = match lang {
+        LANG::C | LANG::Cpp | LANG::Mozcpp | LANG::Objc => flat(
             r"void f() {
     int i = 0;
     do {
@@ -999,11 +1487,7 @@ fn do_while_loop_parity() {
 ",
             "c",
         ),
-    );
-    sums.insert(
-        "java",
-        ccn_sum(
-            LANG::Java,
+        LANG::Java => in_container(
             r"class Parity {
     static void f() {
         int i = 0;
@@ -1015,39 +1499,7 @@ fn do_while_loop_parity() {
 ",
             "java",
         ),
-    );
-    sums.insert(
-        "groovy",
-        ccn_sum(
-            LANG::Groovy,
-            r"def f() {
-    int i = 0
-    do {
-        ++i
-    } while (i < 10)
-}
-",
-            "groovy",
-        ),
-    );
-    sums.insert(
-        "javascript",
-        ccn_sum(
-            LANG::Javascript,
-            r"function f() {
-    let i = 0;
-    do {
-        ++i;
-    } while (i < 10);
-}
-",
-            "js",
-        ),
-    );
-    sums.insert(
-        "csharp",
-        ccn_sum(
-            LANG::Csharp,
+        LANG::Csharp => in_container(
             r"class Parity {
     static void f() {
         int i = 0;
@@ -1059,40 +1511,155 @@ fn do_while_loop_parity() {
 ",
             "cs",
         ),
-    );
-    let offsets = BTreeMap::from([("java", JAVA_CLASS_OFFSET), ("csharp", JAVA_CLASS_OFFSET)]);
-    assert_parity("do_while_loop", &sums, &offsets);
-
-    // Anchor the absolute magnitude (lessons #6 / #23 / #468):
-    // unit(1) + fn(1) + do(1) = 3. The loop fires once via the inner
-    // `while` keyword token; pinning the value catches a regression that
-    // additionally listed `DoStatement` (double-count, #284) symmetrically.
-    assert_normalised(&sums, &offsets, 3.0, "do_while_loop");
+        LANG::Groovy => flat(
+            r"def f() {
+    int i = 0
+    do {
+        ++i
+    } while (i < 10)
+}
+",
+            "groovy",
+        ),
+        LANG::Javascript | LANG::Mozjs => flat(
+            r"function f() {
+    let i = 0;
+    do {
+        ++i;
+    } while (i < 10);
+}
+",
+            "js",
+        ),
+        LANG::Typescript => flat(
+            r"function f() {
+    let i: number = 0;
+    do {
+        ++i;
+    } while (i < 10);
+}
+",
+            "ts",
+        ),
+        LANG::Tsx => flat(
+            r"function f() {
+    let i: number = 0;
+    do {
+        ++i;
+    } while (i < 10);
+}
+",
+            "tsx",
+        ),
+        LANG::Php => flat(
+            r"<?php
+function f() {
+    $i = 0;
+    do {
+        $i++;
+    } while ($i < 10);
+}
+",
+            "php",
+        ),
+        LANG::Kotlin => flat(
+            r"fun f() {
+    var i = 0
+    do {
+        i++
+    } while (i < 10)
+}
+",
+            "kt",
+        ),
+        // Perl spells it as a `do` block with a `while` statement
+        // modifier, which is the same trailing-condition loop.
+        LANG::Perl => flat(
+            r"sub f {
+    my $i = 0;
+    do {
+        $i++;
+    } while ($i < 10);
+}
+",
+            "pl",
+        ),
+        // Ruby spells it `begin … end while cond`.
+        LANG::Ruby => flat(
+            r"def f
+  i = 0
+  begin
+    i += 1
+  end while i < 10
+end
+",
+            "rb",
+        ),
+        // Lua spells it `repeat … until cond`, the same loop with the
+        // condition inverted. It is a distinct keyword, so this row is
+        // what would notice `RepeatStatement` dropping out of the Lua
+        // impl.
+        LANG::Lua => flat(
+            r"function f()
+    local i = 0
+    repeat
+        i = i + 1
+    until i >= 10
+end
+",
+            "lua",
+        ),
+        // No trailing-condition loop. Rust, Go, Python, Bash, Tcl and
+        // iRules offer only head-tested loops (`loop`/`while`, `for`,
+        // `while`, `while`/`until`, `while`); the idiom is a head-tested
+        // loop with an explicit first iteration, which is a different
+        // construct with a different count. Elixir has no loop
+        // statement at all — iteration is recursion or a comprehension.
+        // The two C-family helper grammars parse fragments.
+        LANG::Rust
+        | LANG::Go
+        | LANG::Python
+        | LANG::Bash
+        | LANG::Tcl
+        | LANG::Irules
+        | LANG::Elixir
+        | LANG::Ccomment
+        | LANG::Preproc => return None,
+    };
+    Some(row)
 }
 
-// --- Family 7: range / enhanced for loop ---------------------------------
+#[test]
+fn do_while_loop_parity() {
+    // Anchor the absolute magnitude (lessons #6 / #23 / #468):
+    // unit(1) + fn(1) + loop(1) = 3. The loop fires once via the inner
+    // `while` keyword token; pinning the value catches a regression that
+    // additionally listed `DoStatement` (double-count, #284) symmetrically.
+    check_family("do_while_loop", 3.0, do_while_loop);
+}
+
+// --- Family 7: iterate-over-a-collection loop ----------------------------
 //
-// Iterator-style loops — C++ `for (auto x : xs)` (`ForRangeLoop`),
-// Java enhanced-for `for (T x : xs)` (`EnhancedForStatement`), Groovy
-// enhanced-for `for (T x : xs)` (`EnhancedForStatement`), C#
-// `foreach (var x in xs)` (`ForeachStatement`), Kotlin `for (x in xs)`
-// — each must contribute exactly one decision point.
+// The form that binds each element of a collection in turn — C++
+// `for (auto x : xs)` (`ForRangeLoop`), Java / Groovy enhanced-for
+// (`EnhancedForStatement`), C# `foreach` (`ForeachStatement`), Kotlin /
+// Python / Rust / Ruby `for x in xs`, JS `for…of`, PHP / Perl / Tcl
+// `foreach`, Go `range`, Lua's generic `for … in`, Bash `for x in …`,
+// and Elixir's `for` comprehension — each must contribute exactly one
+// decision point.
 //
 // In C++/Java/Groovy the `for` keyword token fires inside the
 // grammar-specific loop node, so the existing keyword-token arm
 // catches them; listing the statement node would double-count
-// (regression for issue #284's incorrect fix proposal). C# has a
-// dedicated `ForeachStatement` arm; Kotlin counts via `ForStatement`.
+// (regression for issue #284's incorrect fix proposal).
 //
 // Per-language post-offset expectation: unit(1) + fn(1) + for(1) = 3.
 
-#[test]
-fn range_for_loop_parity() {
-    let mut sums = BTreeMap::new();
-    sums.insert(
-        "c",
-        ccn_sum(
-            LANG::Cpp,
+fn range_for_loop(lang: LANG) -> Option<Fixture> {
+    // Exhaustive per-language dispatch table; see `switch_with_default`.
+    // bca: suppress(cyclomatic)
+    let row = match lang {
+        LANG::Cpp | LANG::Mozcpp => flat(
             r"void f(std::vector<int> xs) {
     for (auto x : xs) {
         g(x);
@@ -1101,11 +1668,18 @@ fn range_for_loop_parity() {
 ",
             "cpp",
         ),
-    );
-    sums.insert(
-        "java",
-        ccn_sum(
-            LANG::Java,
+        // Objective-C spells it as fast enumeration over an object, a
+        // different node from the C++ range-for.
+        LANG::Objc => flat(
+            r"void f(NSArray *xs) {
+    for (id x in xs) {
+        g(x);
+    }
+}
+",
+            "m",
+        ),
+        LANG::Java => in_container(
             r"class Parity {
     static void f(int[] xs) {
         for (int x : xs) {
@@ -1116,11 +1690,7 @@ fn range_for_loop_parity() {
 ",
             "java",
         ),
-    );
-    sums.insert(
-        "groovy",
-        ccn_sum(
-            LANG::Groovy,
+        LANG::Groovy => flat(
             r"def f(int[] xs) {
     for (int x : xs) {
         println x
@@ -1129,11 +1699,7 @@ fn range_for_loop_parity() {
 ",
             "groovy",
         ),
-    );
-    sums.insert(
-        "csharp",
-        ccn_sum(
-            LANG::Csharp,
+        LANG::Csharp => in_container(
             r"class Parity {
     static void f(int[] xs) {
         foreach (var x in xs) {
@@ -1144,11 +1710,7 @@ fn range_for_loop_parity() {
 ",
             "cs",
         ),
-    );
-    sums.insert(
-        "kotlin",
-        ccn_sum(
-            LANG::Kotlin,
+        LANG::Kotlin => flat(
             r"fun f(xs: IntArray) {
     for (x in xs) {
         g(x)
@@ -1157,25 +1719,167 @@ fn range_for_loop_parity() {
 ",
             "kt",
         ),
-    );
-    let offsets = BTreeMap::from([("java", JAVA_CLASS_OFFSET), ("csharp", JAVA_CLASS_OFFSET)]);
-    assert_parity("range_for_loop", &sums, &offsets);
+        LANG::Rust => flat(
+            r"fn f(xs: Vec<i32>) {
+    for x in xs {
+        g(x);
+    }
+}
+",
+            "rs",
+        ),
+        LANG::Javascript | LANG::Mozjs => flat(
+            r"function f(xs) {
+    for (const x of xs) {
+        g(x);
+    }
+}
+",
+            "js",
+        ),
+        LANG::Typescript => flat(
+            r"function f(xs: number[]) {
+    for (const x of xs) {
+        g(x);
+    }
+}
+",
+            "ts",
+        ),
+        LANG::Tsx => flat(
+            r"function f(xs: number[]) {
+    for (const x of xs) {
+        g(x);
+    }
+}
+",
+            "tsx",
+        ),
+        LANG::Php => flat(
+            r"<?php
+function f($xs) {
+    foreach ($xs as $x) {
+        g($x);
+    }
+}
+",
+            "php",
+        ),
+        LANG::Python => flat(
+            r"def f(xs):
+    for x in xs:
+        g(x)
+",
+            "py",
+        ),
+        LANG::Go => flat(
+            r"package p
+func f(xs []int) {
+    for _, x := range xs {
+        g(x)
+    }
+}
+",
+            "go",
+        ),
+        LANG::Ruby => flat(
+            r"def f(xs)
+  for x in xs
+    g(x)
+  end
+end
+",
+            "rb",
+        ),
+        // Lua's generic `for … in <iterator>`, distinct from its
+        // numeric `for i = 1, n` form.
+        LANG::Lua => flat(
+            r"function f(xs)
+    for _, x in ipairs(xs) do
+        g(x)
+    end
+end
+",
+            "lua",
+        ),
+        LANG::Perl => flat(
+            r"sub f {
+    my (@xs) = @_;
+    foreach my $x (@xs) {
+        g($x);
+    }
+}
+",
+            "pl",
+        ),
+        LANG::Bash => flat(
+            r#"#!/bin/bash
+f() {
+    for x in "$@"; do
+        echo "$x"
+    done
+}
+"#,
+            "sh",
+        ),
+        LANG::Tcl => flat(
+            r"proc f {xs} {
+    foreach x $xs {
+        puts $x
+    }
+}
+",
+            "tcl",
+        ),
+        LANG::Irules => flat(
+            r"proc f {xs} {
+    foreach x $xs {
+        log local0. $x
+    }
+}
+",
+            "irule",
+        ),
+        // Elixir has no loop statement; `for x <- xs` is a
+        // comprehension, and it is the language's iterate-over-a-
+        // collection form.
+        LANG::Elixir => in_container(
+            r"defmodule Parity do
+  def f(xs) do
+    for x <- xs do
+      g(x)
+    end
+  end
+end
+",
+            "ex",
+        ),
+        // C has no way to bind each element of a collection: its only
+        // loop forms are the three-clause `for`, `while` and `do`. The
+        // C++ range-for above is not valid C, so `LANG::C` cannot share
+        // that arm. The two C-family helper grammars parse fragments.
+        LANG::C | LANG::Ccomment | LANG::Preproc => return None,
+    };
+    Some(row)
+}
 
+#[test]
+fn range_for_loop_parity() {
     // Anchor the absolute magnitude (lessons #6 / #23 / #468):
     // unit(1) + fn(1) + for(1) = 3. Each range/enhanced-for fires exactly
     // one decision point; pinning the value catches a regression that
     // additionally listed the statement node (double-count, #284) across
     // all languages symmetrically.
-    assert_normalised(&sums, &offsets, 3.0, "range_for_loop");
+    check_family("range_for_loop", 3.0, range_for_loop);
 }
 
 // --- Family 8: safe-navigation operator chains ---------------------------
 //
 // A two-link safe-navigation chain — Kotlin `a?.b?.c`, Groovy `a?.b?.c`,
-// PHP `$a?->b?->c`, Ruby `a&.b&.c`, JS `a?.b?.c`, C# `a?.b?.c` — must each
-// contribute exactly two decision points (one short-circuit per operator),
-// matching the inconsistency #281 / c8b7d93 set out to remove and the
-// Ruby/Groovy fix in #452.
+// PHP `$a?->b?->c`, Ruby `a&.b&.c`, JS/TS `a?.b?.c`, C# `a?.b?.c` — must
+// each contribute exactly two decision points (one short-circuit per
+// operator), matching the inconsistency #281 / c8b7d93 set out to remove
+// and the Ruby/Groovy fix in #452.
 //
 // Each operator is short-circuit (it skips the member access/call when the
 // LHS is null/nil), so standard CCN counts it like `&&` / `||`. Kotlin /
@@ -1186,52 +1890,54 @@ fn range_for_loop_parity() {
 //
 // Per-language post-offset expectation: unit(1) + fn(1) + 2 ops = 4.
 
-#[test]
-fn safe_navigation_chain_parity() {
-    let mut sums = BTreeMap::new();
-    sums.insert(
-        "kotlin",
-        ccn_sum(LANG::Kotlin, "fun f(a: A?): C? { return a?.b?.c }\n", "kt"),
-    );
-    sums.insert(
-        "groovy",
-        ccn_sum(LANG::Groovy, "def f(a){ return a?.b?.c }\n", "groovy"),
-    );
-    sums.insert(
-        "php",
-        ccn_sum(
-            LANG::Php,
-            "<?php function f($a){ return $a?->b?->c; }\n",
-            "php",
-        ),
-    );
-    sums.insert(
-        "ruby",
-        ccn_sum(LANG::Ruby, "def f(a); a&.b&.c; end\n", "rb"),
-    );
-    sums.insert(
-        "javascript",
-        ccn_sum(LANG::Javascript, "function f(a){ return a?.b?.c; }\n", "js"),
-    );
-    sums.insert(
-        "csharp",
-        ccn_sum(
-            LANG::Csharp,
+fn safe_navigation_chain(lang: LANG) -> Option<Fixture> {
+    // Exhaustive per-language dispatch table; see `switch_with_default`.
+    // bca: suppress(cyclomatic)
+    let row = match lang {
+        LANG::Kotlin => flat("fun f(a: A?): C? { return a?.b?.c }\n", "kt"),
+        LANG::Groovy => flat("def f(a){ return a?.b?.c }\n", "groovy"),
+        LANG::Php => flat("<?php function f($a){ return $a?->b?->c; }\n", "php"),
+        LANG::Ruby => flat("def f(a); a&.b&.c; end\n", "rb"),
+        LANG::Javascript | LANG::Mozjs => flat("function f(a){ return a?.b?.c; }\n", "js"),
+        LANG::Typescript => flat("function f(a: any): any { return a?.b?.c; }\n", "ts"),
+        LANG::Tsx => flat("function f(a: any): any { return a?.b?.c; }\n", "tsx"),
+        LANG::Csharp => in_container(
             "public class Parity { static object F(Parity a){ return a?.b?.c; } }\n",
             "cs",
         ),
-    );
-    // C# requires the function inside a class, adding one FuncSpace (+1),
-    // identical to the Java structural offset used elsewhere in this file.
-    let offsets = BTreeMap::from([("csharp", JAVA_CLASS_OFFSET)]);
-    assert_parity("safe_navigation_chain", &sums, &offsets);
+        // No safe-navigation operator. Rust models absence in the type
+        // system (`?` on an `Option` is an early exit, not a member
+        // access); the C family, Java, Go, Python, Lua, Perl, Tcl,
+        // iRules and Elixir each spell the guard as an explicit
+        // conditional, which family 4 already covers. Bash has no member
+        // access at all, and the two C-family helper grammars parse
+        // fragments.
+        LANG::Rust
+        | LANG::C
+        | LANG::Cpp
+        | LANG::Mozcpp
+        | LANG::Objc
+        | LANG::Java
+        | LANG::Go
+        | LANG::Python
+        | LANG::Lua
+        | LANG::Perl
+        | LANG::Bash
+        | LANG::Tcl
+        | LANG::Irules
+        | LANG::Elixir
+        | LANG::Ccomment
+        | LANG::Preproc => return None,
+    };
+    Some(row)
+}
 
+#[test]
+fn safe_navigation_chain_parity() {
     // Anchor the absolute magnitude, not just mutual agreement: a shared
     // regression that dropped both `?.` links symmetrically across every
     // language would still satisfy `assert_parity` (all would agree on the
     // wrong value). Pin the hand-derived spec value so the +2 magnitude
-    // itself is guarded (lessons #6 / #23): unit(1) + fn(1) + 2 ops = 4
-    // for the five flat fixtures; C#'s extra class FuncSpace is removed by
-    // JAVA_CLASS_OFFSET, normalising it to 4 as well.
-    assert_normalised(&sums, &offsets, 4.0, "safe_navigation_chain");
+    // itself is guarded (lessons #6 / #23): unit(1) + fn(1) + 2 ops = 4.
+    check_family("safe_navigation_chain", 4.0, safe_navigation_chain);
 }

--- a/tests/parity/exit_cross_language_parity.rs
+++ b/tests/parity/exit_cross_language_parity.rs
@@ -35,12 +35,15 @@
 //!
 //! ## Coverage
 //!
-//! All 23 languages with an `Exit` impl in `src/metrics/nexits.rs` are
-//! covered: Python, Mozjs, Javascript, Typescript, Tsx, Cpp, Mozcpp,
-//! C, Objc, Java, Groovy, Rust, Csharp, Go, Perl, Kotlin, Lua, Bash,
-//! Tcl, Irules, Php, Ruby, Elixir.
+//! The fixture table is an exhaustive `match` on [`LANG`], so the
+//! coverage claim is structural: adding a language variant fails to
+//! compile until someone decides whether it has an `Exit` impl to
+//! exercise, and a variant that has none says so with `None`. Before
+//! #1281 the claim was a prose list ("all 23 languages …") with nothing
+//! holding it to the roster.
 //!
-//! Per-language exit set (see `src/metrics/nexits.rs`):
+//! The per-language exit set (see `src/metrics/nexits.rs`) lives at each
+//! arm. In summary:
 //!
 //! - `return` + abrupt-exit (sum == 2): Rust (`return` + `?`),
 //!   Cpp/Mozcpp/Objc/Java/Groovy/Csharp/Kotlin/JS-family (`return` +
@@ -70,329 +73,206 @@ fn nexits_sum(lang: LANG, source: &str, ext: &str) -> f64 {
         Source::new(lang, source.as_bytes()).with_name(Some(name)),
         MetricsOptions::default(),
     )
-    .expect("parser produced no FuncSpace for parity fixture");
+    .unwrap_or_else(|e| panic!("{lang:?}: analyze failed: {e}"));
     space.metrics.nexits.nexits_sum() as f64
+}
+
+/// Returns `(source, extension)` for a language with an `Exit` impl, or
+/// `None` for one that has no function concept to exit from.
+///
+/// Every `Some` row spells exactly two counted exits: a plain `return`
+/// plus the language's abrupt-exit construct, or two `return`s where
+/// that is the only modelled exit.
+fn fixture(lang: LANG) -> Option<(&'static str, &'static str)> {
+    // Exhaustive per-language dispatch table: one arm per LANG variant
+    // is the point of this function, so a new language cannot be added
+    // without deciding what its exit set is. The repo's own `.bcaignore`
+    // excludes `./tests/**`, so this marker is for the per-edit
+    // `bca check` hook rather than for the self-scan gate.
+    // bca: suppress(cyclomatic)
+    let row = match lang {
+        // Rust: explicit `return` + the `?` operator (TryExpression) are
+        // the two counted exits; the implicit final expression is not an
+        // exit.
+        LANG::Rust => (
+            "fn f(x: bool) -> Result<i32, ()> {\n    if x {\n        return Ok(0);\n    }\n    \
+             Ok(g()?)\n}\n",
+            "rs",
+        ),
+        // C has no exceptions: two `return`s are the only exit form.
+        LANG::C => (
+            "int f(int x) {\n    if (x) {\n        return 1;\n    }\n    return 0;\n}\n",
+            "c",
+        ),
+        // C++ counts `return` + `throw`; Mozcpp mirrors its set.
+        LANG::Cpp | LANG::Mozcpp => (
+            "int f(int x) {\n    if (x) {\n        throw 1;\n    }\n    return 0;\n}\n",
+            "cpp",
+        ),
+        // Objective-C adds `@throw` on top of C's `return`.
+        LANG::Objc => (
+            "int f(int x) {\n    if (x) {\n        @throw @\"boom\";\n    }\n    return 0;\n}\n",
+            "m",
+        ),
+        // Java counts `return` + `throw`.
+        LANG::Java => (
+            "class Parity {\n    static int f(boolean x) {\n        if (x) {\n            \
+             throw new RuntimeException();\n        }\n        return 0;\n    }\n}\n",
+            "java",
+        ),
+        // Groovy mirrors Java's `return` + `throw` set.
+        LANG::Groovy => (
+            "def f(x) {\n    if (x) {\n        throw new RuntimeException()\n    }\n    \
+             return 0\n}\n",
+            "groovy",
+        ),
+        // C# counts `return` + `throw` (statement form).
+        LANG::Csharp => (
+            "class Parity {\n    static int F(bool x) {\n        if (x) {\n            \
+             throw new System.Exception();\n        }\n        return 0;\n    }\n}\n",
+            "cs",
+        ),
+        // Kotlin counts `return` + `throw`.
+        LANG::Kotlin => (
+            "fun f(x: Boolean): Int {\n    if (x) {\n        throw RuntimeException(\"boom\")\n    \
+             }\n    return 0\n}\n",
+            "kt",
+        ),
+        // JavaScript counts `return` + `throw`; Mozjs mirrors its set.
+        LANG::Javascript | LANG::Mozjs => (
+            "function f(x) {\n    if (x) {\n        throw new Error(\"boom\");\n    }\n    \
+             return 0;\n}\n",
+            "js",
+        ),
+        // TypeScript counts `return` + `throw`; Tsx mirrors its set.
+        LANG::Typescript | LANG::Tsx => (
+            "function f(x: boolean): number {\n    if (x) {\n        \
+             throw new Error(\"boom\");\n    }\n    return 0;\n}\n",
+            "ts",
+        ),
+        // Python counts `return` + `raise`.
+        LANG::Python => (
+            "def f(x):\n    if x:\n        raise ValueError()\n    return 0\n",
+            "py",
+        ),
+        // PHP counts `return` + `throw` (throw expression in statement
+        // position).
+        LANG::Php => (
+            "<?php\nfunction f($x) {\n    if ($x) {\n        throw new \\Exception('boom');\n    \
+             }\n    return 0;\n}\n",
+            "php",
+        ),
+        // Bash has no `return_statement` node: `return` and `exit` are
+        // builtins matched by command-name text.
+        LANG::Bash => (
+            "#!/bin/bash\nf() {\n    if [ \"$1\" -eq 1 ]; then\n        exit 1\n    fi\n    \
+             return 0\n}\n",
+            "sh",
+        ),
+        // Go has no `throw`: `panic(...)` is the built-in abrupt-exit
+        // call (#779), matched by callee text alongside `return`.
+        LANG::Go => (
+            "package p\nfunc f(x bool) int {\n    if x {\n        panic(\"boom\")\n    }\n    \
+             return 0\n}\n",
+            "go",
+        ),
+        // Lua has no `throw`: `error(...)` raises and unwinds the stack
+        // (#779), matched by callee text alongside `return`.
+        LANG::Lua => (
+            "local function f(x)\n    if x then\n        error(\"boom\")\n    end\n    \
+             return 0\nend\n",
+            "lua",
+        ),
+        // Elixir has no `return`: both exits are abrupt-exit `Call`s
+        // whose target text spells `raise` / `throw`.
+        LANG::Elixir => (
+            "defmodule Foo do\n  def f(x) do\n    if x do\n      raise \"boom\"\n    end\n    \
+             throw(:done)\n  end\nend\n",
+            "ex",
+        ),
+        // Perl has no `throw`: `die` raises and unwinds to the nearest
+        // `eval` (#1270), matched by bareword-callee text alongside
+        // `return`.
+        LANG::Perl => (
+            "sub f {\n    if ($_[0]) {\n        die \"boom\";\n    }\n    return 0;\n}\n",
+            "pl",
+        ),
+        // Ruby counts `return` + `raise`: `raise` has no grammar node of
+        // its own, so it is matched as a receiver-less `call` whose
+        // method identifier spells the builtin (#1270).
+        LANG::Ruby => (
+            "def f(x)\n    if x\n        raise ArgumentError, \"boom\"\n    end\n    \
+             return 0\nend\n",
+            "rb",
+        ),
+        // Tcl has no `return` keyword node and no dedicated `error` rule
+        // either: both are generic Commands told apart by their leading
+        // word (#1270).
+        LANG::Tcl => (
+            "proc f {x} {\n    if {$x > 0} {\n        error \"boom\"\n    }\n    \
+             return nonpositive\n}\n",
+            "tcl",
+        ),
+        // iRules mirrors Tcl for `return` + `error` (both generic
+        // Commands). Tcl 8.6's `throw` is deliberately absent from the
+        // iRules exit set — TMOS runs a Tcl 8.4-derived interpreter that
+        // has no such builtin — so the fixture uses `error`.
+        LANG::Irules => (
+            "proc f {x} {\n    if {$x > 0} {\n        error \"boom\"\n    }\n    \
+             return nonpositive\n}\n",
+            "irul",
+        ),
+        // The two C-family helper grammars parse fragments — a comment
+        // body, a preprocessor directive — with no function to exit
+        // from and no `Exit` impl in `src/metrics/nexits.rs`.
+        LANG::Ccomment | LANG::Preproc => return None,
+    };
+    Some(row)
 }
 
 #[test]
 fn return_plus_abrupt_exit_parity() {
-    // Rust: explicit `return` + the `?` operator (TryExpression) are the
-    // two counted exits; the implicit final expression is not an exit.
-    let rust = nexits_sum(
-        LANG::Rust,
-        r"fn f(x: bool) -> Result<i32, ()> {
-    if x {
-        return Ok(0);
-    }
-    Ok(g()?)
-}
-",
-        "rs",
-    );
-    // C has no exceptions: two `return`s are the only exit form.
-    let c = nexits_sum(
-        LANG::C,
-        r"int f(int x) {
-    if (x) {
-        return 1;
-    }
-    return 0;
-}
-",
-        "c",
-    );
-    // C++ counts `return` + `throw`.
-    let cpp = nexits_sum(
-        LANG::Cpp,
-        r"int f(int x) {
-    if (x) {
-        throw 1;
-    }
-    return 0;
-}
-",
-        "cpp",
-    );
-    // Mozcpp mirrors Cpp's `return` + `throw` set.
-    let mozcpp = nexits_sum(
-        LANG::Mozcpp,
-        r"int f(int x) {
-    if (x) {
-        throw 1;
-    }
-    return 0;
-}
-",
-        "cpp",
-    );
-    // Objective-C adds `@throw` on top of C's `return`.
-    let objc = nexits_sum(
-        LANG::Objc,
-        r#"int f(int x) {
-    if (x) {
-        @throw @"boom";
-    }
-    return 0;
-}
-"#,
-        "m",
-    );
-    // Java counts `return` + `throw`.
-    let java = nexits_sum(
-        LANG::Java,
-        r"class Parity {
-    static int f(boolean x) {
-        if (x) {
-            throw new RuntimeException();
-        }
-        return 0;
-    }
-}
-",
-        "java",
-    );
-    // Groovy mirrors Java's `return` + `throw` set.
-    let groovy = nexits_sum(
-        LANG::Groovy,
-        r"def f(x) {
-    if (x) {
-        throw new RuntimeException()
-    }
-    return 0
-}
-",
-        "groovy",
-    );
-    // C# counts `return` + `throw` (statement form).
-    let csharp = nexits_sum(
-        LANG::Csharp,
-        r"class Parity {
-    static int F(bool x) {
-        if (x) {
-            throw new System.Exception();
-        }
-        return 0;
-    }
-}
-",
-        "cs",
-    );
-    // Kotlin counts `return` + `throw`.
-    let kotlin = nexits_sum(
-        LANG::Kotlin,
-        r#"fun f(x: Boolean): Int {
-    if (x) {
-        throw RuntimeException("boom")
-    }
-    return 0
-}
-"#,
-        "kt",
-    );
-    // JavaScript counts `return` + `throw`.
-    let javascript = nexits_sum(
-        LANG::Javascript,
-        r#"function f(x) {
-    if (x) {
-        throw new Error("boom");
-    }
-    return 0;
-}
-"#,
-        "js",
-    );
-    // Mozjs mirrors JavaScript's `return` + `throw` set.
-    let mozjs = nexits_sum(
-        LANG::Mozjs,
-        r#"function f(x) {
-    if (x) {
-        throw new Error("boom");
-    }
-    return 0;
-}
-"#,
-        "js",
-    );
-    // TypeScript counts `return` + `throw`.
-    let typescript = nexits_sum(
-        LANG::Typescript,
-        r#"function f(x: boolean): number {
-    if (x) {
-        throw new Error("boom");
-    }
-    return 0;
-}
-"#,
-        "ts",
-    );
-    // Tsx mirrors TypeScript's `return` + `throw` set.
-    let tsx = nexits_sum(
-        LANG::Tsx,
-        r#"function f(x: boolean): number {
-    if (x) {
-        throw new Error("boom");
-    }
-    return 0;
-}
-"#,
-        "tsx",
-    );
-    // Python counts `return` + `raise`.
-    let python = nexits_sum(
-        LANG::Python,
-        r"def f(x):
-    if x:
-        raise ValueError()
-    return 0
-",
-        "py",
-    );
-    // PHP counts `return` + `throw` (throw expression in statement
-    // position).
-    let php = nexits_sum(
-        LANG::Php,
-        r"<?php
-function f($x) {
-    if ($x) {
-        throw new \Exception('boom');
-    }
-    return 0;
-}
-",
-        "php",
-    );
-    // Bash has no `return_statement` node: `return` and `exit` are
-    // builtins matched by command-name text.
-    let bash = nexits_sum(
-        LANG::Bash,
-        r#"#!/bin/bash
-f() {
-    if [ "$1" -eq 1 ]; then
-        exit 1
-    fi
-    return 0
-}
-"#,
-        "sh",
-    );
-    // Go has no `throw`: `panic(...)` is the built-in abrupt-exit call
-    // (#779), matched by callee text alongside `return`.
-    let go = nexits_sum(
-        LANG::Go,
-        r#"package p
-func f(x bool) int {
-    if x {
-        panic("boom")
-    }
-    return 0
-}
-"#,
-        "go",
-    );
-    // Lua has no `throw`: `error(...)` raises and unwinds the stack
-    // (#779), matched by callee text alongside `return`.
-    let lua = nexits_sum(
-        LANG::Lua,
-        r#"local function f(x)
-    if x then
-        error("boom")
-    end
-    return 0
-end
-"#,
-        "lua",
-    );
-    // Elixir has no `return`: both exits are abrupt-exit `Call`s whose
-    // target text spells `raise` / `throw`.
-    let elixir = nexits_sum(
-        LANG::Elixir,
-        "defmodule Foo do\n  def f(x) do\n    if x do\n      raise \"boom\"\n    end\n    throw(:done)\n  end\nend\n",
-        "ex",
-    );
-    // Perl has no `throw`: `die` raises and unwinds to the nearest
-    // `eval` (#1270), matched by bareword-callee text alongside
-    // `return`.
-    let perl = nexits_sum(
-        LANG::Perl,
-        r#"sub f {
-    if ($_[0]) {
-        die "boom";
-    }
-    return 0;
-}
-"#,
-        "pl",
-    );
-    // Ruby counts `return` + `raise`: `raise` has no grammar node of
-    // its own, so it is matched as a receiver-less `call` whose method
-    // identifier spells the builtin (#1270).
-    let ruby = nexits_sum(
-        LANG::Ruby,
-        r#"def f(x)
-    if x
-        raise ArgumentError, "boom"
-    end
-    return 0
-end
-"#,
-        "rb",
-    );
-    // Tcl has no `return` keyword node and no dedicated `error` rule
-    // either: both are generic Commands told apart by their leading
-    // word (#1270).
-    let tcl = nexits_sum(
-        LANG::Tcl,
-        r#"proc f {x} {
-    if {$x > 0} {
-        error "boom"
-    }
-    return nonpositive
-}
-"#,
-        "tcl",
-    );
-    // iRules mirrors Tcl for `return` + `error` (both generic
-    // Commands). Tcl 8.6's `throw` is deliberately absent from the
-    // iRules exit set — TMOS runs a Tcl 8.4-derived interpreter that
-    // has no such builtin — so the fixture uses `error`.
-    let irules = nexits_sum(
-        LANG::Irules,
-        r#"proc f {x} {
-    if {$x > 0} {
-        error "boom"
-    }
-    return nonpositive
-}
-"#,
-        "irul",
-    );
-
     // expected: every fixture has exactly two counted exits — one
     // `return` plus one abrupt-exit construct (or two `return`s where
-    // that is the only modelled exit). A regression that stops counting
-    // a language's abrupt-exit construct drops it to 1 and fails here.
+    // that is the only modelled exit). Hand-derived by reading each
+    // fixture: a regression that stops counting a language's
+    // abrupt-exit construct drops it to 1 and fails here.
     let expected = 2.0;
-    assert_eq!(rust, expected, "rust");
-    assert_eq!(c, expected, "c");
-    assert_eq!(cpp, expected, "cpp");
-    assert_eq!(mozcpp, expected, "mozcpp");
-    assert_eq!(objc, expected, "objc");
-    assert_eq!(java, expected, "java");
-    assert_eq!(groovy, expected, "groovy");
-    assert_eq!(csharp, expected, "csharp");
-    assert_eq!(kotlin, expected, "kotlin");
-    assert_eq!(javascript, expected, "javascript");
-    assert_eq!(mozjs, expected, "mozjs");
-    assert_eq!(typescript, expected, "typescript");
-    assert_eq!(tsx, expected, "tsx");
-    assert_eq!(python, expected, "python");
-    assert_eq!(php, expected, "php");
-    assert_eq!(bash, expected, "bash");
-    assert_eq!(go, expected, "go");
-    assert_eq!(lua, expected, "lua");
-    assert_eq!(elixir, expected, "elixir");
-    assert_eq!(perl, expected, "perl");
-    assert_eq!(ruby, expected, "ruby");
-    assert_eq!(tcl, expected, "tcl");
-    assert_eq!(irules, expected, "irules");
+
+    let mut checked = 0;
+    for lang in LANG::into_enum_iter() {
+        if !lang.is_enabled() {
+            continue;
+        }
+        let Some((source, ext)) = fixture(lang) else {
+            continue;
+        };
+        checked += 1;
+        let got = nexits_sum(lang, source, ext);
+        assert_eq!(
+            got, expected,
+            "{lang:?}: nexits {got} != expected {expected}"
+        );
+    }
+
+    // A table that lost its rows is a real, feature-independent
+    // regression, so assert it directly. A build enabling only the two
+    // helper grammars legitimately checks nothing — the state a
+    // `#[cfg]`-gated-out module would be in — so `checked > 0` is
+    // deliberately not asserted: making it safe would need a
+    // hand-maintained feature union naming every `Some` arm, which is
+    // the drift this restructure removed (#1281).
+    assert!(
+        LANG::into_enum_iter().any(|lang| fixture(lang).is_some()),
+        "the fixture table has no rows at all, so this test cannot fail",
+    );
+    // Re-derive the count independently of the loop, so a `continue`
+    // added above cannot quietly drop rows.
+    let eligible = LANG::into_enum_iter()
+        .filter(|lang| lang.is_enabled() && fixture(*lang).is_some())
+        .count();
+    assert_eq!(
+        checked, eligible,
+        "the loop checked {checked} languages but {eligible} enabled languages have a fixture",
+    );
 }

--- a/tests/parity/main.rs
+++ b/tests/parity/main.rs
@@ -8,10 +8,96 @@ mod cognitive_cross_language_parity;
 mod cpp_mozcpp_parity;
 mod cyclomatic_cross_language_parity;
 mod exit_cross_language_parity;
-mod functions_metrics_parity;
 mod halstead_set_target_parity;
 mod nargs_cross_language_parity;
+
+// The next three suites share `ops_metrics_space_parity::fixture`, an
+// exhaustive `match` on `LANG`, so each sweeps *every* language and each
+// asserts `checked > 0`. Their row set is therefore the whole roster,
+// and a build that compiled no grammar at all — the
+// `no-default-features (lib)` CI configuration — would fail all four of
+// their guards rather than skipping them. Gated as a group so that build
+// drops them together, which is also required: the other two read
+// `fixture` out of the middle one (`.claude/rules/testing.md`, #1286).
+#[cfg(any(
+    feature = "bash",
+    feature = "c",
+    feature = "c-family-helpers",
+    feature = "cpp",
+    feature = "csharp",
+    feature = "elixir",
+    feature = "go",
+    feature = "groovy",
+    feature = "irules",
+    feature = "java",
+    feature = "javascript",
+    feature = "kotlin",
+    feature = "lua",
+    feature = "mozcpp",
+    feature = "mozjs",
+    feature = "objc",
+    feature = "perl",
+    feature = "php",
+    feature = "python",
+    feature = "ruby",
+    feature = "rust",
+    feature = "tcl",
+    feature = "typescript",
+))]
+mod functions_metrics_parity;
+#[cfg(any(
+    feature = "bash",
+    feature = "c",
+    feature = "c-family-helpers",
+    feature = "cpp",
+    feature = "csharp",
+    feature = "elixir",
+    feature = "go",
+    feature = "groovy",
+    feature = "irules",
+    feature = "java",
+    feature = "javascript",
+    feature = "kotlin",
+    feature = "lua",
+    feature = "mozcpp",
+    feature = "mozjs",
+    feature = "objc",
+    feature = "perl",
+    feature = "php",
+    feature = "python",
+    feature = "ruby",
+    feature = "rust",
+    feature = "tcl",
+    feature = "typescript",
+))]
 mod ops_metrics_space_parity;
+#[cfg(any(
+    feature = "bash",
+    feature = "c",
+    feature = "c-family-helpers",
+    feature = "cpp",
+    feature = "csharp",
+    feature = "elixir",
+    feature = "go",
+    feature = "groovy",
+    feature = "irules",
+    feature = "java",
+    feature = "javascript",
+    feature = "kotlin",
+    feature = "lua",
+    feature = "mozcpp",
+    feature = "mozjs",
+    feature = "objc",
+    feature = "perl",
+    feature = "php",
+    feature = "python",
+    feature = "ruby",
+    feature = "rust",
+    feature = "tcl",
+    feature = "typescript",
+))]
+mod space_span_containment;
+
 // Gated on the union of the languages whose fixture rows are `Some`, so
 // a build enabling only self-reference-free languages drops the module
 // rather than failing its non-vacuity guard (`.claude/rules/testing.md`).
@@ -33,4 +119,3 @@ mod ops_metrics_space_parity;
     feature = "typescript",
 ))]
 mod self_reference_operand_parity;
-mod space_span_containment;

--- a/tests/parity/nargs_cross_language_parity.rs
+++ b/tests/parity/nargs_cross_language_parity.rs
@@ -13,155 +13,136 @@
 //! disagreement between languages. This file is the nargs companion
 //! to `tests/parity/cyclomatic_cross_language_parity.rs`.
 //!
-//! The fixture is the simplest possible: a function with exactly
-//! three formal parameters, body empty. Every supported language
-//! whose grammar models a named parameter list reports
-//! `fn_args_sum() == 3`: Rust, C/C++, Java, JavaScript, TypeScript,
-//! Python, PHP, C#, Kotlin, Go, Groovy, Ruby, Tcl, iRules, and
-//! Objective-C.
+//! The fixture is the simplest possible: a function with exactly three
+//! formal parameters, body empty.
 //!
-//! The test uses `fn_args_sum()` (matches the metric definition;
+//! The fixture table is an exhaustive `match` on [`LANG`], so adding a
+//! language variant fails to compile until someone decides whether its
+//! grammar models a named parameter list. A language that does not says
+//! so with `None`, and the reason lives at the arm — the coverage claim
+//! is therefore structural rather than a prose list that can fall behind
+//! the language roster (#1281; the previous hand-maintained list named
+//! 15 languages and silently omitted six that do model one).
+//!
+//! The test uses `function_args_sum()` (matches the metric definition;
 //! file-level sum over functions, but with one function the value
 //! equals that function's nargs).
-//!
-//! **Excluded — Bash**: Bash functions take no formal parameters in
-//! the grammar — arguments are positional (`$1`, `$2`, …), so
-//! `fn_args_sum()` is structurally always `0`. This is a
-//! language-mandated absence, not a metric drift; documented here
-//! rather than asserted.
 
 use big_code_analysis::{LANG, MetricsOptions, Source, analyze};
 
 /// `function_args` file-level sum for the single function in `source`.
-fn fn_args_sum(lang: LANG, source: &str, ext: &str) -> f64 {
+fn function_args_sum(lang: LANG, source: &str, ext: &str) -> f64 {
     let name = format!("parity.{ext}");
     let space = analyze(
         Source::new(lang, source.as_bytes()).with_name(Some(name)),
         MetricsOptions::default(),
     )
-    .expect("parser produced no FuncSpace for parity fixture");
+    .unwrap_or_else(|e| panic!("{lang:?}: analyze failed: {e}"));
     space.metrics.nargs.function_args_sum() as f64
+}
+
+/// Returns `(source, extension)` for a language whose grammar models a
+/// named formal-parameter list, or `None` for one that does not.
+///
+/// Every `Some` row declares the same three parameters `a`, `b`, `c`.
+/// The extension only names the parsed unit; it reaches no metric.
+fn fixture(lang: LANG) -> Option<(&'static str, &'static str)> {
+    // Exhaustive per-language dispatch table: one arm per LANG variant
+    // is the point of this function, so a new language cannot be added
+    // without deciding whether it has a formal parameter list. The
+    // repo's own `.bcaignore` excludes `./tests/**`, so this marker is
+    // for the per-edit `bca check` hook rather than for the self-scan
+    // gate.
+    // bca: suppress(cyclomatic)
+    let row = match lang {
+        LANG::Rust => ("fn f(a: i32, b: i32, c: i32) {}\n", "rs"),
+        // One arm for the whole C family: the fixture is plain C, which
+        // all four grammars accept unchanged.
+        LANG::C | LANG::Cpp | LANG::Mozcpp | LANG::Objc => {
+            ("void f(int a, int b, int c) {}\n", "c")
+        }
+        LANG::Java => (
+            "class Parity {\n    static void f(int a, int b, int c) {}\n}\n",
+            "java",
+        ),
+        LANG::Csharp => (
+            "class Parity {\n    static void F(int a, int b, int c) {}\n}\n",
+            "cs",
+        ),
+        LANG::Javascript | LANG::Mozjs => ("function f(a, b, c) {}\n", "js"),
+        LANG::Typescript => ("function f(a: number, b: number, c: number) {}\n", "ts"),
+        LANG::Tsx => ("function f(a: number, b: number, c: number) {}\n", "tsx"),
+        LANG::Python => ("def f(a, b, c):\n    pass\n", "py"),
+        LANG::Php => ("<?php\nfunction f($a, $b, $c) {}\n", "php"),
+        LANG::Kotlin => ("fun f(a: Int, b: Int, c: Int) {}\n", "kt"),
+        LANG::Go => ("package p\nfunc f(a int, b int, c int) {}\n", "go"),
+        LANG::Groovy => ("def f(int a, int b, int c) {}\n", "groovy"),
+        LANG::Ruby => ("def f(a, b, c)\n  a + b + c\nend\n", "rb"),
+        LANG::Lua => ("function f(a, b, c)\nend\n", "lua"),
+        // Elixir's `def` must live inside a `defmodule`; the module
+        // space contributes no parameters, so no offset is needed.
+        LANG::Elixir => (
+            "defmodule Parity do\n  def f(a, b, c) do\n    a\n  end\nend\n",
+            "ex",
+        ),
+        LANG::Tcl => ("proc f {a b c} { puts $a }\n", "tcl"),
+        LANG::Irules => ("proc f { a b c } { return $a }\n", "irule"),
+        // Bash and Perl functions take no formal parameters in the
+        // grammar: arguments arrive positionally (`$1`, `$2`, … and
+        // `@_`), so `function_args_sum()` is structurally always `0`.
+        // Measured: both report 0 for a three-argument call shape. This
+        // is a language-mandated absence, not a metric drift.
+        //
+        // The two C-family helper grammars parse fragments (a comment
+        // body, a preprocessor directive) and have no function concept
+        // at all.
+        LANG::Bash | LANG::Perl | LANG::Ccomment | LANG::Preproc => return None,
+    };
+    Some(row)
 }
 
 #[test]
 fn three_parameter_function_parity() {
-    let rust = fn_args_sum(
-        LANG::Rust,
-        r"fn f(a: i32, b: i32, c: i32) {}
-",
-        "rs",
-    );
-    let c = fn_args_sum(
-        LANG::Cpp,
-        r"void f(int a, int b, int c) {}
-",
-        "c",
-    );
-    let java = fn_args_sum(
-        LANG::Java,
-        r"class Parity {
-    static void f(int a, int b, int c) {}
-}
-",
-        "java",
-    );
-    let javascript = fn_args_sum(
-        LANG::Javascript,
-        r"function f(a, b, c) {}
-",
-        "js",
-    );
-    let typescript = fn_args_sum(
-        LANG::Typescript,
-        r"function f(a: number, b: number, c: number) {}
-",
-        "ts",
-    );
-    let python = fn_args_sum(
-        LANG::Python,
-        r"def f(a, b, c):
-    pass
-",
-        "py",
-    );
-    let php = fn_args_sum(
-        LANG::Php,
-        r"<?php
-function f($a, $b, $c) {}
-",
-        "php",
-    );
-    let csharp = fn_args_sum(
-        LANG::Csharp,
-        r"class Parity {
-    static void F(int a, int b, int c) {}
-}
-",
-        "cs",
-    );
-    let kotlin = fn_args_sum(
-        LANG::Kotlin,
-        r"fun f(a: Int, b: Int, c: Int) {}
-",
-        "kt",
-    );
-    let go = fn_args_sum(
-        LANG::Go,
-        r"package p
-func f(a int, b int, c int) {}
-",
-        "go",
-    );
-    let groovy = fn_args_sum(
-        LANG::Groovy,
-        r"def f(int a, int b, int c) {}
-",
-        "groovy",
-    );
-    let ruby = fn_args_sum(
-        LANG::Ruby,
-        r"def f(a, b, c)
-  a + b + c
-end
-",
-        "rb",
-    );
-    let tcl = fn_args_sum(
-        LANG::Tcl,
-        r"proc f {a b c} { puts $a }
-",
-        "tcl",
-    );
-    let irules = fn_args_sum(
-        LANG::Irules,
-        r"proc f { a b c } { return $a }
-",
-        "irule",
-    );
-    let objc = fn_args_sum(
-        LANG::Objc,
-        r"void f(int a, int b, int c) {
-    return;
-}
-",
-        "m",
-    );
-
-    // expected: three formal parameters.
+    // expected: three formal parameters, hand-derived from each fixture
+    // by counting the names in its parameter list.
     let expected = 3.0;
-    assert_eq!(rust, expected, "rust");
-    assert_eq!(c, expected, "c");
-    assert_eq!(java, expected, "java");
-    assert_eq!(javascript, expected, "javascript");
-    assert_eq!(typescript, expected, "typescript");
-    assert_eq!(python, expected, "python");
-    assert_eq!(php, expected, "php");
-    assert_eq!(csharp, expected, "csharp");
-    assert_eq!(kotlin, expected, "kotlin");
-    assert_eq!(go, expected, "go");
-    assert_eq!(groovy, expected, "groovy");
-    assert_eq!(ruby, expected, "ruby");
-    assert_eq!(tcl, expected, "tcl");
-    assert_eq!(irules, expected, "irules");
-    assert_eq!(objc, expected, "objc");
+
+    let mut checked = 0;
+    for lang in LANG::into_enum_iter() {
+        if !lang.is_enabled() {
+            continue;
+        }
+        let Some((source, ext)) = fixture(lang) else {
+            continue;
+        };
+        checked += 1;
+        let got = function_args_sum(lang, source, ext);
+        assert_eq!(
+            got, expected,
+            "{lang:?}: nargs {got} != expected {expected}"
+        );
+    }
+
+    // Two ways this loop can assert nothing, and only one is a defect.
+    //
+    // A table that lost its rows is a real regression, and it is
+    // feature-independent, so assert it directly. A build whose enabled
+    // languages all take positional arguments legitimately has nothing
+    // to check — the same state a `#[cfg]`-gated-out module would be in
+    // — so `checked > 0` is deliberately *not* asserted: making it safe
+    // would need a hand-maintained feature union naming every `Some`
+    // arm, which is the drift this restructure removed (#1281).
+    assert!(
+        LANG::into_enum_iter().any(|lang| fixture(lang).is_some()),
+        "the fixture table has no rows at all, so this test cannot fail",
+    );
+    // Re-derive the count independently of the loop, so a `continue`
+    // added above cannot quietly drop rows.
+    let eligible = LANG::into_enum_iter()
+        .filter(|lang| lang.is_enabled() && fixture(*lang).is_some())
+        .count();
+    assert_eq!(
+        checked, eligible,
+        "the loop checked {checked} languages but {eligible} enabled languages have a fixture",
+    );
 }

--- a/tests/parity/self_reference_operand_parity.rs
+++ b/tests/parity/self_reference_operand_parity.rs
@@ -269,9 +269,11 @@ fn every_language_bills_a_self_reference_as_an_operand() {
 
     // Every language is feature-gated, so a build enabling only
     // languages with no self-reference leaves a zero-iteration loop and
-    // a test that reports green while asserting nothing. The `cfg` above
-    // keeps this from firing spuriously: it names exactly the features
-    // whose rows are `Some`.
+    // a test that reports green while asserting nothing. What keeps this
+    // from firing spuriously is the `#[cfg(any(…))]` on this file's
+    // `mod` declaration in `tests/parity/main.rs`, which names exactly
+    // the features whose rows below are `Some` — there is no `cfg` in
+    // this file to look up at.
     assert!(
         checked > 0,
         "at least one language feature with a self-reference must be \

--- a/utils/check-versions-test.py
+++ b/utils/check-versions-test.py
@@ -9,6 +9,11 @@ Two kinds of test live here:
   internal pins (#878) and the `recipes/ci.md` release pins (#879) —
   against synthetic inputs, including the exact strings the *old*
   patterns silently skipped.
+* Tests for the excluded-crate lockfile check (#1234), which build a
+  miniature workspace in a temp directory. The failure direction the
+  issue reproduced — a bumped manifest against a lockfile
+  `cargo update --workspace` never reached — cannot be staged in the
+  checkout itself, because the gate must never mutate the tree.
 * A smoke test that runs the real script against the real repo and
   asserts a clean tree reports lockstep.
 
@@ -22,6 +27,7 @@ import importlib.util
 import pathlib
 import subprocess
 import sys
+import tempfile
 import unittest
 
 # The gate under test is a sibling in `utils/`; every path it reads
@@ -243,6 +249,254 @@ class ChangelogReleaseTest(unittest.TestCase):
         # The README's major-line form ("2") must satisfy the latest
         # published release via prefix normalization.
         self.assertEqual(cv.normalize("2", "2.1.0"), "2.1.0")
+
+
+class ExcludedLockfileTest(unittest.TestCase):
+    """#1234: an excluded crate's Cargo.lock must track its manifests.
+
+    Fixtures are built in a temp tree rather than by perturbing the
+    checkout: `check_excluded_lockfiles` takes its root as a parameter
+    precisely so the failure direction can be exercised without a gate
+    that mutates the working tree.
+    """
+
+    CANONICAL = "2.0.0"
+    REGISTRY = "registry+https://github.com/rust-lang/crates.io-index"
+
+    @staticmethod
+    def _lockfile(entries: list[tuple[str, str, str | None]]) -> str:
+        """Render a Cargo.lock from `(name, version, source)` triples."""
+        out = ["version = 4", ""]
+        for name, version, source in entries:
+            out += ["[[package]]", f'name = "{name}"', f'version = "{version}"']
+            if source is not None:
+                out.append(f'source = "{source}"')
+            out.append("")
+        return "\n".join(out)
+
+    def _build(
+        self,
+        root: pathlib.Path,
+        *,
+        canonical: str,
+        leaf_version: str,
+        locked: list[tuple[str, str, str | None]] | None,
+        lockless_leaf: bool = False,
+    ) -> None:
+        """Lay down a miniature workspace with one excluded leaf.
+
+        `canonical` is what `[workspace.package]` declares (so the root
+        package, which inherits it, moves with it); `leaf_version` is
+        the excluded crate's own `[package].version`; `locked` is what
+        its lockfile records, or None to omit the lockfile entirely.
+        """
+        excludes = ['"leaf"'] + (['"lockless"'] if lockless_leaf else [])
+        (root / "Cargo.toml").write_text(
+            "[workspace]\n"
+            'members = ["member"]\n'
+            f"exclude = [{', '.join(excludes)}, \".claude/worktrees\"]\n\n"
+            f'[workspace.package]\nversion = "{canonical}"\n\n'
+            '[package]\nname = "rootpkg"\nversion.workspace = true\n',
+            encoding="utf-8",
+        )
+        (root / "member").mkdir()
+        (root / "member" / "Cargo.toml").write_text(
+            '[package]\nname = "memberpkg"\nversion.workspace = true\n',
+            encoding="utf-8",
+        )
+        (root / "leaf").mkdir()
+        (root / "leaf" / "Cargo.toml").write_text(
+            # The package name deliberately differs from the directory
+            # name, as `tree-sitter-tcl/` -> `bca-tree-sitter-tcl` does.
+            f'[package]\nname = "leafpkg"\nversion = "{leaf_version}"\n',
+            encoding="utf-8",
+        )
+        if locked is not None:
+            (root / "leaf" / "Cargo.lock").write_text(
+                self._lockfile(locked), encoding="utf-8"
+            )
+        if lockless_leaf:
+            (root / "lockless").mkdir()
+            (root / "lockless" / "Cargo.toml").write_text(
+                '[package]\nname = "locklesspkg"\nversion = "1.0.0"\n',
+                encoding="utf-8",
+            )
+
+    def _failures(
+        self,
+        *,
+        leaf_version: str,
+        locked: list[tuple[str, str, str | None]] | None,
+        canonical: str = CANONICAL,
+        lockless_leaf: bool = False,
+    ) -> list[str]:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            self._build(
+                root,
+                canonical=canonical,
+                leaf_version=leaf_version,
+                locked=locked,
+                lockless_leaf=lockless_leaf,
+            )
+            return cv.check_excluded_lockfiles(root, canonical)
+
+    def test_consistent_tree_passes(self) -> None:
+        self.assertEqual(
+            self._failures(
+                leaf_version="2.0.0",
+                locked=[
+                    ("leafpkg", "2.0.0", None),
+                    ("rootpkg", "2.0.0", None),
+                    ("serde", "1.0.219", self.REGISTRY),
+                ],
+            ),
+            [],
+        )
+
+    def test_bumped_manifest_with_stale_lockfile_fails(self) -> None:
+        # The reproducer from #1234: the bump moved both the workspace
+        # version and the leaf's own, and `cargo update --workspace`
+        # reached neither entry of the leaf's lockfile.
+        failures = self._failures(
+            canonical="2.1.0",
+            leaf_version="2.1.0",
+            locked=[("leafpkg", "2.0.0", None), ("rootpkg", "2.0.0", None)],
+        )
+        self.assertEqual(len(failures), 1, failures)
+        message = failures[0]
+        # The whole point is that the failure currently misattributes
+        # itself, so the message must name the file, the packages, and
+        # both versions.
+        self.assertIn("leaf/Cargo.lock", message)
+        self.assertIn("leafpkg locked at '2.0.0'", message)
+        self.assertIn("leaf/Cargo.toml declares '2.1.0'", message)
+        self.assertIn("rootpkg locked at '2.0.0'", message)
+        self.assertIn("Cargo.toml declares '2.1.0'", message)
+        self.assertIn("cargo update --manifest-path leaf/Cargo.toml", message)
+
+    def test_registry_entry_at_another_version_is_ignored(self) -> None:
+        # A `source`-carrying entry is a registry dependency; its
+        # version has nothing to do with this repository's.
+        self.assertEqual(
+            self._failures(
+                leaf_version="2.0.0",
+                locked=[
+                    ("leafpkg", "2.0.0", None),
+                    # Same name as an owned crate, but resolved from the
+                    # registry — the published copy of an older release.
+                    ("rootpkg", "1.0.0", self.REGISTRY),
+                ],
+            ),
+            [],
+        )
+
+    def test_excluded_crate_without_a_lockfile_is_skipped(self) -> None:
+        # An excluded crate only grows a Cargo.lock once something
+        # resolves it; absence is not staleness. A second, locked leaf
+        # keeps the vacuity guard from firing for an unrelated reason.
+        self.assertEqual(
+            self._failures(
+                leaf_version="2.0.0",
+                locked=[("leafpkg", "2.0.0", None)],
+                lockless_leaf=True,
+            ),
+            [],
+        )
+
+    def test_unowned_path_package_is_reported(self) -> None:
+        # A source-less entry naming no manifest here cannot be
+        # adjudicated. Staying quiet would leave a lockfile entry that
+        # nothing checks, which is the shape of the original gap.
+        failures = self._failures(
+            leaf_version="2.0.0",
+            locked=[("leafpkg", "2.0.0", None), ("stranger", "0.1.0", None)],
+        )
+        self.assertEqual(len(failures), 1, failures)
+        self.assertIn("stranger at '0.1.0' resolves to no manifest here", failures[0])
+
+    def test_versionless_entry_is_reported_not_dropped(self) -> None:
+        # A half-written entry for an owned package cannot be compared,
+        # and dropping it would silently check one entry fewer than the
+        # lockfile holds.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            self._build(
+                root,
+                canonical=self.CANONICAL,
+                leaf_version="2.0.0",
+                locked=[("leafpkg", "2.0.0", None)],
+            )
+            (root / "leaf" / "Cargo.lock").write_text(
+                'version = 4\n\n[[package]]\nname = "leafpkg"\nversion = "2.0.0"\n\n'
+                '[[package]]\nname = "rootpkg"\n',
+                encoding="utf-8",
+            )
+            failures = cv.check_excluded_lockfiles(root, self.CANONICAL)
+        self.assertEqual(len(failures), 1, failures)
+        self.assertIn(f"rootpkg locked at {cv.NO_VERSION!r}", failures[0])
+
+    def test_empty_lockfile_is_reported(self) -> None:
+        # Every real Cargo.lock records at least its own root package.
+        failures = self._failures(leaf_version="2.0.0", locked=[])
+        self.assertEqual(len(failures), 1, failures)
+        self.assertIn("no path packages recorded", failures[0])
+
+    def test_no_candidates_is_not_a_pass(self) -> None:
+        # The vacuity guard. If the `[workspace] exclude` derivation
+        # ever returns nothing, the gate must say so rather than report
+        # lockstep having examined no lockfile at all.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            (root / "Cargo.toml").write_text(
+                "[workspace]\nmembers = []\n"
+                'exclude = [".claude/worktrees"]\n\n'
+                '[workspace.package]\nversion = "2.0.0"\n',
+                encoding="utf-8",
+            )
+            failures = cv.check_excluded_lockfiles(root, "2.0.0")
+        self.assertEqual(len(failures), 1, failures)
+        self.assertIn("derivation in check-versions.py has broken", failures[0])
+
+    def test_fuzz_lockfile_is_in_scope(self) -> None:
+        # The correction to #1234's own resolution plan: deriving the
+        # candidate list from EXCLUDED_LEAF_DIRS would have skipped
+        # `fuzz`, which is deliberately version 0.0.0 and therefore
+        # absent from that tuple — yet `fuzz/Cargo.lock` is one of the
+        # two lockfiles the issue exists for. The `[workspace] exclude`
+        # derivation covers it.
+        self.assertNotIn("fuzz", cv.EXCLUDED_LEAF_DIRS)
+        crates = [crate for crate, _ in cv.excluded_lockfiles(REPO_ROOT)]
+        self.assertIn("fuzz", crates)
+        self.assertIn("enums", crates)
+
+    def test_real_lockfiles_are_in_step(self) -> None:
+        canonical = cv.workspace_version(REPO_ROOT)
+        self.assertEqual(cv.check_excluded_lockfiles(REPO_ROOT, canonical), [])
+
+    def test_real_lockfiles_would_flag_on_a_bump(self) -> None:
+        # Proof the real files are actually in scope, not merely
+        # parsed: at a hypothetical canonical version every lockfile
+        # recording a workspace-inheriting crate goes stale. `fuzz`
+        # must be among them — it records `big-code-analysis`.
+        failures = cv.check_excluded_lockfiles(REPO_ROOT, "9.9.9")
+        self.assertTrue(failures)
+        self.assertTrue(
+            any(f.startswith("fuzz/Cargo.lock:") for f in failures), failures
+        )
+
+    def test_package_name_is_read_from_the_manifest(self) -> None:
+        # `tree-sitter-tcl/` publishes as `bca-tree-sitter-tcl`, so the
+        # version map cannot key on the directory name.
+        versions = cv.owned_package_versions(REPO_ROOT, "2.0.0")
+        self.assertIn("bca-tree-sitter-tcl", versions)
+        self.assertNotIn("tree-sitter-tcl", versions)
+        # `fuzz` is 0.0.0 by design, and must be compared against its
+        # own manifest rather than the canonical workspace version.
+        self.assertEqual(versions["big-code-analysis-fuzz"][0], "0.0.0")
+        # A member inheriting `version.workspace = true` resolves to the
+        # canonical version passed in.
+        self.assertEqual(versions["big-code-analysis-cli"][0], "2.0.0")
 
 
 class SmokeTest(unittest.TestCase):

--- a/utils/check-versions.py
+++ b/utils/check-versions.py
@@ -16,9 +16,23 @@ doc pins), and the `recipes/ci.md` install pins may additionally
 lag one release because they can only move once the release's
 `SHA256SUMS` exists.
 
-See `RELEASING.md` "Lockstep version policy" and "Version strings
-in documentation" for the policies this enforces. Wired into
-`make pre-commit` and the CI lint job.
+The lockfiles of the workspace-excluded crates are checked too.
+Each excluded crate roots its own workspace and so carries its own
+`Cargo.lock`, and `cargo update --workspace` — the refresh
+`RELEASING.md` calls **mandatory** during a bump — reaches none of
+them. Every gate that consumes one passes `--locked`, so a bump
+that misses them strands the recorded path-package versions and the
+next otherwise-correct commit fails with "cannot update the lock
+file … because --locked was passed" — inside `make enums-check`,
+`make fuzz-check`, or `make release-check`, none of which is
+plausibly related to whatever that commit touched. Checking the
+lockfiles here makes the staleness name itself at the bump, where
+the fix is one `cargo update --manifest-path` away (#1234).
+
+See `RELEASING.md` "Lockstep version policy", "Version strings
+in documentation", and "Refresh the workspace-excluded lockfiles
+too" for the policies this enforces. Wired into `make pre-commit`
+and the CI lint job.
 
 Exits 0 on lockstep, non-zero with a per-source listing on drift.
 """
@@ -28,6 +42,23 @@ from __future__ import annotations
 import pathlib
 import re
 import sys
+from typing import Any
+
+# tomllib landed in 3.11. On older Python, fall back to the external
+# `tomli` package (same API), matching check-excluded-manifests.py.
+try:
+    import tomllib
+except ImportError:
+    try:
+        import tomli as tomllib  # type: ignore[import-not-found,no-redef]
+    except ImportError:
+        sys.stderr.write(
+            "error: check-versions.py requires Python 3.11+\n"
+            "       (tomllib lives in the standard library starting at 3.11).\n"
+            "       On older Python, install `tomli` and retry:\n"
+            "           pip install tomli\n"
+        )
+        sys.exit(2)
 
 # `parents[1]`, not `parent`: these gates live in `utils/` but every
 # path they read or write is anchored at the repository root.
@@ -36,6 +67,14 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 # Owned crates that carry an own `[package].version` line (i.e. do
 # not inherit via `version.workspace = true`). Each must match the
 # canonical workspace version.
+#
+# Deliberately *not* the source of the lockfile-staleness check's
+# candidate list: `fuzz` is absent here because it is version `0.0.0`
+# by design and so cannot satisfy this tuple's "== canonical" rule,
+# yet `fuzz/Cargo.lock` is one of the two lockfiles that motivated
+# #1234. The lockfile check derives its own list from the root
+# manifest's `[workspace] exclude` array instead — see
+# `excluded_lockfiles`.
 EXCLUDED_LEAF_DIRS = (
     "enums",
     "tree-sitter-ccomment",
@@ -44,6 +83,16 @@ EXCLUDED_LEAF_DIRS = (
     "tree-sitter-preproc",
     "tree-sitter-tcl",
 )
+
+# `[workspace] exclude` entries that name a directory rather than a
+# crate: no manifest, nothing to resolve. Mirrors the same constant in
+# check-excluded-manifests.py.
+NON_CRATE_EXCLUDES = frozenset({".claude/worktrees"})
+
+# Stand-in for a lockfile entry whose `version` is absent or is not a
+# string. It is deliberately not a version any manifest can declare, so
+# such an entry is reported rather than skipped.
+NO_VERSION = "<no version>"
 
 # Lines of the form
 #     <key> = { ..., version = "=X.Y.Z", ... }
@@ -272,6 +321,188 @@ def check_external_grammar_lockstep(root: pathlib.Path) -> list[str]:
     return failures
 
 
+def parse_toml(path: pathlib.Path, label: str) -> dict[str, Any]:
+    """Parse a TOML file, exiting with a located error on bad syntax.
+
+    Manifests and lockfiles are parsed rather than regex-matched: a
+    literal string (`version = '2.2.1'`), a commented-out entry, and a
+    `[[package]]` header inside a multi-line string all read wrongly
+    under a pattern and correctly under a parser. Same reasoning as
+    check-excluded-manifests.py, which documents the drift each of
+    those produced.
+    """
+    try:
+        return tomllib.loads(read(path))
+    except tomllib.TOMLDecodeError as exc:
+        raise SystemExit(f"error: {label} is not valid TOML: {exc}") from exc
+
+
+def _workspace_array(root: pathlib.Path, key: str) -> list[str]:
+    """Return the root manifest's `[workspace] <key>` string array."""
+    data = parse_toml(root / "Cargo.toml", "Cargo.toml")
+    workspace = data.get("workspace")
+    entries = workspace.get(key) if isinstance(workspace, dict) else None
+    if not isinstance(entries, list) or not all(
+        isinstance(entry, str) for entry in entries
+    ):
+        raise SystemExit(
+            f"error: could not read a [workspace] {key} string array from Cargo.toml"
+        )
+    return entries
+
+
+def owned_crate_dirs(root: pathlib.Path) -> list[str]:
+    """Every directory in this repository holding an owned manifest.
+
+    The repository root, the workspace members, and the excluded
+    crates — in other words every crate a path dependency can resolve
+    to. Derived from the root manifest so the list cannot drift as
+    crates are added or removed.
+    """
+    dirs = ["."]
+    dirs += _workspace_array(root, "members")
+    dirs += [
+        entry
+        for entry in _workspace_array(root, "exclude")
+        if entry not in NON_CRATE_EXCLUDES
+    ]
+    for crate in dirs:
+        if not (root / crate / "Cargo.toml").is_file():
+            raise SystemExit(
+                f"error: {crate}/Cargo.toml is listed in the root manifest "
+                f"but does not exist (a glob in `members` / `exclude` is not "
+                f"supported here)"
+            )
+    return dirs
+
+
+def owned_package_versions(
+    root: pathlib.Path, canonical: str
+) -> dict[str, tuple[str, str]]:
+    """Map every owned package name to `(version, declaring manifest)`.
+
+    The package name is not the directory name — `tree-sitter-tcl/`
+    publishes as `bca-tree-sitter-tcl` — so the name is read from
+    `[package].name` rather than inferred. `version.workspace = true`
+    resolves to the canonical workspace version; a manifest with no
+    `[package]` table at all (a virtual workspace root) contributes
+    nothing and is not an error. The manifest path rides along so a
+    failure can point at the file that decides the expected value.
+    """
+    versions: dict[str, tuple[str, str]] = {}
+    for crate in owned_crate_dirs(root):
+        label = f"{crate}/Cargo.toml" if crate != "." else "Cargo.toml"
+        package = parse_toml(root / crate / "Cargo.toml", label).get("package")
+        if not isinstance(package, dict):
+            continue
+        name = package.get("name")
+        declared = package.get("version")
+        if isinstance(declared, dict) and declared.get("workspace") is True:
+            declared = canonical
+        if isinstance(name, str) and isinstance(declared, str):
+            versions[name] = (declared, label)
+    return versions
+
+
+def locked_path_packages(lockfile: pathlib.Path, label: str) -> list[tuple[str, str]]:
+    """Return `(name, version)` for each path package in a lockfile.
+
+    A `[[package]]` entry with no `source` key was resolved from a
+    path, not from a registry — i.e. it is one of this repository's own
+    crates, recorded at whatever version its manifest carried when the
+    lockfile was last written. Registry entries carry a `source` and
+    are legitimately at unrelated versions, so they are skipped.
+
+    A named entry whose `version` is missing or is not a string gets
+    the placeholder below rather than being dropped: it can equal no
+    manifest version, so the caller reports it instead of quietly
+    checking one entry fewer than the file holds.
+    """
+    packages = parse_toml(lockfile, label).get("package")
+    if not isinstance(packages, list):
+        return []
+    found = []
+    for entry in packages:
+        if not isinstance(entry, dict) or "source" in entry:
+            continue
+        name = entry.get("name")
+        version = entry.get("version")
+        if isinstance(name, str):
+            found.append((name, version if isinstance(version, str) else NO_VERSION))
+    return found
+
+
+def excluded_lockfiles(root: pathlib.Path) -> list[tuple[str, pathlib.Path]]:
+    """Return `(crate dir, lockfile)` for each excluded crate carrying one.
+
+    An excluded crate need not have a `Cargo.lock` — one only exists
+    once something has resolved that crate's manifest — so a missing
+    lockfile is skipped rather than reported. A crate with no manifest
+    at all is a different matter and is rejected by
+    `owned_crate_dirs`.
+    """
+    return [
+        (crate, root / crate / "Cargo.lock")
+        for crate in _workspace_array(root, "exclude")
+        if crate not in NON_CRATE_EXCLUDES and (root / crate / "Cargo.lock").is_file()
+    ]
+
+
+def check_excluded_lockfiles(root: pathlib.Path, canonical: str) -> list[str]:
+    """Report path-package versions stranded by a version bump.
+
+    In an excluded crate's `Cargo.lock`, every path package must sit
+    at the version its own manifest declares. `cargo update
+    --workspace` does not reach these files, so a bump leaves them
+    behind and the failure surfaces later, inside an unrelated commit's
+    `--locked` invocation (#1234).
+    """
+    versions = owned_package_versions(root, canonical)
+    failures: list[str] = []
+    lockfiles = excluded_lockfiles(root)
+    for crate, lockfile in lockfiles:
+        label = f"{crate}/Cargo.lock"
+        locked = locked_path_packages(lockfile, label)
+        if not locked:
+            # Every Cargo.lock records at least its own root package
+            # with no `source`. None at all means the file is empty or
+            # malformed, and checking it proved nothing.
+            failures.append(f"{label}: no path packages recorded (empty or malformed)")
+            continue
+        drifted = []
+        for name, found in locked:
+            declared = versions.get(name)
+            if declared is None:
+                # A path package this repository does not own — the
+                # version map cannot adjudicate it, and staying silent
+                # would mean a lockfile entry nothing checks.
+                drifted.append(f"{name} at {found!r} resolves to no manifest here")
+                continue
+            expected, manifest_label = declared
+            if found != expected:
+                drifted.append(
+                    f"{name} locked at {found!r}, "
+                    f"{manifest_label} declares {expected!r}"
+                )
+        if drifted:
+            failures.append(
+                f"{label}: stale against the manifests: "
+                + "; ".join(drifted)
+                + f" — refresh with `cargo update --manifest-path "
+                f"{crate}/Cargo.toml --workspace`"
+            )
+    if not lockfiles:
+        # A vacuity guard, not a real-world state: the seven excluded
+        # lockfiles are checked in. Reaching zero means the derivation
+        # above broke, and a gate that reports "versions OK" having
+        # examined nothing is the failure this check exists to prevent.
+        failures.append(
+            "no workspace-excluded lockfile was found to check — the "
+            "[workspace] exclude derivation in check-versions.py has broken"
+        )
+    return failures
+
+
 def main() -> int:
     root = REPO_ROOT
     canonical = workspace_version(root)
@@ -341,6 +572,7 @@ def main() -> int:
                 )
 
     failures.extend(check_external_grammar_lockstep(root))
+    failures.extend(check_excluded_lockfiles(root, canonical))
 
     if failures:
         print("lockstep-version check FAILED", file=sys.stderr)
@@ -348,9 +580,12 @@ def main() -> int:
         for f in failures:
             print(f"  {f}", file=sys.stderr)
         return 1
+    # The lockfile count is printed, not just tallied, so a derivation
+    # that silently narrows shows up in the passing output too.
     print(
         f"versions OK: every owned crate at {canonical}, "
-        f"doc pins at published release {latest_release}"
+        f"doc pins at published release {latest_release}, "
+        f"{len(excluded_lockfiles(root))} excluded lockfiles in step"
     )
     return 0
 


### PR DESCRIPTION
Fixes six issues, all but two variations on one theme: **a test that
exercises a language must be gated on that language's Cargo feature**, so
a partial-feature build leaves it *absent* rather than failing with panics
that read as a defect in whatever the contributor was changing — the
#1220 / PR #1221 shape `.claude/rules/testing.md` was written from.

| Commit | Issue | |
|---|---|---|
| `1591bbdc` | #1234 | Gate excluded-crate lockfile staleness |
| `d525e6df` | #1235 | `fuzz-smoke` reports every failing target |
| `bd3001b6` | #1415 | Gate the 24 `flatten_cases!` rows per row |
| `2f0bbd11` | #1281 | Parity fixtures on an exhaustive `match`, +107 rows |
| `7fba2483` | #1286, #1411 | Gate 25 sweeps, split one, add 4 missing guards |
| `f703ad02` | — | Whole-branch review remediation |

## What each one does

**#1234** — a workspace-excluded crate carries its own `Cargo.lock`, and
`cargo update --workspace` (which `RELEASING.md` calls mandatory during a
bump) reaches none of them. Every gate that consumes one passes
`--locked`, so a bump that skipped them turned `make enums-check` /
`fuzz-check` / `release-check` red on a later, unrelated commit.
`check-versions.py` now compares every path package against the version
that package's own manifest declares, and names the lockfile, the
package, both versions, and the `cargo update --manifest-path` line that
repairs it.

Candidates are derived from the root manifest's `[workspace] exclude`
array rather than from the gate's existing `EXCLUDED_LEAF_DIRS` tuple.
That tuple encodes the *first* invariant's admission rule ("must equal
the canonical workspace version"), which is exactly why `fuzz` —
deliberately `0.0.0` — is not in it; reusing it would have silently
dropped one of the two lockfiles the issue exists for.

**#1235** — `.SHELLFLAGS := -eu` meant the first crashing `cargo fuzz
run` ended the loop. `fuzz-smoke` is what the quarterly cron invokes, the
run nobody watches, so a quarter with three unrelated crashes reported
one and rediscovered the rest only after it was fixed. The loop now
collects per-target status and exits naming every failing target.
`fuzz-replay`, the per-PR gate, deliberately still stops at the first.

The workflow's advisory status is now recorded as a decision with its
rationale rather than stated as a bare fact.

**#1415** — every row of `alterator_string_flattening` panics when its
grammar is compiled out, and the module is declared ungated, so any
feature set short of all eight red-Xed up to 24 tests. `flatten_cases!`
now takes a per-row feature literal. A whole-module gate cannot express
this: the table spans eight features, which is why its single-grammar
siblings could use one and this file cannot.

**#1281** — five hand-listed parity suites now key fixtures on an
exhaustive `match` over `LANG`, so a new language cannot be added without
deciding whether it spells each construct. Adds 107 measured rows across
11 families with a reason at every `None` arm, replacing `nargs`'s false
"every supported language …" prose list and `nexits`'s asserted "all 23
languages" claim with a compiler-enforced one. None of the 107 moved a
metric; all were at parity when added.

It also fixes an unfiled defect in the same files: none of them filtered
on `is_enabled()`, so 13 of 19 parity tests panicked under
`--no-default-features --features go`. Now 16 of 16 pass.

**#1286 / #1411** — 25 sweeps had the loud non-vacuity guard without the
`#[cfg(any(feature = …))]` union that makes a test absent rather than
failing. 12 failed under `--features go` and 9 under `rust,typescript`;
both are now 0. Four more had the inverse problem — a filter and no guard,
so they passed having asserted nothing.

Two sites are deliberately not plain unions:

- `comments_in_parameter_lists` has a guard that is a **conjunction over
  two disjoint populations**, which no union can satisfy — a union admits
  every configuration satisfying *one* clause while the guard demands all
  of them. Split into two tests, each with its own gate and guard.
- `c_family_return_type_declarators` needed the opposite, an
  **intersection** (`any(cpp, mozcpp)`), because its `cpp_only` clause
  dominates the other two.

## Verification

`make pre-commit` → `BCA_GATE: pass` on every commit and on the final
branch. For each gating change: the test is absent (not merely passing)
under a subset enabling none of its features, present and passing under
one enabling a row, and the `--all-features` `cargo nextest list` set is
**diffed as a set** before and after. The only intended membership change
in the whole branch is the one-into-two split above.

The partial-feature suites do **not** go green overall, and are not meant
to: ~2,600 ungated per-language tests remain. That is #1413.

## Deferred and filed

- **#1285 / #1413 deferred** after measurement: 2,613 ungated tests naming
  a concrete `*Parser` in `src/` plus 54 in the ast crate, against exactly
  4 gated. #1285's plan counts on gating at `mod` granularity, but the
  per-language files under `src/metrics/<metric>/` are *implementation*
  modules holding 28 tests in total — every per-language test is inline in
  one `mod tests` per metric file, so that route does not exist. Both
  issues carry the full measurement.
- **#1426 filed** — `--no-default-features --features c` fails `cargo
  check` and `--features tcl` fails `clippy -D warnings`, both in
  `tests/api/ast_seam_test.rs`. Pre-existing, invisible to CI, and it
  breaks the exact reproducer subsets `.claude/rules/testing.md`
  prescribes.

## Issue claims that did not survive verification

Corrected in each issue's thread:

- #1234's plan would have missed `fuzz/Cargo.lock` (above).
- #1235 said `main`'s `ci` aggregator gates merges. `main` is governed by
  the `protect-main` **ruleset** — the legacy
  `/branches/main/protection` endpoint answers `404 Branch not protected`
  for a ruleset-governed branch, which is where that reading came from.
  The ruleset names no required status checks, so the advisory decision
  stands, but the premise was wrong and the doc now cites
  `gh api repos/:owner/:repo/rules/branches/main`.
- #1415 said 11 rows (24 — `21230d4a` added the rest) and gave
  `--features go` as the reproducer; `default = ["all-languages"]` makes
  that additive, so it proves nothing without `--no-default-features`.
  It also said `LANG::Mozcpp` rides `cpp`; it has its own feature.
- #1281 was stale on #1272, which shipped — Elixir rows already existed in
  four families. And `LANG::C` was absent only from the *hand-listed*
  suites, not from all of them.
- #1286's `src/c_declarator.rs` path moved to
  `src/c_family_space_names_tests.rs` in the #1376 split.
- #1411 misses that `keyword_negation_parity` holds a third test, which a
  module gate naming only the other two would have dropped from a
  Lua-only build.

## What the whole-branch review caught

`7fba2483` gated `container_scope_tests` on the 16 features its
`FIXTURES` table uses. A module gate is an **outer** `cfg`, so the one
test in that module reading a different table —
`a_language_with_no_member_construct_emits_neither_block`, gated
`any(bash, lua, c)` — stopped existing under exactly the builds it
covers. Silent, and invisible to CI, whose feature matrix enables none of
those three.

Widening the module gate alone would have traded that for the spurious
failure the gate exists to prevent, since `FIXTURES` is empty under
`bash`. `f703ad02` inverts it instead: the module names every feature any
of its tests uses, and the narrower `FIXTURES` union moves onto the four
sweeps that read `FIXTURES`.

Worth noting that this branch's own CHANGELOG describes catching the
identical trap in `abc`'s Lua-only third test. Same shape, two modules,
caught in one and not the other.

## Note for merging

Every commit is **unsigned** — GPG pinentry had no tty during the run.
`protect-main` enforces `required_signatures`, so either re-sign first:

```bash
git rebase --exec 'git commit --amend -S --no-edit' origin/main
```

(safe — the branch is linear, zero merge commits), or squash-merge, which
has GitHub create and sign the resulting commit.
