### PR TITLE
fix(ast): guard Node::utf8_text against an out-of-range span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,22 @@ for historical reference.
 
 ### Fixed
 
+- **`Node::utf8_text` no longer panics on a span that falls outside the
+  buffer it is handed.** Its signature returns `Option` and its doc
+  offered `None` for invalid UTF-8, but it delegated to
+  `tree_sitter::Node::utf8_text`, which is
+  `str::from_utf8(&source[start..end])` — the slice aborts before the
+  `Result` exists, so the `.ok()` could not catch it. It now indexes with
+  `data.get(..)`, the spelling
+  `.claude/rules/grammar-dispatch.md` §10 already prescribes for reading
+  a node's bytes. Every caller passes the buffer the tree was parsed
+  from, so no span could reach the branch and this was not a live crash;
+  it is fixed at the wrapper because the guarantee is one refactor from
+  false — this crate already runs passes that parse one buffer and read
+  another — and because `panic!` is banned in non-test code regardless of
+  reachability. One change covers all 45 call sites; the signature is
+  unchanged, so it is not an API break.
+
 - **A `::`-qualified Tcl or iRules command now resolves to the core
   command it names** in every metric, not just the ones reading the
   braced-word slot table. `::switch` *is* `switch` — a leading `::` names

--- a/big-code-analysis-ast/src/alterator.rs
+++ b/big-code-analysis-ast/src/alterator.rs
@@ -106,7 +106,6 @@ where
     /// `Ast::dump` on 8 KB of nested Tcl braces from 10 ms to 418 ms —
     /// the run `ast.rs` records beside the chain this reads, not a
     /// second measurement.
-    ///
     #[inline]
     #[must_use]
     fn keeps_children<'a>(_node: &Node<'a>, _code: &[u8], _ancestors: Ancestors<'a, '_>) -> bool {

--- a/big-code-analysis-ast/src/node.rs
+++ b/big-code-analysis-ast/src/node.rs
@@ -198,12 +198,26 @@ impl<'a> Node<'a> {
         self.0.kind_id()
     }
 
-    /// The source text this node spans, or `None` when those bytes are
-    /// not valid UTF-8.
+    /// The source text this node spans, or `None` when the span falls
+    /// outside `data` or those bytes are not valid UTF-8.
+    ///
+    /// Indexed with `data.get(..)` rather than delegating to
+    /// [`tree_sitter::Node::utf8_text`], which is
+    /// `str::from_utf8(&source[start..end])` — the slice panics on a span
+    /// reaching past `source`, before the `Result` its signature offers
+    /// ever exists, so `.ok()` cannot catch it. Every caller today passes
+    /// the same buffer the tree was parsed from and so cannot produce
+    /// that span, but the guarantee is one refactor from false: this
+    /// crate already runs passes that parse one buffer and read another
+    /// (`preproc`, `comment_rm`), and `panic!` is banned in non-test code
+    /// whether or not the branch is currently reachable. `data.get(..)`
+    /// is also what `.claude/rules/grammar-dispatch.md` §10 prescribes
+    /// for reading a node's bytes.
     #[inline]
     #[must_use]
     pub fn utf8_text(&self, data: &'a [u8]) -> Option<&'a str> {
-        self.0.utf8_text(data).ok()
+        let bytes = data.get(self.0.start_byte()..self.0.end_byte())?;
+        std::str::from_utf8(bytes).ok()
     }
 
     /// The 0-based byte offset where this node starts.
@@ -1077,6 +1091,32 @@ mod tests {
             }
             false
         })
+    }
+
+    /// `utf8_text` answers `None` for a span outside the buffer instead
+    /// of aborting the process.
+    ///
+    /// The only way to reach that branch is to read against a buffer
+    /// other than the one the tree was parsed from, which no caller does
+    /// today — so this is the whole coverage the guard can have, and it
+    /// is a real one: against the delegating implementation
+    /// (`self.0.utf8_text(data).ok()`) this test panics at
+    /// `str::from_utf8(&source[start..end])` rather than failing, which
+    /// is precisely the behaviour the guard removes. Verified by revert.
+    #[test]
+    #[cfg(feature = "rust")]
+    fn utf8_text_is_none_for_a_span_past_the_buffer() {
+        let code = b"fn f() {}\n";
+        let tree = Tree::new::<crate::langs::RustCode>(code);
+        let root = tree.get_root();
+
+        // Sanity: the span is in range against its own buffer, so a
+        // `None` below means the bound fired and not that the node is
+        // empty or the text is not UTF-8.
+        assert_eq!(root.utf8_text(code), Some("fn f() {}\n"));
+
+        // The same node, read against a buffer that ends mid-span.
+        assert_eq!(root.utf8_text(&code[..4]), None);
     }
 
     #[test]


### PR DESCRIPTION
Resolves both findings from a `/code-review high` pass over the recent
branches. Neither file belongs to the feature-gating work in #1427, so
they land here instead.

## `Node::utf8_text` could panic

`big-code-analysis-ast/src/node.rs` returned `Option<&str>` and its doc
offered `None` for invalid UTF-8, but delegated to
`tree_sitter::Node::utf8_text`, whose body is

```rust
str::from_utf8(&source[self.start_byte()..self.end_byte()])
```

The slice aborts on a span reaching past `source`, **before** the
`Result` its signature offers ever exists — so the `.ok()` never sees it.
A `pub` method whose type says "fallible, returns `None`" had a second,
undocumented failure mode that kills the process.

It now indexes with `data.get(..)` and decodes separately. Signature and
lifetime are unchanged; behaviour is identical for every in-range span,
and an out-of-range one returns `None`, which is what the doc already
promised.

### Why fix it when it is unreachable

Every caller passes the buffer the tree was parsed from, so no span can
currently be out of range, and this was **not** a live crash. Three
reasons to fix it anyway:

- `AGENTS.md` bans `panic!` in non-test code without qualifying on
  reachability.
- The type is misleading in the direction that matters: a reader
  choosing between `utf8_text` and `code.get(..)` sees `Option` and
  reasonably concludes bounds are handled.
- The invariant is one refactor from false. Anything parsing one buffer
  and reading another breaks it silently, and this crate already has
  passes of that shape (`preproc.rs`, `comment_rm.rs`).

### Why at the wrapper and not the call site

The review proposed converting `src/metrics/abc/irules.rs:175` to
`code.get(..)`. There are **45 `utf8_text` call sites** across `src/` and
`big-code-analysis-ast/src/` with identical exposure, so converting one
leaves the hazard everywhere else while turning a single readable call
into three chained combinators. One wrapper change covers all 45 and
touches no call site — `irules.rs` is unmodified in this PR and is fixed
by it.

`data.get(start..end)` is also what `.claude/rules/grammar-dispatch.md`
§10 already prescribes for reading a node's bytes
(`src/metrics/npa/python.rs:178,305,320` uses it), so this makes the
wrapper agree with the rule rather than introducing a pattern.

### Test

The branch is reachable only by reading against a buffer other than the
one the tree was parsed from, so that is exactly what the test does —
and that is the whole coverage such a guard can have.

Verified by revert, which is the point: against the delegating body the
test does not fail, it **aborts** —

```
thread 'node::tests::utf8_text_is_none_for_a_span_past_the_buffer' panicked at
  tree-sitter-0.26.13/binding_rust/lib.rs:2009:31:
range end index 10 out of range for slice of length 4
```

— at precisely the line this PR routes around. Restore was byte-identical.

The test is `#[cfg(feature = "rust")]`-gated per
`.claude/rules/testing.md`. Note the surrounding `node.rs` tests are not
gated; that is the #1413 debt and out of scope here.

## Stray doc line

`Alterator::keeps_children` carried a trailing empty `///` closing its
doc block. Removed.

## Verification

`make pre-commit` → `BCA_GATE: pass`. Also confirmed no caller bypasses
the wrapper to reach `tree_sitter::Node::utf8_text` directly, and that
`utf16_text` — the sibling panicking slice, `&source[start/2..end/2]` —
is unused in this workspace.

## Note for merging

The commit is **unsigned** (GPG pinentry had no tty). `protect-main`
enforces `required_signatures`, so either re-sign —

```bash
git rebase --exec 'git commit --amend -S --no-edit' origin/main
```

— or squash-merge and let GitHub sign the result.
